### PR TITLE
[Improvement] SYST-502: Rename `tableRowContainerStyle` to `tableBodyStyle` and add `tableHeaderStyle`

### DIFF
--- a/components/card.stories.tsx
+++ b/components/card.stories.tsx
@@ -961,7 +961,7 @@ export const WithFullWidthContent: Story = {
         <Table
           selectable
           styles={{
-            tableRowContainerStyle: css`
+            tableBodyStyle: css`
               max-height: 400px;
             `,
           }}
@@ -1067,7 +1067,7 @@ export const Toggleable: Story = {
       return (
         <Table
           styles={{
-            tableRowContainerStyle: css`
+            tableBodyStyle: css`
               max-height: 160px;
             `,
           }}

--- a/components/nav-tab.stories.tsx
+++ b/components/nav-tab.stories.tsx
@@ -314,7 +314,7 @@ export const WithSubItems: Story = {
                 </h2>
                 <Table
                   styles={{
-                    tableRowContainerStyle: css`
+                    tableBodyStyle: css`
                       max-height: 400px;
                     `,
                   }}

--- a/components/paper-dialog.stories.tsx
+++ b/components/paper-dialog.stories.tsx
@@ -569,7 +569,7 @@ export const Nested: Story = {
           <Table
             searchable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -615,7 +615,7 @@ export const Nested: Story = {
               <Table
                 searchable
                 styles={{
-                  tableRowContainerStyle: css`
+                  tableBodyStyle: css`
                     max-height: 400px;
                   `,
                 }}

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -177,7 +177,8 @@ const meta: Meta<typeof Table> = {
 Custom styles for the Table component. This object allows you to override styles for individual parts:
 
 - **containerStyle**: Table wrapper
-- **tableRowContainerStyle**: Scrollable row container
+- **tableBodyStyle**: Scrollable body content
+- **tableHeaderStyle**: Header container
 - **paginationWrapperStyle**: Pagination wrapper
 - **paginationNumberStyle**: Pagination number text
 
@@ -226,7 +227,7 @@ export const Default: Story = {
     return (
       <Table
         styles={{
-          tableRowContainerStyle: css`
+          tableBodyStyle: css`
             max-height: 400px;
           `,
         }}
@@ -446,7 +447,7 @@ export const Appendable: Story = {
       <Table
         selectable
         styles={{
-          tableRowContainerStyle: css`
+          tableBodyStyle: css`
             max-height: 400px;
           `,
         }}
@@ -679,7 +680,7 @@ export const WithOneAction: Story = {
       <Table
         selectable
         styles={{
-          tableRowContainerStyle: css`
+          tableBodyStyle: css`
             max-height: 400px;
           `,
         }}
@@ -1252,7 +1253,7 @@ export const WithSummary: Story = {
 
         <Table
           styles={{
-            tableRowContainerStyle: css`
+            tableBodyStyle: css`
               max-height: 400px;
             `,
           }}
@@ -1813,7 +1814,7 @@ export const WithRowGroup: Story = {
         <Table
           selectable
           styles={{
-            tableRowContainerStyle: css`
+            tableBodyStyle: css`
               max-height: 400px;
             `,
           }}
@@ -2178,7 +2179,7 @@ export const WithRowAppendix: Story = {
 
         <Table
           styles={{
-            tableRowContainerStyle: css`
+            tableBodyStyle: css`
               max-height: 400px;
             `,
           }}
@@ -2768,7 +2769,7 @@ export const Draggable: Story = {
 
           <Table
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -2816,7 +2817,7 @@ export const Draggable: Story = {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -2865,7 +2866,7 @@ export const Draggable: Story = {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -83,7 +83,8 @@ export interface TableProps {
 
 export interface TableStylesProps {
   containerStyle?: CSSProp;
-  tableRowContainerStyle?: CSSProp;
+  tableHeaderStyle?: CSSProp;
+  tableBodyStyle?: CSSProp;
   paginationWrapperStyle?: CSSProp;
   paginationNumberStyle?: CSSProp;
   totalSelectedItemTextStyle?: CSSProp;
@@ -277,10 +278,10 @@ function Table({
     return null;
   });
 
-  const tableRowContainerRef = useRef<HTMLDivElement>(null);
+  const tableBodyRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const el = tableRowContainerRef.current;
+    const el = tableBodyRef.current;
     if (!el || openRowId === null) return;
 
     const startScrollTop = el.scrollTop;
@@ -402,7 +403,10 @@ function Table({
           )}
 
           <TableContainer $hasSelected={selectedData.length > 0}>
-            <TableHeader>
+            <TableHeader
+              aria-label="table-header"
+              $style={styles?.tableHeaderStyle}
+            >
               {selectable && (
                 <CheckboxWrapper>
                   <Checkbox
@@ -489,13 +493,13 @@ function Table({
             </TableHeader>
 
             {rowChildren.length > 0 ? (
-              <TableRowContainer
-                ref={tableRowContainerRef}
-                aria-label="table-scroll-container"
-                $tableRowContainerStyle={styles?.tableRowContainerStyle}
+              <TableBody
+                ref={tableBodyRef}
+                aria-label="table-body"
+                $style={styles?.tableBodyStyle}
               >
                 {rowChildren}
-              </TableRowContainer>
+              </TableBody>
             ) : (
               <EmptyState>{emptySlate}</EmptyState>
             )}
@@ -694,7 +698,7 @@ const TableContainer = styled.div<{ $hasSelected: boolean }>`
     `}
 `;
 
-const TableHeader = styled.div`
+const TableHeader = styled.div<{ $style?: CSSProp }>`
   display: flex;
   flex-direction: row;
   padding: 0.75rem;
@@ -705,30 +709,10 @@ const TableHeader = styled.div`
   border-bottom-width: 1px;
   border-color: #d1d5db;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  ${({ $style }) => $style}
 `;
 
-const TableSummary = styled.div<{ $selectable?: boolean }>`
-  display: flex;
-  flex-direction: row;
-  padding: 10px;
-  ${({ $selectable }) =>
-    $selectable
-      ? css`
-          padding-left: 42px;
-        `
-      : css`
-          padding-left: 10px;
-        `}
-  padding-right: 15px;
-  background: linear-gradient(to bottom, #f0f0f0, #e4e4e4);
-  align-items: center;
-  color: #343434;
-  border-bottom-width: 1px;
-  border-color: #d1d5db;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-`;
-
-const TableRowContainer = styled.div<{ $tableRowContainerStyle?: CSSProp }>`
+const TableBody = styled.div<{ $style?: CSSProp }>`
   display: flex;
   flex-direction: column;
   overflow: auto;
@@ -750,7 +734,28 @@ const TableRowContainer = styled.div<{ $tableRowContainerStyle?: CSSProp }>`
     background: rgba(168, 167, 167, 0.1);
   }
 
-  ${({ $tableRowContainerStyle }) => $tableRowContainerStyle}
+  ${({ $style }) => $style}
+`;
+
+const TableSummary = styled.div<{ $selectable?: boolean }>`
+  display: flex;
+  flex-direction: row;
+  padding: 10px;
+  ${({ $selectable }) =>
+    $selectable
+      ? css`
+          padding-left: 42px;
+        `
+      : css`
+          padding-left: 10px;
+        `}
+  padding-right: 15px;
+  background: linear-gradient(to bottom, #f0f0f0, #e4e4e4);
+  align-items: center;
+  color: #343434;
+  border-bottom-width: 1px;
+  border-color: #d1d5db;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
 `;
 
 const EmptyState = styled.div`

--- a/test/component/action-button.cy.tsx
+++ b/test/component/action-button.cy.tsx
@@ -549,7 +549,7 @@ describe("ActionButton", () => {
             <Table
               selectable
               styles={{
-                tableRowContainerStyle: css`
+                tableBodyStyle: css`
                   max-height: 400px;
                 `,
               }}
@@ -602,7 +602,7 @@ describe("ActionButton", () => {
             <Table
               selectable
               styles={{
-                tableRowContainerStyle: css`
+                tableBodyStyle: css`
                   max-height: 400px;
                 `,
               }}
@@ -654,7 +654,7 @@ describe("ActionButton", () => {
             <Table
               selectable
               styles={{
-                tableRowContainerStyle: css`
+                tableBodyStyle: css`
                   max-height: 400px;
                 `,
               }}
@@ -707,7 +707,7 @@ describe("ActionButton", () => {
               <Table
                 selectable
                 styles={{
-                  tableRowContainerStyle: css`
+                  tableBodyStyle: css`
                     max-height: 400px;
                   `,
                 }}

--- a/test/component/context-menu.cy.tsx
+++ b/test/component/context-menu.cy.tsx
@@ -580,7 +580,7 @@ describe("context-menu", () => {
         cy.mount(
           <Table
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -604,7 +604,7 @@ describe("context-menu", () => {
         cy.mount(
           <Table
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -624,7 +624,7 @@ describe("context-menu", () => {
         cy.mount(
           <Table
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -650,7 +650,7 @@ describe("context-menu", () => {
           cy.mount(
             <Table
               styles={{
-                tableRowContainerStyle: css`
+                tableBodyStyle: css`
                   max-height: 400px;
                 `,
               }}

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -26,6 +26,96 @@ interface TableItemProps {
 }
 
 describe("Table", () => {
+  const columnsBasic: ColumnTableProps[] = [
+    {
+      id: "name",
+      caption: "Name",
+      sortable: true,
+    },
+    {
+      id: "type",
+      caption: "Type",
+      sortable: true,
+    },
+  ];
+
+  const TYPES_DATA = ["HTTP", "HTTPS", "TCP", "UDP", "QUIC"];
+
+  const rawRows = Array.from({ length: 20 }, (_, i) => ({
+    name: `Load Balancer ${i + 1}`,
+    type: TYPES_DATA[i % TYPES_DATA.length],
+  }));
+
+  context("styles", () => {
+    context("tableBodyStyle", () => {
+      context("when given max-height 250px", () => {
+        it("should render the table body with a height of 250px", () => {
+          cy.mount(
+            <Table
+              styles={{
+                tableBodyStyle: css`
+                  max-height: 250px;
+                `,
+              }}
+              columns={columnsBasic}
+            >
+              {rawRows?.map((row, index) => (
+                <Table.Row key={index} rowId={`${row.name}-${row.type}`}>
+                  {[row.name, row.type].map((rowCell, i) => (
+                    <Table.Row.Cell
+                      key={`${row.name}-${row.type}-${rowCell}`}
+                      width={columns[i].width}
+                    >
+                      {rowCell}
+                    </Table.Row.Cell>
+                  ))}
+                </Table.Row>
+              ))}
+            </Table>
+          );
+
+          cy.findAllByLabelText("table-body")
+            .eq(0)
+            .should("have.css", "height", "250px");
+        });
+      });
+    });
+
+    context("tableHeaderStyle", () => {
+      context("when given padding 20px", () => {
+        it("should render the table header with a padding of 20px", () => {
+          cy.mount(
+            <Table
+              styles={{
+                tableHeaderStyle: css`
+                  padding: 20px;
+                `,
+              }}
+              columns={columnsBasic}
+            >
+              {rawRows?.map((row, index) => (
+                <Table.Row key={index} rowId={`${row.name}-${row.type}`}>
+                  {[row.name, row.type].map((rowCell, i) => (
+                    <Table.Row.Cell
+                      key={`${row.name}-${row.type}-${rowCell}`}
+                      width={columns[i].width}
+                    >
+                      {rowCell}
+                    </Table.Row.Cell>
+                  ))}
+                </Table.Row>
+              ))}
+            </Table>
+          );
+
+          cy.findAllByLabelText("table-header")
+            .eq(0)
+            .should("have.css", "padding", "20px");
+        });
+      });
+    });
+  });
+
   function TableWithAppendix(props: TableRowProps) {
     interface TableSummaryProps {
       id?: string;
@@ -635,29 +725,9 @@ describe("Table", () => {
     });
 
     context("totalSelectedItemText", () => {
-      const columns: ColumnTableProps[] = [
-        {
-          id: "name",
-          caption: "Name",
-          sortable: true,
-        },
-        {
-          id: "type",
-          caption: "Type",
-          sortable: true,
-        },
-      ];
-
-      const TYPES_DATA = ["HTTP", "HTTPS", "TCP", "UDP", "QUIC"];
-
-      const rawRows = Array.from({ length: 20 }, (_, i) => ({
-        name: `Load Balancer ${i + 1}`,
-        type: TYPES_DATA[i % TYPES_DATA.length],
-      }));
-
       it("renders with selected text", () => {
         cy.mount(
-          <Table selectable columns={columns}>
+          <Table selectable columns={columnsBasic}>
             {rawRows?.map((row, index) => (
               <Table.Row key={index} rowId={`${row.name}-${row.type}`}>
                 {[row.name, row.type].map((rowCell, i) => (
@@ -688,7 +758,7 @@ describe("Table", () => {
               labels={{
                 totalSelectedItemText: (count) => `${count} email selected`,
               }}
-              columns={columns}
+              columns={columnsBasic}
             >
               {rawRows?.map((row, index) => (
                 <Table.Row key={index} rowId={`${row.name}-${row.type}`}>
@@ -719,7 +789,7 @@ describe("Table", () => {
             <Table
               selectable
               labels={{ totalSelectedItemText: null }}
-              columns={columns}
+              columns={columnsBasic}
             >
               {rawRows?.map((row, index) => (
                 <Table.Row key={index} rowId={`${row.name}-${row.type}`}>
@@ -931,7 +1001,7 @@ describe("Table", () => {
           );
 
           cy.findByLabelText("pagination-wrapper")
-            .should("have.css", "width", "417px")
+            .should("have.css", "width", "432px")
             .and("have.css", "justify-content", "end");
         });
       });

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -210,7 +210,7 @@ describe("Table", () => {
     return (
       <Table
         styles={{
-          tableRowContainerStyle: css`
+          tableBodyStyle: css`
             max-height: 400px;
           `,
         }}
@@ -598,7 +598,7 @@ describe("Table", () => {
             showPagination
             labels={{ pageNumberText: 10 }}
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -753,7 +753,7 @@ describe("Table", () => {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -807,7 +807,7 @@ describe("Table", () => {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -851,7 +851,7 @@ describe("Table", () => {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -949,7 +949,7 @@ describe("Table", () => {
                 paginationNumberStyle: css`
                   font-size: 30px;
                 `,
-                tableRowContainerStyle: css`
+                tableBodyStyle: css`
                   max-height: 400px;
                 `,
               }}
@@ -1103,7 +1103,7 @@ describe("Table", () => {
                 totalSelectedItemTextStyle: css`
                   font-size: 100px;
                 `,
-                tableRowContainerStyle: css`
+                tableBodyStyle: css`
                   max-height: 400px;
                 `,
               }}
@@ -1162,7 +1162,7 @@ describe("Table", () => {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -1235,7 +1235,7 @@ describe("Table", () => {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -1307,7 +1307,7 @@ describe("Table", () => {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -1373,7 +1373,7 @@ describe("Table", () => {
             <Table
               selectable
               styles={{
-                tableRowContainerStyle: css`
+                tableBodyStyle: css`
                   max-height: 400px;
                 `,
               }}
@@ -1419,7 +1419,7 @@ describe("Table", () => {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -1473,7 +1473,7 @@ describe("Table", () => {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -1526,7 +1526,7 @@ describe("Table", () => {
         cy.mount(
           <Table
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -1580,7 +1580,7 @@ describe("Table", () => {
         cy.mount(
           <Table
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -1636,7 +1636,7 @@ describe("Table", () => {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -1683,7 +1683,7 @@ describe("Table", () => {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -1726,7 +1726,7 @@ describe("Table", () => {
           .should("exist")
           .and("be.visible");
 
-        cy.findByLabelText("table-scroll-container").then(($el) => {
+        cy.findByLabelText("table-body").then(($el) => {
           const start = $el[0].scrollTop;
           cy.wrap($el).scrollTo(0, start + 101);
         });
@@ -1741,7 +1741,7 @@ describe("Table", () => {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}
@@ -1796,7 +1796,7 @@ describe("Table", () => {
           <Table
             selectable
             styles={{
-              tableRowContainerStyle: css`
+              tableBodyStyle: css`
                 max-height: 400px;
               `,
             }}

--- a/test/e2e/table.cy.ts
+++ b/test/e2e/table.cy.ts
@@ -81,7 +81,7 @@ describe("Table Component", () => {
 
     context("when scroll to bottom and select", () => {
       it("renders content and have selected item", () => {
-        cy.findByLabelText("table-scroll-container").scrollTo("bottom", {
+        cy.findByLabelText("table-body").scrollTo("bottom", {
           duration: 1000,
         });
 


### PR DESCRIPTION
Description:
This pull request renamse the `tableRowContainerStyle` prop to `tableBodyStyle` in the `styles` table. It also introduces a new `tableHeaderStyle` prop to provide geater styling flexibility, particularly for the `Table.Header` component.

Source:
[[Improvement] SYST-502: Rename `tableRowContainerStyle` to `tableBodyStyle` and add `tableHeaderStyle`](https://linear.app/systatum/issue/SYST-502/rename-tablerowcontainerstyle-to-tablebodystyle-and-add)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself