### PR TITLE
[Improvement] SYST-516: Move table loading spinner to top left of the table body

### DIFF
--- a/components/loading-spinner.tsx
+++ b/components/loading-spinner.tsx
@@ -21,7 +21,11 @@ function LoadingSpinner({
   styles,
 }: LoadingSpinnerProps) {
   return (
-    <SpinnerWrapper $style={styles?.containerStyle} $gap={gap}>
+    <SpinnerWrapper
+      aria-label="loading-spinner"
+      $style={styles?.containerStyle}
+      $gap={gap}
+    >
       <SpinnerIcon
         aria-label="circle"
         $size={iconSize}

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -576,13 +576,6 @@ function Table({
                 self: css`
                   display: flex;
                   align-items: start;
-                  justify-content: center;
-                  padding-top: 60px;
-
-                  ${(actions || showPagination) &&
-                  css`
-                    padding-top: 120px;
-                  `}
 
                   backdrop-filter: blur(0.5px);
                   background-color: rgba(255, 255, 255, 0.6);

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -224,7 +224,10 @@ function Table({
   const rowChildren = Children.map(children, (child, index) => {
     if (!isValidElement<TableRowProps | TableRowGroupProps>(child)) return null;
 
-    if (child.type === TableRowGroup) {
+    const hasRowGroup = child.type === TableRowGroup;
+    const hasRow = child.type === TableRow;
+
+    if (hasRowGroup) {
       return cloneElement(child, {
         selectable,
         selectedData,
@@ -241,7 +244,7 @@ function Table({
         });
     }
 
-    if (child.type === TableRow) {
+    if (hasRow) {
       const props = child.props as TableRowProps;
 
       const isSelected = selectedData.some(
@@ -300,6 +303,10 @@ function Table({
     el.addEventListener("scroll", handleScroll, { passive: true });
     return () => el.removeEventListener("scroll", handleScroll);
   }, [openRowId]);
+
+  const hasRowGroup = Children.toArray(children).some(
+    (child) => isValidElement(child) && child.type === TableRowGroup
+  );
 
   return (
     <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
@@ -576,12 +583,13 @@ function Table({
                 self: css`
                   display: flex;
                   align-items: start;
-                  padding-top: 60px;
-
-                  ${(actions || showPagination) &&
-                  css`
-                    padding-top: 120px;
-                  `}
+                  padding-left: 16px;
+                  padding-top: ${(() => {
+                    if (showPagination && hasRowGroup) return "152px";
+                    if (showPagination || hasRowGroup) return "140px";
+                    if (actions || searchable) return "126px";
+                    return "60px";
+                  })()};
 
                   backdrop-filter: blur(0.5px);
                   background-color: rgba(255, 255, 255, 0.6);

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -576,6 +576,12 @@ function Table({
                 self: css`
                   display: flex;
                   align-items: start;
+                  padding-top: 60px;
+
+                  ${(actions || showPagination) &&
+                  css`
+                    padding-top: 120px;
+                  `}
 
                   backdrop-filter: blur(0.5px);
                   background-color: rgba(255, 255, 255, 0.6);

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -583,8 +583,8 @@ function Table({
                 self: css`
                   display: flex;
                   align-items: start;
-                  padding-left: 16px;
-                  padding-top: 16px;
+                  padding-left: 10px;
+                  padding-top: 10px;
 
                   backdrop-filter: blur(0.5px);
                   background-color: rgba(255, 255, 255, 0.6);
@@ -598,8 +598,9 @@ function Table({
                   containerStyle: css`
                     background-color: black;
                     border-radius: 20px;
-                    opacity: 0.7;
+                    opacity: 0.8;
                     color: white;
+                    padding: 4px;
                     padding-right: 8px;
                   `,
                 }}

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -584,12 +584,7 @@ function Table({
                   display: flex;
                   align-items: start;
                   padding-left: 16px;
-                  padding-top: ${(() => {
-                    if (showPagination && hasRowGroup) return "152px";
-                    if (showPagination || hasRowGroup) return "140px";
-                    if (actions || searchable) return "126px";
-                    return "60px";
-                  })()};
+                  padding-top: 16px;
 
                   backdrop-filter: blur(0.5px);
                   background-color: rgba(255, 255, 255, 0.6);
@@ -598,7 +593,20 @@ function Table({
               show={isLoading}
               onClick="preventDefault"
             >
-              <LoadingSpinner iconSize={24} />
+              <LoadingSpinner
+                styles={{
+                  containerStyle: css`
+                    background-color: black;
+                    border-radius: 20px;
+                    opacity: 0.7;
+                    color: white;
+                    padding-right: 8px;
+                  `,
+                }}
+                label="Loading"
+                gap={10}
+                iconSize={24}
+              />
             </OverlayBlocker>
           )}
         </Wrapper>

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -568,24 +568,32 @@ function Table({
                 })()}
               </TableSummary>
             )}
-
-            {isLoading && (
-              <OverlayBlocker
-                styles={{
-                  self: css`
-                    display: flex;
-                    justify-content: center;
-                    backdrop-filter: blur(0.5px);
-                    background-color: rgba(255, 255, 255, 0.6);
-                  `,
-                }}
-                show={isLoading}
-                onClick="preventDefault"
-              >
-                <LoadingSpinner iconSize={24} />
-              </OverlayBlocker>
-            )}
           </TableContainer>
+
+          {isLoading && (
+            <OverlayBlocker
+              styles={{
+                self: css`
+                  display: flex;
+                  align-items: start;
+                  justify-content: center;
+                  padding-top: 60px;
+
+                  ${(actions || showPagination) &&
+                  css`
+                    padding-top: 120px;
+                  `}
+
+                  backdrop-filter: blur(0.5px);
+                  background-color: rgba(255, 255, 255, 0.6);
+                `,
+              }}
+              show={isLoading}
+              onClick="preventDefault"
+            >
+              <LoadingSpinner iconSize={24} />
+            </OverlayBlocker>
+          )}
         </Wrapper>
       </TableColumnContext.Provider>
     </DnDContext.Provider>
@@ -691,9 +699,9 @@ const PaginationSelectedItem = styled.span<{ $style?: CSSProp }>`
 `;
 
 const TableContainer = styled.div<{ $hasSelected: boolean }>`
+  position: relative;
   display: flex;
   flex-direction: column;
-  position: relative;
   height: 100%;
   overflow: hidden;
 

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -114,8 +114,8 @@ describe("Table", () => {
     );
   }
   context("isLoading", () => {
-    context(`when given true`, () => {
-      it(`should render spinner with position padding-top 10px and padding-left 10px`, () => {
+    context("when given true", () => {
+      it("renders spinner positioned ~10px from the top and ~10px from the left", () => {
         cy.mount(<BasicTable isLoading />);
 
         cy.findByLabelText("overlay-blocker").then(($overlay) => {
@@ -133,7 +133,7 @@ describe("Table", () => {
         });
       });
 
-      it(`should render spinner with padding 4px and with caption loading`, () => {
+      it("renders spinner with padding 4px and with caption loading", () => {
         cy.mount(<BasicTable isLoading />);
 
         cy.findByText("Loading").should("exist");

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -95,7 +95,7 @@ describe("Table", () => {
 
           const distance = spinnerRect.top - overlayRect.top;
 
-          expect(distance).to.be.closeTo(0, 10); // render on the left top
+          expect(distance).to.be.closeTo(60, 10); // 60px is overlay padding-top
         });
       });
     });
@@ -121,7 +121,7 @@ describe("Table", () => {
 
             const distance = spinnerRect.top - overlayRect.top;
 
-            expect(distance).to.be.closeTo(0, 10); // render on the left top
+            expect(distance).to.be.closeTo(110, 10); // 110px is overlay padding-top
           });
         });
       });

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -87,10 +87,6 @@ describe("Table", () => {
     it("should render loading-spinner around the row.level", () => {
       cy.mount(<BasicTable isLoading />);
 
-      cy.findByLabelText("overlay-blocker")
-        .should("exist")
-        .and("have.css", "padding-top", "60px");
-
       cy.findByLabelText("overlay-blocker").then(($overlay) => {
         const overlayRect = $overlay[0].getBoundingClientRect();
 
@@ -99,7 +95,7 @@ describe("Table", () => {
 
           const distance = spinnerRect.top - overlayRect.top;
 
-          expect(distance).to.be.closeTo(60, 10); // 60px is overlay padding-top
+          expect(distance).to.be.closeTo(0, 10); // render on the left top
         });
       });
     });
@@ -117,10 +113,6 @@ describe("Table", () => {
           />
         );
 
-        cy.findByLabelText("overlay-blocker")
-          .should("exist")
-          .and("have.css", "padding-top", "120px");
-
         cy.findByLabelText("overlay-blocker").then(($overlay) => {
           const overlayRect = $overlay[0].getBoundingClientRect();
 
@@ -129,7 +121,7 @@ describe("Table", () => {
 
             const distance = spinnerRect.top - overlayRect.top;
 
-            expect(distance).to.be.closeTo(120, 10); // 120px is overlay padding-top
+            expect(distance).to.be.closeTo(0, 10); // render on the left top
           });
         });
       });

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -114,63 +114,34 @@ describe("Table", () => {
     );
   }
   context("isLoading", () => {
-    const scenarios = [
-      {
-        description: "isLoading only",
-        props: { isLoading: true },
-        expectedPadding: 60,
-      },
-      {
-        description: "isLoading with actions",
-        props: { isLoading: true, actions: [{ caption: "Test" }] },
-        expectedPadding: 126,
-      },
-      {
-        description: "isLoading with showPagination",
-        props: { isLoading: true, showPagination: true },
-        expectedPadding: 140,
-      },
-      {
-        description: "isLoading with showPagination + hasRowGroup",
-        props: {
-          isLoading: true,
-          showPagination: true,
-          labels: { pageNumberText: "12" },
-          hasRowGroup: true,
-        },
-        expectedPadding: 152,
-      },
-      {
-        description: "isLoading with hasRowGroup",
-        props: { isLoading: true, hasRowGroup: true },
-        expectedPadding: 140,
-      },
-      {
-        description: "isLoading with searchable",
-        props: { isLoading: true, searchable: true },
-        expectedPadding: 126,
-      },
-    ];
+    context(`when given true`, () => {
+      it(`should render spinner with position padding-top 10px and padding-left 10px`, () => {
+        cy.mount(<BasicTable isLoading />);
 
-    scenarios.forEach(({ description, props, expectedPadding }) => {
-      context(`when given ${description}`, () => {
-        it(`should render spinner with padding-top ~${expectedPadding}px and padding-left 16px`, () => {
-          cy.mount(<BasicTable {...props} />);
+        cy.findByLabelText("overlay-blocker").then(($overlay) => {
+          const overlayRect = $overlay[0].getBoundingClientRect();
 
-          cy.findByLabelText("overlay-blocker").then(($overlay) => {
-            const overlayRect = $overlay[0].getBoundingClientRect();
+          cy.findByLabelText("circle").then(($spinner) => {
+            const spinnerRect = $spinner[0].getBoundingClientRect();
 
-            cy.findByLabelText("circle").then(($spinner) => {
-              const spinnerRect = $spinner[0].getBoundingClientRect();
+            const paddingTop = spinnerRect.top - overlayRect.top;
+            const paddingLeft = spinnerRect.left - overlayRect.left;
 
-              const paddingTop = spinnerRect.top - overlayRect.top;
-              const paddingLeft = spinnerRect.left - overlayRect.left;
-
-              expect(paddingTop).to.be.closeTo(expectedPadding, 10);
-              expect(paddingLeft).to.be.closeTo(16, 4);
-            });
+            expect(paddingTop).to.be.closeTo(10, 2);
+            expect(paddingLeft).to.be.closeTo(10, 2);
           });
         });
+      });
+
+      it(`should render spinner with padding 4px and with caption loading`, () => {
+        cy.mount(<BasicTable isLoading />);
+
+        cy.findByText("Loading").should("exist");
+
+        cy.findByLabelText("loading-spinner")
+          .should("have.css", "background-color", "rgb(0, 0, 0)")
+          .and("have.css", "opacity", "0.8")
+          .and("have.css", "padding", "4px 8px 4px 4px");
       });
     });
   });

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -57,6 +57,82 @@ describe("Table", () => {
     type: TYPES_DATA[i % TYPES_DATA.length],
   }));
 
+  context("isLoading", () => {
+    it("should render loading-spinner around the row.level", () => {
+      cy.mount(
+        <Table isLoading columns={columnsBasic}>
+          {rawRows?.map((row, index) => (
+            <Table.Row key={index} rowId={`${row.name}-${row.type}`}>
+              {[row.name, row.type].map((rowCell, i) => (
+                <Table.Row.Cell key={`${row.name}-${row.type}-${rowCell}`}>
+                  {rowCell}
+                </Table.Row.Cell>
+              ))}
+            </Table.Row>
+          ))}
+        </Table>
+      );
+
+      cy.findByLabelText("overlay-blocker")
+        .should("exist")
+        .and("have.css", "padding-top", "60px");
+
+      cy.findByLabelText("overlay-blocker").then(($overlay) => {
+        const overlayRect = $overlay[0].getBoundingClientRect();
+
+        cy.findByLabelText("circle").then(($spinner) => {
+          const spinnerRect = $spinner[0].getBoundingClientRect();
+
+          const distance = spinnerRect.top - overlayRect.top;
+
+          expect(distance).to.be.closeTo(60, 10); // 60px is overlay padding-top
+        });
+      });
+    });
+
+    context("when given actions", () => {
+      it("should render loading-spinner around the row.level", () => {
+        cy.mount(
+          <Table
+            actions={[
+              {
+                caption: "Test",
+              },
+            ]}
+            isLoading
+            columns={columnsBasic}
+          >
+            {rawRows?.map((row, index) => (
+              <Table.Row key={index} rowId={`${row.name}-${row.type}`}>
+                {[row.name, row.type].map((rowCell, i) => (
+                  <Table.Row.Cell key={`${row.name}-${row.type}-${rowCell}`}>
+                    {rowCell}
+                  </Table.Row.Cell>
+                ))}
+              </Table.Row>
+            ))}
+          </Table>
+        );
+
+        cy.findByLabelText("overlay-blocker")
+          .should("exist")
+          .and("have.css", "padding-top", "120px");
+
+        cy.findByLabelText("overlay-blocker").then(($overlay) => {
+          const overlayRect = $overlay[0].getBoundingClientRect();
+
+          cy.findByLabelText("circle").then(($spinner) => {
+            const spinnerRect = $spinner[0].getBoundingClientRect();
+
+            const distance = spinnerRect.top - overlayRect.top;
+
+            expect(distance).to.be.closeTo(120, 10); // 120px is overlay padding-top
+          });
+        });
+      });
+    });
+  });
+
   context("actions in main table", () => {
     context("when not given type", () => {
       it("should render with button", () => {

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -59,8 +59,19 @@ describe("Table", () => {
     type: TYPES_DATA[i % TYPES_DATA.length],
   }));
 
-  function BasicTable(props: Omit<TableProps, "children" | "columns">) {
+  function BasicTable(
+    props: Omit<TableProps, "children" | "columns"> & { hasRowGroup?: boolean }
+  ) {
     const [selectedItems, setSelectedItems] = useState([]);
+
+    const pageNumberText = props?.labels?.pageNumberText ?? "12";
+
+    const groupedRows = props.hasRowGroup
+      ? TYPES_DATA.map((type) => ({
+          type,
+          rows: rawRows.filter((r) => r.type === type),
+        }))
+      : null;
 
     return (
       <Table
@@ -68,60 +79,96 @@ describe("Table", () => {
         columns={columnsBasic}
         selectedItems={selectedItems}
         onItemsSelected={setSelectedItems}
+        labels={{
+          pageNumberText: pageNumberText,
+        }}
         {...props}
       >
-        {rawRows?.map((row, index) => (
-          <Table.Row key={index} rowId={`${row.name}-${row.type}`}>
-            {[row.name, row.type].map((rowCell, i) => (
-              <Table.Row.Cell key={`${row.name}-${row.type}-${rowCell}`}>
-                {rowCell}
-              </Table.Row.Cell>
+        {props.hasRowGroup
+          ? groupedRows?.map((group, gi) => (
+              <Table.Row.Group key={gi} id={group.type}>
+                {group.rows.map((row, ri) => (
+                  <Table.Row
+                    key={`${group.type}-${ri}`}
+                    rowId={`${row.name}-${row.type}`}
+                  >
+                    {[row.name, row.type].map((cell, ci) => (
+                      <Table.Row.Cell key={`${row.name}-${cell}`}>
+                        {cell}
+                      </Table.Row.Cell>
+                    ))}
+                  </Table.Row>
+                ))}
+              </Table.Row.Group>
+            ))
+          : rawRows?.map((row, index) => (
+              <Table.Row key={index} rowId={`${row.name}-${row.type}`}>
+                {[row.name, row.type].map((rowCell, i) => (
+                  <Table.Row.Cell key={`${row.name}-${row.type}-${rowCell}`}>
+                    {rowCell}
+                  </Table.Row.Cell>
+                ))}
+              </Table.Row>
             ))}
-          </Table.Row>
-        ))}
       </Table>
     );
   }
-
   context("isLoading", () => {
-    it("should render loading-spinner around the row.level", () => {
-      cy.mount(<BasicTable isLoading />);
+    const scenarios = [
+      {
+        description: "isLoading only",
+        props: { isLoading: true },
+        expectedPadding: 60,
+      },
+      {
+        description: "isLoading with actions",
+        props: { isLoading: true, actions: [{ caption: "Test" }] },
+        expectedPadding: 126,
+      },
+      {
+        description: "isLoading with showPagination",
+        props: { isLoading: true, showPagination: true },
+        expectedPadding: 140,
+      },
+      {
+        description: "isLoading with showPagination + hasRowGroup",
+        props: {
+          isLoading: true,
+          showPagination: true,
+          labels: { pageNumberText: "12" },
+          hasRowGroup: true,
+        },
+        expectedPadding: 152,
+      },
+      {
+        description: "isLoading with hasRowGroup",
+        props: { isLoading: true, hasRowGroup: true },
+        expectedPadding: 140,
+      },
+      {
+        description: "isLoading with searchable",
+        props: { isLoading: true, searchable: true },
+        expectedPadding: 126,
+      },
+    ];
 
-      cy.findByLabelText("overlay-blocker").then(($overlay) => {
-        const overlayRect = $overlay[0].getBoundingClientRect();
+    scenarios.forEach(({ description, props, expectedPadding }) => {
+      context(`when given ${description}`, () => {
+        it(`should render spinner with padding-top ~${expectedPadding}px and padding-left 16px`, () => {
+          cy.mount(<BasicTable {...props} />);
 
-        cy.findByLabelText("circle").then(($spinner) => {
-          const spinnerRect = $spinner[0].getBoundingClientRect();
+          cy.findByLabelText("overlay-blocker").then(($overlay) => {
+            const overlayRect = $overlay[0].getBoundingClientRect();
 
-          const distance = spinnerRect.top - overlayRect.top;
+            cy.findByLabelText("circle").then(($spinner) => {
+              const spinnerRect = $spinner[0].getBoundingClientRect();
 
-          expect(distance).to.be.closeTo(60, 10); // 60px is overlay padding-top
-        });
-      });
-    });
+              const paddingTop = spinnerRect.top - overlayRect.top;
+              const paddingLeft = spinnerRect.left - overlayRect.left;
 
-    context("when given actions", () => {
-      it("should render loading-spinner around the row.level", () => {
-        cy.mount(
-          <BasicTable
-            actions={[
-              {
-                caption: "Test",
-              },
-            ]}
-            isLoading
-          />
-        );
-
-        cy.findByLabelText("overlay-blocker").then(($overlay) => {
-          const overlayRect = $overlay[0].getBoundingClientRect();
-
-          cy.findByLabelText("circle").then(($spinner) => {
-            const spinnerRect = $spinner[0].getBoundingClientRect();
-
-            const distance = spinnerRect.top - overlayRect.top;
-
-            expect(distance).to.be.closeTo(110, 10); // 110px is overlay padding-top
+              expect(paddingTop).to.be.closeTo(expectedPadding, 10);
+              expect(paddingLeft).to.be.closeTo(16, 4);
+            });
           });
         });
       });


### PR DESCRIPTION
Description:
This pull request updates the `loading-spinner` placement to the first `Table.Row` level, improving visbility when the table is loading.

Source:
[[Improvement] SYST-516: Move table loading spinner to top left of the table body](https://linear.app/systatum/issue/SYST-516/move-table-loading-spinner-to-top-left-of-the-table-body)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself