### PR TITLE
[Improvement] SYST-293: Keep focusing on the Textbox when clicking action.

### DIFF
--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -5,7 +5,7 @@ import {
   RiEyeLine,
   RiEyeOffLine,
 } from "@remixicon/react";
-import {
+import React, {
   ChangeEvent,
   InputHTMLAttributes,
   ReactElement,
@@ -176,6 +176,7 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
               <Button
                 key={index}
                 aria-label="action-icon"
+                onMouseDown={(e) => e.preventDefault()}
                 onClick={(e) => {
                   e.stopPropagation();
                   if (props.onClick) {
@@ -254,6 +255,7 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
         {type === "password" && (
           <Button
             type="button"
+            onMouseDown={(e) => e.preventDefault()}
             onClick={() => setShowPassword((prev) => !prev)}
             aria-label="toggle-password"
             containerStyle={css`

--- a/test/component/textbox.cy.tsx
+++ b/test/component/textbox.cy.tsx
@@ -53,6 +53,18 @@ describe("Textbox", () => {
           "delete the message"
         );
       });
+
+      it("should focus on the textbox", () => {
+        cy.mount(
+          <Textbox value="" actions={ACTIONS_OPTION} placeholder="type here" />
+        );
+        cy.findByPlaceholderText("type here").should("not.be.focused");
+        cy.findByPlaceholderText("type here").click().should("be.focused");
+        ACTIONS_OPTION.map((_, index) => {
+          cy.findAllByLabelText("action-icon").eq(index).click();
+          cy.findByPlaceholderText("type here").should("be.focused");
+        });
+      });
     });
 
     context("with type password", () => {


### PR DESCRIPTION
Description:
Currently, when clicking the action can causes to lose focus on the Textbox. Let's add using `onMouseDown` with `preventDefault` ensures the Textbox remains focused when interacting with the action.

<img width="434" height="92" alt="image" src="https://github.com/user-attachments/assets/c6ce69f5-e8c1-4887-8603-935480d2fbe4" />

Sources:
[[Improvement] SYST-293: Keep focusing on the Textbox when clicking action.](https://linear.app/systatum/issue/SYST-293/keep-focusing-on-the-textbox-when-clicking-action)

Tick what you have done:

[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself