### PR TITLE
[Improvement] SYST-458: Add `throttle` handler to improve Window onResize performance

### DIFF
--- a/components/window.stories.tsx
+++ b/components/window.stories.tsx
@@ -237,7 +237,7 @@ export const WithCellRef: Story = {
           `,
         }}
         orientation="horizontal"
-        onResizeComplete={() => {
+        onResize={() => {
           if (secondCellRef.current) {
             const height = secondCellRef.current.clientHeight;
             setTextareaHeight(height);

--- a/components/window.tsx
+++ b/components/window.tsx
@@ -188,6 +188,30 @@ function Window({
   );
 }
 
+/**
+ * useRafThrottle
+ *
+ * A hook that returns a throttled version of a callback using `requestAnimationFrame`.
+ * Ensures the callback runs at most once per animation frame, regardless of how
+ * many times the throttled function is called.
+ *
+ * Useful for performance-heavy operations like dragging, resizing, or scroll events.
+ *
+ * @template T - Function type to be throttled
+ * @param callback - The function to throttle
+ * @returns A throttled version of the callback
+ *
+ * How it works:
+ * 1. Store the latest arguments in `lastArgs`.
+ * 2. If a frame is already scheduled (`frame.current`), ignore the call.
+ * 3. Otherwise, schedule the callback via `requestAnimationFrame`.
+ * 4. Once executed, clear `frame.current` so the next frame can be scheduled.
+ *
+ * This ensures:
+ * - At most one callback per animation frame.
+ * - Calls are synced to the browser’s repaint cycle (~60fps, or higher on high-refresh monitors).
+ */
+
 function useRafThrottle<T extends (...args: any[]) => void>(callback?: T) {
   const frame = useRef<number | null>(null);
   const lastArgs = useRef<Parameters<T> | null>(null);

--- a/test/component/window.cy.tsx
+++ b/test/component/window.cy.tsx
@@ -4,6 +4,38 @@ import { Textarea } from "./../../components/textarea";
 import { useRef, useState } from "react";
 
 describe("Window", () => {
+  context("onResize", () => {
+    it("should call onResize rapid while dragging", () => {
+      const onResize = cy.stub().as("onResize");
+
+      cy.mount(
+        <Window
+          orientation="horizontal"
+          styles={{
+            self: css`
+              height: 500px;
+            `,
+          }}
+          onResize={onResize}
+        >
+          <Window.Cell>Top</Window.Cell>
+          <Window.Cell>Bottom</Window.Cell>
+        </Window>
+      );
+
+      cy.findByLabelText("window-divider").trigger("mousedown", {
+        clientY: 250,
+      });
+
+      for (let i = 0; i < 100; i++) {
+        cy.get("body").trigger("mousemove", { clientY: 250 + i });
+      }
+
+      cy.get("body").trigger("mouseup");
+      cy.get("@onResize").its("callCount").should("eq", 100);
+    });
+  });
+
   context("ref in window.cell level", () => {
     context("when resize", () => {
       it("renders similar height as a reference", () => {
@@ -67,7 +99,8 @@ describe("Window", () => {
 
         cy.findAllByLabelText("window-cell")
           .eq(1)
-          .should("have.css", "height", "350px");
+          .invoke("height")
+          .should("be.closeTo", 350, 4);
 
         cy.findAllByLabelText("textarea-with-window")
           .eq(0)


### PR DESCRIPTION
Description:
Previously, the `onResize` callback was only triggered effectively during the initial executaion of the resize interaction. As a result, resize can't updates throughout the drag process.

This pull request introduces a throttled resize handler to prevent excessive `onResize` executions during dragging, improving performance and ensuring smooth UI updates.

Source:
[[Improvement] SYST-458: Add `throttle` handler to improve Window onResize performance](https://linear.app/systatum/issue/SYST-458/add-throttle-handler-to-improve-window-onresize-performance)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself