### PR TITLE
[Improvement] SYST-542: Remove `falseyOr` and change to `hidden`

### DIFF
--- a/components/action-button.tsx
+++ b/components/action-button.tsx
@@ -14,6 +14,7 @@ export interface ActionButtonProps {
   variant?: ButtonVariants["variant"];
   className?: string;
   pressed?: boolean;
+  hidden?: boolean;
 }
 
 export interface ActionButtonStylesProps {
@@ -35,7 +36,11 @@ export function ActionButton({
   forTable,
   className,
   pressed,
+  hidden,
 }: ActionButtonProps & { forTable?: boolean }) {
+  if (hidden) {
+    return;
+  }
   return (
     <Button
       onClick={(e) => {

--- a/components/badge.tsx
+++ b/components/badge.tsx
@@ -3,7 +3,6 @@ import { ChangeEvent, HTMLAttributes, MouseEvent } from "react";
 import { strToColor } from "./../lib/code-color";
 import { FigureProps } from "./figure";
 import { Button, ButtonStylesProps } from "./button";
-import { FalsyOr } from "./../lib/falsy";
 
 export type BadgeVariantProps = null | "neutral" | "green" | "yellow" | "red";
 
@@ -20,7 +19,7 @@ export interface BadgeProps
   onClick?: (
     e?: ChangeEvent<HTMLInputElement> | MouseEvent<HTMLDivElement>
   ) => void;
-  actions?: FalsyOr<BadgeActionProps>[];
+  actions?: BadgeActionProps[];
   styles?: BadgeStylesProps;
 }
 
@@ -36,6 +35,7 @@ export interface BadgeActionProps {
   size?: number;
   styles?: ButtonStylesProps;
   title?: string;
+  hidden?: boolean;
 }
 
 const BADGE_BACKGROUND_COLORS: string[] = [
@@ -133,7 +133,7 @@ function Badge({
         : (circleColorLocal ?? "black");
 
   const actionsWithStyles = actions
-    ?.filter((action): action is BadgeActionProps => Boolean(action))
+    ?.filter((action) => !action?.hidden)
     .map((action) => ({
       ...action,
       icon: {

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -19,7 +19,6 @@ import {
   getFloatingPlacement,
 } from "./../lib/floating-placement";
 import { Figure, FigureProps } from "./figure";
-import { FalsyOr } from "./../lib/falsy";
 
 export type ButtonVariants = {
   variant?:
@@ -40,7 +39,7 @@ export type ButtonVariants = {
 
 export interface SubMenuButtonProps {
   list?: (
-    subMenuList: FalsyOr<TipMenuItemProps>[],
+    subMenuList: TipMenuItemProps[],
     withFilter?: { withFilter?: boolean }
   ) => React.ReactNode;
   show?: (

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -9,7 +9,6 @@ import styled, { css, CSSProp } from "styled-components";
 import { ActionButton, ActionButtonProps } from "./action-button";
 import { Togglebox } from "./togglebox";
 import { AnimatePresence, motion } from "framer-motion";
-import { FalsyOr } from "./../lib/falsy";
 
 export interface CardProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "title" | "style"> {
@@ -54,9 +53,7 @@ export interface CardStylesProps {
   subtitleStyle?: CSSProp;
 }
 
-export type CardActionsProps = FalsyOr<CardInternalActionsProps>;
-
-type CardInternalActionsProps = ActionButtonProps;
+export type CardActionsProps = ActionButtonProps;
 
 function Card({
   children,
@@ -76,9 +73,7 @@ function Card({
   ...props
 }: CardProps) {
   const filteredHeaderActions = Array.isArray(headerActions)
-    ? headerActions?.filter((action): action is CardInternalActionsProps =>
-        Boolean(action)
-      )
+    ? headerActions?.filter((action) => !action?.hidden)
     : [];
 
   const hasActions = filteredHeaderActions.length > 0;

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -28,7 +28,6 @@ import { Textbox } from "./textbox";
 import styled, { css, CSSProp } from "styled-components";
 import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
-import { isTruthy } from "./../lib/falsy";
 
 export type ChipActionsProps = BadgeActionProps;
 
@@ -605,20 +604,22 @@ function ChipsItem({
   inputRef?: RefObject<HTMLInputElement>;
 }) {
   const finalValueActions =
-    badge.actions?.filter(isTruthy).map((action) => ({
-      ...action,
-      styles: {
-        self: css`
-          opacity: 0;
-          ${hovered === badge.id &&
-          css`
-            opacity: 1;
-          `}
-        `,
-      },
-      size: 14,
-      onClick: () => action.onClick && action.onClick?.(badge),
-    })) ?? [];
+    badge.actions
+      ?.filter((action) => !action?.hidden)
+      .map((action) => ({
+        ...action,
+        styles: {
+          self: css`
+            opacity: 0;
+            ${hovered === badge.id &&
+            css`
+              opacity: 1;
+            `}
+          `,
+        },
+        size: 14,
+        onClick: () => action.onClick && action.onClick?.(badge),
+      })) ?? [];
 
   return (
     <ChipItemWrapper

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -23,7 +23,6 @@ import { List, ListItemStylesProps } from "./list";
 import { FieldLaneProps } from "./field-lane";
 import { Figure, FigureProps } from "./figure";
 import { StatefulForm } from "./stateful-form";
-import { FalsyOr } from "./../lib/falsy";
 
 interface BaseComboboxProps {
   selectedOptions?: SelectboxSelectedOptions;
@@ -56,13 +55,12 @@ export interface ComboboxStylesProps
   labelStyle?: CSSProp;
 }
 
-export type ComboboxActionProps = FalsyOr<ComboboxInternalActionProps>;
-
-export interface ComboboxInternalActionProps {
+export interface ComboboxActionProps {
   onClick?: () => void;
   icon?: FigureProps;
   title: string;
   styles?: ComboboxActionStylesProps;
+  hidden?: boolean;
 }
 
 export type ComboboxActionStylesProps = ListItemStylesProps;
@@ -311,9 +309,7 @@ function ComboboxDrawer({
   }, [highlightedIndex, multiple]);
 
   const filteredActions = Array.isArray(actions)
-    ? actions?.filter((action): action is ComboboxInternalActionProps =>
-        Boolean(action)
-      )
+    ? actions?.filter((action) => !action?.hidden)
     : [];
 
   const hasActions = filteredActions.length > 0;

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -5,7 +5,6 @@ import { Button } from "./button";
 import { StatefulForm } from "./stateful-form";
 import { Tooltip } from "./tooltip";
 import { Figure, FigureProps } from "./figure";
-import { FalsyOr } from "./../lib/falsy";
 
 export interface FieldLaneProps {
   label?: string;
@@ -33,20 +32,17 @@ export interface FieldLaneStylesProps {
   bodyStyle?: CSSProp;
 }
 
-export type FieldLaneActionsProps = FalsyOr<FieldLaneInternalActionsProps>;
-
-interface FieldLaneInternalActionsProps {
+export interface FieldLaneActionsProps {
   title?: string;
   icon?: FigureProps;
   iconColor?: string;
   onClick?: (e: React.MouseEvent) => void;
   disabled?: boolean;
   titleShowDelay?: number;
+  hidden?: boolean;
 }
 
-export type FieldLaneDropdownProps = FalsyOr<FieldLaneDropdownInternalProps>;
-
-interface FieldLaneDropdownInternalProps {
+export interface FieldLaneDropdownProps {
   disabled?: boolean;
   options?: FieldLaneDropdownsOptionProps[];
   caption?: string;
@@ -58,6 +54,7 @@ interface FieldLaneDropdownInternalProps {
     render?: (children?: ReactNode) => ReactNode;
     setCaption?: (caption?: string) => void;
   }) => ReactNode;
+  hidden?: boolean;
 }
 
 export interface FieldLaneDropdownStylesProps {
@@ -91,9 +88,7 @@ function FieldLane({
   required,
 }: FieldLaneProps) {
   const filteredActions = Array.isArray(actions)
-    ? actions?.filter((action): action is FieldLaneInternalActionsProps =>
-        Boolean(action)
-      )
+    ? actions?.filter((action) => !action?.hidden)
     : [];
 
   const hasActions = filteredActions.length > 0;
@@ -102,9 +97,7 @@ function FieldLane({
     <InputWrapper $style={styles?.controlStyle}>
       {Array.isArray(dropdowns) &&
         dropdowns
-          ?.filter((dropdown): dropdown is FieldLaneDropdownInternalProps =>
-            Boolean(dropdown)
-          )
+          ?.filter((dropdown) => !dropdown?.hidden)
           ?.map((dropdown, index) => {
             return (
               <Button

--- a/components/list.tsx
+++ b/components/list.tsx
@@ -30,7 +30,6 @@ import ContextMenu, { ContextMenuActionsProps } from "./context-menu";
 import { ActionButton, ActionButtonProps } from "./action-button";
 import { OverlayBlocker } from "./overlay-blocker";
 import { Figure, FigureProps } from "./figure";
-import { FalsyOr } from "./../lib/falsy";
 
 export interface ListProps extends ListMaxItemsProp {
   searchable?: boolean;
@@ -67,7 +66,7 @@ export interface ListOnOpenProps {
   isOpen?: boolean;
 }
 
-export type ListItemActionProps = FalsyOr<ContextMenuActionsProps>;
+export type ListItemActionProps = ContextMenuActionsProps;
 
 interface ListAlwaysShowDragIconProp {
   alwaysShowDragIcon?: boolean;
@@ -362,9 +361,7 @@ const ListContainer = styled.div<{ $containerStyle?: CSSProp }>`
   ${(props) => props.$containerStyle}
 `;
 
-export type ListGroupActionsProps = FalsyOr<ListGroupInternalActionsProps>;
-
-interface ListGroupInternalActionsProps
+export interface ListGroupActionsProps
   extends Omit<ActionButtonProps, "onClick"> {
   onClick?: (e?: string) => void;
 }
@@ -442,9 +439,7 @@ function ListGroup({
   const opened = isOpen(id, "group");
 
   const filteredActions = Array.isArray(actions)
-    ? actions?.filter((action): action is ListGroupInternalActionsProps =>
-        Boolean(action)
-      )
+    ? actions?.filter((action) => !action?.hidden)
     : [];
 
   const hasActions = filteredActions?.length > 0;
@@ -1132,9 +1127,7 @@ const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
                   const listActions = actions(idFullname);
 
                   const actionsWithIcons = listActions
-                    ?.filter((action): action is ContextMenuActionsProps =>
-                      Boolean(action)
-                    )
+                    ?.filter((action) => !action?.hidden)
                     .map((action) => ({
                       ...action,
                       icon: {

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -14,7 +14,6 @@ import { TipMenuItemProps } from "./tip-menu";
 import { Tooltip, TooltipRef } from "./tooltip";
 import { ActionButton, ActionButtonProps } from "./action-button";
 import { Figure, FigureProps } from "./figure";
-import { FalsyOr } from "./../lib/falsy";
 
 export interface NavTabProps {
   tabs?: NavTabContentProps[];
@@ -37,17 +36,13 @@ export interface NavTabStylesProps {
   boxStyle?: CSSProp;
 }
 
-export type NavTabActionsProps = FalsyOr<NavTabInternalActionsProps>;
-
-interface NavTabInternalActionsProps extends ActionButtonProps {
+export interface NavTabActionsProps extends ActionButtonProps {
   active?: boolean;
 }
 
 export type NavTabSize = "md" | "sm";
 
-export type NavTabContentProps = FalsyOr<NavTabContentInternalProps>;
-
-interface NavTabContentInternalProps {
+export interface NavTabContentProps {
   id: string;
   title: string;
   content?: ReactNode;
@@ -57,20 +52,16 @@ interface NavTabContentInternalProps {
   hidden?: boolean;
 }
 
-export type NavTabSubItemsContentProps =
-  FalsyOr<NavTabSubItemsContentInternalProps>;
-
-interface NavTabSubItemsContentInternalProps {
+export interface NavTabSubItemsContentProps {
   id: string;
   caption: string;
   icon?: FigureProps;
   onClick?: () => void;
   content?: ReactNode;
+  hidden?: boolean;
 }
 
-export type SubMenuNavTab = FalsyOr<SubMenuInternalNavTab>;
-
-interface SubMenuInternalNavTab extends Omit<TipMenuItemProps, "onClick"> {
+export interface SubMenuNavTab extends Omit<TipMenuItemProps, "onClick"> {
   onClick: (id?: string) => void;
 }
 
@@ -101,14 +92,7 @@ function NavTab({
   const isControlled = activeTab !== undefined && onChange;
   const selected = isControlled ? activeTab : selectedLocal;
 
-  const finalTabs = tabs?.filter((tab): tab is NavTabContentInternalProps =>
-    Boolean(tab)
-  );
-
-  const visibleTabs = useMemo(
-    () => finalTabs.filter((tab) => !tab.hidden),
-    [finalTabs]
-  );
+  const visibleTabs = useMemo(() => tabs.filter((tab) => !tab.hidden), [tabs]);
 
   const getHoverPosition = () => {
     if (!isInitialized || tabSizes.length === 0) {
@@ -119,9 +103,7 @@ function NavTab({
       (tab) =>
         tab.id === selected ||
         tab.subItems
-          ?.filter((tab): tab is NavTabSubItemsContentInternalProps =>
-            Boolean(tab)
-          )
+          ?.filter((tab) => !tab?.hidden)
           ?.some((item) => item.id === selected)
     );
 
@@ -177,13 +159,11 @@ function NavTab({
   };
 
   const hoverPosition = getHoverPosition();
-  const filteredTabs = finalTabs.filter(
+  const filteredTabs = tabs.filter(
     (tab) =>
       tab.id === selected ||
       tab.subItems
-        ?.filter((item): item is NavTabSubItemsContentInternalProps =>
-          Boolean(item)
-        )
+        ?.filter((item) => !item?.hidden)
         .some((item) => item.id === selected)
   );
 
@@ -259,10 +239,7 @@ function NavTab({
                   <>
                     {tab.subItems &&
                       tab.subItems
-                        ?.filter(
-                          (item): item is NavTabSubItemsContentInternalProps =>
-                            Boolean(item)
-                        )
+                        ?.filter((item) => !item?.hidden)
                         ?.map((item, idx) => (
                           <NavTabItem
                             key={idx}
@@ -322,9 +299,7 @@ function NavTab({
                     (() => {
                       const listActions = tab.actions;
                       const actionsWithIcons = listActions
-                        ?.filter((action): action is SubMenuInternalNavTab =>
-                          Boolean(action)
-                        )
+                        ?.filter((action) => !action?.hidden)
                         ?.map((action) => ({
                           ...action,
                           icon: {
@@ -403,9 +378,7 @@ function NavTab({
             `}
           >
             {actions
-              .filter(
-                (action): action is NavTabInternalActionsProps => !!action
-              )
+              .filter((action) => !action?.hidden)
               .map((action, index) => {
                 return (
                   <ActionButton
@@ -434,9 +407,7 @@ function NavTab({
       <NavContent $contentStyle={styles?.contentStyle}>
         {filteredTabs.map((tab, index) => {
           const selectedSubItem = tab.subItems
-            ?.filter((item): item is NavTabSubItemsContentInternalProps =>
-              Boolean(item)
-            )
+            ?.filter((item) => !item?.hidden)
             ?.find((subItem) => subItem.id === selected);
           if (selectedSubItem) {
             return <Fragment key={index}>{selectedSubItem.content}</Fragment>;

--- a/components/statusbar.tsx
+++ b/components/statusbar.tsx
@@ -2,7 +2,6 @@ import styled, { css, CSSProp } from "styled-components";
 import { Figure, FigureProps } from "./figure";
 import { ReactNode } from "react";
 import { Button, ButtonProps } from "./button";
-import { FalsyOr } from "@/lib/falsy";
 
 export interface StatusbarProps {
   styles?: StatusbarStylesProps;
@@ -76,39 +75,36 @@ const renderSection = (
 
   return (
     <ActionWrapper aria-label="statusbar-content-wrapper" $style={style}>
-      {items.filter(isValidStatusbarItem).map((component, index) => (
-        <StatusbarItem
-          key={index}
-          {...component}
-          styles={{
-            self: css`
-              ${itemStyle}
-              ${component?.styles?.self}
-            `,
-          }}
-          size={size}
-          transparent={transparent}
-          activeBackgroundColor={activeBackgroundColor}
-          hoverBackgroundColor={hoverBackgroundColor}
-        />
-      ))}
+      {items
+        .filter((item) => !item?.hidden)
+        .map((component, index) => (
+          <StatusbarItem
+            key={index}
+            {...component}
+            styles={{
+              self: css`
+                ${itemStyle}
+                ${component?.styles?.self}
+              `,
+            }}
+            size={size}
+            transparent={transparent}
+            activeBackgroundColor={activeBackgroundColor}
+            hoverBackgroundColor={hoverBackgroundColor}
+          />
+        ))}
     </ActionWrapper>
   );
 };
 
-const isValidStatusbarItem = (
-  component?: StatusbarItemInternalProps
-): component is StatusbarItemInternalProps => Boolean(component);
-
-type StatusbarItemProps = FalsyOr<StatusbarItemInternalProps>;
-
-interface StatusbarItemInternalProps {
+export interface StatusbarItemProps {
   text?: string;
   icon?: FigureProps;
   render?: ReactNode;
   button?: ButtonProps;
   styles?: StatusbarItemStylesProps;
   width?: string;
+  hidden?: boolean;
 }
 
 interface StatusbarItemStylesProps {
@@ -126,7 +122,7 @@ function StatusbarItem({
   size,
   width,
   transparent,
-}: StatusbarItemInternalProps & {
+}: StatusbarItemProps & {
   activeBackgroundColor?: string;
   hoverBackgroundColor?: string;
   size?: number;

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -32,7 +32,6 @@ import { Capsule, CapsuleProps } from "./capsule";
 import ContextMenu from "./context-menu";
 import { ActionButton, ActionButtonProps } from "./action-button";
 import { OverlayBlocker } from "./overlay-blocker";
-import { FalsyOr } from "./../lib/falsy";
 
 export type RowData = (string | ReactNode)[];
 
@@ -44,9 +43,7 @@ export interface ColumnTableProps {
   id: string;
 }
 
-export type TableActionsProps = FalsyOr<TableInternalActionsProps>;
-
-interface TableInternalActionsProps extends ActionButtonProps {
+export interface TableActionsProps extends ActionButtonProps {
   type?: "button" | "capsule";
   capsuleProps?: CapsuleProps;
 }
@@ -82,7 +79,7 @@ export interface TableProps {
   searchbox?: SearchboxProps;
 }
 
-export type SubMenuListTableProps = FalsyOr<TipMenuItemProps>;
+export type SubMenuListTableProps = TipMenuItemProps;
 
 export interface TableStylesProps {
   containerStyle?: CSSProp;
@@ -308,9 +305,7 @@ function Table({
   }, [openRowId]);
 
   const filteredActions = Array.isArray(actions)
-    ? actions?.filter((action): action is TableInternalActionsProps =>
-        Boolean(action)
-      )
+    ? actions?.filter((action) => !action?.hidden)
     : [];
 
   const hasActions = filteredActions.length > 0;
@@ -995,7 +990,7 @@ export interface TableRowProps {
   handleSelect?: (data: string) => void;
   rowId?: string;
   children?: ReactNode;
-  actions?: (columnCaption: string) => FalsyOr<TipMenuItemProps>[];
+  actions?: (columnCaption: string) => TipMenuItemProps[];
   onClick?: (args?: {
     toggleCheckbox: () => void;
     isFirstClick?: boolean;

--- a/components/tip-menu.tsx
+++ b/components/tip-menu.tsx
@@ -4,13 +4,12 @@ import React, { ReactNode, useMemo, useState } from "react";
 import { Button } from "./button";
 import { Searchbox } from "./searchbox";
 import { Figure, FigureProps } from "./figure";
-import { FalsyOr } from "./../lib/falsy";
 
 export type TipMenuItemVariantType = "sm" | "md";
 
 export interface TipMenuProps {
   children?: ReactNode;
-  subMenuList?: FalsyOr<TipMenuItemProps>[];
+  subMenuList?: TipMenuItemProps[];
   setIsOpen?: () => void;
   variant?: TipMenuItemVariantType;
   withFilter?: boolean;
@@ -88,6 +87,7 @@ function TipMenu({
           icon={menu.icon}
           isDangerous={menu.isDangerous}
           className={menu.className}
+          hidden={menu.hidden}
           onClick={(e) => {
             e.stopPropagation();
 
@@ -110,6 +110,7 @@ export interface TipMenuItemProps {
   isDangerous?: boolean;
   variant?: TipMenuItemVariantType;
   className?: string;
+  hidden?: boolean;
 }
 
 function TipMenuItem({
@@ -119,7 +120,12 @@ function TipMenuItem({
   isDangerous = false,
   variant,
   className,
+  hidden,
 }: TipMenuItemProps) {
+  if (hidden) {
+    return;
+  }
+
   return (
     <StyledTipMenuItem
       $variant={variant}

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -20,7 +20,6 @@ import {
 } from "@floating-ui/react";
 import styled, { css, CSSProp } from "styled-components";
 import { Figure, FigureProps } from "./figure";
-import { FalsyOr } from "./../lib/falsy";
 
 export interface ToolbarProps {
   children: ReactNode;
@@ -46,7 +45,7 @@ export interface ToolbarMenuProps {
   iconSize?: number;
 }
 
-export type ToolbarSubMenuProps = FalsyOr<TipMenuItemProps>;
+export type ToolbarSubMenuProps = TipMenuItemProps;
 
 export interface ToolbarMenuSylesProps {
   dropdownStyle?: CSSProp;

--- a/components/treelist.tsx
+++ b/components/treelist.tsx
@@ -13,7 +13,6 @@ import { LoadingSpinner } from "./loading-spinner";
 import { SubMenuButtonProps } from "./button";
 import { Tooltip } from "./tooltip";
 import { Figure, FigureProps } from "./figure";
-import { FalsyOr } from "./../lib/falsy";
 
 export interface TreeListProps
   extends Omit<
@@ -68,10 +67,7 @@ export interface TreeListContentProps {
   actions?: TreeListContentActionsProps[];
 }
 
-export type TreeListContentActionsProps =
-  FalsyOr<TreeListContentInternalActions>;
-
-interface TreeListContentInternalActions
+export interface TreeListContentActionsProps
   extends Omit<ContextMenuActionsProps, "onClick"> {
   onClick?: (id?: string) => void;
 }
@@ -89,9 +85,7 @@ export interface TreeListItemsProps {
   initialState?: TreeListInitialState;
 }
 
-export type TreeListItemsActionsProps = FalsyOr<TreeListItemInternalActions>;
-
-interface TreeListItemInternalActions
+export interface TreeListItemsActionsProps
   extends Omit<ContextMenuActionsProps, "onClick"> {
   onClick?: (id?: string) => void;
 }
@@ -101,15 +95,14 @@ export interface TreeListItemsOnClickProps {
   preventDefault?: () => void;
 }
 
-export type TreeListActionsProps = FalsyOr<TreeListInternalActionsProps>;
-
-interface TreeListInternalActionsProps {
+export interface TreeListActionsProps {
   id: string;
   caption?: string;
   onClick?: (props?: { setActive?: (prop: boolean) => void }) => void;
   icon?: FigureProps;
   styles?: { self?: CSSProp };
   subMenu?: (props: SubMenuTreeListProps) => ReactNode;
+  hidden?: boolean;
 }
 
 type SubMenuTreeListProps = Omit<SubMenuButtonProps, "list">;
@@ -232,9 +225,7 @@ function TreeList({
   const selectedGroupId = findGroupOfItem(content, isSelected);
 
   const filteredActions = Array.isArray(actions)
-    ? actions?.filter((action): action is TreeListInternalActionsProps =>
-        Boolean(action)
-      )
+    ? actions?.filter((action) => !action?.hidden)
     : [];
 
   const hasActions = filteredActions.length > 0;
@@ -390,10 +381,7 @@ function TreeList({
                       const listActions = item.actions;
 
                       const actionsWithIcons = item.actions
-                        ?.filter(
-                          (action): action is TreeListContentInternalActions =>
-                            Boolean(action)
-                        )
+                        ?.filter((action) => !action?.hidden)
                         .map((action) => ({
                           ...action,
                           icon: {
@@ -958,9 +946,7 @@ function TreeListItem<T extends TreeListItemsProps>({
             const listActions = item.actions;
 
             const actionsWithIcons = item.actions
-              ?.filter((action): action is TreeListItemInternalActions =>
-                Boolean(action)
-              )
+              ?.filter((action) => !action?.hidden)
               .map((action) => ({
                 ...action,
                 icon: {

--- a/components/window.tsx
+++ b/components/window.tsx
@@ -17,7 +17,6 @@ import styled, { css, CSSProp } from "styled-components";
 import { Button, ButtonStylesProps } from "./button";
 import { Figure, FigureProps } from "./figure";
 import { RiCloseLine } from "@remixicon/react";
-import { FalsyOr } from "./../lib/falsy";
 
 export interface WindowProps {
   orientation?: "horizontal" | "vertical";
@@ -37,7 +36,7 @@ export interface WindowCellProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "style"> {
   children?: ReactNode;
   styles?: WindowCellStylesProps;
-  actions?: FalsyOr<WindowActionProps>[];
+  actions?: WindowActionProps[];
 }
 
 export interface WindowCellStylesProps {
@@ -48,6 +47,7 @@ export interface WindowActionProps {
   onClick?: () => void;
   icon?: FigureProps;
   styles?: WindowActionStylesProps;
+  hidden?: boolean;
 }
 
 export type WindowActionStylesProps = ButtonStylesProps;
@@ -257,9 +257,7 @@ const WindowCell = forwardRef<HTMLDivElement, WindowCellProps>(
     } = props as WindowCellInternalProps;
 
     const filteredActions = Array.isArray(actions)
-      ? actions?.filter((action): action is WindowActionProps =>
-          Boolean(action)
-        )
+      ? actions?.filter((action) => !action?.hidden)
       : [];
 
     const hasActions = filteredActions.length > 0;

--- a/generate-export.cjs
+++ b/generate-export.cjs
@@ -56,10 +56,6 @@ const additionalExports = {
     import: "./dist/lib/floating-placement.js",
     types: "./dist/lib/floating-placement.d.ts",
   },
-  "./falsy": {
-    import: "./dist/lib/falsy.js",
-    types: "./dist/lib/falsy.d.ts",
-  },
   "./text": {
     import: "./dist/lib/text.js",
     types: "./dist/lib/text.d.ts",

--- a/lib/falsy.ts
+++ b/lib/falsy.ts
@@ -1,7 +1,0 @@
-export type FalsyOr<T> = T | boolean | null | undefined;
-
-export function isTruthy<T>(
-  value: T
-): value is Exclude<T, boolean | null | undefined> {
-  return Boolean(value);
-}

--- a/package.json
+++ b/package.json
@@ -289,10 +289,6 @@
       "import": "./dist/lib/floating-placement.js",
       "types": "./dist/lib/floating-placement.d.ts"
     },
-    "./falsy": {
-      "import": "./dist/lib/falsy.js",
-      "types": "./dist/lib/falsy.d.ts"
-    },
     "./text": {
       "import": "./dist/lib/text.js",
       "types": "./dist/lib/text.d.ts"

--- a/test/component/badge.cy.tsx
+++ b/test/component/badge.cy.tsx
@@ -1,7 +1,6 @@
 import { RiCheckLine, RiCloseLine } from "@remixicon/react";
 import { Badge, BadgeActionProps } from "./../../components/badge";
 import { strToColor } from "./../../lib/code-color";
-import { FalsyOr } from "./../../lib/falsy";
 
 describe("Badge", () => {
   function BadgeDefault() {
@@ -115,8 +114,9 @@ describe("Badge", () => {
       },
     ];
 
-    const contentWithFalsyActions: FalsyOr<BadgeActionProps>[] = [
-      false && {
+    const contentWithHiddenActions: BadgeActionProps[] = [
+      {
+        hidden: true,
         icon: { image: RiCheckLine },
         onClick: () => {
           console.log("Data was deleted");
@@ -132,12 +132,12 @@ describe("Badge", () => {
       },
     ];
 
-    context("when given with falsy", () => {
-      it("renders action button when not falsy", () => {
+    context("when given with hidden", () => {
+      it("renders action button when not hidden", () => {
         cy.mount(
           <Badge
             withCircle
-            actions={contentWithFalsyActions}
+            actions={contentWithHiddenActions}
             caption="With Actions"
           />
         );

--- a/test/component/card.cy.tsx
+++ b/test/component/card.cy.tsx
@@ -271,8 +271,8 @@ describe("Card", () => {
       cy.findByLabelText("action-button-icon").should("not.exist");
     });
 
-    context("when given falsy action", () => {
-      it("should render without falsy action", () => {
+    context("when given hidden action", () => {
+      it("should render without hidden action", () => {
         cy.mount(
           <ProductCard
             headerActions={[
@@ -283,7 +283,8 @@ describe("Card", () => {
                   console.log(`Edit button was clicked`);
                 },
               },
-              false && {
+              {
+                hidden: true,
                 caption: "Delete fields",
                 icon: { image: RiDeleteBack2Fill },
                 onClick: () => {

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -252,7 +252,8 @@ describe("Combobox", () => {
           image: RiAddLine,
         },
       },
-      false && {
+      {
+        hidden: true,
         title: "Delete Fruit",
         onClick: () => {},
         icon: {
@@ -276,8 +277,8 @@ describe("Combobox", () => {
       cy.findByText("Add Fruit").should("exist");
     });
 
-    context("when given with falsy field", () => {
-      it("renders without falsy action", () => {
+    context("when given with hidden field", () => {
+      it("renders without hidden action", () => {
         cy.mount(
           <ProductCombobox
             options={null}

--- a/test/component/field-lane.cy.tsx
+++ b/test/component/field-lane.cy.tsx
@@ -93,8 +93,8 @@ describe("FieldLane", () => {
       );
     });
 
-    context("when given with falsy field", () => {
-      it("renders without falsy dropdown", () => {
+    context("when given with hidden field", () => {
+      it("renders without hidden dropdown", () => {
         cy.mount(
           <FieldLane
             dropdowns={[
@@ -131,7 +131,8 @@ describe("FieldLane", () => {
                   },
                 ],
               },
-              false && {
+              {
+                hidden: true,
                 caption: "False Dropdown",
                 options: [
                   {

--- a/test/component/list.cy.tsx
+++ b/test/component/list.cy.tsx
@@ -1747,7 +1747,8 @@ describe("List", () => {
             console.log(`action was clicked ${id}`);
           },
         },
-        false && {
+        {
+          hidden: true,
           caption: "Edit",
           icon: { image: RiArrowRightSLine },
           onClick: () => {
@@ -1860,8 +1861,8 @@ describe("List", () => {
           });
       });
 
-      context("when given with falsy field", () => {
-        it("renders without falsy action", () => {
+      context("when given with hidden field", () => {
+        it("renders without hidden action", () => {
           cy.mount(
             <List
               searchable
@@ -2054,7 +2055,8 @@ describe("List", () => {
             console.log(`action was clicked ${id}`);
           },
         },
-        false && {
+        {
+          hidden: true,
           caption: "False",
           onClick: (id: string) => {
             console.log(`action was false ${id}`);

--- a/test/component/nav-tab.cy.tsx
+++ b/test/component/nav-tab.cy.tsx
@@ -27,8 +27,8 @@ describe("NavTab", () => {
   ];
 
   context("tabs", () => {
-    context("when given falsy", () => {
-      it("renders without falsy tab", () => {
+    context("when given hidden", () => {
+      it("renders without hidden tab", () => {
         cy.mount(<NavTab tabs={TABS_ITEMS} activeTab={"2"} />);
         cy.findAllByLabelText("nav-tab-item").should("have.length", 2);
         cy.findByText("Write").should("exist");
@@ -298,7 +298,8 @@ describe("NavTab", () => {
       return (
         <NavTab
           actions={[
-            false && {
+            {
+              hidden: true,
               caption: "Settings",
               icon: { image: RiSettings5Line },
               onClick: () => {
@@ -343,8 +344,8 @@ describe("NavTab", () => {
       });
     });
 
-    context("when given with falsy", () => {
-      it("should render without falsy actions", () => {
+    context("when given with hidden", () => {
+      it("should render without hidden actions", () => {
         cy.window().then((win) => {
           cy.spy(win.console, "log").as("consoleLog");
         });
@@ -370,8 +371,9 @@ describe("NavTab", () => {
             content: "This is chart content",
             onClick: () => console.log("chart was clicked"),
           },
-          false && {
+          {
             id: "2-2",
+            hidden: true,
             icon: { image: RiProfileFill },
             caption: "Identity",
             content: "This is identity content",
@@ -395,8 +397,8 @@ describe("NavTab", () => {
       cy.get("@consoleLog").should("have.been.calledWith", "chart was clicked");
     });
 
-    context("when given with falsy subitem", () => {
-      it("renders without falsy subitem", () => {
+    context("when given with hidden subitem", () => {
+      it("renders without hidden subitem", () => {
         cy.mount(<NavTab tabs={tabsWithSubItems} activeTab={"2"} />);
         cy.findByText("This is review content").should("exist");
         cy.findByText("Review").realHover();
@@ -590,7 +592,8 @@ const TABS_ITEMS: NavTabContentProps[] = [
       },
     ],
   },
-  false && {
+  {
+    hidden: true,
     id: "3",
     title: "Empty",
     content: "Empty",

--- a/test/component/statusbar.cy.tsx
+++ b/test/component/statusbar.cy.tsx
@@ -461,6 +461,31 @@ describe("Statusbar", () => {
           cy.findByText("This is the button").should("exist");
         });
       });
+
+      context("when given hidden", () => {
+        it("should render without hidden button", () => {
+          cy.mount(
+            <ProductStatusbar
+              transparent={false}
+              content={{
+                left: [
+                  {
+                    text: "Test",
+                  },
+                  {
+                    hidden: true,
+                    text: "Hidden",
+                  },
+                ],
+              }}
+            />
+          );
+          cy.findAllByLabelText("statusbar-text-wrapper").eq(0).should("exist");
+          cy.findAllByLabelText("statusbar-text-wrapper")
+            .eq(1)
+            .should("not.exist");
+        });
+      });
     });
 
     context("button", () => {
@@ -482,6 +507,33 @@ describe("Statusbar", () => {
         cy.findByLabelText("statusbar-button")
           .should("exist")
           .and("have.css", "background-color", "rgb(236, 236, 236)");
+      });
+
+      context("when given hidden", () => {
+        it("should render without hidden button", () => {
+          cy.mount(
+            <ProductStatusbar
+              transparent={false}
+              content={{
+                left: [
+                  {
+                    button: {
+                      children: "Button",
+                    },
+                  },
+                  {
+                    hidden: true,
+                    button: {
+                      children: "Button",
+                    },
+                  },
+                ],
+              }}
+            />
+          );
+          cy.findAllByLabelText("statusbar-button").eq(0).should("exist");
+          cy.findAllByLabelText("statusbar-button").eq(1).should("not.exist");
+        });
       });
     });
   });

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -892,7 +892,8 @@ describe("Table", () => {
           console.log(`${rowId} was deleted`);
         },
       },
-      false && {
+      {
+        hidden: true,
         caption: "Arhive",
         icon: { image: RiArchive2Fill, color: "gray" },
         onClick: () => {
@@ -2042,8 +2043,8 @@ describe("Table", () => {
         );
       });
 
-      context("when given with falsy field", () => {
-        it("renders without falsy action", () => {
+      context("when given with hidden field", () => {
+        it("renders without hidden action", () => {
           cy.mount(<TableWithRowActions actions={ROW_ACTIONS} />);
 
           cy.findAllByLabelText("table-row").eq(2).trigger("mouseover");

--- a/test/component/tip-menu.cy.tsx
+++ b/test/component/tip-menu.cy.tsx
@@ -35,6 +35,28 @@ describe("TipMenu", () => {
     ];
   });
 
+  context("when given hidden action", () => {
+    it("should render without hidden action", () => {
+      cy.mount(
+        <TipMenu
+          subMenuList={[
+            {
+              caption: "Sender",
+              icon: { image: RiShieldLine, color: "orange" },
+              isDangerous: true,
+            },
+            {
+              caption: "Read",
+              hidden: true,
+            },
+          ]}
+        />
+      );
+      cy.findAllByLabelText("tip-menu-icon").should("have.length", 1);
+      cy.findAllByLabelText("tip-menu-item").should("have.length", 1);
+    });
+  });
+
   context("when given item without icon", () => {
     it("should be renders the tip menu and only display caption", () => {
       cy.mount(

--- a/test/component/toolbar.cy.tsx
+++ b/test/component/toolbar.cy.tsx
@@ -57,7 +57,8 @@ describe("Toolbar", () => {
       isDangerous: true,
       onClick: () => console.log("Shared"),
     },
-    false && {
+    {
+      hidden: true,
       caption: "Edit",
       icon: { image: RiEditLine, color: "yellow" },
       onClick: () => console.log("Edit mode"),
@@ -165,8 +166,8 @@ describe("Toolbar", () => {
           });
       });
 
-      context("when given with falsy", () => {
-        it("should not show falsy item", () => {
+      context("when given with hidden", () => {
+        it("should not show hidden item", () => {
           cy.viewport(800, 700);
           cy.mount(
             <Toolbar>

--- a/test/component/treelist.cy.tsx
+++ b/test/component/treelist.cy.tsx
@@ -302,7 +302,8 @@ describe("Treelist", () => {
             onClick: onMention,
             icon: { image: RiAtLine },
           },
-          false && {
+          {
+            hidden: true,
             id: "test",
             caption: "Test",
             icon: { image: RiAtLine },
@@ -328,8 +329,8 @@ describe("Treelist", () => {
         });
       });
 
-      context("when given with falsy field", () => {
-        it("renders without falsy content", () => {
+      context("when given with hidden field", () => {
+        it("renders without hidden content", () => {
           cy.mount(
             <TreeList
               content={TREE_LIST_DATA}

--- a/test/component/window.cy.tsx
+++ b/test/component/window.cy.tsx
@@ -39,7 +39,8 @@ describe("Window", () => {
           onMouseLeave={() => console.log("now is leaving window-cell")}
           onClick={() => console.log("now is clicking window-cell")}
           actions={[
-            false && {
+            {
+              hidden: true,
               icon: {
                 image: RiCloseFill,
               },
@@ -56,8 +57,8 @@ describe("Window", () => {
       );
     }
     context("actions", () => {
-      context("when given with falsy", () => {
-        it("should ignore falsy actions", () => {
+      context("when given with hidden", () => {
+        it("should ignore hidden actions", () => {
           cy.mount(<WindowCellDefault />);
           cy.findAllByLabelText("window-button").should("have.length", 1);
         });


### PR DESCRIPTION
Description:
This pull request refactors the system's usage of the `falsyOr` interface by replacing it with `hidden`. Previously, this implementation caused improper behavior and reduced usability of the `options` props.

Source:
[[Improvement] SYST-542: Remove `falseyOr` and change to `hidden`](https://linear.app/systatum/issue/SYST-542/remove-falseyor-and-change-to-hidden)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself