### PR TITLE
[Bug] SYST-189: Add word break and white space on table

### DIFF
--- a/components/table.tsx
+++ b/components/table.tsx
@@ -576,6 +576,22 @@ const TableRowContainer = styled.div<{ $tableRowContainerStyle?: CSSProp }>`
   position: relative;
   width: 100%;
 
+  &::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.3);
+    border-radius: 3px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  scrollbar-gutter: stable;
+
   ${({ $tableRowContainerStyle }) => $tableRowContainerStyle}
 `;
 
@@ -898,7 +914,7 @@ const TableRowWrapper = styled.div<{
 }>`
   display: flex;
   position: relative;
-  padding: 0.75rem;
+  padding: 12px;
   align-items: stretch;
   width: 100%;
   height: 100%;
@@ -958,12 +974,15 @@ const CellContent = styled.div<{ width?: string; $contentStyle?: CSSProp }>`
   padding-right: 0.5rem;
   display: flex;
   align-items: center;
+  word-break: break-word;
+  white-space: pre-wrap;
+
   ${({ width }) =>
     !width &&
     css`
       flex: 1;
       height: fit-content;
-      width: "100%";
+      width: 100%;
     `}
 
   width: ${({ width }) => width};

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -577,20 +577,18 @@ const TableRowContainer = styled.div<{ $tableRowContainerStyle?: CSSProp }>`
   width: 100%;
 
   &::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
+    width: 5px;
+    height: 5px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: rgba(0, 0, 0, 0.3);
-    border-radius: 3px;
+    background-color: rgba(145, 142, 142, 0.3);
+    border-radius: 2px;
   }
 
   &::-webkit-scrollbar-track {
-    background: transparent;
+    background: rgba(168, 167, 167, 0.1);
   }
-
-  scrollbar-gutter: stable;
 
   ${({ $tableRowContainerStyle }) => $tableRowContainerStyle}
 `;


### PR DESCRIPTION
On before, we have buggy text if that's have a lot and not controlled of that, let's introduced on TableRowCellfor white space and word-break

before:
<img width="741" height="156" alt="Screenshot 2025-09-10 at 12 49 47" src="https://github.com/user-attachments/assets/12828945-c698-402f-b041-d8444ca2d90f" />


```
word-break: break-word;
white-space: pre-wrap;
```

after:

<img width="734" height="730" alt="image (4)" src="https://github.com/user-attachments/assets/02da136e-a36b-40be-a7ca-5bcacb29cca0" />
