### PR TITLE
[Improvement] WORKATY-100: Add some shadow to sidebar

### DIFF
--- a/components/sidebar.stories.tsx
+++ b/components/sidebar.stories.tsx
@@ -42,6 +42,7 @@ export const Default: Story = {
           { id: 2, title: "Mohamad Naufal Alim", onClick: setPerson },
         ],
       },
+
       {
         title: "Product Management Team",
         items: [
@@ -98,6 +99,7 @@ export const Default: Story = {
             />
           </Sidebar.Item>
         </Sidebar>
+        <Sidebar.Spacer />
         <div className="items-center justify-center flex w-full">
           Empty Content
         </div>
@@ -155,6 +157,7 @@ export const FixedRight: Story = {
         <div className="items-center justify-center flex w-full">
           Empty Content
         </div>
+        <Sidebar.Spacer />
         <Sidebar position="right">
           <Sidebar.Item>
             <Searchbox

--- a/components/sidebar.stories.tsx
+++ b/components/sidebar.stories.tsx
@@ -99,7 +99,7 @@ export const Default: Story = {
           </Sidebar.Item>
         </Sidebar>
         <Sidebar.Spacer />
-        <div className="items-center justify-center flex w-full">
+        <div className="items-center min-h-screen justify-center flex w-full">
           Empty Content
         </div>
       </div>
@@ -153,7 +153,7 @@ export const FixedRight: Story = {
 
     return (
       <div className="flex flex-row w-full justify-between">
-        <div className="items-center justify-center flex w-full">
+        <div className="items-center min-h-screen justify-center flex w-full">
           Empty Content
         </div>
         <Sidebar.Spacer />

--- a/components/sidebar.stories.tsx
+++ b/components/sidebar.stories.tsx
@@ -42,7 +42,6 @@ export const Default: Story = {
           { id: 2, title: "Mohamad Naufal Alim", onClick: setPerson },
         ],
       },
-
       {
         title: "Product Management Team",
         items: [

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -104,7 +104,7 @@ function Sidebar({ children, className, position = "left" }: SidebarProps) {
         }
         animate={isMobile ? controls : { x: 0 }}
         className={cn(
-          `fixed z-40 flex h-full min-h-screen w-64 min-w-[300px] flex-col border border-gray-300 bg-white p-6 pt-10 shadow-lg md:static md:hidden md:translate-x-0 md:shadow-none`,
+          `fixed z-40 flex h-full min-h-screen w-64 min-w-[300px] flex-col border-r shadow-lg border-gray-300 bg-white p-6 pt-10 md:static md:hidden md:translate-x-0 md:shadow-none`,
           position === "left" ? "left-0" : "right-0",
           className
         )}
@@ -117,7 +117,7 @@ function Sidebar({ children, className, position = "left" }: SidebarProps) {
           {...handlers}
           onClick={() => handleToggleSidebar(true)}
           className={cn(
-            "fixed top-0 z-30 block h-full cursor-pointer rounded-xs border border-gray-300 bg-white p-[2px] shadow-xs md:hidden",
+            "fixed top-0 z-30 block h-full cursor-pointer rounded-xs border border-gray-200 bg-white p-[2px] shadow-xl md:hidden",
             position === "left" ? "left-0" : "right-0"
           )}
         >
@@ -127,8 +127,8 @@ function Sidebar({ children, className, position = "left" }: SidebarProps) {
 
       <div
         className={cn(
-          `fixed top-0 z-40 hidden h-full min-h-screen w-64 min-w-[300px] border-gray-300 border bg-white p-6 pt-10 shadow-lg md:static md:flex md:translate-x-0 md:flex-col md:shadow-none`,
-          position === "left" ? "left-0" : "right-0",
+          `fixed top-0 z-40 hidden h-full min-h-screen w-64 min-w-[300px] border-gray-200 bg-white p-6 pt-10 shadow-xl md:static md:flex md:translate-x-0 md:flex-col`,
+          position === "left" ? "left-0 border-r" : "right-0 border-l",
           className
         )}
       >

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -104,8 +104,8 @@ function Sidebar({ children, className, position = "left" }: SidebarProps) {
         }
         animate={isMobile ? controls : { x: 0 }}
         className={cn(
-          `fixed z-40 flex h-full min-h-screen w-64 min-w-[300px] flex-col border-r shadow-lg border-gray-300 bg-white p-6 pt-10 md:static md:hidden md:translate-x-0 md:shadow-none`,
-          position === "left" ? "left-0" : "right-0",
+          `fixed z-40 flex h-full min-h-screen w-64 min-w-[300px] flex-col shadow-md border-gray-300 bg-white p-6 pt-10 md:static md:hidden md:translate-x-0`,
+          position === "left" ? "left-0 border-r" : "right-0 border-l",
           className
         )}
       >
@@ -117,7 +117,7 @@ function Sidebar({ children, className, position = "left" }: SidebarProps) {
           {...handlers}
           onClick={() => handleToggleSidebar(true)}
           className={cn(
-            "fixed top-0 z-30 block h-full cursor-pointer rounded-xs border border-gray-200 bg-white p-[2px] shadow-xl md:hidden",
+            "fixed top-0 z-30 block h-full cursor-pointer rounded-xs border border-gray-200 bg-white p-[2px] shadow-md md:hidden",
             position === "left" ? "left-0" : "right-0"
           )}
         >
@@ -127,7 +127,7 @@ function Sidebar({ children, className, position = "left" }: SidebarProps) {
 
       <div
         className={cn(
-          `fixed overflow-y-auto top-0 z-40 hidden h-full min-h-screen w-64 min-w-[300px] border-gray-200 bg-white p-6 pt-10 shadow-xl md:fixed md:flex md:translate-x-0 md:flex-col`,
+          `fixed overflow-y-auto top-0 z-40 hidden h-full min-h-screen w-64 min-w-[300px] border-gray-200 bg-white p-6 pt-10 shadow-md md:fixed md:flex md:translate-x-0 md:flex-col`,
           position === "left" ? "left-0 border-r" : "right-0 border-l",
           className
         )}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -127,7 +127,7 @@ function Sidebar({ children, className, position = "left" }: SidebarProps) {
 
       <div
         className={cn(
-          `fixed top-0 z-40 hidden h-full min-h-screen w-64 min-w-[300px] border-gray-200 bg-white p-6 pt-10 shadow-xl md:static md:flex md:translate-x-0 md:flex-col`,
+          `fixed overflow-y-auto top-0 z-40 hidden h-full min-h-screen w-64 min-w-[300px] border-gray-200 bg-white p-6 pt-10 shadow-xl md:fixed md:flex md:translate-x-0 md:flex-col`,
           position === "left" ? "left-0 border-r" : "right-0 border-l",
           className
         )}
@@ -147,5 +147,10 @@ function SidebarItem({ isFixed, className, children }: SidebarItemProps) {
   return <div className={sidebarItemClass}>{children}</div>;
 }
 
+function SidebarSpacer() {
+  return <div className="hidden md:block md:min-w-[300px]" />;
+}
+
+Sidebar.Spacer = SidebarSpacer;
 Sidebar.Item = SidebarItem;
 export { Sidebar };

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -12,7 +12,6 @@ import {
   OnCompleteFunctionProps,
   OnFileDroppedFunctionProps,
 } from "./file-drop-box";
-import { OptionsProps } from "./selectbox";
 import { BadgeProps } from "./badge";
 import { ColorPickProps } from "./colorbox";
 import { CountryCodeProps } from "./phonebox";


### PR DESCRIPTION
<img width="1129" height="633" alt="image" src="https://github.com/user-attachments/assets/88b171e7-8563-4860-a8b8-793cc70bb684" />

So for now, I make sidebar it's have shadow as your request, and then make fixed content (we can scroll, always stick on left/right, and after that we must use with `<sidebar.spacer/>` to fueled space of fix content and we don't have necessary to add manually on tailwind styling