### PR TITLE
[Bug] SYST-137: Fix bug combo may not be highlighted when going backward

### DIFF
--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -94,6 +94,7 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
             return (
               <ComboboxDrawer
                 {...props}
+                highlightOnMatch={highlightOnMatch}
                 emptySlate={emptySlate}
                 actions={actions}
                 onClick={onClick}
@@ -133,6 +134,7 @@ function ComboboxDrawer({
   floatingStyles,
   getFloatingProps,
   highlightedIndex,
+  highlightOnMatch,
   listRef,
   options,
   refs,
@@ -197,17 +199,19 @@ function ComboboxDrawer({
       )}
       {options.length > 0 ? (
         options.map((option, index) => {
+          const isSelected = option.value === inputValue.value;
+          const shouldHighlight =
+            highlightOnMatch && isSelected ? true : highlightedIndex === index;
+
           return (
             <OptionItem
               key={option.value}
               id={`option-${index}`}
               role="option"
-              aria-selected={
-                option.value.toString() === inputValue.value.toString()
-              }
-              data-highlighted={highlightedIndex === index}
-              selected={option.value === inputValue.value}
-              highlighted={highlightedIndex === index}
+              aria-selected={isSelected}
+              selected={isSelected}
+              data-highlighted={shouldHighlight}
+              highlighted={shouldHighlight}
               onMouseDown={() => {
                 setInputValue(option);
                 setIsOpen(false);

--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -1,7 +1,7 @@
 import { RiArrowLeftSLine, RiArrowRightSLine } from "@remixicon/react";
 import { Combobox } from "./combobox";
 import { OptionsProps } from "./selectbox";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect, useMemo, useState } from "react";
 import styled, { css, CSSProp } from "styled-components";
 
 type PaginationProps = {
@@ -46,6 +46,16 @@ function Pagination({
       }
     }
   };
+
+  function clamp(val: number, min: number, max: number) {
+    return Math.min(Math.max(val, min), max);
+  }
+
+  useEffect(() => {
+    const comboboxPagesNumber = totalPages - 3;
+    const safePage = clamp(currentPage, 1, comboboxPagesNumber);
+    setCurrentPageLocal({ value: safePage, text: safePage.toString() });
+  }, []);
 
   return (
     <PaginationWrapper $style={style}>
@@ -99,17 +109,13 @@ const PaginationItem = ({
   onPageChange: (page: number) => void;
   setCurrentPageLocal: (page: OptionsProps) => void;
 }) => {
-  const [highlightOnMatch, setHighlightOnMatch] = useState(false);
-
   const comboboxPagesNumber = totalPages - 3;
 
-  useEffect(() => {
-    if (currentPage > comboboxPagesNumber) {
-      setHighlightOnMatch(false);
-    } else {
-      setHighlightOnMatch(true);
-    }
+  const highlightOnMatch = useMemo(() => {
+    return currentPage <= comboboxPagesNumber;
   }, [currentPage, comboboxPagesNumber]);
+
+  console.log(highlightOnMatch);
 
   const threshold = 5;
 

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -116,9 +116,8 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
         )
       : options;
 
-    const FILTERED_ACTIVE = options.filter(
-      (opt) => opt.text === inputValueLocal.text
-    );
+    const activeValue = inputValue?.text || inputValueLocal.text;
+    const FILTERED_ACTIVE = options.some((opt) => opt.text === activeValue);
 
     const { refs, floatingStyles, context } = useFloating({
       placement: "bottom-start" as Placement,
@@ -209,6 +208,7 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
           }}
           onBlur={() => {
             setIsFocused(false);
+            setIsHovered(false);
             if (strict) {
               const matched = options.find(
                 (opt) => opt.text === inputValueLocal.text
@@ -232,7 +232,7 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
           onMouseLeave={() => setIsHovered(false)}
           $focused={isFocused}
           $hovered={isHovered}
-          $highlight={highlightOnMatch && FILTERED_ACTIVE.length > 0}
+          $highlight={highlightOnMatch && FILTERED_ACTIVE}
         />
 
         {clearable && inputValueLocal.text !== "" && (
@@ -247,7 +247,7 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
                 setIsOpen(false);
                 setHasInteracted(false);
               }}
-              $highlight={highlightOnMatch && FILTERED_ACTIVE.length > 0}
+              $highlight={highlightOnMatch && FILTERED_ACTIVE}
               size={16}
             />
             <Divider
@@ -277,9 +277,7 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
               onMouseEnter={() => setIsHovered(true)}
               size={18}
               color={
-                highlightOnMatch && FILTERED_ACTIVE.length > 0
-                  ? "#61a9f9"
-                  : "#9ca3af"
+                highlightOnMatch && FILTERED_ACTIVE ? "#61a9f9" : "#9ca3af"
               }
             />
           )}


### PR DESCRIPTION
<img width="390" height="87" alt="image" src="https://github.com/user-attachments/assets/24bd352f-fe46-4cb8-b0d4-6592b3429785" />

wdyt for that, for now we have 2 choice to fix this, for the first if we want have combobox still have on 33 after refresh on combobox (assumption now we have value on 50) just have one way to make consistent, just using like localstorage (that's not affect with any state),
 
but we have 1 solution option also, it's like if we have value same like before ( I mean at 50), we can make the value of combo it's using with clamp (that's the last number of combo -> we can add using useEffect to make this)...