### PR TITLE
[Bug] SYST-439: Fix bug when combobox `options` is `[]` and the value is `null`

### DIFF
--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -205,7 +205,7 @@ function ComboboxDrawer({
     if (Array.isArray(selectedOptions)) {
       return selectedOptions.map(String);
     }
-    if (selectedOptions !== undefined) {
+    if (selectedOptions != null) {
       return [String(selectedOptions)];
     }
     return [];

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -134,7 +134,7 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
       if (Array.isArray(selectedOptions)) {
         return selectedOptions.map(String);
       }
-      if (selectedOptions !== undefined) {
+      if (selectedOptions != null) {
         return [String(selectedOptions)];
       }
       return [];

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -14,6 +14,54 @@ describe("Combobox", () => {
     function ProductCombobox(props: ComboboxProps) {
       return <Combobox {...props} />;
     }
+
+    context("when given empty array ([])", () => {
+      it("should not have option", () => {
+        cy.mount(
+          <ProductCombobox options={[]} placeholder="Select a fruit..." />
+        );
+
+        cy.findByPlaceholderText("Select a fruit...")
+          .should("have.value", "")
+          .click();
+        cy.findByText("Not available.").should("be.visible");
+      });
+
+      context("when given selectedOptions null", () => {
+        it("should render normally and not available", () => {
+          cy.mount(
+            <ProductCombobox
+              options={[]}
+              placeholder="Select a fruit..."
+              selectedOptions={null}
+            />
+          );
+
+          cy.findByPlaceholderText("Select a fruit...")
+            .should("have.value", "")
+            .click();
+          cy.findByText("Not available.").should("be.visible");
+        });
+      });
+
+      context("when given selectedOptions any value", () => {
+        it("should not match render value and option still not available", () => {
+          cy.mount(
+            <ProductCombobox
+              options={[]}
+              placeholder="Select a fruit..."
+              selectedOptions={null}
+            />
+          );
+
+          cy.findByPlaceholderText("Select a fruit...")
+            .should("have.value", "")
+            .click();
+          cy.findByText("Not available.").should("be.visible");
+        });
+      });
+    });
+
     context("when using option.value number", () => {
       context("when initialize with selectedOptions string", () => {
         it("should select the option when values match", () => {


### PR DESCRIPTION
Description:
Previously, the `combobox` component when using  `selectedOptions` prop with null value, could cause a bug, as shown in the image below, because the component did not properly handle null values. This pull request fixes `combobox` to have properly filtering and always converting with string array ( `string[]` ).

```tsx
 const finalSelectedOptions = useMemo(() => {
      if (Array.isArray(selectedOptions)) {
        return selectedOptions.map(String);
      }
      if (selectedOptions != null) {
        return [String(selectedOptions)];
      }
      return [];
    }, [selectedOptions]);
```

<img width="583" height="78" alt="Screen Shot 2026-02-10 at 11 34 43 AM" src="https://github.com/user-attachments/assets/a4800a41-2eac-4a2f-9722-ceb8b54eee8e" />

Source:
[[Bug] SYST-439: Fix bug when combobox options is [] and the value is null](https://linear.app/systatum/issue/SYST-439/fix-bug-when-combobox-options-is-and-the-value-is-null)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself