### PR TITLE
[Bug] SYST-296: Show the datebox value when initialize from outside of component

### DIFF
--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -12,8 +12,9 @@ import styled, { css, CSSProp } from "styled-components";
 import {
   getValidMultipleDate,
   isValidDateString,
+  isWeekend,
   removeWeekend,
-} from "./../constants/valid-date";
+} from "../lib/date";
 
 export interface BaseCalendarProps {
   options?: OptionsProps[];
@@ -802,7 +803,7 @@ function Calendar({
               date.getMonth() === today.getMonth() &&
               date.getFullYear() === today.getFullYear();
 
-            const isWeekend = date.getDay() === 0 || date.getDay() === 6;
+            const isDateWeekend = isWeekend(date);
 
             return (
               <DateCellWrapper
@@ -833,7 +834,7 @@ function Calendar({
                 $isHighlighted={isHighlighted}
                 $isDisabled={disableWeekend || isDisabled}
                 $isWeekend={
-                  disableWeekend ? isWeekend || isDisabled : isDisabled
+                  disableWeekend ? isDateWeekend || isDisabled : isDisabled
                 }
               >
                 {selectabilityMode === "ranged" && (
@@ -842,7 +843,7 @@ function Calendar({
                     $isPickingProcess={startPicked.picked}
                     $isInRange={
                       disableWeekend
-                        ? !isWeekend &&
+                        ? !isDateWeekend &&
                           ((isCurrentDate && !startPicked.picked) ||
                             (isHighlightedPicked && !isDisabled))
                         : (isCurrentDate && !startPicked.picked) ||
@@ -868,7 +869,7 @@ function Calendar({
                   }
                   $isDisabled={isDisabled}
                   $disableWeekend={disableWeekend}
-                  $isWeekend={isWeekend}
+                  $isWeekend={isDateWeekend}
                   $isHighlighted={isHighlighted}
                   $isCurrentDate={
                     isCurrentDate ||
@@ -888,7 +889,7 @@ function Calendar({
                       aria-label="today-dot"
                       $isToday={isToday}
                       $isDisabled={isDisabled}
-                      $isWeekend={isWeekend}
+                      $isWeekend={isDateWeekend}
                       $isPickingProcess={startPicked.picked}
                       $disableWeekend={disableWeekend}
                       $isCurrentDate={isCurrentDate}
@@ -1245,10 +1246,5 @@ function formatDate(date: Date, format: FormatProps) {
       return `${month}/${day}/${year}`;
   }
 }
-
-const isWeekend = (dateToCheck: Date): boolean => {
-  const day = dateToCheck.getDay();
-  return day === 0 || day === 6;
-};
 
 export { Calendar };

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -817,7 +817,7 @@ function Calendar({
                 aria-selected={isHighlighted}
                 id={`option-${idx}`}
                 onClick={async (e) => {
-                  if ((isWeekend && disableWeekend) || isDisabled) {
+                  if ((isDateWeekend && disableWeekend) || isDisabled) {
                     return;
                   }
 

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -18,6 +18,7 @@ export type DateboxProps = BaseCalendarProps & {
   calendarFooter?: ReactNode;
   calendarTodayButtonCaption?: string;
   calendarSelectabilityMode?: SelectabilityModeState;
+  placeholder?: string;
 };
 
 type CalendarDrawerProps = BaseCalendarProps &
@@ -33,7 +34,15 @@ type CalendarDrawerProps = BaseCalendarProps &
   >;
 
 const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
-  const { selectedDates, errorMessage, containerStyle, ...rest } = props;
+  const {
+    selectedDates,
+    setSelectedDates,
+    errorMessage,
+    containerStyle,
+    placeholder = "mm/dd/yyyy",
+    ...rest
+  } = props;
+
   return (
     <InputWrapper $style={containerStyle} $disabled={props.disabled}>
       {props.label && <Label $style={props.labelStyle}>{props.label}</Label>}
@@ -41,6 +50,8 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
         <Selectbox
           {...rest}
           ref={ref}
+          selectedOptions={selectedDates}
+          setSelectedOptions={setSelectedDates}
           selectboxStyle={css`
             ${props.selectboxStyle}
             ${props.showError &&
@@ -48,19 +59,22 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
               border-color: #f87171;
             `}
           `}
-          placeholder="mm/dd/yyyy"
+          placeholder={placeholder}
           iconClosed={RiCalendar2Line}
           iconOpened={RiCalendar2Line}
           type="calendar"
           clearable
         >
-          {(selectBoxProps) => (
-            <CalendarDrawer
-              {...rest}
-              {...selectBoxProps}
-              selectedDates={selectedDates}
-            />
-          )}
+          {(selectBoxProps) => {
+            return (
+              <CalendarDrawer
+                {...rest}
+                {...selectBoxProps}
+                setSelectedDates={setSelectedDates}
+                selectedDates={selectedDates}
+              />
+            );
+          }}
         </Selectbox>
         {props.showError && errorMessage && (
           <ErrorText>{errorMessage}</ErrorText>
@@ -102,15 +116,6 @@ const ErrorText = styled.span`
 `;
 
 function CalendarDrawer(props: CalendarDrawerProps) {
-  useEffect(() => {
-    if (props.selectedDates.length > 0) {
-      props.setSelectedOptionsLocal({
-        text: props.selectedDates?.[0],
-        value: props.selectedDates?.[0],
-      });
-    }
-  }, [props.selectedDates]);
-
   return (
     <CalendarWrapper
       {...(props.getFloatingProps?.() ?? {})}
@@ -126,6 +131,15 @@ function CalendarDrawer(props: CalendarDrawerProps) {
       <Calendar
         {...props}
         footer={props.calendarFooter}
+        setSelectedDates={(data: string[]) => {
+          if (props.setSelectedDates) {
+            props.setSelectedDates(data);
+          }
+          props.setSelectedOptionsLocal({
+            text: data[0],
+            value: data[0],
+          });
+        }}
         todayButtonCaption={props.calendarTodayButtonCaption}
         selectabilityMode={props.calendarSelectabilityMode}
         label={null}

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -28,7 +28,7 @@ import {
   RiCloseLine,
 } from "@remixicon/react";
 import styled, { css, CSSProp } from "styled-components";
-import { isValidDateString } from "./../constants/valid-date";
+import { isValidDateString } from "../lib/date";
 
 export interface SelectboxProps {
   options?: OptionsProps[];

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -28,6 +28,7 @@ import {
   RiCloseLine,
 } from "@remixicon/react";
 import styled, { css, CSSProp } from "styled-components";
+import { isValidDateString } from "./../constants/valid-date";
 
 export interface SelectboxProps {
   options?: OptionsProps[];
@@ -107,7 +108,10 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
   ) => {
     const initialState = options.find(
       (opt) => opt.value === selectedOptions?.[0]
-    ) ?? { text: "", value: "0" };
+    ) ?? {
+      text: isValidDateString(selectedOptions?.[0]) ? selectedOptions?.[0] : "",
+      value: "0",
+    };
 
     const [selectedOptionsLocal, setSelectedOptionsLocal] =
       useState<OptionsProps>(initialState);

--- a/constants/valid-date.ts
+++ b/constants/valid-date.ts
@@ -1,0 +1,31 @@
+export function isValidDateString(value: string): boolean {
+  if (!value) return false;
+
+  const parts = value.includes(",")
+    ? value.split(",").map((s) => s.trim())
+    : value.includes("-")
+      ? value.split("-").map((s) => s.trim())
+      : [value];
+
+  return parts.every((p) => !isNaN(new Date(p).getTime()));
+}
+
+export function isValidSingleDate(v: string): boolean {
+  return !isNaN(new Date(v).getTime());
+}
+
+export function getValidMultipleDate(raw: string): string[] {
+  if (!raw) return [];
+  return raw
+    ?.split(",")
+    ?.map((s) => s.trim())
+    ?.filter(isValidSingleDate);
+}
+
+export function removeWeekend(dates: string[]): string[] {
+  return dates.filter((d) => {
+    const dd = new Date(d);
+    const day = dd.getDay();
+    return day !== 0 && day !== 6;
+  });
+}

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -29,3 +29,8 @@ export function removeWeekend(dates: string[]): string[] {
     return day !== 0 && day !== 6;
   });
 }
+
+export function isWeekend(dateToCheck: Date): boolean {
+  const day = dateToCheck.getDay();
+  return day === 0 || day === 6;
+}

--- a/test/component/datebox.cy.tsx
+++ b/test/component/datebox.cy.tsx
@@ -1,8 +1,8 @@
 import { Datebox } from "./../../components/datebox";
 
 describe("Datebox", () => {
-  context("when initialize first", () => {
-    it("render the value on input", () => {
+  context("when initialized with selected date", () => {
+    it("renders the value on input", () => {
       cy.mount(<Datebox selectedDates={["11/30/2025"]} />);
       cy.findByPlaceholderText("mm/dd/yyyy")
         .should("be.visible")
@@ -20,7 +20,7 @@ describe("Datebox", () => {
       );
     });
 
-    context("when wrong date", () => {
+    context("when given invalid date", () => {
       it("renders an empty input and shows today's date in the calendar", () => {
         cy.mount(<Datebox selectedDates={["2025/11/300"]} />);
         const today = new Date();
@@ -39,8 +39,8 @@ describe("Datebox", () => {
   });
 
   context("multiple", () => {
-    context("when initialize first", () => {
-      it("render the value on input", () => {
+    context("when initialized with selected date", () => {
+      it("renders the value on input", () => {
         cy.mount(
           <Datebox
             calendarSelectabilityMode="multiple"
@@ -86,7 +86,7 @@ describe("Datebox", () => {
         });
       });
 
-      context("when wrong date", () => {
+      context("when given invalid date", () => {
         it("renders an empty input and shows today's date in the calendar", () => {
           cy.mount(<Datebox selectedDates={["11/01/2025, 11/300/2025"]} />);
           const today = new Date();
@@ -106,8 +106,8 @@ describe("Datebox", () => {
   });
 
   context("ranged", () => {
-    context("when initialize first", () => {
-      it("render the value on input", () => {
+    context("when initialized with selected date", () => {
+      it("renders the value on input", () => {
         cy.mount(
           <Datebox
             calendarSelectabilityMode="ranged"
@@ -140,7 +140,7 @@ describe("Datebox", () => {
         );
       });
 
-      context("when wrong date", () => {
+      context("when given invalid date", () => {
         it("renders an empty input and shows today's date in the calendar", () => {
           cy.mount(<Datebox selectedDates={["11/01/2025-11/300/2025"]} />);
           const today = new Date();

--- a/test/component/datebox.cy.tsx
+++ b/test/component/datebox.cy.tsx
@@ -1,0 +1,161 @@
+import { Datebox } from "./../../components/datebox";
+
+describe("Datebox", () => {
+  context("when initialize first", () => {
+    it("render the value on input", () => {
+      cy.mount(<Datebox selectedDates={["11/30/2025"]} />);
+      cy.findByPlaceholderText("mm/dd/yyyy")
+        .should("be.visible")
+        .and("have.value", "11/30/2025")
+        .click();
+      cy.findByText("30").should(
+        "have.css",
+        "background-color",
+        "rgb(97, 169, 249)"
+      );
+      cy.findByText("29").should(
+        "have.css",
+        "background-color",
+        "rgba(0, 0, 0, 0)"
+      );
+    });
+
+    context("when wrong date", () => {
+      it("renders an empty input and shows today's date in the calendar", () => {
+        cy.mount(<Datebox selectedDates={["2025/11/300"]} />);
+        const today = new Date();
+        cy.findByPlaceholderText("mm/dd/yyyy")
+          .should("be.visible")
+          .and("have.value", "")
+          .click();
+
+        cy.findByText(String(today.getDate())).should(
+          "have.css",
+          "background-color",
+          "rgb(97, 169, 249)"
+        );
+      });
+    });
+  });
+
+  context("multiple", () => {
+    context("when initialize first", () => {
+      it("render the value on input", () => {
+        cy.mount(
+          <Datebox
+            calendarSelectabilityMode="multiple"
+            selectedDates={[
+              "11/03/2025, 11/04/2025, 11/05/2025, 11/06/2025, 11/07/2025, 11/10/2025, 11/11/2025, 11/12/2025, 11/13/2025, 11/14/2025, 11/17/2025, 11/18/2025, 11/19/2025, 11/20/2025, 11/21/2025, 11/24/2025, 11/25/2025, 11/26/2025, 11/27/2025, 11/28/2025",
+            ]}
+          />
+        );
+        cy.findByPlaceholderText("mm/dd/yyyy")
+          .should("be.visible")
+          .and(
+            "have.value",
+            "11/03/2025, 11/04/2025, 11/05/2025, 11/06/2025, 11/07/2025, 11/10/2025, 11/11/2025, 11/12/2025, 11/13/2025, 11/14/2025, 11/17/2025, 11/18/2025, 11/19/2025, 11/20/2025, 11/21/2025, 11/24/2025, 11/25/2025, 11/26/2025, 11/27/2025, 11/28/2025"
+          )
+          .click();
+        [
+          "3",
+          "4",
+          "5",
+          "6",
+          "7",
+          "10",
+          "11",
+          "12",
+          "13",
+          "14",
+          "17",
+          "18",
+          "19",
+          "20",
+          "21",
+          "24",
+          "25",
+          "26",
+          "27",
+          "28",
+        ].map((day) => {
+          cy.findByText(day).should(
+            "have.css",
+            "background-color",
+            "rgb(97, 169, 249)"
+          );
+        });
+      });
+
+      context("when wrong date", () => {
+        it("renders an empty input and shows today's date in the calendar", () => {
+          cy.mount(<Datebox selectedDates={["11/01/2025, 11/300/2025"]} />);
+          const today = new Date();
+          cy.findByPlaceholderText("mm/dd/yyyy")
+            .should("be.visible")
+            .and("have.value", "")
+            .click();
+
+          cy.findByText(String(today.getDate())).should(
+            "have.css",
+            "background-color",
+            "rgb(97, 169, 249)"
+          );
+        });
+      });
+    });
+  });
+
+  context("ranged", () => {
+    context("when initialize first", () => {
+      it("render the value on input", () => {
+        cy.mount(
+          <Datebox
+            calendarSelectabilityMode="ranged"
+            selectedDates={["11/01/2025-11/30/2025"]}
+          />
+        );
+        cy.findByPlaceholderText("mm/dd/yyyy")
+          .should("be.visible")
+          .and("have.value", "11/01/2025-11/30/2025")
+          .click();
+        cy.findByText("1").should(
+          "have.css",
+          "background-color",
+          "rgb(97, 169, 249)"
+        );
+        cy.findByText("2").should(
+          "have.css",
+          "background-color",
+          "rgba(0, 0, 0, 0)"
+        );
+        cy.findByText("29").should(
+          "have.css",
+          "background-color",
+          "rgba(0, 0, 0, 0)"
+        );
+        cy.findByText("30").should(
+          "have.css",
+          "background-color",
+          "rgb(97, 169, 249)"
+        );
+      });
+
+      context("when wrong date", () => {
+        it("renders an empty input and shows today's date in the calendar", () => {
+          cy.mount(<Datebox selectedDates={["11/01/2025-11/300/2025"]} />);
+          const today = new Date();
+          cy.findByPlaceholderText("mm/dd/yyyy")
+            .should("be.visible")
+            .and("have.value", "")
+            .click();
+
+          cy.findByText(String(today.getDate())).should(
+            "have.css",
+            "background-color",
+            "rgb(97, 169, 249)"
+          );
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Description:
For now, we can't initialize the value from outside of component. The selectbox doesn't respond because it currently filters strictly based on the avalivable `options`

So, we must add this text with `isValidDateString`:
   ```tsx
   const initialState = options.find(
      (opt) => opt.value === selectedOptions?.[0]
    ) ?? {
      text: isValidDateString(selectedOptions?.[0]) ? selectedOptions?.[0] : "",
      value: "0",
    };
```

This PR includes several improvement related to how calendar handles and displays values:
1. Handle to show the first date when initialize on the `calendar`
2. Update the filtering logic for `single | multiple | ranged` on the level calendar, including when disableWeekend.
3. Improves value setup on the selectbox show the initial value.
4. Can add some placeholder to the selectbox.

Result:
<img width="335" height="317" alt="image" src="https://github.com/user-attachments/assets/ce9a4e36-4f00-4a3c-833e-f20bcbc474ff" />

Source:
[[Bug] SYST-296: Show the datebox value when initialize from outside of component](https://linear.app/systatum/issue/SYST-296/show-the-datebox-value-when-initialize-from-outside-of-component)

Tick what you have done:

[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself