### PR TITLE
[Bug] WORKATY-106: Fix bug closable dialog story on PaperDialog

### DIFF
--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -134,7 +134,7 @@ const PaperDialogBase = forwardRef<PaperDialogRef, PaperDialogProps>(
                 >
                   <button
                     aria-label="button-close"
-                    onClick={() => setDialogState(null)}
+                    onClick={() => setDialogState("closed")}
                     className={cn(
                       "relative w-fit cursor-pointer bg-white border-[#ebebeb] shadow-sm hover:bg-gray-100",
                       isLeft

--- a/test/e2e/paper-dialog.cy.ts
+++ b/test/e2e/paper-dialog.cy.ts
@@ -28,6 +28,7 @@ context("PaperDialog Component", () => {
       cy.findByText("Add New Employee").should("exist");
 
       cy.findByLabelText("button-close").click();
+      cy.findByText("Add New Employee").should("not.exist");
     });
   });
 
@@ -40,6 +41,7 @@ context("PaperDialog Component", () => {
       cy.findByText("Add New Employee").should("exist");
 
       cy.findByLabelText("button-close").click();
+      cy.findByText("Add New Employee").should("not.exist");
     });
   });
 });


### PR DESCRIPTION
For now, we can't close dialog with button close, so after that we must add test to check the result and re-check onClick condition

<img width="756" height="469" alt="Screenshot 2025-08-02 at 07 47 59" src="https://github.com/user-attachments/assets/9c9121f9-2ea5-4a7f-bd4c-863e19621846" />

for now we can to assert exist or not after click.

```
 it("Should open and close the dialog using the close icon", () => {
      cy.visit(getIdContent("stage-paperdialog--closable"));

      cy.findByRole("button", { name: /trigger/i }).click();

      cy.findByText("Add New Employee").should("exist");

      cy.findByLabelText("button-close").click();
      cy.findByText("Add New Employee").should("not.exist");
    });
```
