### PR TITLE
[Improvement] SYST-477: Change default border color to #e5e7eb

### DIFF
--- a/components/badge.tsx
+++ b/components/badge.tsx
@@ -232,7 +232,7 @@ const BadgeWrapper = styled.div<{
   align-items: center;
   padding: 2px 8px;
   font-size: 0.75rem;
-  border: 1px solid #f3f4f6;
+  border: 1px solid #e5e7eb;
   border-radius: 6px;
   width: fit-content;
   gap: 0.5rem;

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -368,7 +368,7 @@ function ButtonTipMenuContainer({
 const TipMenuContainer = styled.div<{ $style?: CSSProp }>`
   display: flex;
   flex-direction: column;
-  border: 1px solid #f3f4f6;
+  border: 1px solid #e5e7eb;
   padding: 4px;
   background-color: white;
   gap: 2px;

--- a/test/component/badge.cy.tsx
+++ b/test/component/badge.cy.tsx
@@ -13,6 +13,21 @@ describe("Badge", () => {
       />
     );
   }
+  context("default", () => {
+    it("renders with border-color #e5e7eb", () => {
+      cy.window().then((win) => {
+        cy.spy(win.console, "log").as("consoleLog");
+      });
+
+      cy.mount(<BadgeDefault />);
+      cy.findByLabelText("badge").should(
+        "have.css",
+        "border-color",
+        "rgb(229, 231, 235)"
+      );
+    });
+  });
+
   context("onMouseEnter", () => {
     context("when hovering", () => {
       it("should give callback", () => {

--- a/test/component/button.cy.tsx
+++ b/test/component/button.cy.tsx
@@ -12,63 +12,55 @@ import {
   RiEditLine,
 } from "@remixicon/react";
 import { Calendar } from "./../../components/calendar";
+import { TipMenuItemProps } from "./../../components/tip-menu";
 
 describe("Button", () => {
-  const TIP_MENU_ITEMS = [
+  const TIP_MENU_ITEMS: TipMenuItemProps[] = [
     {
       caption: "Report Phishing",
-      icon: RiSpam2Line,
-      iconColor: "blue",
+      icon: { image: RiSpam2Line, color: "blue" },
       onClick: () => console.log("Phishing reported"),
     },
     {
       caption: "Report Junk",
-      icon: RiForbid2Line,
-      iconColor: "red",
+      icon: { image: RiForbid2Line, color: "red" },
       onClick: () => console.log("Junk reported"),
     },
     {
       caption: "Block Sender",
-      icon: RiShieldLine,
-      iconColor: "orange",
+      icon: { image: RiShieldLine, color: "orange" },
       isDangerous: true,
       onClick: () => console.log("Sender blocked"),
     },
     {
       caption: "Mark as Read",
-      icon: RiCheckLine,
-      iconColor: "green",
+      icon: { image: RiCheckLine, color: "green" },
       onClick: () => console.log("Marked as read"),
     },
     {
       caption: "Move to Spam",
-      icon: RiInboxArchiveLine,
-      iconColor: "purple",
+      icon: { image: RiInboxArchiveLine, color: "purple" },
       onClick: () => console.log("Moved to spam"),
     },
     {
       caption: "Download Attachment",
-      icon: RiDownloadLine,
-      iconColor: "teal",
+      icon: { image: RiDownloadLine, color: "teal" },
       onClick: () => console.log("Downloading"),
     },
     {
       caption: "Copy Link",
-      icon: RiLink,
-      iconColor: "gray",
+      icon: { image: RiLink, color: "gray" },
       onClick: () => console.log("Link copied"),
     },
     {
       caption: "Share",
-      icon: RiShareLine,
-      iconColor: "indigo",
+      icon: { image: RiShareLine, color: "indigo" },
       isDangerous: true,
       onClick: () => console.log("Shared"),
     },
     {
       caption: "Edit",
-      icon: RiEditLine,
-      iconColor: "yellow",
+      icon: { image: RiEditLine, color: "yellow" },
       onClick: () => console.log("Edit mode"),
     },
   ];
@@ -97,6 +89,30 @@ describe("Button", () => {
             TIP_MENU_ITEMS.forEach((item) => {
               cy.contains(item.caption).should("exist");
             });
+          });
+
+          it("renders with border tip menu #e5e7eb", () => {
+            cy.viewport(800, 700);
+            cy.mount(
+              <Button
+                variant="default"
+                styles={{
+                  dropdownStyle: css`
+                    min-width: 240px;
+                  `,
+                }}
+                subMenu={({ list }) => list(TIP_MENU_ITEMS)}
+              >
+                Test
+              </Button>
+            );
+
+            cy.findByLabelText("button-toggle").click();
+            cy.findByLabelText("button-tip-menu-container").should(
+              "have.css",
+              "border-color",
+              "rgb(229, 231, 235)"
+            );
           });
         });
 


### PR DESCRIPTION
Description:
Previously, the `Badge` and `Button` tip menu container used `#f3f4f6` as the default border color. This pull request updates the default `border-color` to `#e5e7eb` to improve the component's visual appearance.

Source:
[[Improvement] SYST-477: Change default border color to #e5e7eb](https://linear.app/systatum/issue/SYST-477/change-default-border-color-to-e5e7eb)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself