### PR TITLE
[Bug] SYST-529: Fix bug setting disabled not working on stateful form's combobox

### DIFF
--- a/components/capsule.tsx
+++ b/components/capsule.tsx
@@ -29,6 +29,7 @@ interface BaseCapsuleProps {
   id?: string;
   name?: string;
   fontSize?: number;
+  disabled?: boolean;
 }
 
 interface BaseCapsuleStylesProps {
@@ -45,6 +46,7 @@ function BaseCapsule({
   styles,
   id,
   fontSize = 12,
+  disabled,
 }: BaseCapsuleProps) {
   const [hovered, setHovered] = useState<string | null>(null);
 
@@ -156,6 +158,7 @@ function BaseCapsule({
   return (
     <CapsuleWrapper
       id={id}
+      $disabled={disabled}
       aria-label="capsule"
       $containerStyle={styles?.capsuleWrapperStyle}
       $full={full}
@@ -206,13 +209,14 @@ function BaseCapsule({
         return (
           <Tab
             $isActive={isActive}
+            $disabled={disabled}
             role="tab"
             key={index}
             ref={setTabRef(index)}
             $activeTabStyle={styles?.tabStyle}
-            onMouseEnter={() => setHovered(tab.id)}
-            onMouseLeave={() => setHovered(null)}
-            onClick={() => onTabChange(tab.id)}
+            onMouseEnter={() => !disabled && setHovered(tab.id)}
+            onMouseLeave={() => !disabled && setHovered(null)}
+            onClick={() => !disabled && onTabChange(tab.id)}
             $fontSize={fontSize}
           >
             {tab.icon && (
@@ -282,6 +286,7 @@ function Capsule({
       <BaseCapsule
         {...rest}
         id={inputId}
+        disabled={disabled}
         styles={{
           capsuleWrapperStyle: styles?.capsuleWrapperStyle,
           tabStyle: styles?.tabStyle,
@@ -294,6 +299,7 @@ function Capsule({
 const CapsuleWrapper = styled.div<{
   $full?: boolean;
   $containerStyle?: CSSProp;
+  $disabled?: boolean;
 }>`
   position: relative;
   display: flex;
@@ -318,7 +324,14 @@ const CapsuleWrapper = styled.div<{
           width: fit-content;
           border-width: 1px;
           border-radius: 12px;
-        `}
+        `};
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+      user-select: none;
+    `};
 
   ${({ $containerStyle }) => $containerStyle}
 `;
@@ -358,6 +371,7 @@ const Tab = styled.div<{
   $isActive?: boolean;
   $activeTabStyle?: CSSProp;
   $fontSize?: number;
+  $disabled?: boolean;
 }>`
   display: flex;
   flex-direction: row;
@@ -382,6 +396,13 @@ const Tab = styled.div<{
         `}
 
   font-size: ${({ $fontSize }) => `${$fontSize}px`};
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+      user-select: none;
+    `};
 
   ${({ $activeTabStyle }) => css`
     ${$activeTabStyle}

--- a/components/checkbox.tsx
+++ b/components/checkbox.tsx
@@ -87,11 +87,13 @@ function BaseCheckbox({
             type="checkbox"
             name={name}
             id={id}
+            aria-label="checkbox"
             checked={props.checked}
             onChange={props.onChange}
             $isError={showError}
             $indeterminate={indeterminate}
             $checked={isChecked}
+            role="checkbox"
             $style={styles?.self}
             $disabled={props.disabled}
             disabled={props.disabled}

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -29,6 +29,7 @@ import { Textbox } from "./textbox";
 import styled, { css, CSSProp } from "styled-components";
 import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { isTruthy } from "./../lib/falsy";
 
 export type ChipActionsProps = BadgeActionProps;
 
@@ -51,6 +52,7 @@ interface BaseChipsProps {
   styles?: BaseChipsStylesProps;
   name?: string;
   id?: string;
+  disabled?: boolean;
 }
 
 export interface BaseChipsStylesProps {
@@ -80,7 +82,7 @@ function BaseChips(props: BaseChipsProps) {
 
   const { refs, floatingStyles, context } = useFloating({
     open: isOpen,
-    onOpenChange: setIsOpen,
+    onOpenChange: props?.disabled ? null : setIsOpen,
     middleware: [
       offset(6),
       flip({ fallbackPlacements: ["bottom-end", "top-start", "top-end"] }),
@@ -122,7 +124,10 @@ function BaseChips(props: BaseChipsProps) {
 
   return (
     <>
-      <InputGroup $containerStyle={props?.styles?.chipsContainerStyle}>
+      <InputGroup
+        $disabled={props?.disabled}
+        $containerStyle={props?.styles?.chipsContainerStyle}
+      >
         {CLICKED_OPTIONS.map((data) =>
           typeof props.renderer === "function" ? (
             props.renderer({
@@ -154,6 +159,7 @@ function BaseChips(props: BaseChipsProps) {
         )}
 
         <AddButton
+          $disabled={props?.disabled}
           ref={refs.setReference}
           role="button"
           $isOpen={isOpen}
@@ -177,39 +183,24 @@ function BaseChips(props: BaseChipsProps) {
 
 const InputGroup = styled.div<{
   $containerStyle?: CSSProp;
+  $disabled?: boolean;
 }>`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   gap: 3px;
 
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      user-select: none;
+      cursor: not-allowed;
+    `};
+
   ${({ $containerStyle }) => $containerStyle}
 `;
 
-const InputWrapper = styled.div<{ $style?: CSSProp }>`
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  font-size: 0.75rem;
-  width: 100%;
-  position: relative;
-
-  ${({ $style }) => $style}
-`;
-
-const InputContent = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  font-size: 12px;
-`;
-
-const ErrorText = styled.span`
-  color: #dc2626;
-  font-size: 0.75rem;
-`;
-
-const AddButton = styled(RiAddLine)<{ $isOpen?: boolean }>`
+const AddButton = styled(RiAddLine)<{ $isOpen?: boolean; $disabled?: boolean }>`
   cursor: pointer;
   border: 1px solid transparent;
   border-radius: 9999px;
@@ -219,10 +210,18 @@ const AddButton = styled(RiAddLine)<{ $isOpen?: boolean }>`
     box-shadow 0.2s ease,
     border-color 0.2s ease;
 
-  &:hover {
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    border-color: #d1d5db;
-  }
+  ${({ $disabled }) =>
+    $disabled
+      ? css`
+          user-select: none;
+          cursor: not-allowed;
+        `
+      : css`
+          &:hover {
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            border-color: #d1d5db;
+          }
+        `};
 
   ${({ $isOpen }) =>
     $isOpen &&
@@ -256,6 +255,7 @@ function ChipsDrawer({
   emptySlate,
   name = "chips",
   styles,
+  disabled,
 }: ChipsDrawerProps) {
   const [hovered, setHovered] = useState<string | null>(null);
   const [mode, setMode] = useState<"idle" | "create">("idle");
@@ -530,7 +530,12 @@ function Chips({
         labelStyle,
       }}
     >
-      <BaseChips {...rest} id={inputId} styles={baseChipStyles} />
+      <BaseChips
+        {...rest}
+        id={inputId}
+        styles={baseChipStyles}
+        disabled={disabled}
+      />
     </FieldLane>
   );
 }
@@ -556,6 +561,7 @@ const ChipsDrawerWrapper = styled.ul<{
   list-style: none;
   outline: none;
   z-index: 9999;
+
   ${({ $style }) => $style}
 `;
 
@@ -600,7 +606,7 @@ function ChipsItem({
   inputRef?: RefObject<HTMLInputElement>;
 }) {
   const finalValueActions =
-    badge.actions?.map((action) => ({
+    badge.actions?.filter(isTruthy).map((action) => ({
       ...action,
       styles: {
         self: css`

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -125,6 +125,7 @@ function BaseChips(props: BaseChipsProps) {
   return (
     <>
       <InputGroup
+        aria-label="chip-input"
         $disabled={props?.disabled}
         $containerStyle={props?.styles?.chipsContainerStyle}
       >

--- a/components/colorbox.tsx
+++ b/components/colorbox.tsx
@@ -26,7 +26,17 @@ export interface ColorboxStylesProps {
 
 const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
   (
-    { onChange, value, showError, placeholder, onClick, styles, id, ...props },
+    {
+      onChange,
+      value,
+      showError,
+      placeholder,
+      onClick,
+      styles,
+      id,
+      disabled,
+      ...props
+    },
     ref
   ) => {
     const [hovered, setHovered] = useState(false);
@@ -57,6 +67,7 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
 
     return (
       <ColorInputContainer
+        $disabled={disabled}
         $style={styles?.self}
         $hovered={hovered}
         $showError={!!showError}
@@ -65,6 +76,7 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
         }}
       >
         <ColorBox
+          $disabled={disabled}
           onClick={() => {
             document.getElementById(id)?.click();
             setHovered(true);
@@ -77,18 +89,25 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
 
         <HiddenColorInput
           {...props}
+          disabled={disabled}
           id={id}
           type="color"
           value={value}
           onChange={handleColorChange}
         />
 
-        <TextInputGroup $hovered={hovered} $showError={!!showError}>
+        <TextInputGroup
+          $disabled={disabled}
+          $hovered={hovered}
+          $showError={!!showError}
+        >
           <Prefix $showError={!!showError}>#</Prefix>
           <TextInput
             {...props}
+            $disabled={disabled}
             type="text"
             ref={ref}
+            disabled={disabled}
             value={value?.replace(/^#/, "")}
             onChange={(e) => {
               const cleanValue = e.target.value.replace(/#/g, "");
@@ -190,6 +209,7 @@ const ColorInputContainer = styled.div<{
   $hovered: boolean;
   $showError: boolean;
   $style?: CSSProp;
+  $disabled?: boolean;
 }>`
   position: relative;
   display: flex;
@@ -199,8 +219,21 @@ const ColorInputContainer = styled.div<{
   height: 100%;
   width: 100%;
   border: 1px solid
-    ${({ $showError, $hovered }) =>
-      $showError ? "#f87171" : $hovered ? "#61A9F9" : "#d1d5db"};
+    ${({ $showError, $hovered, $disabled }) =>
+      $disabled
+        ? "#d1d5db"
+        : $showError
+          ? "#f87171"
+          : $hovered
+            ? "#61A9F9"
+            : "#d1d5db"};
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      user-select: none;
+      cursor: not-allowed;
+    `};
 
   ${({ $style }) => $style}
 `;
@@ -208,15 +241,25 @@ const ColorInputContainer = styled.div<{
 const ColorBox = styled.div<{
   $bgColor?: string;
   $showError?: boolean;
+  $disabled?: boolean;
 }>`
   min-width: 24px;
   min-height: 24px;
   margin: 4px;
   border-radius: 2px;
-  border: 1px solid ${({ $showError }) => ($showError ? "#f87171" : "#d1d5db")};
+  border: 1px solid
+    ${({ $showError, $disabled }) =>
+      $disabled ? "#d1d5db" : $showError ? "#f87171" : "#d1d5db"};
   background-color: ${({ $bgColor }) => ($bgColor ? $bgColor : "#ffffff")};
   overflow: hidden;
   cursor: pointer;
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      user-select: none;
+      cursor: not-allowed;
+    `};
 `;
 
 const HiddenColorInput = styled.input`
@@ -231,6 +274,7 @@ const HiddenColorInput = styled.input`
 const TextInputGroup = styled.span<{
   $hovered: boolean;
   $showError: boolean;
+  $disabled?: boolean;
 }>`
   display: flex;
   align-items: center;
@@ -238,8 +282,15 @@ const TextInputGroup = styled.span<{
   height: 34px;
   padding: 2px 12px;
   border-left: 1px solid
-    ${({ $showError, $hovered }) =>
-      $showError ? "#f87171" : $hovered ? "#61A9F9" : "#d1d5db"};
+    ${({ $showError, $hovered, $disabled }) =>
+      $disabled
+        ? "#d1d5db"
+        : $showError
+          ? "#f87171"
+          : $hovered
+            ? "#61A9F9"
+            : "#d1d5db"};
+
   width: 100%;
 `;
 
@@ -247,7 +298,7 @@ const Prefix = styled.span<{ $showError: boolean }>`
   color: ${({ $showError }) => ($showError ? "#f87171" : "#6b7280")};
 `;
 
-const TextInput = styled.input<{ $showError: boolean }>`
+const TextInput = styled.input<{ $showError: boolean; $disabled?: boolean }>`
   flex: 1;
   width: 100%;
   overflow: scroll;
@@ -255,7 +306,16 @@ const TextInput = styled.input<{ $showError: boolean }>`
   background: transparent;
   border: none;
   outline: none;
-  color: ${({ $showError }) => ($showError ? "#f87171" : "#1f2937")};
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      user-select: none;
+      cursor: not-allowed;
+    `};
+
+  color: ${({ $disabled, $showError }) =>
+    $disabled ? "#d1d5db" : $showError ? "#f87171" : "#1f2937"};
 `;
 
 export { Colorbox };

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -138,7 +138,6 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         labelWidth={labelWidth}
         labelPosition={labelPosition}
         label={label}
-        disabled={disabled}
         highlightOnMatch={highlightOnMatch}
         required={required}
         labels={labels}
@@ -174,6 +173,7 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         multiple={multiple}
         maxSelectableItems={maxSelectableItems}
         actions={actions}
+        disabled={disabled}
       >
         {(props) => {
           return (

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -218,11 +218,11 @@ function FieldLane({
               onMouseDown={(e) => e.preventDefault()}
               onClick={(e) => {
                 e.stopPropagation();
-                if (props.onClick) {
+                if ((!disabled || !props?.disabled) && props.onClick) {
                   props.onClick(e);
                 }
               }}
-              disabled={props.disabled}
+              disabled={disabled ? disabled : props.disabled}
               styles={{
                 containerStyle: css`
                   position: absolute;

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -71,6 +71,11 @@ export interface DropdownOptionProps {
   value: string;
   icon?: FigureProps;
 }
+export interface DropdownOptionProps {
+  text: string;
+  value: string;
+  icon?: FigureProps;
+}
 
 function FieldLane({
   label,
@@ -168,8 +173,10 @@ function FieldLane({
                     ${dropdown.width &&
                     css`
                       width: ${dropdown.width};
-                    `}
-                    
+                    `};
+
+                    height: 100%;
+
                     ${dropdown.styles?.self};
                   `,
                   dropdownStyle: (placement) => css`

--- a/components/file-drop-box.tsx
+++ b/components/file-drop-box.tsx
@@ -46,6 +46,7 @@ export interface FileDropBoxProps {
   labelGap?: FieldLaneProps["labelGap"];
   labelWidth?: FieldLaneProps["labelWidth"];
   required?: boolean;
+  disabled?: boolean;
 }
 
 export interface FileDropBoxStylesProps {
@@ -73,6 +74,7 @@ function FileDropBox({
   labelGap,
   labelWidth,
   required,
+  disabled,
 }: FileDropBoxProps) {
   const FILE_ICON = [
     { id: 1, icon: RiImageLine, size: 50 },
@@ -231,6 +233,7 @@ function FileDropBox({
           accept={accept}
           required={required}
           onChange={handleFileChange}
+          disabled={disabled}
           multiple
           hidden
         />
@@ -240,6 +243,7 @@ function FileDropBox({
 
   return (
     <InputWrapper
+      $disabled={disabled}
       $labelPosition={labelPosition}
       aria-label="file-drop-box-container"
       $hide={progress === null}
@@ -248,7 +252,7 @@ function FileDropBox({
     >
       {label && (
         <StatefulForm.Label
-          htmlFor={inputId}
+          htmlFor={disabled ? null : inputId}
           labelWidth={labelWidth}
           labelPosition={labelPosition}
           required={required}
@@ -275,6 +279,7 @@ const InputWrapper = styled.div<{
   $hide?: boolean;
   $labelPosition?: FieldLaneProps["labelPosition"];
   $labelGap?: FieldLaneProps["labelGap"];
+  $disabled?: boolean;
 }>`
   display: flex;
   width: 100%;
@@ -289,6 +294,14 @@ const InputWrapper = styled.div<{
     css`
       display: none;
     `}
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      opacity: 0.5;
+      user-select: none;
+      cursor: not-allowed;
+    `};
 
   ${({ $containerStyle }) => $containerStyle}
 `;
@@ -321,7 +334,6 @@ const DropArea = styled.div<{
   position: relative;
   align-items: center;
   justify-content: space-between;
-  cursor: pointer;
   border-radius: 4px;
   color: #6b7280;
   width: 100%;
@@ -372,7 +384,7 @@ const DropArea = styled.div<{
       background-repeat: no-repeat;
 
       ${$dragOverStyle}
-    `}
+    `};
 
   ${({ $isDragging }) =>
     $isDragging &&
@@ -419,14 +431,14 @@ const DropArea = styled.div<{
         bottom right,
         bottom left;
       background-repeat: no-repeat;
-    `}
+    `};
 
   ${({ $progress, $successStyle }) =>
     $progress === "succeed" &&
     css`
       border: 1px solid #f3f4f6;
       ${$successStyle}
-    `}
+    `};
 `;
 
 const UploadContent = styled.div`

--- a/components/file-drop-box.tsx
+++ b/components/file-drop-box.tsx
@@ -184,10 +184,10 @@ function FileDropBox({
       $isDragging={isDragging}
       $progress={progress}
       aria-label="filedropbox"
-      onClick={handleBrowseClick}
-      onDrop={handleDrop}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
+      onClick={!disabled && handleBrowseClick}
+      onDrop={!disabled && handleDrop}
+      onDragOver={!disabled && handleDragOver}
+      onDragLeave={!disabled && handleDragLeave}
     >
       {progress === "loading" && currentIndex !== null ? (
         <ProgressContainer>

--- a/components/file-input-box.tsx
+++ b/components/file-input-box.tsx
@@ -97,12 +97,12 @@ function BaseFileInputBox({
   return (
     <InputBox
       $style={styles?.self}
-      $isDragging={isDragging}
+      $isDragging={!disabled && isDragging}
       $hasFile={selectedFiles.length > 0}
-      onClick={handleBrowseClick}
-      onDrop={handleDrop}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
+      onClick={!disabled && handleBrowseClick}
+      onDrop={!disabled && handleDrop}
+      onDragOver={!disabled && handleDragOver}
+      onDragLeave={!disabled && handleDragLeave}
       aria-label="fileinputbox"
       $disabled={disabled}
       $isError={showError}
@@ -288,6 +288,12 @@ const InputBox = styled.div<{
     bottom right,
     bottom left;
   background-repeat: no-repeat;
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      user-select: none;
+    `};
 
   ${({ $style }) => $style}
 `;

--- a/components/imagebox.tsx
+++ b/components/imagebox.tsx
@@ -185,6 +185,7 @@ function BaseImagebox({
         id={inputId}
         name={name}
         aria-label="imagebox"
+        disabled={disabled}
         onChange={handleFileChange}
       />
 

--- a/components/imagebox.tsx
+++ b/components/imagebox.tsx
@@ -21,6 +21,7 @@ interface BaseImageboxProps {
   editable?: boolean;
   url?: string;
   id?: string;
+  disabled?: boolean;
 }
 interface BaseImageboxStylesProps {
   self?: CSSProp;
@@ -53,6 +54,7 @@ function BaseImagebox({
   value,
   borderless,
   editable = true,
+  disabled,
   url,
   id,
 }: BaseImageboxProps) {
@@ -149,6 +151,7 @@ function BaseImagebox({
 
   return (
     <InputBox
+      $disabled={disabled}
       aria-label="imagebox-input"
       $style={styles?.self}
       $dimension={dimension}
@@ -255,7 +258,12 @@ function Imagebox({
         labelStyle,
       }}
     >
-      <BaseImagebox {...rest} id={inputId} styles={ImageboxStyles} />
+      <BaseImagebox
+        {...rest}
+        id={inputId}
+        disabled={disabled}
+        styles={ImageboxStyles}
+      />
     </FieldLane>
   );
 }
@@ -266,6 +274,7 @@ const InputBox = styled.div<{
   $style?: CSSProp;
   $editable?: boolean;
   $borderless?: boolean;
+  $disabled?: boolean;
 }>`
   position: relative;
   width: ${({ $dimension }) => $dimension};
@@ -287,6 +296,14 @@ const InputBox = styled.div<{
     $editable &&
     css`
       cursor: pointer;
+    `};
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      user-select: none;
+      pointer-events: none;
+      cursor: not-allowed;
     `};
 
   ${({ $style }) => $style}

--- a/components/moneybox.tsx
+++ b/components/moneybox.tsx
@@ -297,6 +297,7 @@ const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
           {...rest}
           id={inputId}
           showError={showError}
+          disabled={disabled}
           styles={{
             inputWrapperStyle: css`
               ${dropdowns &&
@@ -339,8 +340,8 @@ const Box = styled.div<{
   ${({ $disabled }) =>
     $disabled &&
     css`
-      background-color: rgb(227 227 227);
-      opacity: 0.5;
+      user-select: none;
+      pointer-events: none;
       cursor: not-allowed;
     `}
 

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -168,6 +168,8 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
     };
 
     const handlePhoneChange = (e: ChangeEvent<HTMLInputElement>) => {
+      if (disabled) return;
+
       const raw = e.target.value;
       const trimmed = trimPhone(raw);
       const formatted = formatPhoneboxNumber(
@@ -187,6 +189,8 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
     };
 
     const handleSelectCountry = async (country: CountryCodeProps) => {
+      if (disabled) return;
+
       await setSelectedCountry(country);
       await setIsOpen(false);
       await setSearchTerm("");
@@ -299,6 +303,7 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
                 />
                 <SearchInput
                   type="text"
+                  $disabled={disabled}
                   ref={searchInputRef}
                   placeholder="Search your country..."
                   value={searchTerm}
@@ -447,14 +452,14 @@ const InputWrapper = styled.div<{
       $hasError ? "#ef4444" : $isOpen ? "#d1d5db" : "#d1d5db"};
 
   &:focus-within {
-    border-color: ${({ $hasError }) => ($hasError ? "#ef4444" : "#61A9F9")};
+    border-color: ${({ $hasError, $disabled }) =>
+      $disabled ? "#d1d5db" : $hasError ? "#ef4444" : "#61A9F9"};
   }
 
   ${({ $disabled }) =>
     $disabled &&
     css`
       border-color: #d1d5db;
-      opacity: 0.5;
     `}
 
   border-radius: 2px;
@@ -476,7 +481,8 @@ const CountryButton = styled.button<{
     ${({ $hasError }) => ($hasError ? "#ef4444" : "#d1d5db")};
 
   ${InputWrapper}:focus-within & {
-    border-color: ${({ $hasError }) => ($hasError ? "#ef4444" : "#61A9F9")};
+    border-color: ${({ $hasError, $disabled }) =>
+      $disabled ? "#d1d5db" : $hasError ? "#ef4444" : "#61A9F9"};
   }
 
   padding: 0 8px;
@@ -553,7 +559,7 @@ const SearchWrapper = styled.div`
   position: relative;
 `;
 
-const SearchInput = styled.input`
+const SearchInput = styled.input<{ $disabled?: boolean }>`
   width: 100%;
   border: 1px solid #d1d5db;
   padding: 8px 8px 8px 32px;
@@ -562,8 +568,17 @@ const SearchInput = styled.input`
   outline: none;
 
   &:focus {
-    border-color: #61a9f9;
+    border-color: ${({ $disabled }) => ($disabled ? "#d1d5db" : "#61a9f9")};
   }
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+      user-select: none;
+      pointer-events: none;
+      border-color: #d1d5db;
+    `};
 `;
 
 const CountryOption = styled.div<{ $highlighted?: boolean }>`

--- a/components/rating.tsx
+++ b/components/rating.tsx
@@ -139,7 +139,13 @@ function BaseRating({
           </StarSpan>
         ))}
       </StarsWrapper>
-      <input type="hidden" name={name} value={ratingLocal} id={id} />
+      <input
+        disabled={disabled}
+        type="hidden"
+        name={name}
+        value={ratingLocal}
+        id={id}
+      />
 
       {withLabel && (
         <RatingLabel $size={size}>{ratingLocal.toFixed(1)} / 5</RatingLabel>

--- a/components/rating.tsx
+++ b/components/rating.tsx
@@ -27,6 +27,7 @@ function BaseRating({
   withLabel = false,
   size = "md",
   name,
+  disabled,
 }: BaseRatingProps) {
   const ratingState = Number(rating || 0);
   const [ratingLocal, setRatingLocal] = useState(ratingState);
@@ -128,10 +129,11 @@ function BaseRating({
           <StarSpan
             role="img"
             key={i}
-            onMouseMove={(e) => editable && handleMouseMove(e, i)}
-            onMouseLeave={() => editable && setHoverRating(0)}
-            onClick={(e) => editable && handleClick(e, i)}
+            onMouseMove={(e) => !disabled && editable && handleMouseMove(e, i)}
+            onMouseLeave={() => !disabled && editable && setHoverRating(0)}
+            onClick={(e) => !disabled && editable && handleClick(e, i)}
             $editable={editable}
+            $disabled={disabled}
           >
             {renderStar(getStarType(i))}
           </StarSpan>
@@ -227,12 +229,18 @@ const StarsWrapper = styled.div`
   gap: 2px;
 `;
 
-const StarSpan = styled.span<{ $editable?: boolean }>`
-  ${({ $editable }) =>
-    $editable &&
-    css`
-      cursor: pointer;
-    `}
+const StarSpan = styled.span<{ $editable?: boolean; $disabled?: boolean }>`
+  ${({ $editable, $disabled }) =>
+    $disabled
+      ? css`
+          cursor: not-allowed;
+          user-select: none;
+          pointer-events: none;
+        `
+      : $editable &&
+        css`
+          cursor: pointer;
+        `}
 `;
 
 const RatingLabel = styled.span<{ $size: "sm" | "md" | "lg" }>`

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -136,6 +136,7 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
       autoComplete = "off",
       isLoading,
       labels,
+      disabled,
       ...props
     },
     ref
@@ -377,6 +378,7 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
         role="combobox"
         $style={styles?.selectboxStyle}
         aria-expanded={isOpen}
+        $disabled={disabled}
         onClick={() => {
           if (multiple) inputRef.current?.focus();
         }}
@@ -409,8 +411,8 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           aria-label={id}
           id={id}
           $clearable={clearable}
-          disabled={isLoading || props?.disabled}
-          $disabled={isLoading || props?.disabled}
+          disabled={disabled || isLoading}
+          $disabled={disabled || isLoading}
           ref={(el) => {
             refs.setReference(el);
             if (!multiple) {
@@ -608,6 +610,7 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
           id={inputId}
           actions={actions}
           showError={showError}
+          disabled={disabled}
           styles={{
             self: css`
               ${dropdowns &&
@@ -646,7 +649,11 @@ export function castValue<T extends SelectboxSelectedOptions>(
   return String(value) as T;
 }
 
-const Container = styled.div<{ $style?: CSSProp; $isLoading?: boolean }>`
+const Container = styled.div<{
+  $style?: CSSProp;
+  $isLoading?: boolean;
+  $disabled?: boolean;
+}>`
   position: relative;
   width: 100%;
   font-size: 12px;
@@ -657,7 +664,15 @@ const Container = styled.div<{ $style?: CSSProp; $isLoading?: boolean }>`
       user-select: none;
       pointer-events: none;
       opacity: 0.5;
-    `}
+    `};
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+      user-select: none;
+      pointer-events: none;
+    `};
 
   ${({ $style }) => $style}
 `;

--- a/components/signbox.tsx
+++ b/components/signbox.tsx
@@ -34,6 +34,7 @@ function BaseSignbox({
   height,
   width,
   id,
+  disabled,
 }: BaseSignboxProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const isDrawing = useRef(false);
@@ -128,11 +129,13 @@ function BaseSignbox({
   };
 
   const startDrawing = (e: MouseEvent | TouchEvent) => {
+    if (disabled) return;
     isDrawing.current = true;
     lastPoint.current = getCoordinates(e);
   };
 
   const draw = (e: MouseEvent | TouchEvent) => {
+    if (disabled) return;
     if (!isDrawing.current) return;
 
     const ctx = canvasRef.current?.getContext("2d");
@@ -159,11 +162,13 @@ function BaseSignbox({
   };
 
   const stopDrawing = () => {
+    if (disabled) return;
     isDrawing.current = false;
     lastPoint.current = null;
   };
 
   const clearCanvas = (e?: React.MouseEvent) => {
+    if (disabled) return;
     e?.stopPropagation();
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext("2d");
@@ -180,6 +185,7 @@ function BaseSignbox({
 
   return (
     <SignatureWrapper
+      $disabled={disabled}
       aria-label="signbox-canvas"
       $error={showError}
       $canvasStyle={styles?.self}
@@ -272,6 +278,7 @@ function Signbox({
         onChange={onChange}
         clearable={clearable}
         showError={showError}
+        disabled={disabled}
         styles={{
           self: css`
             ${dropdowns &&
@@ -296,6 +303,7 @@ const SignatureWrapper = styled.div<{
   $height?: string;
   $canvasStyle?: CSSProp;
   $error?: boolean;
+  $disabled?: boolean;
 }>`
   position: relative;
   width: ${({ $width }) => $width ?? "100%"};
@@ -303,6 +311,14 @@ const SignatureWrapper = styled.div<{
   border: 1px solid ${({ $error }) => ($error ? "#f87171" : "#d1d5db")};
   border-radius: 2px;
   cursor: ${cursorDataUrl};
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+      user-select: none;
+      pointer-events: none;
+    `}
 
   ${({ $canvasStyle }) => $canvasStyle};
 `;

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -1100,6 +1100,7 @@ function FormFields<T extends FieldValues>({
                   helper={field.helper}
                   name={field.name}
                   required={field.required}
+                  disabled={field.disabled}
                   {...register(field.name as Path<T>, {
                     onChange: (e) => {
                       if (field.onChange) {
@@ -1142,6 +1143,7 @@ function FormFields<T extends FieldValues>({
                   showError={shouldShowError(field.name)}
                   helper={field.helper}
                   name={field.name}
+                  disabled={field.disabled}
                   errorMessage={
                     errors[field.name as keyof T]?.message as string | undefined
                   }
@@ -1538,6 +1540,7 @@ function FormFields<T extends FieldValues>({
                         }
                       }}
                       selectedOptions={controllerField.value}
+                      disabled={field.disabled}
                       {...field.comboboxProps}
                       styles={{
                         ...field?.comboboxProps?.styles,
@@ -1591,6 +1594,7 @@ function FormFields<T extends FieldValues>({
                       labelPosition={field.labelPosition}
                       required={field.required}
                       filterPlaceholder={field.placeholder}
+                      disabled={field.disabled}
                       inputValue={controllerField.value}
                       setInputValue={(e) => {
                         controllerField?.onChange(e);
@@ -1834,6 +1838,7 @@ function FormFields<T extends FieldValues>({
                       required={field.required}
                       activeTab={controllerField.value}
                       helper={field.helper}
+                      disabled={field.disabled}
                       onTabChange={(e) => {
                         const inputValueEvent = {
                           target: { name: field.name, value: e },

--- a/components/textarea.tsx
+++ b/components/textarea.tsx
@@ -41,6 +41,7 @@ const BaseTextarea = forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
 
     return (
       <TextareaInput
+        $disabled={props?.disabled}
         $autogrow={autogrow}
         id={id}
         ref={(el) => {
@@ -97,24 +98,13 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       id: props.id,
     });
 
-    const DropdownProps = dropdowns?.map((dropdown) => ({
-      ...dropdown,
-      styles: {
-        ...dropdown?.styles,
-        self: css`
-          height: 100%;
-          ${dropdown?.styles?.self}
-        `,
-      },
-    }));
-
     return (
       <FieldLane
         id={inputId}
         labelGap={labelGap}
         labelWidth={labelWidth}
         labelPosition={labelPosition}
-        dropdowns={DropdownProps}
+        dropdowns={dropdowns}
         showError={showError}
         errorMessage={errorMessage}
         label={label}
@@ -133,6 +123,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         <BaseTextarea
           {...rest}
           id={inputId}
+          disabled={disabled}
           showError={showError}
           styles={{
             self: css`
@@ -156,6 +147,7 @@ const TextareaInput = styled.textarea<{
   $error?: boolean;
   $style?: CSSProp;
   $autogrow?: boolean;
+  $disabled?: boolean;
 }>`
   border-radius: 2px;
   font-size: 0.75rem;
@@ -165,6 +157,13 @@ const TextareaInput = styled.textarea<{
   border: 1px solid ${({ $error }) => ($error ? "#f87171" : "#d1d5db")};
   z-index: 10;
   resize: none;
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+      user-select: none;
+      pointer-events: none;
+    `};
 
   ${({ $autogrow }) =>
     $autogrow &&
@@ -175,7 +174,7 @@ const TextareaInput = styled.textarea<{
       &::-webkit-scrollbar {
         display: none;
       }
-    `}
+    `};
 
   ${({ $error }) =>
     $error
@@ -191,7 +190,7 @@ const TextareaInput = styled.textarea<{
             border-color: #61a9f9;
             box-shadow: 0 0 0 1px #61a9f9;
           }
-        `}
+        `};
   ${({ $style }) => $style}
 `;
 

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -53,6 +53,7 @@ const BaseTextbox = forwardRef<HTMLInputElement, BaseTextboxProps>(
           $style={styles?.self}
           {...(props as InputHTMLAttributes<HTMLInputElement>)}
           $disabled={props?.disabled}
+          disabled={props?.disabled}
           autoComplete={type === "password" ? "off" : props.autoComplete}
         />
 

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -59,6 +59,7 @@ const BaseTextbox = forwardRef<HTMLInputElement, BaseTextboxProps>(
         {type === "password" && (
           <Button
             type="button"
+            disabled={props?.disabled}
             onMouseDown={(e) => e.preventDefault()}
             onClick={() => setShowPassword((prev) => !prev)}
             aria-label="toggle-password"

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -52,6 +52,7 @@ const BaseTextbox = forwardRef<HTMLInputElement, BaseTextboxProps>(
           $error={showError}
           $style={styles?.self}
           {...(props as InputHTMLAttributes<HTMLInputElement>)}
+          $disabled={props?.disabled}
           autoComplete={type === "password" ? "off" : props.autoComplete}
         />
 
@@ -151,6 +152,7 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
           {...rest}
           id={inputId}
           showError={showError}
+          disabled={disabled}
           styles={{
             self: css`
               ${dropdowns &&
@@ -172,6 +174,7 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
 const Input = styled.input<{
   $error?: boolean;
   $style?: CSSProp;
+  $disabled?: boolean;
 }>`
   border-radius: 2px;
   font-size: 0.75rem;
@@ -197,6 +200,14 @@ const Input = styled.input<{
             box-shadow: 0 0 0 0.5px #61a9f9;
           }
         `}
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+      user-select: none;
+      pointer-events: none;
+    `};
 
   ${({ $style }) => $style}
 `;

--- a/components/thumb-field.tsx
+++ b/components/thumb-field.tsx
@@ -53,6 +53,8 @@ function BaseThumbField({
   const thumbInputRef = useRef<HTMLInputElement>(null);
 
   const handleChangeValue = (data: ThumbFieldValue) => {
+    if (disabled) return;
+
     if (thumbValue !== data) {
       setThumbValue(data);
     }
@@ -90,6 +92,7 @@ function BaseThumbField({
         $active={thumbValue === "up"}
         $activeColor={thumbsUpBackgroundColor}
         $showError={showError}
+        $disabled={disabled}
       >
         {thumbValue === "up" ? (
           <RiThumbUpFill size={24} />
@@ -105,6 +108,7 @@ function BaseThumbField({
         $active={thumbValue === "down"}
         $activeColor={thumbsDownBackgroundColor}
         $showError={showError}
+        $disabled={disabled}
       >
         {thumbValue === "down" ? (
           <RiThumbDownFill size={24} />
@@ -183,6 +187,7 @@ function ThumbField({
     >
       <BaseThumbField
         {...rest}
+        disabled={disabled}
         id={inputId}
         styles={thumbFieldStyles}
         showError={showError}
@@ -204,8 +209,8 @@ const TriggerWrapper = styled.div<{
   $active?: boolean;
   $activeColor?: string;
   $showError?: boolean;
+  $disabled?: boolean;
 }>`
-  cursor: pointer;
   display: flex;
   align-items: center;
 
@@ -221,6 +226,15 @@ const TriggerWrapper = styled.div<{
       css`
         color: #dc2626;
       `}
+
+      ${({ $disabled }) =>
+      $disabled
+        ? css`
+            cursor: not-allowed;
+          `
+        : css`
+            cursor: pointer;
+          `}
   }
 
   ${({ $triggerStyle }) => $triggerStyle}

--- a/components/timebox.tsx
+++ b/components/timebox.tsx
@@ -181,6 +181,7 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
         $style={styles?.inputWrapperStyle}
         $focused={isFocused}
         $error={!!showError}
+        $disabled={disabled}
         onKeyDown={(e) => {
           if (onKeyDown) {
             onKeyDown(e);
@@ -353,6 +354,7 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
           {...rest}
           id={inputId}
           showError={showError}
+          disabled={disabled}
           styles={{
             inputWrapperStyle: css`
               ${dropdowns &&
@@ -375,6 +377,7 @@ const InputGroup = styled.div<{
   $focused: boolean;
   $error: boolean;
   $style?: CSSProp;
+  $disabled?: boolean;
 }>`
   display: flex;
   flex-direction: row;
@@ -385,6 +388,14 @@ const InputGroup = styled.div<{
 
   border-color: ${({ $error, $focused }) =>
     $error ? "#dc2626" : $focused ? "#61A9F9" : "#d1d5db"};
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+      user-select: none;
+      pointer-events: none;
+    `};
 
   ${({ $style }) => $style}
 `;

--- a/components/togglebox.tsx
+++ b/components/togglebox.tsx
@@ -39,6 +39,7 @@ function BaseTogglebox({
   styles,
   size = 24,
   id,
+  disabled,
   ...props
 }: BaseToggleboxProps) {
   const { heightWrapper, widthWrapper, thumbShift, iconSize } =
@@ -46,6 +47,7 @@ function BaseTogglebox({
 
   return (
     <ToggleboxWrapper
+      $disabled={disabled}
       $style={styles?.rowStyle}
       aria-label="togglebox-row-wrapper"
     >
@@ -67,6 +69,7 @@ function BaseTogglebox({
           name={name}
           type="checkbox"
           checked={checked}
+          disabled={disabled}
           onChange={onChange}
         />
         <ToggleBackground checked={checked} />
@@ -102,7 +105,7 @@ function BaseTogglebox({
         >
           {label && (
             <StatefulForm.Label
-              htmlFor={props.disabled ? null : id}
+              htmlFor={disabled ? null : id}
               styles={{ self: styles?.labelStyle }}
               label={label}
             />
@@ -209,7 +212,7 @@ const getToggleboxSize = (size: number) => {
   };
 };
 
-const ToggleboxWrapper = styled.div<{ $style?: CSSProp }>`
+const ToggleboxWrapper = styled.div<{ $style?: CSSProp; $disabled?: boolean }>`
   display: flex;
   flex-direction: row;
   gap: 0.5rem;
@@ -217,6 +220,14 @@ const ToggleboxWrapper = styled.div<{ $style?: CSSProp }>`
   font-size: 0.75rem;
   align-items: center;
   width: 100%;
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+      user-select: none;
+      pointer-events: none;
+    `};
 
   ${({ $style }) => $style}
 `;

--- a/lib/falsy.ts
+++ b/lib/falsy.ts
@@ -1,1 +1,7 @@
 export type FalsyOr<T> = T | boolean | null | undefined;
+
+export function isTruthy<T>(
+  value: T
+): value is Exclude<T, boolean | null | undefined> {
+  return Boolean(value);
+}

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -514,6 +514,62 @@ describe("StatefulForm", () => {
     });
   });
 
+  context("disabled", () => {
+    const INPUT_WITH_DISABLED: FormFieldGroup[] = ALL_INPUT.map((group) =>
+      Array.isArray(group)
+        ? group.map((item) => ({
+            ...item,
+            disabled: true,
+          }))
+        : {
+            ...group,
+            disabled: true,
+          }
+    );
+    context("when given true", () => {
+      it("should render with cursor not-allowed and user-select none", () => {
+        cy.mount(
+          <StatefulForm
+            fields={INPUT_WITH_DISABLED}
+            formValues={allValue}
+            mode="onChange"
+            styles={{
+              containerStyle: css`
+                width: 480px;
+              `,
+            }}
+          />
+        );
+
+        cy.findAllByLabelText("field-lane-wrapper")
+          .should("have.css", "cursor", "not-allowed")
+          .and("have.css", "user-select", "none");
+        cy.findAllByLabelText("chip-input")
+          .should("have.css", "cursor", "not-allowed")
+          .and("have.css", "user-select", "none");
+        cy.findAllByLabelText("file-drop-box-container")
+          .should("have.css", "cursor", "not-allowed")
+          .and("have.css", "user-select", "none");
+      });
+    });
+
+    it("should renders with disabled each input", () => {
+      cy.mount(
+        <StatefulForm
+          fields={INPUT_WITH_DISABLED}
+          formValues={allValue}
+          mode="onChange"
+        />
+      );
+
+      cy.get("input, textarea, [role='radio'], [role='checkbox']").each(
+        ($el) => {
+          cy.wrap($el).should("be.disabled");
+        }
+      );
+    });
+  });
+
   context("label", () => {
     context("labelPosition", () => {
       context("when given labelPosition left", () => {


### PR DESCRIPTION
Description:
Previously, the `Combobox` remained editable even when the `disabled` prop was set to `true`. This pull request fixes that issue by ensuring the `Combobox` becomes non-editable when `disabled`. Additionally, other relevant components within the `StatefulForm` have been updated to respect the `disabled` state consistently. 

Source:
[[Bug] SYST-529: Fix bug setting disabled not working on stateful form's combobox](https://linear.app/systatum/issue/SYST-529/fix-bug-setting-disabled-not-working-on-stateful-forms-combobox)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself