### PR TITLE
[Improvement] SYST-276: Allow StatefulForm not to have checker/validator

### DIFF
--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -52,7 +52,7 @@ export type FormValueType =
 interface StatefulFormProps<Z extends ZodTypeAny> {
   fields: FormFieldGroup[];
   formValues: TypeOf<Z>;
-  validationSchema: Z;
+  validationSchema?: Z;
   mode?: "onChange" | "onBlur" | "onSubmit";
   onValidityChange?: (e: boolean) => void;
   labelSize?: string;
@@ -114,16 +114,21 @@ function StatefulForm<Z extends ZodTypeAny>({
 
   const finalSchema = getSchemaForVisibleFields(validationSchema, fields);
 
+  const formConfig: Parameters<typeof useForm<TypeOf<Z>>>[0] = {
+    mode,
+    defaultValues: formValues,
+  };
+
+  if (validationSchema) {
+    formConfig.resolver = zodResolver(finalSchema);
+  }
+
   const {
     register,
     control,
     setValue,
     formState: { errors, touchedFields, isValid },
-  } = useForm<TypeOf<Z>>({
-    resolver: zodResolver(finalSchema),
-    mode,
-    defaultValues: formValues,
-  });
+  } = useForm<TypeOf<Z>>(formConfig);
 
   useEffect(() => {
     if (onValidityChange) {
@@ -201,9 +206,11 @@ function StatefulForm<Z extends ZodTypeAny>({
 }
 
 function getSchemaForVisibleFields<Z extends ZodTypeAny>(
-  validationSchema: Z,
-  fields: FormFieldGroup[]
+  validationSchema?: Z,
+  fields?: FormFieldGroup[]
 ) {
+  if (!validationSchema) return undefined;
+
   if (!(validationSchema instanceof ZodObject)) {
     throw new Error("StatefulForm only supports Zod object schemas");
   }

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -1,4 +1,4 @@
-import { useForm, UseFormSetValue } from "react-hook-form";
+import { useForm, UseFormProps, UseFormSetValue } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import z, { ZodTypeAny, TypeOf, ZodObject } from "zod";
 import { ChangeEvent, ReactNode, useEffect, useRef } from "react";
@@ -114,7 +114,7 @@ function StatefulForm<Z extends ZodTypeAny>({
 
   const finalSchema = getSchemaForVisibleFields(validationSchema, fields);
 
-  const formConfig: Parameters<typeof useForm<TypeOf<Z>>>[0] = {
+  const formConfig: UseFormProps<TypeOf<Z>> = {
     mode,
     defaultValues: formValues,
   };

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -32,22 +32,6 @@ describe("StatefulForm", () => {
       country_code: DEFAULT_COUNTRY_CODES,
     };
 
-    const employeeSchema = z.object({
-      first_name: z
-        .string()
-        .min(3, "First name must be at least 3 characters long"),
-      last_name: z.string().optional(),
-      email: z.string().email("Please enter a valid email address"),
-      phone: z
-        .string()
-        .regex(/^\d{10,15}$/, "Phone number must be between 10 and 15 digits")
-        .optional(),
-      note: z.string().optional(),
-      access: z.boolean().refine((val) => val === true, {
-        message: "Access must be true",
-      }),
-    });
-
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
         {
@@ -99,7 +83,6 @@ describe("StatefulForm", () => {
         <StatefulForm
           fields={EMPLOYEE_FIELDS}
           formValues={value}
-          validationSchema={employeeSchema}
           mode="onChange"
         />
       );
@@ -136,22 +119,6 @@ describe("StatefulForm", () => {
       country_code: DEFAULT_COUNTRY_CODES,
     };
 
-    const employeeSchema = z.object({
-      first_name: z
-        .string()
-        .min(3, "First name must be at least 3 characters long"),
-      last_name: z.string().optional(),
-      email: z.string().email("Please enter a valid email address"),
-      phone: z
-        .string()
-        .regex(/^\d{10,15}$/, "Phone number must be between 10 and 15 digits")
-        .optional(),
-      note: z.string().optional(),
-      access: z.boolean().refine((val) => val === true, {
-        message: "Access must be true",
-      }),
-    });
-
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
         {
@@ -203,7 +170,6 @@ describe("StatefulForm", () => {
         <StatefulForm
           fields={EMPLOYEE_FIELDS}
           formValues={value}
-          validationSchema={employeeSchema}
           mode="onChange"
           autoFocusField="first_name"
         />
@@ -230,15 +196,6 @@ describe("StatefulForm", () => {
       access: false,
     };
 
-    const employeeSchema = z.object({
-      first_name: z
-        .string()
-        .min(3, "First name must be at least 3 characters long"),
-      access: z.boolean().refine((val) => val === true, {
-        message: "Access must be true",
-      }),
-    });
-
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       {
         name: "first_name",
@@ -263,7 +220,6 @@ describe("StatefulForm", () => {
         <StatefulForm
           fields={EMPLOYEE_FIELDS}
           formValues={value}
-          validationSchema={employeeSchema}
           mode="onChange"
         />
       );
@@ -289,15 +245,6 @@ describe("StatefulForm", () => {
       first_name: "",
       access: false,
     };
-
-    const employeeSchema = z.object({
-      first_name: z
-        .string()
-        .min(3, "First name must be at least 3 characters long"),
-      access: z.boolean().refine((val) => val === true, {
-        message: "Access must be true",
-      }),
-    });
 
     const BADGE_OPTIONS = [
       {
@@ -386,7 +333,6 @@ describe("StatefulForm", () => {
         <StatefulForm
           fields={EMPLOYEE_FIELDS}
           formValues={value}
-          validationSchema={employeeSchema}
           mode="onChange"
         />
       );
@@ -412,18 +358,6 @@ describe("StatefulForm", () => {
       first_name: "",
       access: false,
     };
-
-    const employeeSchema = z.object({
-      first_name: z
-        .string()
-        .min(3, "First name must be at least 3 characters long"),
-      middle_name: z
-        .string()
-        .min(3, "Middle name must be at least 3 characters long"),
-      access: z.boolean().refine((val) => val === true, {
-        message: "Access must be true",
-      }),
-    });
 
     const EMPLOYEE_FIELDS_WITH_HIDDEN: FormFieldGroup[] = [
       {
@@ -454,7 +388,6 @@ describe("StatefulForm", () => {
         <StatefulForm
           fields={EMPLOYEE_FIELDS_WITH_HIDDEN}
           formValues={value}
-          validationSchema={employeeSchema}
           mode="onChange"
         />
       );
@@ -471,7 +404,6 @@ describe("StatefulForm", () => {
         <StatefulForm
           fields={EMPLOYEE_FIELDS_WITH_HIDDEN}
           formValues={value}
-          validationSchema={employeeSchema}
           mode="onChange"
         />
       );
@@ -820,7 +752,6 @@ describe("StatefulForm", () => {
           <StatefulForm
             fields={ALL_INPUT}
             formValues={valueAll}
-            validationSchema={schema}
             mode="onChange"
           />
         );


### PR DESCRIPTION
Description:
Make the validator optional, if not given, don't perform validation. This makes sense because maybe the user don't want to perform validation or install 3rd party library for validation, or even for [test](https://github.com/systatum/coneto/pull/124#discussion_r2492433479).

After that, please remove schema test on tests THAT are not testing about schema validation; so if the test is testing schema validation, fine, otherwise, let's remove it like [this one](https://github.com/systatum/coneto/pull/124/files#diff-9e0a2a2f39761127ff83e21587036e314d724d352686b24a5a89a9569155b1e5R529).


Source:
[[Improvement] SYST-276: Allow StatefulForm not to have checker/validator
](https://linear.app/systatum/issue/SYST-276/allow-statefulform-not-to-have-checkervalidator)


Tick what you have done:

[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself