### PR TITLE
[Improvement] SYST-597: Standardizing interface and field names

### DIFF
--- a/components/action-button.tsx
+++ b/components/action-button.tsx
@@ -1,15 +1,17 @@
 import { css, CSSProp } from "styled-components";
-import { Button, ButtonVariants, SubMenuButtonProps } from "./button";
+import { Button, ButtonVariants, ButtonSubMenu } from "./button";
 import { ReactNode } from "react";
 import { FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
+
+export type ActionButtonSubMenu = ButtonSubMenu;
 
 export interface ActionButtonProps {
   caption?: string;
   icon?: FigureProps;
   onClick?: () => void;
-  styles?: ActionButtonStylesProps;
-  subMenu?: (props: SubMenuButtonProps) => ReactNode;
+  styles?: ActionButtonStyles;
+  subMenu?: (props: ActionButtonSubMenu) => ReactNode;
   disabled?: boolean;
   showSubMenuOn?: "caret" | "self";
   variant?: ButtonVariants["variant"];
@@ -18,7 +20,7 @@ export interface ActionButtonProps {
   hidden?: boolean;
 }
 
-export interface ActionButtonStylesProps {
+export interface ActionButtonStyles {
   self?: CSSProp;
   toggleStyle?: CSSProp;
   dividerStyle?: CSSProp;

--- a/components/action-button.tsx
+++ b/components/action-button.tsx
@@ -3,14 +3,14 @@ import {
   Button,
   ButtonVariants,
   ButtonSubMenu,
-  ButtonShowSubMenuOn,
+  ButtonShowSubMenuPosition,
 } from "./button";
 import { ReactNode } from "react";
 import { FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 
 export type ActionButtonSubMenu = ButtonSubMenu;
-export type ActionButtonShowSubMenuOn = ButtonShowSubMenuOn;
+export type ActionButtonShowSubMenuPosition = ButtonShowSubMenuPosition;
 
 export interface ActionButtonProps {
   caption?: string;
@@ -19,7 +19,7 @@ export interface ActionButtonProps {
   styles?: ActionButtonStyles;
   subMenu?: (props: ActionButtonSubMenu) => ReactNode;
   disabled?: boolean;
-  showSubMenuOn?: ActionButtonShowSubMenuOn;
+  showSubMenuOn?: ActionButtonShowSubMenuPosition;
   variant?: ButtonVariants["variant"];
   className?: string;
   pressed?: boolean;

--- a/components/action-button.tsx
+++ b/components/action-button.tsx
@@ -1,10 +1,16 @@
 import { css, CSSProp } from "styled-components";
-import { Button, ButtonVariants, ButtonSubMenu } from "./button";
+import {
+  Button,
+  ButtonVariants,
+  ButtonSubMenu,
+  ButtonShowSubMenuOn,
+} from "./button";
 import { ReactNode } from "react";
 import { FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 
 export type ActionButtonSubMenu = ButtonSubMenu;
+export type ActionButtonShowSubMenuOn = ButtonShowSubMenuOn;
 
 export interface ActionButtonProps {
   caption?: string;
@@ -13,7 +19,7 @@ export interface ActionButtonProps {
   styles?: ActionButtonStyles;
   subMenu?: (props: ActionButtonSubMenu) => ReactNode;
   disabled?: boolean;
-  showSubMenuOn?: "caret" | "self";
+  showSubMenuOn?: ActionButtonShowSubMenuOn;
   variant?: ButtonVariants["variant"];
   className?: string;
   pressed?: boolean;

--- a/components/avatar.stories.tsx
+++ b/components/avatar.stories.tsx
@@ -204,7 +204,7 @@ Accepts \`CSSProp\` (styled-components).
       `,
       control: false,
       table: {
-        type: { summary: "AvatarStylesProps" },
+        type: { summary: "AvatarStyles" },
       },
     },
   },

--- a/components/avatar.stories.tsx
+++ b/components/avatar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { AvatarProps } from "./avatar";
 import { ChangeEvent, useState } from "react";
-import { ModalDialog, ModalButtonProps } from "./modal-dialog";
+import { ModalDialog, ModalDialogButton } from "./modal-dialog";
 import { Avatar } from "./avatar";
 
 const meta: Meta<typeof Avatar> = {
@@ -236,7 +236,7 @@ export const WithActions: Story = {
   render: (args: AvatarProps) => {
     const [isOpen, setIsOpen] = useState(false);
 
-    const BUTTONS: ModalButtonProps[] = [
+    const BUTTONS: ModalDialogButton[] = [
       {
         id: "cancel",
         caption: "Cancel",

--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -14,10 +14,10 @@ export interface AvatarProps
   onChange?: (e: ChangeEvent<HTMLInputElement>, file?: File) => void;
   frameSize?: number;
   fontSize?: number;
-  styles?: AvatarStylesProps;
+  styles?: AvatarStyles;
 }
 
-export interface AvatarStylesProps {
+export interface AvatarStyles {
   self?: CSSProp;
 }
 

--- a/components/badge.stories.tsx
+++ b/components/badge.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Badge, BadgeVariantProps } from "./badge";
+import { Badge, BadgeVariant } from "./badge";
 import { css } from "styled-components";
 import { RiCloseLine } from "@remixicon/react";
 
@@ -188,7 +188,7 @@ Used for inline operations (e.g. remove, edit).
       `,
       control: false,
       table: {
-        type: { summary: "BadgeActionProps[]" },
+        type: { summary: "BadgeAction[]" },
       },
     },
 
@@ -204,7 +204,7 @@ Accepts \`CSSProp\` (styled-components).
       `,
       control: false,
       table: {
-        type: { summary: "BadgeStylesProps" },
+        type: { summary: "BadgeStyles" },
       },
     },
   },
@@ -335,7 +335,7 @@ export const Custom: Story = {
             }}
             backgroundColor={badge.backgroundColor}
             textColor={badge.textColor}
-            variant={badge.variant as BadgeVariantProps}
+            variant={badge.variant as BadgeVariant}
             key={badge.id}
             withCircle
             caption={badge.caption}

--- a/components/badge.tsx
+++ b/components/badge.tsx
@@ -2,17 +2,24 @@ import styled, { css, CSSProp } from "styled-components";
 import { ChangeEvent, HTMLAttributes, MouseEvent } from "react";
 import { strToColor } from "./../lib/code-color";
 import { FigureProps } from "./figure";
-import { Button, ButtonStylesProps } from "./button";
+import { Button, ButtonStyles } from "./button";
 import { useTheme } from "./../theme/provider";
 import { BadgeThemeConfig } from "./../theme";
 
-export type BadgeVariantProps = null | "neutral" | "green" | "yellow" | "red";
+export const BadgeVariant = {
+  Neutral: "neutral",
+  Green: "green",
+  Yellow: "yellow",
+  Red: "red",
+} as const;
+
+export type BadgeVariant = (typeof BadgeVariant)[keyof typeof BadgeVariant];
 
 export interface BadgeProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "style"> {
   id?: string;
   metadata?: Record<string, unknown>;
-  variant?: BadgeVariantProps;
+  variant?: BadgeVariant;
   withCircle?: boolean;
   caption?: string;
   backgroundColor?: string;
@@ -21,21 +28,21 @@ export interface BadgeProps
   onClick?: (
     e?: ChangeEvent<HTMLInputElement> | MouseEvent<HTMLDivElement>
   ) => void;
-  actions?: BadgeActionProps[];
-  styles?: BadgeStylesProps;
+  actions?: BadgeAction[];
+  styles?: BadgeStyles;
 }
 
-export interface BadgeStylesProps {
+export interface BadgeStyles {
   self?: CSSProp;
   actionWrapperStyle?: CSSProp;
 }
 
-export interface BadgeActionProps {
+export interface BadgeAction {
   icon?: FigureProps;
   onClick?: (badge?: BadgeProps) => void;
   disabled?: boolean;
   size?: number;
-  styles?: ButtonStylesProps;
+  styles?: ButtonStyles;
   title?: string;
   hidden?: boolean;
 }

--- a/components/boxbar.stories.tsx
+++ b/components/boxbar.stories.tsx
@@ -89,7 +89,7 @@ Available fields:
 Accepts \`CSSProp\` (styled-components).
       `,
       table: {
-        type: { summary: "BoxbarStylesProps" },
+        type: { summary: "BoxbarStyles" },
         defaultValue: { summary: "undefined" },
       },
     },

--- a/components/boxbar.tsx
+++ b/components/boxbar.tsx
@@ -7,10 +7,10 @@ import { BoxbarThemeConfig } from "./../theme";
 
 export interface BoxbarProps {
   children: ReactNode;
-  styles?: BoxbarStylesProps;
+  styles?: BoxbarStyles;
 }
 
-export interface BoxbarStylesProps {
+export interface BoxbarStyles {
   self: CSSProp;
 }
 

--- a/components/button.stories.tsx
+++ b/components/button.stories.tsx
@@ -258,7 +258,7 @@ Available fields:
 Accepts \`CSSProp\`.
       `,
       table: {
-        type: { summary: "ButtonStylesProps" },
+        type: { summary: "ButtonStyles" },
       },
     },
   },

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -70,11 +70,9 @@ export const ButtonDisplayLabel = {
 export type ButtonDisplayLabel =
   (typeof ButtonDisplayLabel)[keyof typeof ButtonDisplayLabel];
 
-export type ButtonTipMenu = TipMenuItemProps;
-
 export interface ButtonSubMenu {
   list?: (
-    subMenuList: ButtonTipMenu[],
+    subMenuList: TipMenuItemProps[],
     withFilter?: { withFilter?: boolean }
   ) => React.ReactNode;
   show?: (
@@ -84,17 +82,15 @@ export interface ButtonSubMenu {
   render?: (children?: React.ReactNode) => React.ReactNode;
 }
 
-export type ButtonTipMenuSize = TipMenuVariant;
-
 export type ButtonProps = Omit<React.ComponentProps<"button">, "style"> &
   ButtonVariants & {
     isLoading?: boolean;
     subMenu?: (props: ButtonSubMenu) => React.ReactNode;
     openedIcon?: FigureProps["image"];
     closedIcon?: FigureProps["image"];
-    tipMenuSize?: ButtonTipMenuSize;
+    tipMenuSize?: TipMenuVariant;
     safeAreaAriaLabels?: string[];
-    dialogPlacement?: ButtonDialogPlacement;
+    dialogPlacement?: DialogPlacement;
     onOpen?: (prop: boolean) => void;
     open?: boolean;
     styles?: ButtonStyles;
@@ -106,8 +102,6 @@ export type ButtonProps = Omit<React.ComponentProps<"button">, "style"> &
     showSubMenuOn?: ButtonShowSubMenuPosition;
     displayLabel?: ButtonDisplayLabel;
   };
-
-export type ButtonDialogPlacement = DialogPlacement;
 
 export interface ButtonStyles {
   dropdownStyle?: CSSProp | ((placement: Placement) => CSSProp);

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -54,13 +54,13 @@ export type ButtonVariants = {
   size?: ButtonSize;
 };
 
-export const ButtonShowSubMenuOn = {
+export const ButtonShowSubMenuPosition = {
   Caret: "caret",
   Self: "self",
 } as const;
 
-export type ButtonShowSubMenuOn =
-  (typeof ButtonShowSubMenuOn)[keyof typeof ButtonShowSubMenuOn];
+export type ButtonShowSubMenuPosition =
+  (typeof ButtonShowSubMenuPosition)[keyof typeof ButtonShowSubMenuPosition];
 
 export const ButtonDisplayLabel = {
   Flex: "flex",
@@ -103,7 +103,7 @@ export type ButtonProps = Omit<React.ComponentProps<"button">, "style"> &
     pressed?: boolean;
     activeBackgroundColor?: string;
     hoverBackgroundColor?: string;
-    showSubMenuOn?: ButtonShowSubMenuOn;
+    showSubMenuOn?: ButtonShowSubMenuPosition;
     displayLabel?: ButtonDisplayLabel;
   };
 

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -90,8 +90,8 @@ export type ButtonProps = Omit<React.ComponentProps<"button">, "style"> &
   ButtonVariants & {
     isLoading?: boolean;
     subMenu?: (props: ButtonSubMenu) => React.ReactNode;
-    openedIcon?: ButtonIcon["image"];
-    closedIcon?: ButtonIcon["image"];
+    openedIcon?: FigureProps["image"];
+    closedIcon?: FigureProps["image"];
     tipMenuSize?: ButtonTipMenuSize;
     safeAreaAriaLabels?: string[];
     dialogPlacement?: ButtonDialogPlacement;
@@ -99,15 +99,13 @@ export type ButtonProps = Omit<React.ComponentProps<"button">, "style"> &
     open?: boolean;
     styles?: ButtonStyles;
     anchorRef?: React.RefObject<HTMLElement>;
-    icon?: ButtonIcon;
+    icon?: FigureProps;
     pressed?: boolean;
     activeBackgroundColor?: string;
     hoverBackgroundColor?: string;
     showSubMenuOn?: ButtonShowSubMenuPosition;
     displayLabel?: ButtonDisplayLabel;
   };
-
-export type ButtonIcon = FigureProps;
 
 export type ButtonDialogPlacement = DialogPlacement;
 

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -62,13 +62,13 @@ export const ButtonShowSubMenuPosition = {
 export type ButtonShowSubMenuPosition =
   (typeof ButtonShowSubMenuPosition)[keyof typeof ButtonShowSubMenuPosition];
 
-export const ButtonDisplayLabel = {
+export const ButtonLabelMode = {
   Flex: "flex",
   Ellipsis: "ellipsis",
 } as const;
 
-export type ButtonDisplayLabel =
-  (typeof ButtonDisplayLabel)[keyof typeof ButtonDisplayLabel];
+export type ButtonLabelMode =
+  (typeof ButtonLabelMode)[keyof typeof ButtonLabelMode];
 
 export interface ButtonSubMenu {
   list?: (
@@ -100,7 +100,7 @@ export type ButtonProps = Omit<React.ComponentProps<"button">, "style"> &
     activeBackgroundColor?: string;
     hoverBackgroundColor?: string;
     showSubMenuOn?: ButtonShowSubMenuPosition;
-    displayLabel?: ButtonDisplayLabel;
+    labelMode?: ButtonLabelMode;
   };
 
 export type ButtonDialogPlacement = DialogPlacement;
@@ -135,7 +135,7 @@ function Button({
   pressed,
   icon,
   hoverBackgroundColor,
-  displayLabel = "ellipsis",
+  labelMode = "ellipsis",
   ...props
 }: ButtonProps) {
   const [isOpenLocal, setIsOpenLocal] = React.useState(false);
@@ -280,7 +280,7 @@ function Button({
         )}
         {children && (
           <ButtonLabel
-            $withFlex={displayLabel === "flex"}
+            $withFlex={labelMode === "flex"}
             aria-label="button-label"
           >
             {children}

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { LoadingSpinner } from "./loading-spinner";
 import { RiArrowDownSLine, RiArrowUpSLine } from "@remixicon/react";
-import { TipMenu, TipMenuItemProps, TipMenuItemVariantType } from "./tip-menu";
+import { TipMenu, TipMenuItemProps, TipMenuVariant } from "./tip-menu";
 import styled, { css, CSSProp } from "styled-components";
 import {
   autoUpdate,
@@ -22,26 +22,59 @@ import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { TipMenuContainerThemeConfig } from "./../theme";
 
+export const ButtonVariant = {
+  Link: "link",
+  Default: "default",
+  Primary: "primary",
+  Danger: "danger",
+  Secondary: "secondary",
+  Ghost: "ghost",
+  Transparent: "transparent",
+  Success: "success",
+  OutlineDefault: "outline-default",
+  OutlineSuccess: "outline-success",
+  OutlinePrimary: "outline-primary",
+  OutlineDanger: "outline-danger",
+} as const;
+
+export type ButtonVariant = (typeof ButtonVariant)[keyof typeof ButtonVariant];
+
+export const ButtonSize = {
+  Icon: "icon",
+  Xs: "xs",
+  Sm: "sm",
+  Md: "md",
+  Lg: "lg",
+} as const;
+
+export type ButtonSize = (typeof ButtonSize)[keyof typeof ButtonSize];
+
 export type ButtonVariants = {
-  variant?:
-    | "link"
-    | "default"
-    | "primary"
-    | "danger"
-    | "secondary"
-    | "ghost"
-    | "transparent"
-    | "success"
-    | "outline-default"
-    | "outline-success"
-    | "outline-primary"
-    | "outline-danger";
-  size?: "icon" | "xs" | "md" | "sm" | "lg";
+  variant?: ButtonVariant;
+  size?: ButtonSize;
 };
 
-export interface SubMenuButtonProps {
+export const ButtonShowSubMenuOn = {
+  Caret: "caret",
+  Self: "self",
+} as const;
+
+export type ButtonShowSubMenuOn =
+  (typeof ButtonShowSubMenuOn)[keyof typeof ButtonShowSubMenuOn];
+
+export const ButtonDisplayLabel = {
+  Flex: "flex",
+  Ellipsis: "ellipsis",
+} as const;
+
+export type ButtonDisplayLabel =
+  (typeof ButtonDisplayLabel)[keyof typeof ButtonDisplayLabel];
+
+export type ButtonTipMenu = TipMenuItemProps;
+
+export interface ButtonSubMenu {
   list?: (
-    subMenuList: TipMenuItemProps[],
+    subMenuList: ButtonTipMenu[],
     withFilter?: { withFilter?: boolean }
   ) => React.ReactNode;
   show?: (
@@ -51,28 +84,34 @@ export interface SubMenuButtonProps {
   render?: (children?: React.ReactNode) => React.ReactNode;
 }
 
+export type ButtonTipMenuSize = TipMenuVariant;
+
 export type ButtonProps = Omit<React.ComponentProps<"button">, "style"> &
   ButtonVariants & {
     isLoading?: boolean;
-    subMenu?: (props: SubMenuButtonProps) => React.ReactNode;
-    openedIcon?: FigureProps["image"];
-    closedIcon?: FigureProps["image"];
-    showSubMenuOn?: "caret" | "self";
-    tipMenuSize?: TipMenuItemVariantType;
+    subMenu?: (props: ButtonSubMenu) => React.ReactNode;
+    openedIcon?: ButtonIcon["image"];
+    closedIcon?: ButtonIcon["image"];
+    tipMenuSize?: ButtonTipMenuSize;
     safeAreaAriaLabels?: string[];
-    dialogPlacement?: DialogPlacement;
+    dialogPlacement?: ButtonDialogPlacement;
     onOpen?: (prop: boolean) => void;
     open?: boolean;
-    styles?: ButtonStylesProps;
+    styles?: ButtonStyles;
     anchorRef?: React.RefObject<HTMLElement>;
-    icon?: FigureProps;
+    icon?: ButtonIcon;
     pressed?: boolean;
     activeBackgroundColor?: string;
     hoverBackgroundColor?: string;
-    displayLabel?: "flex" | "ellipsis";
+    showSubMenuOn?: ButtonShowSubMenuOn;
+    displayLabel?: ButtonDisplayLabel;
   };
 
-export interface ButtonStylesProps {
+export type ButtonIcon = FigureProps;
+
+export type ButtonDialogPlacement = DialogPlacement;
+
+export interface ButtonStyles {
   dropdownStyle?: CSSProp | ((placement: Placement) => CSSProp);
   self?: CSSProp;
   toggleStyle?: CSSProp;
@@ -387,7 +426,7 @@ const ButtonLabel = styled.span<{
   flex: 1;
 `;
 
-export interface ButtonTipMenuContainerStylesProps {
+export interface ButtonTipMenuContainerStyles {
   self?: CSSProp;
 }
 
@@ -396,7 +435,7 @@ function ButtonTipMenuContainer({
   children,
   ...props
 }: Omit<React.ComponentProps<"div">, "style"> & {
-  styles?: ButtonTipMenuContainerStylesProps;
+  styles?: ButtonTipMenuContainerStyles;
   children?: React.ReactNode;
 }) {
   const { currentTheme } = useTheme();

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -90,7 +90,7 @@ export type ButtonProps = Omit<React.ComponentProps<"button">, "style"> &
     closedIcon?: FigureProps["image"];
     tipMenuSize?: TipMenuVariant;
     safeAreaAriaLabels?: string[];
-    dialogPlacement?: DialogPlacement;
+    dialogPlacement?: ButtonDialogPlacement;
     onOpen?: (prop: boolean) => void;
     open?: boolean;
     styles?: ButtonStyles;
@@ -102,6 +102,8 @@ export type ButtonProps = Omit<React.ComponentProps<"button">, "style"> &
     showSubMenuOn?: ButtonShowSubMenuPosition;
     displayLabel?: ButtonDisplayLabel;
   };
+
+export type ButtonDialogPlacement = DialogPlacement;
 
 export interface ButtonStyles {
   dropdownStyle?: CSSProp | ((placement: Placement) => CSSProp);

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -41,10 +41,10 @@ export type ButtonVariant = (typeof ButtonVariant)[keyof typeof ButtonVariant];
 
 export const ButtonSize = {
   Icon: "icon",
-  Xs: "xs",
-  Sm: "sm",
-  Md: "md",
-  Lg: "lg",
+  ExtraSmall: "xs",
+  Small: "sm",
+  Medium: "md",
+  Large: "lg",
 } as const;
 
 export type ButtonSize = (typeof ButtonSize)[keyof typeof ButtonSize];

--- a/components/calendar.stories.tsx
+++ b/components/calendar.stories.tsx
@@ -233,7 +233,7 @@ Custom styles override for the calendar.
 Includes container, label, and body styling.
       `,
       table: {
-        type: { summary: "CalendarStylesProps" },
+        type: { summary: "CalendarStyles" },
       },
     },
   },

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -7,7 +7,7 @@ import { Fragment, useMemo, ReactNode } from "react";
 import React, { useState, useEffect } from "react";
 import { Button } from "./button";
 import { Combobox } from "./combobox";
-import { DrawerProps, OptionProps } from "./selectbox";
+import { DrawerProps, SelectboxOption } from "./selectbox";
 import styled, { css, CSSProp } from "styled-components";
 import {
   getValidMultipleDate,
@@ -16,37 +16,39 @@ import {
   removeWeekend,
 } from "../lib/date";
 import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { CalendarThemeConfig } from "./../theme";
 
 export interface BaseCalendarProps extends Partial<DrawerProps> {
-  options?: OptionProps[];
+  options?: CalendarOption[];
   selectedDates?: string[];
   onChange?: (dates: string[]) => void;
-  dayNames?: OptionProps[];
-  monthNames?: OptionProps[];
+  dayNames?: CalendarOption[];
+  monthNames?: CalendarOption[];
   disableWeekend?: boolean;
-  format?: FormatProps;
+  format?: CalendarFormat;
   yearPastReach?: number;
   futurePastReach?: number;
   onClick?: () => void;
   onCalendarPeriodChanged?: (date: Date) => void;
-  styles?: BaseCalendarStylesProps;
+  styles?: BaseCalendarStyles;
   footer?: ReactNode;
   todayButtonCaption?: string;
-  selectabilityMode?: SelectabilityModeState;
+  selectabilityMode?: CalendarSelectabilityMode;
   id?: string;
   name?: string;
 }
 
-export interface BaseCalendarStylesProps {
+export type CalendarOption = SelectboxOption;
+
+export interface BaseCalendarStyles {
   self?: CSSProp;
   containerStyle?: CSSProp;
   labelStyle?: CSSProp;
 }
 
-interface CalendarStateProps {
+interface CalendarState {
   open: boolean;
   month: string[];
   year: string[];
@@ -59,9 +61,31 @@ type CustomChangeEvent = {
   };
 };
 
-export type FormatProps = "mm/dd/yyyy" | "yyyy/mm/dd" | "dd/mm/yyyy";
-export type DateBoxOpen = "open" | "month" | "year";
-export type SelectabilityModeState = "single" | "multiple" | "ranged";
+export const CalendarFormat = {
+  MM_DD_YYYY: "mm/dd/yyyy",
+  YYYY_MM_DD: "yyyy/mm/dd",
+  DD_MM_YYYY: "dd/mm/yyyy",
+} as const;
+
+export type CalendarFormat =
+  (typeof CalendarFormat)[keyof typeof CalendarFormat];
+
+const DateBoxOpen = {
+  Open: "open",
+  Month: "month",
+  Year: "year",
+} as const;
+
+type DateBoxOpen = (typeof DateBoxOpen)[keyof typeof DateBoxOpen];
+
+export const CalendarSelectabilityMode = {
+  Single: "single",
+  Multiple: "multiple",
+  Ranged: "ranged",
+} as const;
+
+export type CalendarSelectabilityMode =
+  (typeof CalendarSelectabilityMode)[keyof typeof CalendarSelectabilityMode];
 
 const DEFAULT_DAY_NAMES = [
   { text: "Su", value: "1" },
@@ -166,7 +190,7 @@ function BaseCalendar({
 
   const [currentDate, setCurrentDate] = useState(stateDate);
 
-  const [calendarState, setCalendarState] = useState<CalendarStateProps>({
+  const [calendarState, setCalendarState] = useState<CalendarState>({
     open: false,
     month: [String(stateDate.getMonth() + 1)],
     year: [String(stateDate.getFullYear())],
@@ -949,13 +973,12 @@ function BaseCalendar({
   );
 }
 
-export type CalendarStylesProps = BaseCalendarStylesProps &
-  FieldLaneStylesProps;
+export type CalendarStyles = BaseCalendarStyles & FieldLaneStyles;
 
 export interface CalendarProps
   extends Omit<BaseCalendarProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns"> {
-  styles?: CalendarStylesProps;
+  styles?: CalendarStyles;
 }
 
 function Calendar({
@@ -1306,7 +1329,7 @@ const DateCellTodayDot = styled.div<{
         `}
 `;
 
-function formatDate(date: Date, format: FormatProps) {
+function formatDate(date: Date, format: CalendarFormat) {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");

--- a/components/capsule-tab.stories.tsx
+++ b/components/capsule-tab.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { CapsuleTab, CapsuleTabContentProps } from "./capsule-tab";
+import { CapsuleTab, CapsuleTabTab } from "./capsule-tab";
 import { Button } from "./button";
 import { ChangeEvent, useState } from "react";
 import { Textbox } from "./textbox";
@@ -67,7 +67,7 @@ List of tab items.
       `,
       control: false,
       table: {
-        type: { summary: "CapsuleTabContentProps[]" },
+        type: { summary: "CapsuleTabTab[]" },
       },
     },
 
@@ -143,7 +143,7 @@ Available fields:
 All fields accept \`CSSProp\` (styled-components).
       `,
       table: {
-        type: { summary: "CapsuleTabStylesProps" },
+        type: { summary: "CapsuleTabStyles" },
       },
     },
   },
@@ -219,7 +219,7 @@ export const Default: Story = {
       );
     };
 
-    const TABS_ITEMS: CapsuleTabContentProps[] = [
+    const TABS_ITEMS: CapsuleTabTab[] = [
       {
         id: "1",
         title: "Write",

--- a/components/capsule-tab.tsx
+++ b/components/capsule-tab.tsx
@@ -5,22 +5,22 @@ import { CapsuleTabThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
 
 export interface CapsuleTabProps {
-  tabs: CapsuleTabContentProps[];
+  tabs: CapsuleTabTab[];
   activeTab?: string;
   activeBackgroundColor?: string;
-  styles?: CapsuleTabStylesProps;
+  styles?: CapsuleTabStyles;
   onTabChange?: (id: string) => void;
   children?: ReactNode;
 }
 
-export interface CapsuleTabStylesProps {
+export interface CapsuleTabStyles {
   self?: CSSProp;
   contentStyle?: CSSProp;
   capsuleWrapperStyle?: CSSProp;
   tabStyle?: CSSProp;
 }
 
-export interface CapsuleTabContentProps {
+export interface CapsuleTabTab {
   id: string;
   title: string;
   content: ReactNode;

--- a/components/capsule.stories.tsx
+++ b/components/capsule.stories.tsx
@@ -199,7 +199,7 @@ Available fields:
 All fields accept \`CSSProp\`.
       `,
       table: {
-        type: { summary: "CapsuleStylesProps" },
+        type: { summary: "CapsuleStyles" },
       },
     },
   },

--- a/components/capsule.tsx
+++ b/components/capsule.tsx
@@ -3,11 +3,11 @@ import { motion } from "framer-motion";
 import styled, { css, CSSProp } from "styled-components";
 import { StatefulForm } from "./stateful-form";
 import { Figure, FigureProps } from "./figure";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { CapsuleThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
 
-export interface CapsuleContentProps {
+export interface CapsuleTab {
   id: string;
   title?: string;
   content?: ReactNode;
@@ -15,20 +15,20 @@ export interface CapsuleContentProps {
 }
 
 interface BaseCapsuleProps {
-  tabs: CapsuleContentProps[];
+  tabs: CapsuleTab[];
   activeTab?: string | null;
   onTabChange?: (id: string) => void;
   full?: boolean;
   activeBackgroundColor?: string;
   activeColor?: string;
-  styles?: BaseCapsuleStylesProps;
+  styles?: BaseCapsuleStyles;
   id?: string;
   name?: string;
   fontSize?: number;
   disabled?: boolean;
 }
 
-interface BaseCapsuleStylesProps {
+interface BaseCapsuleStyles {
   capsuleWrapperStyle?: CSSProp;
   tabStyle?: CSSProp;
 }
@@ -239,12 +239,12 @@ function BaseCapsule({
   );
 }
 
-export type CapsuleStylesProps = BaseCapsuleStylesProps & FieldLaneStylesProps;
+export type CapsuleStyles = BaseCapsuleStyles & FieldLaneStyles;
 
 export interface CapsuleProps
   extends Omit<BaseCapsuleProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns"> {
-  styles?: CapsuleStylesProps;
+  styles?: CapsuleStyles;
 }
 
 function Capsule({

--- a/components/card.stories.tsx
+++ b/components/card.stories.tsx
@@ -15,14 +15,14 @@ import {
   RiRefreshLine,
   RiAddBoxLine,
 } from "@remixicon/react";
-import { Toolbar, ToolbarSubMenuProps } from "./toolbar";
+import { Toolbar, ToolbarSubMenuList } from "./toolbar";
 import { Searchbox } from "./searchbox";
 import React, { ChangeEvent, useMemo, useState } from "react";
 import { Checkbox } from "./checkbox";
 import { Button } from "./button";
-import { List, ListGroupContentProps, ListItemProps } from "./list";
+import { List, ListGroupContent, ListItemProps } from "./list";
 import { css } from "styled-components";
-import { ColumnTableProps, SubMenuListTableProps, Table } from "./table";
+import { TableColumn, TableSubMenuList, Table } from "./table";
 import { DormantText } from "./dormant-text";
 import { Textbox } from "./textbox";
 import { useTheme } from "./../theme/provider";
@@ -165,7 +165,7 @@ export const Default: Story = {
     padding: "sm",
   },
   render: () => {
-    const SUB_MENU_LIST: ToolbarSubMenuProps[] = [
+    const SUB_MENU_LIST: ToolbarSubMenuList[] = [
       {
         caption: "Report Phishing",
         icon: { image: RiSpam2Line, color: "blue" },
@@ -443,7 +443,7 @@ export const WithHeaderAndFooter: Story = {
   render: () => {
     const { mode } = useTheme();
 
-    const LIST_GROUPS: ListGroupContentProps[] = [
+    const LIST_GROUPS: ListGroupContent[] = [
       {
         id: "breakfast",
         title: "Breakfast",
@@ -799,7 +799,7 @@ export const WithFullWidthContent: Story = {
       subtitle: value.subtitle,
     });
 
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "name",
         caption: "Name",
@@ -920,7 +920,7 @@ export const WithFullWidthContent: Story = {
 
     const TIP_MENU_ACTION = (
       columnCaption: DepartmentKeys
-    ): SubMenuListTableProps[] => {
+    ): TableSubMenuList[] => {
       return [
         {
           caption: "Sort Ascending",
@@ -946,7 +946,7 @@ export const WithFullWidthContent: Story = {
       ];
     };
 
-    const ROW_ACTION = (rowId: string): SubMenuListTableProps[] => {
+    const ROW_ACTION = (rowId: string): TableSubMenuList[] => {
       return [
         {
           caption: "Edit",
@@ -1093,7 +1093,7 @@ export const Toggleable: Story = {
       originalData,
       getRowId,
     }: {
-      columns: ColumnTableProps[];
+      columns: TableColumn[];
       rows: T[];
       setRows: React.Dispatch<React.SetStateAction<T[]>>;
       originalData: T[];
@@ -1110,7 +1110,7 @@ export const Toggleable: Story = {
         setRows(sorted);
       };
 
-      const tipMenu = (column: keyof T): SubMenuListTableProps[] => [
+      const tipMenu = (column: keyof T): TableSubMenuList[] => [
         {
           caption: "Sort Ascending",
           icon: { image: RiArrowUpSLine, color: "gray" },
@@ -1183,7 +1183,7 @@ export const Toggleable: Story = {
       },
     ];
 
-    const departmentColumns: ColumnTableProps[] = [
+    const departmentColumns: TableColumn[] = [
       { id: "departmentName", caption: "Department", sortable: true },
       { id: "head", caption: "Department Head", sortable: true },
       { id: "employeeCount", caption: "Employees", sortable: true },
@@ -1225,7 +1225,7 @@ export const Toggleable: Story = {
       },
     ];
 
-    const assetColumns: ColumnTableProps[] = [
+    const assetColumns: TableColumn[] = [
       { id: "assetName", caption: "Asset Name", sortable: true },
       { id: "category", caption: "Category", sortable: true },
       { id: "assignedTo", caption: "Assigned To", sortable: true },

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -12,39 +12,70 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useTheme } from "./../theme/provider";
 import { CardThemeConfig } from "./../theme";
 
+export const CardShadow = {
+  None: "none",
+  Sm: "sm",
+  Md: "md",
+  Lg: "lg",
+  Xl: "xl",
+  "2Xl": "2xl",
+} as const;
+
+export type CardShadow = (typeof CardShadow)[keyof typeof CardShadow];
+
+export const CardBorderRadius = {
+  None: "none",
+  Xs: "xs",
+  Sm: "sm",
+  Md: "md",
+  Lg: "lg",
+  Xl: "xl",
+  "2Xl": "2xl",
+  "3Xl": "3xl",
+  Full: "full",
+} as const;
+
+export type CardBorderRadius =
+  (typeof CardBorderRadius)[keyof typeof CardBorderRadius];
+
+export const CardPadding = {
+  None: "none",
+  Sm: "sm",
+  Md: "md",
+  Lg: "lg",
+  Xl: "xl",
+  "2Xl": "2xl",
+  "3Xl": "3xl",
+  4: "4",
+  5: "5",
+  6: "6",
+  7: "7",
+  8: "8",
+  9: "9",
+  10: "10",
+} as const;
+
+export type CardPadding = (typeof CardPadding)[keyof typeof CardPadding];
+
 export interface CardProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "title" | "style"> {
-  shadow?: "none" | "sm" | "md" | "lg" | "xl" | "2xl";
-  radius?: "none" | "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "full";
-  padding?:
-    | "none"
-    | "sm"
-    | "md"
-    | "lg"
-    | "xl"
-    | "2xl"
-    | "3xl"
-    | "4"
-    | "5"
-    | "6"
-    | "7"
-    | "8"
-    | "9"
-    | "10";
+  shadow?: CardShadow;
+  radius?: CardBorderRadius;
+  padding?: CardPadding;
   children: ReactNode;
   title?: ReactNode;
   subtitle?: ReactNode;
   footerContent?: ReactNode;
   closable?: boolean;
   onCloseRequest?: () => void;
-  headerActions?: CardActionsProps[];
-  styles?: CardStylesProps;
+  headerActions?: CardAction[];
+  styles?: CardStyles;
   toggleable?: boolean;
   onToggleChange?: (isOpen?: boolean) => void;
   open?: boolean;
 }
 
-export interface CardStylesProps {
+export interface CardStyles {
   textContainerStyle?: CSSProp;
   actionContainerStyle?: CSSProp;
   containerStyle?: CSSProp;
@@ -55,7 +86,7 @@ export interface CardStylesProps {
   subtitleStyle?: CSSProp;
 }
 
-export type CardActionsProps = ActionButtonProps;
+export type CardAction = ActionButtonProps;
 
 function Card({
   children,

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -25,13 +25,13 @@ export type CardShadow = (typeof CardShadow)[keyof typeof CardShadow];
 
 export const CardBorderRadius = {
   None: "none",
-  Xs: "xs",
-  Sm: "sm",
-  Md: "md",
-  Lg: "lg",
-  Xl: "xl",
-  "2Xl": "2xl",
-  "3Xl": "3xl",
+  ExtraSmall: "xs",
+  Small: "sm",
+  Medium: "md",
+  Large: "lg",
+  ExtraLarge: "xl",
+  ExtraExtraLarge: "2xl",
+  ExtraExtraExtraLarge: "3xl",
   Full: "full",
 } as const;
 
@@ -40,19 +40,12 @@ export type CardBorderRadius =
 
 export const CardPadding = {
   None: "none",
-  Sm: "sm",
-  Md: "md",
-  Lg: "lg",
-  Xl: "xl",
-  "2Xl": "2xl",
-  "3Xl": "3xl",
-  4: "4",
-  5: "5",
-  6: "6",
-  7: "7",
-  8: "8",
-  9: "9",
-  10: "10",
+  Small: "sm",
+  Medium: "md",
+  Large: "lg",
+  ExtraLarge: "xl",
+  ExtraExtraLarge: "2xl",
+  ExtraExtraExtraLarge: "3xl",
 } as const;
 
 export type CardPadding = (typeof CardPadding)[keyof typeof CardPadding];

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -61,7 +61,7 @@ export interface CardProps
   footerContent?: ReactNode;
   closable?: boolean;
   onCloseRequest?: () => void;
-  headerActions?: CardAction[];
+  headerActions?: ActionButtonProps[];
   styles?: CardStyles;
   toggleable?: boolean;
   onToggleChange?: (isOpen?: boolean) => void;
@@ -78,8 +78,6 @@ export interface CardStyles {
   titleStyle?: CSSProp;
   subtitleStyle?: CSSProp;
 }
-
-export type CardAction = ActionButtonProps;
 
 function Card({
   children,

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -14,11 +14,11 @@ import { CardThemeConfig } from "./../theme";
 
 export const CardShadow = {
   None: "none",
-  Sm: "sm",
-  Md: "md",
-  Lg: "lg",
-  Xl: "xl",
-  "2Xl": "2xl",
+  Small: "sm",
+  Medium: "md",
+  Large: "lg",
+  ExtraLarge: "xl",
+  ExtraExtraLarge: "2xl",
 } as const;
 
 export type CardShadow = (typeof CardShadow)[keyof typeof CardShadow];

--- a/components/checkbox.stories.tsx
+++ b/components/checkbox.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChangeEvent, useState } from "react";
 import { css } from "styled-components";
-import { Checkbox, CheckboxOptionProps, CheckboxProps } from "./checkbox";
+import { Checkbox, CheckboxOption, CheckboxProps } from "./checkbox";
 
 const meta: Meta<typeof Checkbox> = {
   title: "Input Elements/Checkbox",
@@ -133,7 +133,7 @@ export const WithDescription: StoryWithDescription = {
     valueSelected: [],
   },
   render: () => {
-    const CHECKBOX_OPTIONS: CheckboxOptionProps[] = [
+    const CHECKBOX_OPTIONS: CheckboxOption[] = [
       {
         value: "email",
         label: "Email",
@@ -208,7 +208,7 @@ export const Disabled: StoryWithDescription = {
     valueSelected: [],
   },
   render: () => {
-    const CHECKBOX_OPTIONS: CheckboxOptionProps[] = [
+    const CHECKBOX_OPTIONS: CheckboxOption[] = [
       {
         value: "email",
         label: "Email",
@@ -222,7 +222,7 @@ export const Disabled: StoryWithDescription = {
     ];
 
     const [, setSelected] = useState({
-      checked: [] as CheckboxOptionProps[],
+      checked: [] as CheckboxOption[],
     });
 
     const onChangeValue = (e: ChangeEvent<HTMLInputElement>) => {
@@ -235,7 +235,7 @@ export const Disabled: StoryWithDescription = {
           [name]: checked
             ? [...prev[name], parsed]
             : prev[name].filter(
-                (val: CheckboxOptionProps) => val.value !== parsed.value
+                (val: CheckboxOption) => val.value !== parsed.value
               ),
         }));
       } else {

--- a/components/checkbox.tsx
+++ b/components/checkbox.tsx
@@ -6,12 +6,12 @@ import {
   useRef,
 } from "react";
 import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 
 type WithoutStyle<T> = Omit<T, "style">;
 
-export interface CheckboxOptionProps {
+export interface CheckboxOption {
   value: string;
   label: string;
   description: string;
@@ -28,11 +28,11 @@ interface BaseCheckboxProps
   indeterminate?: boolean;
   description?: string;
   highlightOnChecked?: boolean;
-  styles?: BaseCheckboxStylesProps;
+  styles?: BaseCheckboxStyles;
   helper?: string;
 }
 
-interface BaseCheckboxStylesProps {
+interface BaseCheckboxStyles {
   self?: CSSProp;
   inputWrapperStyle?: CSSProp;
   titleStyle?: CSSProp;
@@ -155,13 +155,12 @@ function BaseCheckbox({
   );
 }
 
-export type CheckboxStylesProps = BaseCheckboxStylesProps &
-  FieldLaneStylesProps;
+export type CheckboxStyles = BaseCheckboxStyles & FieldLaneStyles;
 
 export interface CheckboxProps
   extends Omit<BaseCheckboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns"> {
-  styles?: CheckboxStylesProps;
+  styles?: CheckboxStyles;
 }
 
 function Checkbox({

--- a/components/chips.stories.tsx
+++ b/components/chips.stories.tsx
@@ -7,7 +7,7 @@ import { Badge, BadgeProps } from "./badge";
 import { Button } from "./button";
 import { Chips, MissingOptionFormProps } from "./chips";
 import { Colorbox } from "./colorbox";
-import { OptionProps } from "./selectbox";
+import { SelectboxOption } from "./selectbox";
 import { FormFieldProps, StatefulForm } from "./stateful-form";
 import { Textbox } from "./textbox";
 import { Tooltip } from "./tooltip";
@@ -979,7 +979,7 @@ export const CustomRenderer: Story = {
       </div>
     );
 
-    const EMPLOYEE_OPTIONS: OptionProps[] = [
+    const EMPLOYEE_OPTIONS: SelectboxOption[] = [
       { text: "Organization Owner", value: "1" },
       { text: "HR Manager", value: "2" },
       { text: "Member", value: "3" },

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -1,5 +1,5 @@
 import { RiAddLine } from "@remixicon/react";
-import { Badge, BadgeActionProps, BadgeProps } from "./badge";
+import { Badge, BadgeAction, BadgeProps } from "./badge";
 import { Checkbox } from "./checkbox";
 import {
   ChangeEvent,
@@ -27,14 +27,16 @@ import {
 import { Textbox } from "./textbox";
 import styled, { css, CSSProp } from "styled-components";
 import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { ChipsThemeConfig } from "./../theme";
 
-export type ChipActionsProps = BadgeActionProps;
+export type ChipAction = BadgeAction;
+
+export type ChipProps = BadgeProps;
 
 interface BaseChipsProps {
-  options?: BadgeProps[];
+  options?: ChipProps[];
   inputValue?: string;
   setInputValue?: (
     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -42,20 +44,20 @@ interface BaseChipsProps {
   filterPlaceholder?: string;
   missingOptionLabel?: string;
   creatable?: boolean;
-  onOptionClicked?: (badge: BadgeProps) => void;
-  selectedOptions?: BadgeProps[];
+  onOptionClicked?: (badge: ChipProps) => void;
+  selectedOptions?: ChipProps[];
   missingOptionForm?:
     | ReactNode
     | ((props?: MissingOptionFormProps) => ReactNode);
   emptySlate?: ReactNode;
   renderer?: (props: ChipRendererProps) => ReactNode;
-  styles?: BaseChipsStylesProps;
+  styles?: BaseChipsStyles;
   name?: string;
   id?: string;
   disabled?: boolean;
 }
 
-export interface BaseChipsStylesProps {
+export interface BaseChipsStyles {
   chipsContainerStyle?: CSSProp;
   chipContainerStyle?: CSSProp;
   chipSelectedStyle?: CSSProp;
@@ -419,13 +421,13 @@ function ChipsDrawer({
 
             {options && options.length > 0 ? (
               <>
-                {options.map((data, index) => {
+                {options.map((chip, index) => {
                   const isClicked = selectedOptions?.some(
-                    (clicked) => clicked.id === data.id
+                    (clicked) => clicked.id === chip.id
                   );
 
                   return (
-                    <div key={data.id}>
+                    <div key={chip.id}>
                       {index > 0 &&
                         options[index - 1] &&
                         selectedOptions?.some(
@@ -436,7 +438,7 @@ function ChipsDrawer({
                         )}
 
                       <ChipsItem
-                        badge={data}
+                        chip={chip}
                         chipContainerStyle={styles?.chipContainerStyle}
                         hovered={hovered}
                         isClicked={isClicked}
@@ -487,12 +489,12 @@ function ChipsDrawer({
   );
 }
 
-export type ChipsStylesProps = BaseChipsStylesProps & FieldLaneStylesProps;
+export type ChipsStyles = BaseChipsStyles & FieldLaneStyles;
 
 export interface ChipsProps
   extends Omit<BaseChipsProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns"> {
-  styles?: ChipsStylesProps;
+  styles?: ChipsStyles;
 }
 
 function Chips({
@@ -618,7 +620,7 @@ const EmptyOptionContainer = styled.div<{
 `;
 
 function ChipsItem({
-  badge,
+  chip,
   isClicked,
   hovered,
   setHovered,
@@ -627,11 +629,11 @@ function ChipsItem({
   chipStyle,
   inputRef,
 }: {
-  badge: BadgeProps;
+  chip: ChipProps;
   isClicked: boolean;
   hovered: string | null;
   setHovered: (number: string) => void;
-  onOptionClicked?: (badge: BadgeProps) => void;
+  onOptionClicked?: (badge: ChipProps) => void;
   chipStyle?: CSSProp;
   chipContainerStyle?: CSSProp;
   inputRef?: RefObject<HTMLInputElement>;
@@ -640,34 +642,34 @@ function ChipsItem({
   const chipsTheme = currentTheme.chips;
 
   const finalValueActions =
-    badge.actions
+    chip.actions
       ?.filter((action) => !action?.hidden)
       .map((action) => ({
         ...action,
         styles: {
           self: css`
             opacity: 0;
-            ${hovered === badge.id &&
+            ${hovered === chip.id &&
             css`
               opacity: 1;
             `}
           `,
         },
         size: 14,
-        onClick: () => action.onClick && action.onClick?.(badge),
+        onClick: () => action.onClick && action.onClick?.(chip),
       })) ?? [];
 
   return (
     <ChipItemWrapper
-      $hovered={hovered === badge.id}
+      $hovered={hovered === chip.id}
       $style={chipContainerStyle}
       onClick={async (e) => {
         await e.stopPropagation();
-        await onOptionClicked?.(badge);
+        await onOptionClicked?.(chip);
         await inputRef.current.focus();
       }}
       $theme={chipsTheme}
-      onMouseEnter={() => setHovered(badge.id)}
+      onMouseEnter={() => setHovered(chip.id)}
     >
       <Checkbox
         checked={isClicked}
@@ -692,7 +694,7 @@ function ChipsItem({
         readOnly
       />
       <Badge
-        {...badge}
+        {...chip}
         styles={{
           self: css`
             cursor: pointer;

--- a/components/choice-group.stories.tsx
+++ b/components/choice-group.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { ChoiceGroup } from "./choice-group";
 import { ChangeEvent, ComponentProps, useState } from "react";
-import { Radio, RadioOptionProps } from "./radio";
+import { Radio, RadioOption } from "./radio";
 import { Checkbox } from "./checkbox";
 import { useArgs } from "@storybook/preview-api";
 import {
@@ -102,7 +102,7 @@ export const WithRadio: StoryRadio = {
   },
 
   render: (args) => {
-    const RADIO_OPTIONS: RadioOptionProps[] = [
+    const RADIO_OPTIONS: RadioOption[] = [
       {
         value: "comments",
         label: "Comments",
@@ -167,7 +167,7 @@ export const WithRadioAndIcon: StoryRadio = {
   },
 
   render: (args) => {
-    const RADIO_OPTIONS: RadioOptionProps[] = [
+    const RADIO_OPTIONS: RadioOption[] = [
       {
         value: "comments",
         label: "Comments",
@@ -240,7 +240,7 @@ export const WithRadioButton: StoryRadio = {
     const GROUP_B = "radio_group_b";
     const GROUP_C = "radio_group_c";
 
-    const RADIO_OPTIONS_WITH_ICON: RadioOptionProps[] = [
+    const RADIO_OPTIONS_WITH_ICON: RadioOption[] = [
       {
         value: "text",
         label: "Text",
@@ -268,7 +268,7 @@ export const WithRadioButton: StoryRadio = {
       },
     ];
 
-    const RADIO_OPTIONS_WITH_IMAGE: RadioOptionProps[] = [
+    const RADIO_OPTIONS_WITH_IMAGE: RadioOption[] = [
       {
         value: "text",
         label: "Text",
@@ -401,13 +401,13 @@ export const WithCheckbox: StoryCheckbox = {
     valueSelected: [],
   },
   render: () => {
-    interface CheckboxOptionProps {
+    interface CheckboxOption {
       value: string;
       label: string;
       description: string;
     }
 
-    const CHECKBOX_OPTIONS: CheckboxOptionProps[] = [
+    const CHECKBOX_OPTIONS: CheckboxOption[] = [
       {
         value: "email",
         label: "Email",

--- a/components/choice-group.tsx
+++ b/components/choice-group.tsx
@@ -13,10 +13,10 @@ import { useTheme } from "./../theme/provider";
 
 export interface ChoiceGroupProps {
   children: ReactNode;
-  styles?: ChoiceGroupStylesProps;
+  styles?: ChoiceGroupStyles;
 }
 
-export interface ChoiceGroupStylesProps {
+export interface ChoiceGroupStyles {
   containerStyle?: CSSProp;
   dividerStyle?: CSSProp;
 }

--- a/components/colorbox.stories.tsx
+++ b/components/colorbox.stories.tsx
@@ -4,7 +4,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { ChangeEvent, useState } from "react";
 import { css } from "styled-components";
 import { Colorbox } from "./colorbox";
-import { FieldLaneDropdownsOptionProps } from "./field-lane";
+import { FieldLaneDropdownsOption } from "./field-lane";
 
 const meta: Meta<typeof Colorbox> = {
   title: "Input Elements/Colorbox",
@@ -133,7 +133,7 @@ export const WithDropdown: Story = {
       value: "",
     });
 
-    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOptionProps[] = [
+    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOption[] = [
       {
         text: "On-site",
         value: "1",

--- a/components/colorbox.tsx
+++ b/components/colorbox.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from "react";
 import styled, { css, CSSProp } from "styled-components";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { ColorboxThemeConfig } from "theme";
 import { useTheme } from "./../theme/provider";
@@ -18,11 +18,11 @@ interface BaseColorboxProps
   value?: string;
   showError?: boolean;
   onClick?: () => void;
-  styles?: ColorboxStylesProps;
+  styles?: BaseColorboxStyles;
   id?: string;
 }
 
-export interface ColorboxStylesProps {
+export interface BaseColorboxStyles {
   self?: CSSProp;
 }
 
@@ -146,10 +146,11 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
   }
 );
 
+export type ColorboxStyles = BaseColorboxStyles & FieldLaneStyles;
 export interface ColorboxProps
   extends Omit<BaseColorboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type"> {
-  styles?: ColorboxStylesProps & FieldLaneStylesProps;
+  styles?: ColorboxStyles;
 }
 
 const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(

--- a/components/combobox.stories.tsx
+++ b/components/combobox.stories.tsx
@@ -2,14 +2,14 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import {
   Combobox,
-  ComboboxActionProps,
-  ComboboxOptionProps,
-  ComboboxSingleOptionProps,
+  ComboboxAction,
+  ComboboxOption,
+  ComboboxSingleOption,
 } from "./combobox";
 import { SelectboxSelectedOptions } from "./selectbox";
 import { RiAddLine } from "@remixicon/react";
 import styled, { css } from "styled-components";
-import { FieldLaneDropdownsOptionProps } from "./field-lane";
+import { FieldLaneDropdownsOption } from "./field-lane";
 import * as RemixIcons from "@remixicon/react";
 
 const meta: Meta<typeof Combobox> = {
@@ -50,7 +50,7 @@ Combobox makes use of the base Selectbox, featuring searchability, options-group
 \`\`\`ts
 {
   category: string;
-  options: OptionProps[];
+  options: SelectboxOption[];
   collapsible?: boolean;
   initialState?: "opened" | "closed";
 }
@@ -160,7 +160,7 @@ export const Default: Story = {
   render: () => {
     const [value, setValue] = useState<SelectboxSelectedOptions>("");
 
-    const FRUIT_OPTIONS: ComboboxSingleOptionProps[] = [
+    const FRUIT_OPTIONS: ComboboxSingleOption[] = [
       { text: "Apple", value: "1" },
       { text: "Banana", value: "2" },
       { text: "Orange", value: "3" },
@@ -191,7 +191,7 @@ export const WithLoading: Story = {
   render: () => {
     const [value, setValue] = useState<SelectboxSelectedOptions>("");
 
-    const FRUIT_OPTIONS: ComboboxSingleOptionProps[] = [
+    const FRUIT_OPTIONS: ComboboxSingleOption[] = [
       { text: "Apple", value: "1" },
       { text: "Banana", value: "2" },
       { text: "Orange", value: "3" },
@@ -227,7 +227,7 @@ export const WithDropdown: Story = {
       value: "1",
     });
 
-    const FRUIT_OPTIONS: ComboboxSingleOptionProps[] = [
+    const FRUIT_OPTIONS: ComboboxSingleOption[] = [
       { text: "Apple", value: "1" },
       { text: "Banana", value: "2" },
       { text: "Orange", value: "3" },
@@ -237,7 +237,7 @@ export const WithDropdown: Story = {
       { text: "Watermelon", value: "7" },
     ];
 
-    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOptionProps[] = [
+    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOption[] = [
       {
         text: "On-site",
         value: "1",
@@ -348,7 +348,7 @@ export const WithActions: Story = {
   render: () => {
     const [value, setValue] = useState<SelectboxSelectedOptions>("");
 
-    const FRUIT_OPTIONS: ComboboxSingleOptionProps[] = [
+    const FRUIT_OPTIONS: ComboboxSingleOption[] = [
       { text: "Apple", value: "1" },
       { text: "Banana", value: "2" },
       { text: "Orange", value: "3" },
@@ -358,7 +358,7 @@ export const WithActions: Story = {
       { text: "Watermelon", value: "7" },
     ];
 
-    const FRUIT_ACTIONS: ComboboxActionProps[] = [
+    const FRUIT_ACTIONS: ComboboxAction[] = [
       {
         title: "Add Fruit",
         onClick: () => {
@@ -393,7 +393,7 @@ export const StrictValue: Story = {
   render: () => {
     const [value, setValue] = useState<string>("");
 
-    const FRUIT_OPTIONS: ComboboxSingleOptionProps[] = [
+    const FRUIT_OPTIONS: ComboboxSingleOption[] = [
       { text: "Apple", value: "1" },
       { text: "Banana", value: "2" },
       { text: "Orange", value: "3" },
@@ -497,7 +497,7 @@ export const WithCustomRenderer: Story = {
       );
     };
 
-    const FRUIT_OPTIONS: ComboboxSingleOptionProps[] = [
+    const FRUIT_OPTIONS: ComboboxSingleOption[] = [
       {
         text: "Apple",
         value: "1",
@@ -727,7 +727,7 @@ export const Categorized: Story = {
     const [value1, setValue1] = useState<SelectboxSelectedOptions>("");
     const [value2, setValue2] = useState<SelectboxSelectedOptions>([""]);
 
-    const FRUIT_OPTIONS: ComboboxOptionProps[] = [
+    const FRUIT_OPTIONS: ComboboxOption[] = [
       {
         category: "Sweet",
         options: [
@@ -782,7 +782,7 @@ export const Categorized: Story = {
       { text: "Eggplants", value: "100", hidden: true },
     ];
 
-    const FRUIT_OPTIONS_WITH_INITIAL_OPENED: ComboboxOptionProps[] =
+    const FRUIT_OPTIONS_WITH_INITIAL_OPENED: ComboboxOption[] =
       FRUIT_OPTIONS.map((item) => {
         if ("category" in item && item.options) {
           return {

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -12,14 +12,14 @@ import {
 import {
   castValue,
   DrawerProps,
-  OptionProps,
+  SelectboxOption,
   Selectbox,
   SelectboxLabelsProps,
   SelectboxSelectedOptions,
-  SelectboxStylesProps,
+  SelectboxStyles,
 } from "./selectbox";
 import styled, { css, CSSProp } from "styled-components";
-import { List, ListItemStylesProps } from "./list";
+import { List, ListItemStyles } from "./list";
 import { FieldLaneProps } from "./field-lane";
 import { Figure, FigureProps } from "./figure";
 import { StatefulForm } from "./stateful-form";
@@ -33,63 +33,60 @@ interface BaseComboboxProps {
   placeholder?: string;
   emptySlate?: string;
   highlightOnMatch?: boolean;
-  actions?: ComboboxActionProps[];
+  actions?: ComboboxAction[];
   name?: string;
   multiple?: boolean;
   maxSelectableItems?: number | undefined;
-  styles?: ComboboxStylesProps;
+  styles?: ComboboxStyles;
   helper?: string;
   disabled?: boolean;
   onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
   onClick?: () => void;
   strict?: boolean;
-  options: ComboboxOptionProps[];
+  options: ComboboxOption[];
   isLoading?: boolean;
   labels?: ComboboxLabelsProps;
   controlled?: boolean;
 }
 
-export interface ComboboxGroupedOptionProps {
+export interface ComboboxGroupedOption {
   category?: string;
-  options?: OptionProps[];
+  options?: ComboboxSingleOption[];
   collapsible?: boolean;
   hidden?: boolean;
   initialState?: "closed" | "opened";
 }
 
-export type ComboboxSingleOptionProps = OptionProps;
+export type ComboboxSingleOption = SelectboxOption;
 
-export type ComboboxOptionProps =
-  | ComboboxSingleOptionProps
-  | ComboboxGroupedOptionProps;
+export type ComboboxOption = ComboboxSingleOption | ComboboxGroupedOption;
 
 export interface ComboboxLabelsProps extends SelectboxLabelsProps {}
 
-export interface ComboboxStylesProps
-  extends Omit<SelectboxStylesProps, "self"> {
+export interface ComboboxStyles extends Omit<SelectboxStyles, "self"> {
   containerStyle?: CSSProp;
   selectboxStyle?: CSSProp;
   labelStyle?: CSSProp;
 }
 
-export interface ComboboxActionProps {
+export interface ComboboxAction {
   onClick?: () => void;
   icon?: FigureProps;
   title: string;
-  styles?: ComboboxActionStylesProps;
+  styles?: ComboboxActionStyles;
   hidden?: boolean;
 }
 
-export type ComboboxActionStylesProps = ListItemStylesProps;
+export type ComboboxActionStyles = ListItemStyles;
 
 type ComboboxDrawerProps = Omit<DrawerProps, "refs"> &
   BaseComboboxProps & {
     inputRef?: Ref<HTMLInputElement>;
     handleKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
-    selectedOptionsLocal: OptionProps;
-    setSelectedOptionsLocal: (value: OptionProps) => void;
+    selectedOptionsLocal: SelectboxOption;
+    setSelectedOptionsLocal: (value: SelectboxOption) => void;
     setHasInteracted?: (value: boolean) => void;
-    setConfirmedValue?: (option: OptionProps | null) => void;
+    setConfirmedValue?: (option: SelectboxOption | null) => void;
     openedCategoryGroup?: Set<String>;
     setOpenedCategoryGroup?: (
       updater: (prev: Set<string>) => Set<string>
@@ -313,7 +310,7 @@ function ComboboxDrawer({
 
   const floatingRef = useRef<HTMLUListElement>(null);
 
-  const finalOptions = useMemo<OptionProps[]>(() => {
+  const finalOptions = useMemo<SelectboxOption[]>(() => {
     return (
       options?.flatMap((item) => {
         if (isGroupedOption(item)) {
@@ -445,7 +442,7 @@ function ComboboxDrawer({
     return { mapped, totalOptions };
   }, [options, openedCategoryGroup]);
 
-  function renderOption(option: OptionProps, index: number) {
+  function renderOption(option: SelectboxOption, index: number) {
     const optionValue = String(option.value);
     const isSelected = finalSelectedOptions.includes(optionValue);
 
@@ -807,8 +804,8 @@ const EmptyState = styled.li<{ $theme: ComboboxThemeConfig }>`
 `;
 
 function isGroupedOption(
-  item: ComboboxSingleOptionProps | ComboboxGroupedOptionProps
-): item is ComboboxGroupedOptionProps {
+  item: ComboboxSingleOption | ComboboxGroupedOption
+): item is ComboboxGroupedOption {
   return "options" in item;
 }
 

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -14,7 +14,7 @@ import {
   DrawerProps,
   SelectboxOption,
   Selectbox,
-  SelectboxLabelsProps,
+  SelectboxLabels,
   SelectboxSelectedOptions,
   SelectboxStyles,
 } from "./selectbox";
@@ -49,19 +49,27 @@ interface BaseComboboxProps {
   controlled?: boolean;
 }
 
+export const ComboboxGroupInitialState = {
+  Opened: "opened",
+  Closed: "closed",
+} as const;
+
+export type ComboboxGroupInitialState =
+  (typeof ComboboxGroupInitialState)[keyof typeof ComboboxGroupInitialState];
+
 export interface ComboboxGroupedOption {
   category?: string;
   options?: ComboboxSingleOption[];
   collapsible?: boolean;
   hidden?: boolean;
-  initialState?: "closed" | "opened";
+  initialState?: ComboboxGroupInitialState;
 }
 
 export type ComboboxSingleOption = SelectboxOption;
 
 export type ComboboxOption = ComboboxSingleOption | ComboboxGroupedOption;
 
-export interface ComboboxLabelsProps extends SelectboxLabelsProps {}
+export interface ComboboxLabelsProps extends SelectboxLabels {}
 
 export interface ComboboxStyles extends Omit<SelectboxStyles, "self"> {
   containerStyle?: CSSProp;

--- a/components/context-menu.tsx
+++ b/components/context-menu.tsx
@@ -3,10 +3,10 @@ import { Button, ButtonProps } from "./button";
 import { RiMoreFill } from "@remixicon/react";
 import { TipMenuItemProps } from "./tip-menu";
 
-export type ContextMenuActionsProps = TipMenuItemProps;
+export type ContextMenuAction = TipMenuItemProps;
 
 export interface ContextMenuProps {
-  actions: ContextMenuActionsProps[];
+  actions: ContextMenuAction[];
   onOpen?: (prop: boolean) => void;
   focusBackgroundColor?: string;
   activeBackgroundColor?: string;
@@ -14,10 +14,10 @@ export interface ContextMenuProps {
   maxActionsBeforeCollapsing?: number;
   iconSize?: number;
   open?: boolean;
-  styles?: ContextMenuStylesProps;
+  styles?: ContextMenuStyles;
 }
 
-export interface ContextMenuStylesProps {
+export interface ContextMenuStyles {
   containerStyle?: CSSProp;
   self?: CSSProp;
   dropdownStyle?: CSSProp;

--- a/components/crumb.tsx
+++ b/components/crumb.tsx
@@ -16,7 +16,7 @@ import { CrumbThemeConfig } from "./../theme";
 export interface CrumbProps {
   children?: ReactNode;
   maxShown?: number;
-  iconSeparator?: CrumbIconSeparator;
+  iconSeparator?: FigureProps["image"];
   fontSize?: number;
   textColor?: string;
   hoverColor?: string;
@@ -24,8 +24,6 @@ export interface CrumbProps {
   arrowColor?: string;
   styles?: CrumbStyles;
 }
-
-export type CrumbIconSeparator = FigureProps["image"];
 
 export interface CrumbStyles {
   self?: CSSProp;

--- a/components/crumb.tsx
+++ b/components/crumb.tsx
@@ -16,15 +16,18 @@ import { CrumbThemeConfig } from "./../theme";
 export interface CrumbProps {
   children?: ReactNode;
   maxShown?: number;
-  iconSeparator?: FigureProps["image"];
+  iconSeparator?: CrumbIconSeparator;
   fontSize?: number;
   textColor?: string;
   hoverColor?: string;
   lastTextColor?: string;
   arrowColor?: string;
-  styles?: CrumbStylesProps;
+  styles?: CrumbStyles;
 }
-export interface CrumbStylesProps {
+
+export type CrumbIconSeparator = FigureProps["image"];
+
+export interface CrumbStyles {
   self?: CSSProp;
 }
 
@@ -185,7 +188,7 @@ export interface CrumbItemProps {
   path?: string;
   children?: ReactNode;
   isLast?: boolean;
-  styles?: CrumbItemStylesProps;
+  styles?: CrumbItemStyles;
   onClick?: () => void;
   fontSize?: number;
   textColor?: string;
@@ -193,7 +196,7 @@ export interface CrumbItemProps {
   lastTextColor?: string;
 }
 
-export interface CrumbItemStylesProps {
+export interface CrumbItemStyles {
   self?: CSSProp;
 }
 

--- a/components/datebox.stories.tsx
+++ b/components/datebox.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { ReactElement, useState } from "react";
 import { css } from "styled-components";
 import { Datebox } from "./datebox";
-import { FieldLaneDropdownsOptionProps } from "./field-lane";
+import { FieldLaneDropdownsOption } from "./field-lane";
 import { Messagebox } from "./messagebox";
 
 const meta: Meta<typeof Datebox> = {
@@ -203,7 +203,7 @@ export const WithDropdown: Story = {
       { text: "NOV", value: "11" },
       { text: "DEC", value: "12" },
     ];
-    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOptionProps[] = [
+    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOption[] = [
       {
         text: "On-site",
         value: "1",

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -17,8 +17,6 @@ import { FieldLaneProps } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 
-type DateboxSelectabilityMode = CalendarSelectabilityMode;
-
 type BaseDateboxProps = BaseCalendarProps & {
   name?: string;
   label?: string;
@@ -27,7 +25,7 @@ type BaseDateboxProps = BaseCalendarProps & {
   disabled?: boolean;
   calendarFooter?: ReactNode;
   calendarTodayButtonCaption?: string;
-  calendarSelectabilityMode?: DateboxSelectabilityMode;
+  calendarSelectabilityMode?: CalendarSelectabilityMode;
   placeholder?: string;
   styles?: DateboxStyles;
   helper?: string;
@@ -45,7 +43,7 @@ type CalendarDrawerProps = BaseCalendarProps &
       setSelectedOptionsLocal?: (option: SelectboxOption) => void;
       calendarFooter?: ReactNode;
       calendarTodayButtonCaption?: string;
-      calendarSelectabilityMode?: DateboxSelectabilityMode;
+      calendarSelectabilityMode?: CalendarSelectabilityMode;
       showError?: boolean;
     }
   >;

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -33,10 +33,8 @@ type BaseDateboxProps = BaseCalendarProps & {
   helper?: string;
   id?: string;
   isLoading?: boolean;
-  labels?: DateboxLabels;
+  labels?: SelectboxLabels;
 };
-
-export interface DateboxLabels extends SelectboxLabels {}
 
 export type DateboxStyles = SelectboxStyles;
 

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -1,21 +1,24 @@
 import { RiCalendar2Line } from "@remixicon/react";
 import {
   DrawerProps,
-  OptionProps,
+  SelectboxOption,
   Selectbox,
   SelectboxLabelsProps,
-  SelectboxStylesProps,
+  SelectboxStyles,
 } from "./selectbox";
 import {
   Calendar,
   BaseCalendarProps,
-  SelectabilityModeState,
+  CalendarSelectabilityMode,
 } from "./calendar";
 import styled, { css, CSSProp } from "styled-components";
 import { forwardRef, ReactNode } from "react";
 import { FieldLaneProps } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
+
+type DateboxSelectabilityMode = CalendarSelectabilityMode;
+type DateboxLabels = ComboboxLabelsProps;
 
 type BaseDateboxProps = BaseCalendarProps & {
   name?: string;
@@ -25,27 +28,27 @@ type BaseDateboxProps = BaseCalendarProps & {
   disabled?: boolean;
   calendarFooter?: ReactNode;
   calendarTodayButtonCaption?: string;
-  calendarSelectabilityMode?: SelectabilityModeState;
+  calendarSelectabilityMode?: DateboxSelectabilityMode;
   placeholder?: string;
-  styles?: DateboxStylesProps;
+  styles?: DateboxStyles;
   helper?: string;
   id?: string;
   isLoading?: boolean;
-  labels?: ComboboxLabelsProps;
+  labels?: DateboxLabels;
 };
 
 export interface ComboboxLabelsProps extends SelectboxLabelsProps {}
 
-export type DateboxStylesProps = SelectboxStylesProps;
+export type DateboxStyles = SelectboxStyles;
 
 type CalendarDrawerProps = BaseCalendarProps &
   Partial<
     DrawerProps & {
-      selectedOptionsLocal?: OptionProps;
-      setSelectedOptionsLocal?: (data: OptionProps) => void;
+      selectedOptionsLocal?: SelectboxOption;
+      setSelectedOptionsLocal?: (data: SelectboxOption) => void;
       calendarFooter?: ReactNode;
       calendarTodayButtonCaption?: string;
-      calendarSelectabilityMode?: SelectabilityModeState;
+      calendarSelectabilityMode?: DateboxSelectabilityMode;
       showError?: boolean;
     }
   >;

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -3,7 +3,7 @@ import {
   DrawerProps,
   SelectboxOption,
   Selectbox,
-  SelectboxLabelsProps,
+  SelectboxLabels,
   SelectboxStyles,
 } from "./selectbox";
 import {
@@ -18,7 +18,6 @@ import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 
 type DateboxSelectabilityMode = CalendarSelectabilityMode;
-type DateboxLabels = ComboboxLabelsProps;
 
 type BaseDateboxProps = BaseCalendarProps & {
   name?: string;
@@ -37,7 +36,7 @@ type BaseDateboxProps = BaseCalendarProps & {
   labels?: DateboxLabels;
 };
 
-export interface ComboboxLabelsProps extends SelectboxLabelsProps {}
+export interface DateboxLabels extends SelectboxLabels {}
 
 export type DateboxStyles = SelectboxStyles;
 
@@ -45,7 +44,7 @@ type CalendarDrawerProps = BaseCalendarProps &
   Partial<
     DrawerProps & {
       selectedOptionsLocal?: SelectboxOption;
-      setSelectedOptionsLocal?: (data: SelectboxOption) => void;
+      setSelectedOptionsLocal?: (option: SelectboxOption) => void;
       calendarFooter?: ReactNode;
       calendarTodayButtonCaption?: string;
       calendarSelectabilityMode?: DateboxSelectabilityMode;

--- a/components/dialog.stories.tsx
+++ b/components/dialog.stories.tsx
@@ -116,7 +116,7 @@ Each button object supports:
       description:
         "Custom style overrides for different Dialog sections (container, header, title, subtitle, footer, overlay, etc.).",
       table: {
-        type: { summary: "DialogStylesProps" },
+        type: { summary: "DialogStyles" },
       },
     },
   },

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -11,7 +11,7 @@ import {
 import ReactDOM from "react-dom";
 import styled, { keyframes, CSSProp, css } from "styled-components";
 import { RiCloseLine } from "@remixicon/react";
-import { Button, ButtonStylesProps, ButtonVariants } from "./button";
+import { Button, ButtonStyles, ButtonVariants } from "./button";
 import { OverlayBlocker } from "./overlay-blocker";
 import { Figure, FigureProps } from "./figure";
 import { darkenColor, lightenColor } from "../lib/color";
@@ -44,7 +44,7 @@ export interface DialogProps {
   isOpen?: boolean;
   onVisibilityChange?: (isOpen?: boolean) => void;
   closable?: boolean;
-  styles?: DialogStylesProps;
+  styles?: DialogStyles;
   onClick?: (args: { id: string; closeDialog: () => void }) => void;
   buttons?: DialogButtonProps[];
   title?: ReactNode;
@@ -53,7 +53,7 @@ export interface DialogProps {
   onClosed?: () => void;
 }
 
-export interface DialogStylesProps {
+export interface DialogStyles {
   overlayStyle?: CSSProp;
   closeButtonStyle?: CSSProp;
   headerStyle?: CSSProp;
@@ -70,7 +70,7 @@ export interface DialogButtonProps extends Pick<ButtonVariants, "variant"> {
   caption: string;
   isLoading?: boolean;
   disabled?: boolean;
-  styles?: ButtonStylesProps;
+  styles?: ButtonStyles;
 }
 
 function Dialog({

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -49,9 +49,11 @@ export interface DialogProps {
   buttons?: DialogButton[];
   title?: ReactNode;
   subtitle?: ReactNode;
-  icon?: FigureProps;
+  icon?: DialogIcon;
   onClosed?: () => void;
 }
+
+export type DialogIcon = FigureProps;
 
 export interface DialogStyles {
   overlayStyle?: CSSProp;

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -22,7 +22,7 @@ import {
   ThemeProvider,
   useTheme,
 } from "./../theme/provider";
-import { DialogThemeConfig, ThemeMode } from "./../theme";
+import { DialogThemeConfig } from "./../theme";
 
 const zoomIn = keyframes`from {transform: translate(-50%, -50%) scale(0.95); opacity: 0;} to {transform: translate(-50%, -50%) scale(1); opacity: 1;}`;
 const zoomOut = keyframes`from {transform: translate(-50%, -50%) scale(1); opacity: 1;} to {transform: translate(-50%, -50%) scale(0.95); opacity: 0;}`;
@@ -46,7 +46,7 @@ export interface DialogProps {
   closable?: boolean;
   styles?: DialogStyles;
   onClick?: (args: { id: string; closeDialog: () => void }) => void;
-  buttons?: DialogButtonProps[];
+  buttons?: DialogButton[];
   title?: ReactNode;
   subtitle?: ReactNode;
   icon?: FigureProps;
@@ -65,7 +65,7 @@ export interface DialogStyles {
   buttonWrapperStyle?: CSSProp;
 }
 
-export interface DialogButtonProps extends Pick<ButtonVariants, "variant"> {
+export interface DialogButton extends Pick<ButtonVariants, "variant"> {
   id: string;
   caption: string;
   isLoading?: boolean;

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -49,11 +49,9 @@ export interface DialogProps {
   buttons?: DialogButton[];
   title?: ReactNode;
   subtitle?: ReactNode;
-  icon?: DialogIcon;
+  icon?: FigureProps;
   onClosed?: () => void;
 }
-
-export type DialogIcon = FigureProps;
 
 export interface DialogStyles {
   overlayStyle?: CSSProp;

--- a/components/document-viewer.stories.tsx
+++ b/components/document-viewer.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import {
-  BoundingBoxes,
+  BoundingBox,
   BoundingBoxState,
   DocumentViewerRef,
   DocumentViewer,
@@ -100,7 +100,7 @@ DocumentViewer is a powerful component for displaying documents such as PDFs, im
         "List of bounding boxes displayed on the document with optional hover content.",
       control: false,
       table: {
-        type: { summary: "BoundingBoxes[]" },
+        type: { summary: "BoundingBox[]" },
         defaultValue: { summary: "[]" },
       },
     },
@@ -168,7 +168,7 @@ export const PDF: Story = {
     const ref = useRef<DocumentViewerRef>(null);
 
     const [popupVisibility, setPopupVisibility] = useState<boolean>(false);
-    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBoxes[]>([
+    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBox[]>([
       {
         page: 1,
         x: 0.1319796954314721,
@@ -176,7 +176,7 @@ export const PDF: Story = {
         width: 0.751269035532995,
         height: 0.34532374100719426,
         contentOnHover: <p>heyyy</p>,
-        boxStyle: { borderColor: "#aqua", backgroundColor: "#aqua" },
+        styles: { self: { borderColor: "#aqua", backgroundColor: "#aqua" } },
       },
     ]);
 
@@ -225,7 +225,7 @@ export const PDF: Story = {
 
     const handleCommentSubmission = async () => {
       await setBoundingBoxes((prev) => {
-        const box: BoundingBoxes = {
+        const box: BoundingBox = {
           ...currentlySelectedRegion,
           contentOnHover: <p>{commentText}</p>,
         };
@@ -416,7 +416,7 @@ export const PNG: Story = {
     const ref = useRef<DocumentViewerRef>(null);
 
     const [popupVisibility, setPopupVisibility] = useState<boolean>(false);
-    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBoxes[]>([
+    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBox[]>([
       {
         contentOnHover: <p>This document viewer show using PNG format</p>,
         height: 0.04973118279569892,
@@ -424,7 +424,7 @@ export const PNG: Story = {
         width: 0.1949579831932773,
         x: 0.03361344537815126,
         y: 0.033602150537634407,
-        boxStyle: { borderColor: "#aqua", backgroundColor: "#aqua" },
+        styles: { self: { borderColor: "#aqua", backgroundColor: "#aqua" } },
       },
     ]);
 
@@ -473,7 +473,7 @@ export const PNG: Story = {
 
     const handleCommentSubmission = async () => {
       await setBoundingBoxes((prev) => {
-        const box: BoundingBoxes = {
+        const box: BoundingBox = {
           ...currentlySelectedRegion,
           contentOnHover: <p>{commentText}</p>,
         };
@@ -607,7 +607,7 @@ export const WithFile: Story = {
     }, []);
 
     const [popupVisibility, setPopupVisibility] = useState<boolean>(false);
-    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBoxes[]>([
+    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBox[]>([
       {
         contentOnHover: <p>This document viewer show using PNG format</p>,
         height: 0.04973118279569892,
@@ -615,7 +615,7 @@ export const WithFile: Story = {
         width: 0.1949579831932773,
         x: 0.03361344537815126,
         y: 0.033602150537634407,
-        boxStyle: { borderColor: "#aqua", backgroundColor: "#aqua" },
+        styles: { self: { borderColor: "#aqua", backgroundColor: "#aqua" } },
       },
     ]);
 
@@ -664,7 +664,7 @@ export const WithFile: Story = {
 
     const handleCommentSubmission = async () => {
       await setBoundingBoxes((prev) => {
-        const box: BoundingBoxes = {
+        const box: BoundingBox = {
           ...currentlySelectedRegion,
           contentOnHover: <p>{commentText}</p>,
         };
@@ -796,7 +796,7 @@ export const Base64: Story = {
     }, []);
 
     const [popupVisibility, setPopupVisibility] = useState<boolean>(false);
-    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBoxes[]>([
+    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBox[]>([
       {
         contentOnHover: <p>This document viewer show using PNG format</p>,
         height: 0.04973118279569892,
@@ -804,7 +804,7 @@ export const Base64: Story = {
         width: 0.1949579831932773,
         x: 0.03361344537815126,
         y: 0.033602150537634407,
-        boxStyle: { borderColor: "#aqua", backgroundColor: "#aqua" },
+        styles: { self: { borderColor: "#aqua", backgroundColor: "#aqua" } },
       },
     ]);
 
@@ -853,7 +853,7 @@ export const Base64: Story = {
 
     const handleCommentSubmission = async () => {
       await setBoundingBoxes((prev) => {
-        const box: BoundingBoxes = {
+        const box: BoundingBox = {
           ...currentlySelectedRegion,
           contentOnHover: <p>{commentText}</p>,
         };

--- a/components/document-viewer.stories.tsx
+++ b/components/document-viewer.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import {
-  BoundingBoxesProps,
+  BoundingBoxes,
   BoundingBoxState,
   DocumentViewerRef,
   DocumentViewer,
@@ -12,7 +12,7 @@ import { Button } from "./button";
 import { Textbox } from "./textbox";
 import styled, { css } from "styled-components";
 import { Window } from "./window";
-import { ColumnTableProps, Table } from "./table";
+import { TableColumn, Table } from "./table";
 import { createPortal } from "react-dom";
 import { urlToBase64 } from "./../lib/base64";
 
@@ -100,7 +100,7 @@ DocumentViewer is a powerful component for displaying documents such as PDFs, im
         "List of bounding boxes displayed on the document with optional hover content.",
       control: false,
       table: {
-        type: { summary: "BoundingBoxesProps[]" },
+        type: { summary: "BoundingBoxes[]" },
         defaultValue: { summary: "[]" },
       },
     },
@@ -153,7 +153,7 @@ Example:
         "Custom styling overrides for container, zoom combobox, and selection box.",
       control: false,
       table: {
-        type: { summary: "DocumentViewerStylesProps" },
+        type: { summary: "DocumentViewerStyles" },
       },
     },
   },
@@ -168,7 +168,7 @@ export const PDF: Story = {
     const ref = useRef<DocumentViewerRef>(null);
 
     const [popupVisibility, setPopupVisibility] = useState<boolean>(false);
-    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBoxesProps[]>([
+    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBoxes[]>([
       {
         page: 1,
         x: 0.1319796954314721,
@@ -225,7 +225,7 @@ export const PDF: Story = {
 
     const handleCommentSubmission = async () => {
       await setBoundingBoxes((prev) => {
-        const box: BoundingBoxesProps = {
+        const box: BoundingBoxes = {
           ...currentlySelectedRegion,
           contentOnHover: <p>{commentText}</p>,
         };
@@ -260,7 +260,7 @@ export const PDF: Story = {
       };
     }, [popupVisibility]);
 
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "page",
         caption: "Page",
@@ -416,7 +416,7 @@ export const PNG: Story = {
     const ref = useRef<DocumentViewerRef>(null);
 
     const [popupVisibility, setPopupVisibility] = useState<boolean>(false);
-    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBoxesProps[]>([
+    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBoxes[]>([
       {
         contentOnHover: <p>This document viewer show using PNG format</p>,
         height: 0.04973118279569892,
@@ -473,7 +473,7 @@ export const PNG: Story = {
 
     const handleCommentSubmission = async () => {
       await setBoundingBoxes((prev) => {
-        const box: BoundingBoxesProps = {
+        const box: BoundingBoxes = {
           ...currentlySelectedRegion,
           contentOnHover: <p>{commentText}</p>,
         };
@@ -607,7 +607,7 @@ export const WithFile: Story = {
     }, []);
 
     const [popupVisibility, setPopupVisibility] = useState<boolean>(false);
-    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBoxesProps[]>([
+    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBoxes[]>([
       {
         contentOnHover: <p>This document viewer show using PNG format</p>,
         height: 0.04973118279569892,
@@ -664,7 +664,7 @@ export const WithFile: Story = {
 
     const handleCommentSubmission = async () => {
       await setBoundingBoxes((prev) => {
-        const box: BoundingBoxesProps = {
+        const box: BoundingBoxes = {
           ...currentlySelectedRegion,
           contentOnHover: <p>{commentText}</p>,
         };
@@ -796,7 +796,7 @@ export const Base64: Story = {
     }, []);
 
     const [popupVisibility, setPopupVisibility] = useState<boolean>(false);
-    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBoxesProps[]>([
+    const [boundingBoxes, setBoundingBoxes] = useState<BoundingBoxes[]>([
       {
         contentOnHover: <p>This document viewer show using PNG format</p>,
         height: 0.04973118279569892,
@@ -853,7 +853,7 @@ export const Base64: Story = {
 
     const handleCommentSubmission = async () => {
       await setBoundingBoxes((prev) => {
-        const box: BoundingBoxesProps = {
+        const box: BoundingBoxes = {
           ...currentlySelectedRegion,
           contentOnHover: <p>{commentText}</p>,
         };

--- a/components/document-viewer.tsx
+++ b/components/document-viewer.tsx
@@ -33,35 +33,35 @@ export type DocumentSource = (builder: {
 export interface DocumentViewerProps {
   source?: DocumentSource;
   onRegionSelected?: (region: BoundingBoxState) => void;
-  boundingBoxes?: BoundingBoxesProps[];
+  boundingBoxes?: BoundingBoxes[];
   initialZoom?: 75 | 100 | 110 | 120 | 130 | 140 | 150;
   libPdfJsWorkerSrc?: string;
-  styles?: DocumentViewerStylesProps;
+  styles?: DocumentViewerStyles;
   selectable?: boolean;
-  labels?: DocumentViewerLabelProps;
+  labels?: DocumentViewerLabel;
   title?: string;
 }
 
-export interface DocumentViewerLabelProps {
+export interface DocumentViewerLabel {
   zoomPlaceholder?: string;
   totalPages?: (props: { currentPage?: number; totalPages?: number }) => string;
 }
 
-export interface DocumentViewerStylesProps {
+export interface DocumentViewerStyles {
   containerStyle?: CSSProp;
   zoomStyle?: CSSProp;
   selectionStyle?: CSSProp;
   boxStyle?: CSSProp;
 }
 
-export interface BoundingBoxesProps {
+export interface BoundingBoxes {
   page?: number;
   x: number;
   y: number;
   width: number;
   height: number;
   contentOnHover?: React.ReactNode;
-  boxStyle?: BoxStyleProps;
+  boxStyle?: BoxStyle;
 }
 
 export interface BoundingBoxState {
@@ -82,7 +82,7 @@ export interface DocumentViewerRef {
    */
   repositionPopUp: (data: HTMLDivElement) => void;
 }
-interface BoxStyleProps {
+interface BoxStyle {
   borderColor?: string;
   backgroundColor?: string;
 }

--- a/components/document-viewer.tsx
+++ b/components/document-viewer.tsx
@@ -61,7 +61,7 @@ export interface BoundingBox {
   width: number;
   height: number;
   contentOnHover?: React.ReactNode;
-  boxStyle?: BoxStyle;
+  styles?: { self?: BoxStyle };
 }
 
 export interface BoundingBoxState {
@@ -767,8 +767,8 @@ const DocumentViewer = forwardRef<DocumentViewerRef, DocumentViewerProps>(
                     $selectionStyle={css`
                       ${styles?.boxStyle}
 
-                      border-color: ${box.boxStyle?.borderColor};
-                      background-color: ${box.boxStyle?.backgroundColor};
+                      border-color: ${box.styles?.self?.borderColor};
+                      background-color: ${box.styles?.self?.backgroundColor};
 
                       ${selection &&
                       css`
@@ -790,8 +790,8 @@ const DocumentViewer = forwardRef<DocumentViewerRef, DocumentViewerProps>(
                         style={{
                           left: contentLeft,
                           top: contentTop,
-                          borderColor: box.boxStyle?.borderColor,
-                          backgroundColor: box.boxStyle?.backgroundColor,
+                          borderColor: box.styles?.self?.borderColor,
+                          backgroundColor: box.styles?.self?.backgroundColor,
                         }}
                         aria-label="selection-content-hovered"
                       >

--- a/components/document-viewer.tsx
+++ b/components/document-viewer.tsx
@@ -30,24 +30,11 @@ export type DocumentSource = (builder: {
   ) => { type: "encoded"; src: string };
 }) => ResolvedSource;
 
-export const DocumentViewerInitialZoom = {
-  75: 75,
-  100: 100,
-  110: 110,
-  120: 120,
-  130: 130,
-  140: 140,
-  150: 150,
-} as const;
-
-export type DocumentViewerInitialZoom =
-  (typeof DocumentViewerInitialZoom)[keyof typeof DocumentViewerInitialZoom];
-
 export interface DocumentViewerProps {
   source?: DocumentSource;
   onRegionSelected?: (region: BoundingBoxState) => void;
   boundingBoxes?: BoundingBoxes[];
-  initialZoom?: DocumentViewerInitialZoom;
+  initialZoom?: 75 | 100 | 110 | 120 | 130 | 140 | 150;
   libPdfJsWorkerSrc?: string;
   styles?: DocumentViewerStyles;
   selectable?: boolean;

--- a/components/document-viewer.tsx
+++ b/components/document-viewer.tsx
@@ -33,7 +33,7 @@ export type DocumentSource = (builder: {
 export interface DocumentViewerProps {
   source?: DocumentSource;
   onRegionSelected?: (region: BoundingBoxState) => void;
-  boundingBoxes?: BoundingBoxes[];
+  boundingBoxes?: BoundingBox[];
   initialZoom?: 75 | 100 | 110 | 120 | 130 | 140 | 150;
   libPdfJsWorkerSrc?: string;
   styles?: DocumentViewerStyles;
@@ -54,7 +54,7 @@ export interface DocumentViewerStyles {
   boxStyle?: CSSProp;
 }
 
-export interface BoundingBoxes {
+export interface BoundingBox {
   page?: number;
   x: number;
   y: number;

--- a/components/document-viewer.tsx
+++ b/components/document-viewer.tsx
@@ -30,11 +30,24 @@ export type DocumentSource = (builder: {
   ) => { type: "encoded"; src: string };
 }) => ResolvedSource;
 
+export const DocumentViewerInitialZoom = {
+  75: 75,
+  100: 100,
+  110: 110,
+  120: 120,
+  130: 130,
+  140: 140,
+  150: 150,
+} as const;
+
+export type DocumentViewerInitialZoom =
+  (typeof DocumentViewerInitialZoom)[keyof typeof DocumentViewerInitialZoom];
+
 export interface DocumentViewerProps {
   source?: DocumentSource;
   onRegionSelected?: (region: BoundingBoxState) => void;
   boundingBoxes?: BoundingBoxes[];
-  initialZoom?: 75 | 100 | 110 | 120 | 130 | 140 | 150;
+  initialZoom?: DocumentViewerInitialZoom;
   libPdfJsWorkerSrc?: string;
   styles?: DocumentViewerStyles;
   selectable?: boolean;

--- a/components/document-viewer.tsx
+++ b/components/document-viewer.tsx
@@ -38,11 +38,11 @@ export interface DocumentViewerProps {
   libPdfJsWorkerSrc?: string;
   styles?: DocumentViewerStyles;
   selectable?: boolean;
-  labels?: DocumentViewerLabel;
+  labels?: DocumentViewerLabels;
   title?: string;
 }
 
-export interface DocumentViewerLabel {
+export interface DocumentViewerLabels {
   zoomPlaceholder?: string;
   totalPages?: (props: { currentPage?: number; totalPages?: number }) => string;
 }

--- a/components/dormant-text.tsx
+++ b/components/dormant-text.tsx
@@ -17,6 +17,14 @@ import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { DormantTextThemeConfig } from "./../theme";
 
+export const DormantTextAcceptChangeOn = {
+  Enter: "enter",
+  Click: "click",
+  All: "all",
+} as const;
+
+export type DormantTextAcceptChangeOn =
+  (typeof DormantTextAcceptChangeOn)[keyof typeof DormantTextAcceptChangeOn];
 export interface DormantTextProps {
   onActionClick?: () => void;
   icons?: DormantTextIconsProps;
@@ -24,7 +32,7 @@ export interface DormantTextProps {
   children?: ReactNode;
   content?: string | number;
   fullWidth?: boolean;
-  acceptChangeOn?: "enter" | "click" | "all";
+  acceptChangeOn?: DormantTextAcceptChangeOn;
   cancelable?: boolean;
   onActive?: () => void;
   onCancelRequested?: () => void;

--- a/components/dormant-text.tsx
+++ b/components/dormant-text.tsx
@@ -29,7 +29,7 @@ export interface DormantTextProps {
   onActive?: () => void;
   onCancelRequested?: () => void;
   dormantedMaxWidth?: string;
-  styles?: DormantTextStylesProps;
+  styles?: DormantTextStyles;
 }
 
 export interface DormantTextIconsProps {
@@ -37,7 +37,7 @@ export interface DormantTextIconsProps {
   cancel?: FigureProps;
 }
 
-export interface DormantTextStylesProps {
+export interface DormantTextStyles {
   dormantedStyle?: CSSProp;
   activeStyle?: CSSProp;
   actionStyle?: CSSProp;

--- a/components/drawer-tab.stories.tsx
+++ b/components/drawer-tab.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { DrawerTab, DrawerTabContentProps } from "./drawer-tab";
+import { DrawerTab, DrawerTabTab } from "./drawer-tab";
 import { Textbox } from "./textbox";
 import { ChangeEvent, useState } from "react";
 import { RiListCheck, RiNodeTree } from "@remixicon/react";
@@ -147,7 +147,7 @@ export const Default: Story = {
       );
     };
 
-    const tabs: DrawerTabContentProps[] = [
+    const tabs: DrawerTabTab[] = [
       {
         id: "1",
         title: "File Attributes",
@@ -218,7 +218,7 @@ export const FixedRight: Story = {
         </div>
       );
     };
-    const tabs: DrawerTabContentProps[] = [
+    const tabs: DrawerTabTab[] = [
       {
         id: "1",
         title: "File Attributes",

--- a/components/drawer-tab.tsx
+++ b/components/drawer-tab.tsx
@@ -6,9 +6,17 @@ import { FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { DrawerTabThemeConfig } from "./../theme";
 
+export const DrawerTabPosition = {
+  Left: "left",
+  Right: "right",
+} as const;
+
+export type DrawerTabPosition =
+  (typeof DrawerTabPosition)[keyof typeof DrawerTabPosition];
+
 export interface DrawerTabProps {
-  tabs: DrawerTabContentProps[];
-  position?: "left" | "right";
+  tabs: DrawerTabTab[];
+  position?: DrawerTabPosition;
   styles?: DrawerTabStyles;
 }
 export interface DrawerTabStyles {
@@ -16,7 +24,7 @@ export interface DrawerTabStyles {
   drawerTabStyle?: CSSProp;
 }
 
-export interface DrawerTabContentProps {
+export interface DrawerTabTab {
   id: string;
   title: string;
   icon: FigureProps["image"];

--- a/components/drawer-tab.tsx
+++ b/components/drawer-tab.tsx
@@ -9,9 +9,9 @@ import { DrawerTabThemeConfig } from "./../theme";
 export interface DrawerTabProps {
   tabs: DrawerTabContentProps[];
   position?: "left" | "right";
-  styles?: DrawerTabStylesProps;
+  styles?: DrawerTabStyles;
 }
-export interface DrawerTabStylesProps {
+export interface DrawerTabStyles {
   tabStyle?: CSSProp;
   drawerTabStyle?: CSSProp;
 }

--- a/components/empty-slate.tsx
+++ b/components/empty-slate.tsx
@@ -6,10 +6,10 @@ export interface EmptySlateProps {
   title: string;
   subtitle?: string;
   actions?: ReactNode;
-  styles?: EmptySlateStylesProps;
+  styles?: EmptySlateStyles;
 }
 
-export interface EmptySlateStylesProps {
+export interface EmptySlateStyles {
   containerStyle?: CSSProp;
   imageStyle?: CSSProp;
   contentStyle?: CSSProp;

--- a/components/error-slate.tsx
+++ b/components/error-slate.tsx
@@ -24,10 +24,10 @@ export interface ErrorSlateProps {
     | "505";
   children?: ReactNode;
   title?: string;
-  styles?: ErrorSlateStylesProps;
+  styles?: ErrorSlateStyles;
 }
 
-export interface ErrorSlateStylesProps {
+export interface ErrorSlateStyles {
   titleStyle?: CSSProp;
   cubeFaceStyle?: CSSProp;
 }

--- a/components/field-land.stories.tsx
+++ b/components/field-land.stories.tsx
@@ -1,12 +1,12 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { FieldLaneDropdownsOptionProps, FieldLane } from "./field-lane";
+import { FieldLaneDropdownsOption, FieldLane } from "./field-lane";
 import { useState } from "react";
 import { css } from "styled-components";
 import * as RemixIcons from "@remixicon/react";
 import { Calendar } from "./calendar";
 import { Textbox, TextboxProps } from "./textbox";
 import { Combobox, ComboboxProps } from "./combobox";
-import { OptionProps } from "./selectbox";
+import { SelectboxOption } from "./selectbox";
 
 const meta: Meta<typeof FieldLane> = {
   title: "Stage/FieldLane",
@@ -164,7 +164,7 @@ export const Default: Story = {
       selectedOption: "2",
     });
 
-    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOptionProps[] = [
+    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOption[] = [
       {
         text: "On-site",
         value: "1",
@@ -237,7 +237,7 @@ export const CustomRenderer: Story = {
       value: "",
     });
 
-    const FRUIT_OPTIONS: OptionProps[] = [
+    const FRUIT_OPTIONS: SelectboxOption[] = [
       { text: "Apple", value: "1" },
       { text: "Banana", value: "2" },
       { text: "Orange", value: "3" },
@@ -247,7 +247,7 @@ export const CustomRenderer: Story = {
       { text: "Watermelon", value: "7" },
     ];
 
-    const MONTH_NAMES: OptionProps[] = [
+    const MONTH_NAMES: SelectboxOption[] = [
       { text: "JAN", value: "1" },
       { text: "FEB", value: "2" },
       { text: "MAR", value: "3" },
@@ -284,7 +284,7 @@ export const CustomRenderer: Story = {
       },
     };
 
-    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOptionProps[] = [
+    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOption[] = [
       {
         text: "On-site",
         value: "1",

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -8,10 +8,27 @@ import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { FieldLaneThemeConfig } from "./../theme";
 
+export const FieldLaneErrorIconPosition = {
+  Absolute: "absolute",
+  Relative: "relative",
+  None: "none",
+} as const;
+
+export type FieldLaneErrorIconPosition =
+  (typeof FieldLaneErrorIconPosition)[keyof typeof FieldLaneErrorIconPosition];
+
+export const FieldLaneLabelPosition = {
+  Top: "top",
+  Left: "left",
+} as const;
+
+export type FieldLaneLabelPosition =
+  (typeof FieldLaneLabelPosition)[keyof typeof FieldLaneLabelPosition];
+
 export interface FieldLaneProps {
   label?: string;
   showError?: boolean;
-  errorIconPosition?: "absolute" | "relative" | "none";
+  errorIconPosition?: FieldLaneErrorIconPosition;
   errorMessage?: string;
   dropdowns?: FieldLaneDropdownProps[];
   styles?: FieldLaneStyles;
@@ -21,7 +38,7 @@ export interface FieldLaneProps {
   id?: string;
   actions?: FieldLaneAction[];
   type?: string;
-  labelPosition?: "top" | "left";
+  labelPosition?: FieldLaneLabelPosition;
   labelWidth?: string;
   labelGap?: number;
   required?: boolean;

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -14,12 +14,12 @@ export interface FieldLaneProps {
   errorIconPosition?: "absolute" | "relative" | "none";
   errorMessage?: string;
   dropdowns?: FieldLaneDropdownProps[];
-  styles?: FieldLaneStylesProps;
+  styles?: FieldLaneStyles;
   helper?: string;
   disabled?: boolean;
   children?: ReactNode;
   id?: string;
-  actions?: FieldLaneActionsProps[];
+  actions?: FieldLaneAction[];
   type?: string;
   labelPosition?: "top" | "left";
   labelWidth?: string;
@@ -27,14 +27,14 @@ export interface FieldLaneProps {
   required?: boolean;
 }
 
-export interface FieldLaneStylesProps {
+export interface FieldLaneStyles {
   containerStyle?: CSSProp;
   labelStyle?: CSSProp;
   controlStyle?: CSSProp;
   bodyStyle?: CSSProp;
 }
 
-export interface FieldLaneActionsProps {
+export interface FieldLaneAction {
   title?: string;
   icon?: FigureProps;
   iconColor?: string;
@@ -46,11 +46,11 @@ export interface FieldLaneActionsProps {
 
 export interface FieldLaneDropdownProps {
   disabled?: boolean;
-  options?: FieldLaneDropdownsOptionProps[];
+  options?: FieldLaneDropdownsOption[];
   caption?: string;
   onChange?: (id: string) => void;
   width?: string;
-  styles?: FieldLaneDropdownStylesProps;
+  styles?: FieldLaneDropdownStyles;
   withFilter?: boolean;
   render?: (props: {
     render?: (children?: ReactNode) => ReactNode;
@@ -59,13 +59,13 @@ export interface FieldLaneDropdownProps {
   hidden?: boolean;
 }
 
-export interface FieldLaneDropdownStylesProps {
+export interface FieldLaneDropdownStyles {
   drawerStyle?: CSSProp;
   containerStyle?: CSSProp;
   self?: CSSProp;
 }
 
-export interface FieldLaneDropdownsOptionProps {
+export interface FieldLaneDropdownsOption {
   text: string;
   value: string;
   icon?: FigureProps;
@@ -352,8 +352,8 @@ function FieldLane({
             styles={{
               self: css`
                 color: ${disabled
-                  ? fieldLaneTheme?.labelDisabledColor
-                  : fieldLaneTheme?.labelColor};
+                  ? fieldLaneTheme?.disabledTextColor
+                  : fieldLaneTheme?.textColor};
 
                 ${styles?.labelStyle};
               `,

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -234,7 +234,7 @@ function FieldLane({
           return (
             <Button
               key={index}
-              displayLabel="flex"
+              labelMode="flex"
               aria-label="action-icon"
               onMouseDown={(e) => e.preventDefault()}
               onClick={(e) => {

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -30,7 +30,7 @@ export interface FieldLaneProps {
   showError?: boolean;
   errorIconPosition?: FieldLaneErrorIconPosition;
   errorMessage?: string;
-  dropdowns?: FieldLaneDropdownProps[];
+  dropdowns?: FieldLaneDropdown[];
   styles?: FieldLaneStyles;
   helper?: string;
   disabled?: boolean;
@@ -61,7 +61,7 @@ export interface FieldLaneAction {
   hidden?: boolean;
 }
 
-export interface FieldLaneDropdownProps {
+export interface FieldLaneDropdown {
   disabled?: boolean;
   options?: FieldLaneDropdownsOption[];
   caption?: string;

--- a/components/figure.tsx
+++ b/components/figure.tsx
@@ -6,10 +6,10 @@ export interface FigureProps
   image?: ComponentType<any> | string;
   size?: number;
   color?: string;
-  styles?: FigureStylesProps;
+  styles?: FigureStyles;
 }
 
-export interface FigureStylesProps {
+export interface FigureStyles {
   self?: CSSProp;
 }
 

--- a/components/file-drop-box.stories.tsx
+++ b/components/file-drop-box.stories.tsx
@@ -4,8 +4,8 @@ import { useRef, useState } from "react";
 import { css } from "styled-components";
 import {
   FileDropBox,
-  OnCompleteFunctionProps,
-  OnFileDroppedFunctionProps,
+  OnCompleteFunction,
+  OnFileDroppedFunction,
 } from "./file-drop-box";
 import { Table } from "./table";
 
@@ -179,7 +179,7 @@ export const Default: Story = {
       files,
       setProgressLabel,
       succeed,
-    }: OnFileDroppedFunctionProps) => {
+    }: OnFileDroppedFunction) => {
       const file = files[0];
       setFiles((prev) => [...prev, file]);
       setProgressLabel(`Uploading ${file.name}`);
@@ -209,7 +209,7 @@ export const Default: Story = {
       succeedFiles,
       hideProgressLabel,
       showUploaderForm,
-    }: OnCompleteFunctionProps) => {
+    }: OnCompleteFunction) => {
       console.log(succeedFiles, "This is succeedFiles");
       console.log(failedFiles, "This is failedFiles");
       await setProgressLabel(
@@ -280,7 +280,7 @@ export const Error: Story = {
       files,
       setProgressLabel,
       succeed,
-    }: OnFileDroppedFunctionProps) => {
+    }: OnFileDroppedFunction) => {
       const file = files[0];
 
       if (allFilesRef.current.length === 0) {
@@ -316,7 +316,7 @@ export const Error: Story = {
       failedFiles,
       setProgressLabel,
       succeedFiles,
-    }: OnCompleteFunctionProps) => {
+    }: OnCompleteFunction) => {
       console.log(succeedFiles, "This is succeedFiles");
       console.log(failedFiles, "This is failedFiles");
 

--- a/components/file-drop-box.tsx
+++ b/components/file-drop-box.tsx
@@ -16,7 +16,7 @@ import { FieldLaneProps } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { FileDropBoxThemeConfig } from "./../theme";
 
-export interface OnFileDroppedFunctionProps {
+export interface OnFileDroppedFunction {
   files: File[];
   succeed: (file: File) => void;
   error: (file: File, errorMessage: string) => void;
@@ -24,7 +24,7 @@ export interface OnFileDroppedFunctionProps {
   progressPercentage?: number;
 }
 
-export interface OnCompleteFunctionProps {
+export interface OnCompleteFunction {
   succeedFiles?: File[];
   failedFiles?: File[];
   setProgressLabel?: (label: string) => void;
@@ -36,12 +36,12 @@ export interface FileDropBoxProps {
   placeholder?: string;
   accept?: string;
   label?: string;
-  onFileDropped?: (props: OnFileDroppedFunctionProps) => void;
-  onComplete?: (props: OnCompleteFunctionProps) => void;
+  onFileDropped?: (props: OnFileDroppedFunction) => void;
+  onComplete?: (props: OnCompleteFunction) => void;
   progressPercentage?: number;
   helper?: string;
   children?: ReactNode;
-  styles?: FileDropBoxStylesProps;
+  styles?: FileDropBoxStyles;
   name?: string;
   id?: string;
   labelPosition?: FieldLaneProps["labelPosition"];
@@ -51,7 +51,7 @@ export interface FileDropBoxProps {
   disabled?: boolean;
 }
 
-export interface FileDropBoxStylesProps {
+export interface FileDropBoxStyles {
   containerStyle?: CSSProp;
   dragOverStyle?: CSSProp;
   successStyle?: CSSProp;

--- a/components/file-input-box.stories.tsx
+++ b/components/file-input-box.stories.tsx
@@ -212,7 +212,7 @@ All accept \`CSSProp\` (styled-components).
       `,
       control: false,
       table: {
-        type: { summary: "FileInputBoxStylesProps" },
+        type: { summary: "FileInputBoxStyles" },
       },
     },
   },

--- a/components/file-input-box.tsx
+++ b/components/file-input-box.tsx
@@ -9,7 +9,7 @@ import { RiCloseLine } from "@remixicon/react";
 import styled, { css, CSSProp } from "styled-components";
 import { Button } from "./button";
 import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { FileInputBoxThemeConfig } from "./../theme";
 
@@ -21,11 +21,11 @@ interface BaseFileInputBoxProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   showError?: boolean;
   errorMessage?: string;
-  styles?: BaseFileInputBoxStylesProps;
+  styles?: BaseFileInputBoxStyles;
   helper?: string;
 }
 
-interface BaseFileInputBoxStylesProps {
+interface BaseFileInputBoxStyles {
   containerStyle?: CSSProp;
   labelStyle?: CSSProp;
   self?: CSSProp;
@@ -156,13 +156,12 @@ function BaseFileInputBox({
   );
 }
 
-export type FileInputBoxStylesProps = BaseFileInputBoxStylesProps &
-  FieldLaneStylesProps;
+export type FileInputBoxStyles = BaseFileInputBoxStyles & FieldLaneStyles;
 
 export interface FileInputBoxProps
   extends Omit<BaseFileInputBoxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns"> {
-  styles?: FileInputBoxStylesProps;
+  styles?: FileInputBoxStyles;
 }
 
 function FileInputBox({

--- a/components/grid.tsx
+++ b/components/grid.tsx
@@ -9,13 +9,13 @@ export interface GridProps
   height?: number | string;
   width?: number | string;
   gap?: number | string;
-  styles?: GridStylesProps;
+  styles?: GridStyles;
   preset?: GridPresetKey;
 }
 
 export interface GridCardProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "style"> {
-  styles?: GridCardStylesProps;
+  styles?: GridCardStyles;
   children?: ReactNode;
   thumbnail?: string;
   isSelected?: boolean;
@@ -23,11 +23,11 @@ export interface GridCardProps
   selectable?: boolean;
 }
 
-export interface GridStylesProps {
+export interface GridStyles {
   self?: CSSProp;
 }
 
-export type GridCardStylesProps = GridStylesProps;
+export type GridCardStyles = GridStyles;
 
 function Grid({
   children,

--- a/components/imagebox.tsx
+++ b/components/imagebox.tsx
@@ -6,9 +6,18 @@ import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { ImageboxThemeConfig } from "theme";
 
+export const ImageboxSize = {
+  ExtraSmall: "xs",
+  Small: "sm",
+  Medium: "md",
+  Large: "lg",
+} as const;
+
+export type ImageboxSize = (typeof ImageboxSize)[keyof typeof ImageboxSize];
+
 interface BaseImageboxProps {
   onFileSelected?: (file: File | undefined) => void;
-  size?: "xs" | "sm" | "md" | "lg";
+  size?: ImageboxSize;
   name?: string;
   styles?: BaseImageboxStyles;
   value?: File | string | null;

--- a/components/imagebox.tsx
+++ b/components/imagebox.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, DragEvent, useEffect, useRef, useState } from "react";
 import { RiAddLine, RiImageLine } from "@remixicon/react";
 import styled, { css, CSSProp } from "styled-components";
 import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { ImageboxThemeConfig } from "theme";
 
@@ -10,7 +10,7 @@ interface BaseImageboxProps {
   onFileSelected?: (file: File | undefined) => void;
   size?: "xs" | "sm" | "md" | "lg";
   name?: string;
-  styles?: BaseImageboxStylesProps;
+  styles?: BaseImageboxStyles;
   value?: File | string | null;
   borderless?: boolean;
   editable?: boolean;
@@ -19,7 +19,7 @@ interface BaseImageboxProps {
   disabled?: boolean;
 }
 
-interface BaseImageboxStylesProps {
+interface BaseImageboxStyles {
   self?: CSSProp;
 }
 
@@ -201,13 +201,12 @@ function BaseImagebox({
   );
 }
 
-export type ImageboxStylesProps = BaseImageboxStylesProps &
-  FieldLaneStylesProps;
+export type ImageboxStyles = BaseImageboxStyles & FieldLaneStyles;
 
 export interface ImageboxProps
   extends Omit<BaseImageboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns"> {
-  styles?: ImageboxStylesProps;
+  styles?: ImageboxStyles;
 }
 
 function Imagebox({

--- a/components/launchpad.tsx
+++ b/components/launchpad.tsx
@@ -20,11 +20,11 @@ export interface LaunchpadProps {
 export interface LaunchpadSectionProps {
   children: ReactNode;
   title?: string;
-  styles?: LaunchpadSectionStylesProps;
+  styles?: LaunchpadSectionStyles;
   gridPreset?: GridPresetKey;
 }
 
-export interface LaunchpadSectionStylesProps {
+export interface LaunchpadSectionStyles {
   containerStyle?: CSSProp;
   gridStyle?: CSSProp;
   separatorStyle?: CSSProp;
@@ -34,10 +34,10 @@ export interface LaunchpadSectionItemProps {
   href: string;
   iconUrl: string;
   label: string;
-  styles?: LaunchpadSectionItemStylesProps;
+  styles?: LaunchpadSectionItemStyles;
 }
 
-export interface LaunchpadSectionItemStylesProps {
+export interface LaunchpadSectionItemStyles {
   containerStyle?: CSSProp;
   iconStyle?: CSSProp;
 }

--- a/components/list.stories.tsx
+++ b/components/list.stories.tsx
@@ -1034,7 +1034,7 @@ export const WithSubcontent: Story = {
         name: "button",
         title: "Save",
         type: "button",
-        rowJustifyContent: "end",
+        rowJustifyPosition: "flex-end",
         onClick: () => {
           const current = inputValue.statefulValue.find((v) => v.id === itemId);
 

--- a/components/list.stories.tsx
+++ b/components/list.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, StoryObj } from "@storybook/react";
 import {
   List,
-  ListGroupActionsProps,
-  ListGroupContentProps,
-  ListItemActionProps,
+  ListGroupaction,
+  ListGroupContent,
+  ListItemAction,
   ListItemProps,
 } from "./list";
 import {
@@ -248,7 +248,7 @@ export const Default: Story = {
 
 export const Draggable: Story = {
   render: () => {
-    const LIST_GROUPS: ListGroupContentProps[] = [
+    const LIST_GROUPS: ListGroupContent[] = [
       {
         id: "recent-content",
         title: "Recent Content",
@@ -454,7 +454,7 @@ export const Draggable: Story = {
 
 export const WithLoading: Story = {
   render: () => {
-    const LIST_GROUPS: ListGroupContentProps[] = [
+    const LIST_GROUPS: ListGroupContent[] = [
       {
         id: "recent-content",
         title: "Recent Content",
@@ -651,7 +651,7 @@ export const WithLoading: Story = {
 
 export const ReactNodeTitle: Story = {
   render: () => {
-    const LIST_GROUPS: ListGroupContentProps[] = [
+    const LIST_GROUPS: ListGroupContent[] = [
       {
         id: "form-fields",
         title: "Form Fields",
@@ -730,7 +730,7 @@ export const ReactNodeTitle: Story = {
       }
     };
 
-    const LIST_GROUP_ACTIONS: ListGroupActionsProps[] = [
+    const LIST_GROUP_ACTIONS: ListGroupaction[] = [
       {
         caption: "Add",
         onClick: () =>
@@ -753,7 +753,7 @@ export const ReactNodeTitle: Story = {
       },
     ];
 
-    const LIST_ITEM_ACTIONS = (id: string): ListItemActionProps[] => {
+    const LIST_ITEM_ACTIONS = (id: string): ListItemAction[] => {
       const selectedByFormFieldsGroup = id.split("form-fields-");
       return [
         {
@@ -926,7 +926,7 @@ export const ReactNodeTitle: Story = {
 
 export const WithSubcontent: Story = {
   render: () => {
-    const LIST_GROUPS: ListGroupContentProps[] = [
+    const LIST_GROUPS: ListGroupContent[] = [
       {
         id: "form-fields",
         title: "Form Fields",
@@ -948,7 +948,7 @@ export const WithSubcontent: Story = {
       statefulValue: { id: string; value: string }[];
     }
 
-    function useListController(initialGroups: ListGroupContentProps[]) {
+    function useListController(initialGroups: ListGroupContent[]) {
       const [groups, setGroups] = useState(initialGroups);
 
       const [inputValue, setInputValue] = useState<InputValueProps>({
@@ -1021,7 +1021,7 @@ export const WithSubcontent: Story = {
     const FIELDS = (
       itemId: string,
       inputValue: InputValueProps,
-      setGroups: React.Dispatch<React.SetStateAction<ListGroupContentProps[]>>
+      setGroups: React.Dispatch<React.SetStateAction<ListGroupContent[]>>
     ): FormFieldGroup[] => [
       {
         name: "value",
@@ -1053,8 +1053,8 @@ export const WithSubcontent: Story = {
     ];
 
     const LIST_ACTIONS_GROUP = (
-      setGroups: React.Dispatch<React.SetStateAction<ListGroupContentProps[]>>
-    ): ListGroupActionsProps[] => [
+      setGroups: React.Dispatch<React.SetStateAction<ListGroupContent[]>>
+    ): ListGroupaction[] => [
       {
         caption: "Add",
         onClick: () =>
@@ -1077,9 +1077,9 @@ export const WithSubcontent: Story = {
 
     const LIST_ITEM_ACTIONS = (
       itemId: string,
-      setGroups: React.Dispatch<React.SetStateAction<ListGroupContentProps[]>>,
+      setGroups: React.Dispatch<React.SetStateAction<ListGroupContent[]>>,
       setInputValue: React.Dispatch<React.SetStateAction<InputValueProps>>
-    ): ListItemActionProps[] => {
+    ): ListItemAction[] => {
       const selectedByFormFieldsGroup = itemId.split("form-fields-");
 
       return [
@@ -1428,7 +1428,7 @@ export const WithBadge: Story = {
       leftSideContent?: number;
     };
 
-    type ListGroupContentWithNumber = Omit<ListGroupContentProps, "items"> & {
+    type ListGroupContentWithNumber = Omit<ListGroupContent, "items"> & {
       items: ListItem[];
     };
 
@@ -1646,7 +1646,7 @@ export const CustomOpener: Story = {
       />
     );
 
-    const ACTIONS_GROUPS: ListGroupActionsProps[] = [
+    const ACTIONS_GROUPS: ListGroupaction[] = [
       {
         caption: "Add",
         onClick: (id: string) => {
@@ -1655,7 +1655,7 @@ export const CustomOpener: Story = {
       },
     ];
 
-    const LIST_GROUPS: ListGroupContentProps[] = [
+    const LIST_GROUPS: ListGroupContent[] = [
       {
         id: "recent-content",
         title: "Recent Content",
@@ -1711,7 +1711,7 @@ export const CustomOpener: Story = {
       },
     ];
 
-    const [groups, setGroups] = useState<ListGroupContentProps[]>(LIST_GROUPS);
+    const [groups, setGroups] = useState<ListGroupContent[]>(LIST_GROUPS);
     const [value, setValue] = useState({
       search: "",
       checked: [],
@@ -2086,7 +2086,7 @@ export const WithMaxItems: Story = {
 
 export const Accordion: Story = {
   render: () => {
-    const ACTIONS_GROUPS: ListGroupActionsProps[] = [
+    const ACTIONS_GROUPS: ListGroupaction[] = [
       {
         caption: "Refresh",
         onClick: (id: string) => {

--- a/components/list.tsx
+++ b/components/list.tsx
@@ -905,6 +905,8 @@ const EmptyContent = styled(motion.div)<{
   ${({ $style }) => $style}
 `;
 
+export type ListItemAction = ContextMenuAction;
+
 export interface ListItemProps {
   id: string;
   title?: ReactNode;
@@ -916,7 +918,7 @@ export interface ListItemProps {
   onSelected?: (selected: ChangeEvent<HTMLInputElement>) => void;
   onClick?: () => void;
   rightSideContent?: ((prop: string) => ReactNode) | ReactNode;
-  actions?: (id?: string) => ContextMenuAction[];
+  actions?: (id?: string) => ListItemAction[];
   children?: ReactNode;
   openable?: boolean;
   selectedOptions?: {

--- a/components/list.tsx
+++ b/components/list.tsx
@@ -76,8 +76,6 @@ export interface ListOnOpen {
   isOpen?: boolean;
 }
 
-export type ListItemAction = ContextMenuAction;
-
 interface ListAlwaysShowDragIcon {
   alwaysShowDragIcon?: boolean;
 }
@@ -918,7 +916,7 @@ export interface ListItemProps {
   onSelected?: (selected: ChangeEvent<HTMLInputElement>) => void;
   onClick?: () => void;
   rightSideContent?: ((prop: string) => ReactNode) | ReactNode;
-  actions?: (id?: string) => ListItemAction[];
+  actions?: (id?: string) => ContextMenuAction[];
   children?: ReactNode;
   openable?: boolean;
   selectedOptions?: {

--- a/components/list.tsx
+++ b/components/list.tsx
@@ -20,20 +20,28 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { Searchbox, SearchboxStylesProps } from "./searchbox";
+import { Searchbox, SearchboxStyles } from "./searchbox";
 import { AnimatePresence, motion } from "framer-motion";
 import { LoadingSpinner } from "./loading-spinner";
 import { Checkbox } from "./checkbox";
 import { Togglebox } from "./togglebox";
 import styled, { css, CSSProp } from "styled-components";
-import ContextMenu, { ContextMenuActionsProps } from "./context-menu";
+import ContextMenu, { ContextMenuAction } from "./context-menu";
 import { ActionButton, ActionButtonProps } from "./action-button";
 import { OverlayBlocker } from "./overlay-blocker";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
-import { ListThemeConfig, TreeListThemeConfig } from "theme";
+import { ListThemeConfig } from "theme";
 
-export interface ListProps extends ListMaxItemsProp {
+export const ListOpenerBehavior = {
+  Any: "any",
+  OnlyOne: "onlyOne",
+} as const;
+
+export type ListOpenerBehavior =
+  (typeof ListOpenerBehavior)[keyof typeof ListOpenerBehavior];
+
+export interface ListProps extends ListMaxItems {
   searchable?: boolean;
   onSearchRequested?: (search: ChangeEvent<HTMLInputElement>) => void;
   children: ReactNode;
@@ -41,7 +49,7 @@ export interface ListProps extends ListMaxItemsProp {
   draggable?: boolean;
   selectable?: boolean;
   searchValue?: string;
-  styles?: ListStylesProps;
+  styles?: ListStyles;
   onDragged?: (props: {
     id: string;
     oldGroupId: string;
@@ -49,43 +57,43 @@ export interface ListProps extends ListMaxItemsProp {
     oldPosition: number;
     newPosition: number;
   }) => void;
-  groupOpenerBehavior?: "any" | "onlyOne";
-  openerBehavior?: "any" | "onlyOne";
-  onOpen?: (props?: ListOnOpenProps) => void;
+  groupOpenerBehavior?: ListOpenerBehavior;
+  openerBehavior?: ListOpenerBehavior;
+  onOpen?: (props?: ListOnOpen) => void;
   alwaysShowDragIcon?: boolean;
   inputRef?: Ref<HTMLInputElement>;
   onSearchKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
-  labels?: ListLabelsProps;
+  labels?: ListLabels;
 }
 
-export interface ListLabelsProps {
+export interface ListLabels {
   moreItemsText?: ReactNode;
   lessItemsText?: ReactNode;
 }
 
-export interface ListOnOpenProps {
+export interface ListOnOpen {
   id?: string;
   isOpen?: boolean;
 }
 
-export type ListItemActionProps = ContextMenuActionsProps;
+export type ListItemAction = ContextMenuAction;
 
-interface ListAlwaysShowDragIconProp {
+interface ListAlwaysShowDragIcon {
   alwaysShowDragIcon?: boolean;
 }
 
-interface ListMaxItemsProp {
+interface ListMaxItems {
   maxItems?: number;
   maxItemsWithIcon?: boolean;
 }
 
-export interface ListStylesProps {
+export interface ListStyles {
   maxItemsStyle?: CSSProp;
-  searchboxStyles?: SearchboxStylesProps;
+  searchboxStyles?: SearchboxStyles;
   containerStyle?: CSSProp;
 }
 
-export interface LeftSideContentMenuProps {
+export interface LeftSideContentMenu {
   badge?: (badge: ReactNode, withStyle?: { withStyle?: CSSProp }) => ReactNode;
   render?: (children?: ReactNode) => ReactNode;
 }
@@ -279,8 +287,8 @@ function List({
             const componentChild = child as ReactElement<
               ListItemProps &
                 ListItemWithId &
-                ListAlwaysShowDragIconProp &
-                ListMaxItemsProp & { labels?: ListLabelsProps }
+                ListAlwaysShowDragIcon &
+                ListMaxItems & { labels?: ListLabels }
             >;
 
             if (child.type === React.Fragment) {
@@ -370,10 +378,26 @@ const ListContainer = styled.div<{
 
   ${({ $containerStyle }) => $containerStyle}
 `;
-export interface ListGroupActionsProps
-  extends Omit<ActionButtonProps, "onClick"> {
+export interface ListGroupaction extends Omit<ActionButtonProps, "onClick"> {
   onClick?: (e?: string) => void;
 }
+
+export const ListGroupOpenerStyle = {
+  Chevron: "chevron",
+  ToggleBox: "togglebox",
+  None: "none",
+} as const;
+
+export type ListGroupOpenerStyle =
+  (typeof ListGroupOpenerStyle)[keyof typeof ListGroupOpenerStyle];
+
+export const ListGroupInitialState = {
+  Opened: "opened",
+  Closed: "closed",
+} as const;
+
+export type ListGroupInitialState =
+  (typeof ListGroupInitialState)[keyof typeof ListGroupInitialState];
 
 export interface ListGroupProps {
   id: string;
@@ -382,16 +406,16 @@ export interface ListGroupProps {
   children: ReactNode;
   draggable?: boolean;
   rightSideContent?: ((prop: string) => ReactNode) | ReactNode;
-  actions?: ListGroupActionsProps[];
-  openerStyle?: "chevron" | "togglebox" | "none";
+  actions?: ListGroupaction[];
   emptySlate?: ReactNode;
-  initialState?: "opened" | "closed";
+  openerStyle?: ListGroupOpenerStyle;
+  initialState?: ListGroupInitialState;
   selectable?: boolean;
-  styles?: ListGroupStylesProps;
+  styles?: ListGroupStyles;
   onClick?: ({ toggle }: { toggle: () => void }) => void;
 }
 
-interface ListGroupStylesProps {
+interface ListGroupStyles {
   containerStyle?: CSSProp;
   rowStyle?: CSSProp;
   titleStyle?: CSSProp;
@@ -403,15 +427,15 @@ interface ListGroupStylesProps {
   rightSideWrapperStyle?: CSSProp;
 }
 
-export interface ListGroupContentProps {
+export interface ListGroupContent {
   id: string;
   title: string;
   subtitle?: string;
-  actions?: ListGroupActionsProps[];
+  actions?: ListGroupaction[];
   rightSideContent?: ((prop: string) => ReactNode) | ReactNode;
-  initialState?: "opened" | "closed";
+  initialState?: ListGroupInitialState;
   items: ListItemProps[];
-  styles?: ListGroupStylesProps;
+  styles?: ListGroupStyles;
 }
 
 function ListGroup({
@@ -440,8 +464,8 @@ function ListGroup({
     maxItems,
     maxItemsWithIcon,
   } = props as ListItemWithId &
-    ListAlwaysShowDragIconProp &
-    ListMaxItemsProp & { labels?: ListLabelsProps };
+    ListAlwaysShowDragIcon &
+    ListMaxItems & { labels?: ListLabels };
 
   const childArray = Children.toArray(children).filter(isValidElement);
   const { dragItem, setDragItem, onDragged } = useContext(DnDContext);
@@ -582,7 +606,7 @@ function ListGroup({
             const componentChild = child as ReactElement<
               ListItemProps &
                 ListItemWithId &
-                ListAlwaysShowDragIconProp & {
+                ListAlwaysShowDragIcon & {
                   index: number;
                   onDropItem?: (position: number) => void;
                   groupLength?: number;
@@ -709,9 +733,9 @@ function ListShowMoreButton({
   expanded: boolean;
   setExpanded: (prop: boolean) => void;
   isOpen?: boolean | undefined;
-  labels?: ListLabelsProps;
+  labels?: ListLabels;
   maxItemsStyle?: CSSProp;
-} & ListMaxItemsProp) {
+} & ListMaxItems) {
   const { currentTheme } = useTheme();
   const listTheme = currentTheme.list;
 
@@ -896,7 +920,7 @@ export interface ListItemProps {
   onSelected?: (selected: ChangeEvent<HTMLInputElement>) => void;
   onClick?: () => void;
   rightSideContent?: ((prop: string) => ReactNode) | ReactNode;
-  actions?: (id?: string) => ListItemActionProps[];
+  actions?: (id?: string) => ListItemAction[];
   children?: ReactNode;
   openable?: boolean;
   selectedOptions?: {
@@ -904,10 +928,8 @@ export interface ListItemProps {
     checked?: boolean;
     name?: string;
   };
-  leftSideContent?:
-    | ReactNode
-    | ((props?: LeftSideContentMenuProps) => ReactNode);
-  styles?: ListItemStylesProps;
+  leftSideContent?: ReactNode | ((props?: LeftSideContentMenu) => ReactNode);
+  styles?: ListItemStyles;
   hoverTextColor?: string;
   hoverBackgroundColor?: string;
   selected?: boolean;
@@ -917,7 +939,7 @@ export interface ListItemProps {
   onMouseMove?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
-export interface ListItemStylesProps {
+export interface ListItemStyles {
   containerStyle?: CSSProp;
   rowStyle?: CSSProp;
   titleStyle?: CSSProp;
@@ -971,7 +993,7 @@ const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
       onDropItem,
       ...domProps
     } = props as ListItemWithId &
-      ListAlwaysShowDragIconProp & {
+      ListAlwaysShowDragIcon & {
         index?: number;
         onDropItem?: (position: number) => void;
         groupLength?: number;

--- a/components/list.tsx
+++ b/components/list.tsx
@@ -741,8 +741,7 @@ function ListShowMoreButton({
 
   return (
     <ShowMoreButton
-      $borderColor={listTheme.borderColor}
-      $textColor={listTheme.textColor}
+      $theme={listTheme}
       aria-label="list-show-more-button"
       $style={css`
         ${maxItemsStyle}
@@ -795,8 +794,7 @@ const ListGroupRightSideWrapper = styled.div<{ $style?: CSSProp }>`
 
 const ShowMoreButton = styled.button<{
   $style?: CSSProp;
-  $textColor?: string;
-  $borderColor?: string;
+  $theme?: ListThemeConfig;
 }>`
   margin-top: 0.25rem;
   padding: 0.25rem 0.5rem;
@@ -811,8 +809,8 @@ const ShowMoreButton = styled.button<{
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  border: 1px solid ${({ $borderColor }) => $borderColor};
-  color: ${({ $textColor }) => $textColor};
+  border: 1px solid ${({ $theme }) => $theme?.borderColor};
+  color: ${({ $theme }) => $theme?.maxItemTextColor};
 
   ${({ $style }) => $style}
 `;

--- a/components/loading-skeleton.stories.tsx
+++ b/components/loading-skeleton.stories.tsx
@@ -1,8 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import {
-  LoadingSkeleton,
-  LoadingSkeletonOptionProps,
-} from "./loading-skeleton";
+import { LoadingSkeleton, LoadingSkeletonOption } from "./loading-skeleton";
 import { css } from "styled-components";
 import { Grid } from "./grid";
 import { useTheme } from "./../theme/provider";
@@ -115,7 +112,7 @@ export const Card: Story = {
     const { currentTheme } = useTheme();
     const loadingSkeletonTheme = currentTheme.loadingSkeleton;
 
-    const CARD_SAMPLE: LoadingSkeletonOptionProps[] = [
+    const CARD_SAMPLE: LoadingSkeletonOption[] = [
       {
         flashDirection: "left-to-right",
         flashRate: "normal",

--- a/components/loading-skeleton.tsx
+++ b/components/loading-skeleton.tsx
@@ -9,15 +9,27 @@ import {
 import styled, { css, CSSProp, keyframes } from "styled-components";
 import { useTheme } from "./../theme/provider";
 
-type FlashDirection =
-  | "left-to-right"
-  | "right-to-left"
-  | "top-to-bottom"
-  | "bottom-to-top";
+export const FlashDirection = {
+  LeftToRight: "left-to-right",
+  RightToLeft: "right-to-left",
+  TopToBottom: "top-to-bottom",
+  BottomToTop: "bottom-to-top",
+} as const;
 
-type FlashRate = "slow" | "normal" | "fast" | number;
+export type FlashDirection =
+  (typeof FlashDirection)[keyof typeof FlashDirection];
 
-export interface LoadingSkeletonOptionProps {
+export const FlashRate = {
+  Slow: "slow",
+  Normal: "normal",
+  Fast: "fast",
+} as const;
+
+export type FlashRatePreset = (typeof FlashRate)[keyof typeof FlashRate];
+
+export type FlashRate = FlashRatePreset | number;
+
+export interface LoadingSkeletonOption {
   flashDirection?: FlashDirection;
   flashRate?: FlashRate;
   baseColor?: string;
@@ -36,7 +48,7 @@ export interface LoadingSkeletonStyles {
 
 export interface LoadingSkeletonProps
   extends LoadingSkeletonBaseProps,
-    LoadingSkeletonOptionProps {
+    LoadingSkeletonOption {
   height?: number | string;
   width?: number | string;
 }
@@ -67,7 +79,7 @@ function LoadingSkeleton({
     >
       {childArray.map((child, index) => {
         const componentChild = child as ReactElement<
-          LoadingSkeletonItemProps & LoadingSkeletonOptionProps
+          LoadingSkeletonItemProps & LoadingSkeletonOption
         >;
 
         const isItem = componentChild.type === LoadingSkeleton.Item;
@@ -98,7 +110,7 @@ const LoadingSkeletonWrapper = styled.div<{ $style?: CSSProp }>`
 
 export interface LoadingSkeletonItemProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "style">,
-    LoadingSkeletonOptionProps {
+    LoadingSkeletonOption {
   styles?: LoadingSkeletonStyles;
   height?: number | string;
   width?: number | string;

--- a/components/loading-spinner.tsx
+++ b/components/loading-spinner.tsx
@@ -7,9 +7,9 @@ export interface LoadingSpinnerProps {
   textSize?: number;
   label?: string;
   gap?: number;
-  styles?: LoadingSpinnerStylesProps;
+  styles?: LoadingSpinnerStyles;
 }
-export interface LoadingSpinnerStylesProps {
+export interface LoadingSpinnerStyles {
   containerStyle?: CSSProp;
   labelStyle?: CSSProp;
   iconStyle?: CSSProp;

--- a/components/messagebox.tsx
+++ b/components/messagebox.tsx
@@ -17,23 +17,31 @@ export interface MessageboxProps {
   title: string;
   icon?: FigureProps;
   children: ReactNode;
-  actionLinks?: ActionLinkProps[];
+  actionLinks?: MessageActionLinks[];
   closable?: boolean;
   onCloseRequest?: () => void;
-  styles?: MessageboxStylesProps;
+  styles?: MessageboxStyles;
 }
 
-export interface MessageboxStylesProps {
+export interface MessageboxStyles {
   containerStyle?: CSSProp;
   titleStyle?: CSSProp;
   contentWrapperStyle?: CSSProp;
   contentStyle?: CSSProp;
 }
-export interface ActionLinkProps {
+export const MessageActionType = {
+  Button: "button",
+  Link: "link",
+} as const;
+
+export type MessageActionType =
+  (typeof MessageActionType)[keyof typeof MessageActionType];
+
+export interface MessageActionLinks {
   caption: string;
   onClick?: () => void;
   href?: string;
-  type: "button" | "link";
+  type: MessageActionType;
 }
 
 function Messagebox({

--- a/components/messagebox.tsx
+++ b/components/messagebox.tsx
@@ -6,14 +6,18 @@ import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { MessageboxThemeConfig } from "./../theme";
 
-export type MessageboxVariantState =
-  | "primary"
-  | "success"
-  | "danger"
-  | "warning";
+export const MessageboxVariant = {
+  Primary: "primary",
+  Success: "success",
+  Danger: "danger",
+  Warning: "warning",
+} as const;
+
+export type MessageboxVariant =
+  (typeof MessageboxVariant)[keyof typeof MessageboxVariant];
 
 export interface MessageboxProps {
-  variant?: MessageboxVariantState;
+  variant?: MessageboxVariant;
   title: string;
   icon?: FigureProps;
   children: ReactNode;
@@ -148,7 +152,7 @@ function Messagebox({
 
 const Wrapper = styled.div<{
   $style?: CSSProp;
-  $variant: MessageboxVariantState;
+  $variant: MessageboxVariant;
   $theme: MessageboxThemeConfig;
 }>`
   display: flex;
@@ -192,7 +196,7 @@ const Children = styled.span<{ $style?: CSSProp }>`
 `;
 
 const BorderAccent = styled.div<{
-  $variant: MessageboxVariantState;
+  $variant: MessageboxVariant;
   $theme: MessageboxThemeConfig;
 }>`
   position: absolute;
@@ -209,7 +213,7 @@ const ActionList = styled.div`
 `;
 
 const ActionItem = styled.button<{
-  $variant: MessageboxVariantState;
+  $variant: MessageboxVariant;
   $theme: MessageboxThemeConfig;
 }>`
   cursor: pointer;
@@ -230,7 +234,7 @@ const ActionItem = styled.button<{
 `;
 
 const ActionLink = styled.a<{
-  $variant: MessageboxVariantState;
+  $variant: MessageboxVariant;
   $theme: MessageboxThemeConfig;
 }>`
   font-size: 0.875rem;

--- a/components/modal-dialog.stories.tsx
+++ b/components/modal-dialog.stories.tsx
@@ -96,7 +96,7 @@ Each button object supports:
       description:
         "Custom style overrides for different ModalDialog sections (container, content, overlay, etc.).",
       table: {
-        type: { summary: "ModalDialogStylesProps" },
+        type: { summary: "ModalDialogStyles" },
       },
     },
   },

--- a/components/modal-dialog.tsx
+++ b/components/modal-dialog.tsx
@@ -13,7 +13,7 @@ import styled, { css, CSSProp } from "styled-components";
 
 export type ModalDialogProps = DialogProps;
 export type ModalDialogStyles = DialogStyles;
-export type ModalButton = DialogButton;
+export type ModalDialogButton = DialogButton;
 
 function ModalDialog({
   onVisibilityChange,

--- a/components/modal-dialog.tsx
+++ b/components/modal-dialog.tsx
@@ -5,15 +5,15 @@ import { useTheme } from "./../theme/provider";
 import {
   createDialogController,
   Dialog,
-  DialogButtonProps,
+  DialogButton,
   DialogProps,
-  DialogStylesProps,
+  DialogStyles,
 } from "./dialog";
 import styled, { css, CSSProp } from "styled-components";
 
 export type ModalDialogProps = DialogProps;
-export type ModalDialogStylesProps = DialogStylesProps;
-export type ModalButtonProps = DialogButtonProps;
+export type ModalDialogStyles = DialogStyles;
+export type ModalButton = DialogButton;
 
 function ModalDialog({
   onVisibilityChange,

--- a/components/moneybox.stories.tsx
+++ b/components/moneybox.stories.tsx
@@ -4,7 +4,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { ChangeEvent, useState } from "react";
 import { css } from "styled-components";
 import { Calendar } from "./calendar";
-import { FieldLaneDropdownsOptionProps } from "./field-lane";
+import { FieldLaneDropdownsOption } from "./field-lane";
 import { Moneybox } from "./moneybox";
 
 const meta: Meta<typeof Moneybox> = {
@@ -76,7 +76,7 @@ optional currency dropdown.
         "Available currencies when `editableCurrency` is enabled. Each item: `{ id, name, symbol }`.",
       table: {
         type: {
-          summary: "CurrencyOptionProps[]",
+          summary: "MoneyboxCurrencyOption[]",
           detail: `{ id: string; name: string; symbol: string }[]`,
         },
       },
@@ -230,7 +230,7 @@ export const WithDropdown: Story = {
       { text: "DEC", value: "12" },
     ];
 
-    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOptionProps[] = [
+    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOption[] = [
       {
         text: "On-site",
         value: "1",

--- a/components/moneybox.tsx
+++ b/components/moneybox.tsx
@@ -10,14 +10,20 @@ import {
 } from "react";
 import { Button } from "./button";
 import { List } from "./list";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { MoneyboxThemeConfig } from "./../theme";
 
-export type SeparatorTypeProps = "dot" | "comma";
+export const MoneyboxSeparator = {
+  Dot: "dot",
+  Comma: "comma",
+} as const;
 
-export interface CurrencyOptionProps {
+export type MoneyboxSeparator =
+  (typeof MoneyboxSeparator)[keyof typeof MoneyboxSeparator];
+
+export interface MoneyboxCurrencyOption {
   id: string;
   name: string;
   symbol: string;
@@ -33,16 +39,16 @@ interface BaseMoneyboxProps
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
   name?: string;
   placeholder?: string;
-  separator?: SeparatorTypeProps;
+  separator?: MoneyboxSeparator;
   showError?: boolean;
   onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
-  styles?: MoneyboxStylesProps;
+  styles?: MoneyboxStyles;
   editableCurrency?: boolean;
-  currencyOptions?: CurrencyOptionProps[];
+  currencyOptions?: MoneyboxCurrencyOption[];
   id?: string;
 }
 
-export interface MoneyboxStylesProps {
+export interface MoneyboxStyles {
   self?: CSSProp;
   inputWrapperStyle?: CSSProp;
 }
@@ -250,7 +256,7 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
 export interface MoneyboxProps
   extends Omit<BaseMoneyboxProps, "styles" | "actions">,
     Omit<FieldLaneProps, "styles" | "type" | "actions"> {
-  styles?: MoneyboxStylesProps & FieldLaneStylesProps;
+  styles?: MoneyboxStyles & FieldLaneStyles;
 }
 
 const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
@@ -394,7 +400,7 @@ const MoneyboxInput = styled.input<{
 
 const unformatMoneyboxNumber = (
   val: string,
-  separator: SeparatorTypeProps
+  separator: MoneyboxSeparator
 ): string => {
   if (!val) return "";
 
@@ -431,7 +437,7 @@ const unformatMoneyboxNumber = (
 
 const formatMoneyboxNumber = (
   val: string,
-  separator: SeparatorTypeProps
+  separator: MoneyboxSeparator
 ): string => {
   if (!val) return "";
 

--- a/components/nav-tab.stories.tsx
+++ b/components/nav-tab.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { NavTab, NavTabContentProps } from "./nav-tab";
+import { NavTab, NavTabTabProps } from "./nav-tab";
 import { Textbox } from "./textbox";
 import { useState } from "react";
 import { StatefulOnChangeType } from "./stateful-form";
@@ -13,7 +13,7 @@ import {
   RiSettings5Line,
   RiTable2,
 } from "@remixicon/react";
-import { ColumnTableProps, Table } from "./table";
+import { TableColumn, Table } from "./table";
 import { css } from "styled-components";
 import { generateSentence } from "./../lib/text";
 
@@ -108,7 +108,7 @@ Configuration for right-side action buttons in the NavTab component. Each action
 - **caption**: Optional text label displayed on the action button.
 - **icon**: FigureProps object to render a custom icon inside the button.
 - **onClick**: Callback function triggered when the button is clicked.
-- **styles**: Optional styling overrides using \`ActionButtonStylesProps\` (styled-components compatible).
+- **styles**: Optional styling overrides using \`ActionButtonStyles\` (styled-components compatible).
 - **subMenu**: Function returning a ReactNode to render a dropdown or sub-menu associated with the button.
 - **disabled**: Boolean to disable the button interaction.
 - **showSubMenuOn**: Determines how the sub-menu is triggered: "caret" (click on caret) or "self" (click anywhere on button).
@@ -149,7 +149,7 @@ export const Default: Story = {
   render: () => {
     const [activeTab, setActiveTab] = useState("2");
 
-    const TABS_ITEMS: NavTabContentProps[] = [
+    const TABS_ITEMS: NavTabTabProps[] = [
       {
         id: "1",
         title: "Write",
@@ -182,7 +182,7 @@ export const Small: Story = {
   render: () => {
     const [activeTab, setActiveTab] = useState("2");
 
-    const TABS_ITEMS: NavTabContentProps[] = [
+    const TABS_ITEMS: NavTabTabProps[] = [
       {
         id: "1",
         title: "Write",
@@ -225,7 +225,7 @@ export const WithActions: Story = {
   render: () => {
     const [activeTab, setActiveTab] = useState("3");
 
-    const TABS_ITEMS: NavTabContentProps[] = [
+    const TABS_ITEMS: NavTabTabProps[] = [
       {
         id: "1",
         title: "Write",
@@ -325,7 +325,7 @@ export const WithSubItems: Story = {
       );
     });
 
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "name",
         caption: "Name",
@@ -338,7 +338,7 @@ export const WithSubItems: Story = {
       },
     ];
 
-    const TABS_ITEMS: NavTabContentProps[] = [
+    const TABS_ITEMS: NavTabTabProps[] = [
       {
         id: "1",
         title: "Write",

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -18,18 +18,18 @@ import { useTheme } from "../theme/provider";
 import { NavTabThemeConfig } from "./../theme";
 
 export interface NavTabProps {
-  tabs?: NavTabContentProps[];
+  tabs?: NavTabTabProps[];
   activeTab?: string;
   activeColor?: string;
   children?: ReactNode;
-  actions?: NavTabActionsProps[];
-  styles?: NavTabStylesProps;
+  actions?: NavTabAction[];
+  styles?: NavTabStyles;
   size?: NavTabSize;
   onChange?: (activeTab: string) => void;
   active?: boolean;
 }
 
-export interface NavTabStylesProps {
+export interface NavTabStyles {
   contentStyle?: CSSProp;
   containerStyle?: CSSProp;
   containerBoxStyle?: CSSProp;
@@ -38,23 +38,28 @@ export interface NavTabStylesProps {
   boxStyle?: CSSProp;
 }
 
-export interface NavTabActionsProps extends ActionButtonProps {
+export interface NavTabAction extends ActionButtonProps {
   active?: boolean;
 }
 
-export type NavTabSize = "md" | "sm";
+export const NavTabSize = {
+  Small: "sm",
+  Medium: "md",
+};
 
-export interface NavTabContentProps {
+export type NavTabSize = (typeof NavTabSize)[keyof typeof NavTabSize];
+
+export interface NavTabTabProps {
   id: string;
   title: string;
   content?: ReactNode;
   onClick?: () => void;
-  actions?: SubMenuNavTab[];
-  subItems?: NavTabSubItemsContentProps[];
+  actions?: NavTabTabAction[];
+  subItems?: NavTabSubItem[];
   hidden?: boolean;
 }
 
-export interface NavTabSubItemsContentProps {
+export interface NavTabSubItem {
   id: string;
   caption: string;
   icon?: FigureProps;
@@ -63,7 +68,7 @@ export interface NavTabSubItemsContentProps {
   hidden?: boolean;
 }
 
-export interface SubMenuNavTab extends Omit<TipMenuItemProps, "onClick"> {
+export interface NavTabTabAction extends Omit<TipMenuItemProps, "onClick"> {
   onClick: (id?: string) => void;
 }
 

--- a/components/overlay-blocker.tsx
+++ b/components/overlay-blocker.tsx
@@ -24,11 +24,11 @@ export interface OverlayBlockerProps {
   show?: boolean;
   zIndex?: number;
   onClick?: OverlayBlockerClickHandler;
-  styles?: OverlayBlockerStylesProps;
+  styles?: OverlayBlockerStyles;
   children?: ReactNode;
 }
 
-export interface OverlayBlockerStylesProps {
+export interface OverlayBlockerStyles {
   self?: CSSProp;
 }
 

--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -11,10 +11,10 @@ export interface PaginationProps {
   totalPages: number;
   onPageChange: (page: number) => void;
   showNumbers?: boolean;
-  styles?: PaginationStylesProps;
+  styles?: PaginationStyles;
 }
 
-export interface PaginationStylesProps {
+export interface PaginationStyles {
   containerStyle?: CSSProp;
   buttonStyle?: CSSProp;
   selectboxStyle?: CSSProp;
@@ -112,7 +112,7 @@ const PaginationItem = ({
   onPageChange: (page: number) => void;
   setCurrentPageLocal: (page: string[]) => void;
   comboboxPagesNumber?: number;
-  styles?: PaginationStylesProps;
+  styles?: PaginationStyles;
 }) => {
   const highlightOnMatch = useMemo(() => {
     return currentPage <= comboboxPagesNumber;
@@ -222,10 +222,10 @@ interface PaginationButtonProps {
   children: ReactNode;
   isActive?: boolean;
   disabled?: boolean;
-  styles?: PaginationButtonStylesProps;
+  styles?: PaginationButtonStyles;
 }
 
-interface PaginationButtonStylesProps {
+interface PaginationButtonStyles {
   self?: CSSProp;
 }
 

--- a/components/paper-dialog.stories.tsx
+++ b/components/paper-dialog.stories.tsx
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { COUNTRY_CODES } from "./../constants/countries";
 import { css } from "styled-components";
 import { Card } from "./card";
-import { ColumnTableProps, SubMenuListTableProps, Table } from "./table";
+import { TableColumn, TableSubMenuList, Table } from "./table";
 import { RiAddBoxLine, RiDeleteBin2Line, RiEdit2Line } from "@remixicon/react";
 
 const meta: Meta<typeof PaperDialog> = {
@@ -466,7 +466,7 @@ export const Nested: Story = {
       throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
     }
 
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "name",
         caption: "Name",
@@ -564,7 +564,7 @@ export const Nested: Story = {
     const ROW_ACTIONS = (
       rowId: string,
       withOnClick?: boolean
-    ): SubMenuListTableProps[] => {
+    ): TableSubMenuList[] => {
       const name = rowId.split("-")[0];
       const dataFamily = rows.find((props) => props.name === name);
       return [

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -24,10 +24,25 @@ import { OverlayBlocker } from "./overlay-blocker";
 import { useTheme } from "./../theme/provider";
 import { PaperDialogThemeConfig } from "./../theme";
 
-export type DialogState = "restored" | "closed" | "minimized";
+export const PaperDialogState = {
+  Restored: "restored",
+  Closed: "closed",
+  Minimized: "minimized",
+} as const;
+
+export type PaperDialogState =
+  (typeof PaperDialogState)[keyof typeof PaperDialogState];
+
+export const PaperDialogPosition = {
+  Left: "left",
+  Right: "right",
+} as const;
+
+export type PaperDialogPosition =
+  (typeof PaperDialogPosition)[keyof typeof PaperDialogPosition];
 
 export interface PaperDialogProps {
-  position?: "left" | "right";
+  position?: PaperDialogPosition;
   children?: ReactNode;
   closable?: boolean;
   width?: string;
@@ -44,7 +59,7 @@ export interface PaperDialogStyles {
 
 export interface PaperDialogTriggerProps {
   children?: ReactNode;
-  setDialogState?: (dialogState: DialogState) => void;
+  setDialogState?: (dialogState: PaperDialogState) => void;
   icon?: FigureProps;
   variant?: ButtonVariants["variant"];
   styles?: PaperDialogTriggerStyles;
@@ -75,7 +90,7 @@ const PaperDialogBase = forwardRef<PaperDialogRef, PaperDialogProps>(
     const { currentTheme } = useTheme();
     const paperDialogTheme = currentTheme.paperDialog;
 
-    const [dialogState, setDialogState] = useState<DialogState>("closed");
+    const [dialogState, setDialogState] = useState<PaperDialogState>("closed");
     const controls = useAnimation();
     const isLeft = position === "left";
 
@@ -96,7 +111,7 @@ const PaperDialogBase = forwardRef<PaperDialogRef, PaperDialogProps>(
       return () => document.removeEventListener("keydown", handleEscape);
     }, [handleEscape]);
 
-    const handleToggleDrawer = (open: DialogState) => {
+    const handleToggleDrawer = (open: PaperDialogState) => {
       setDialogState(open);
       controls.start({
         x: open === "minimized" ? (isLeft ? "-100%" : "100%") : 0,
@@ -246,7 +261,7 @@ const PaperDialogBase = forwardRef<PaperDialogRef, PaperDialogProps>(
 );
 
 const DialogOverlay = styled.div<{
-  $dialogState: DialogState;
+  $dialogState: PaperDialogState;
   $paperDialogStyle?: CSSProp;
 }>`
   position: fixed;

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -62,10 +62,8 @@ export interface PaperDialogTriggerProps {
   setDialogState?: (dialogState: PaperDialogState) => void;
   icon?: FigureProps;
   variant?: ButtonVariants["variant"];
-  styles?: PaperDialogTriggerStyles;
+  styles?: ButtonStyles;
 }
-
-export type PaperDialogTriggerStyles = ButtonStyles;
 
 export interface PaperDialogContentProps {
   children?: ReactNode;

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -17,7 +17,7 @@ import {
   useCallback,
   useEffect,
 } from "react";
-import { Button, ButtonStylesProps, ButtonVariants } from "./button";
+import { Button, ButtonStyles, ButtonVariants } from "./button";
 import styled, { css, CSSProp } from "styled-components";
 import { Figure, FigureProps } from "./figure";
 import { OverlayBlocker } from "./overlay-blocker";
@@ -31,11 +31,11 @@ export interface PaperDialogProps {
   children?: ReactNode;
   closable?: boolean;
   width?: string;
-  styles?: PaperDialogStylesProps;
+  styles?: PaperDialogStyles;
   onClosed?: () => void;
 }
 
-export interface PaperDialogStylesProps {
+export interface PaperDialogStyles {
   self?: CSSProp;
   tabStyle?: CSSProp;
   tabCloseStyle?: CSSProp;
@@ -47,17 +47,17 @@ export interface PaperDialogTriggerProps {
   setDialogState?: (dialogState: DialogState) => void;
   icon?: FigureProps;
   variant?: ButtonVariants["variant"];
-  styles?: PaperDialogTriggerStylesProps;
+  styles?: PaperDialogTriggerStyles;
 }
 
-export type PaperDialogTriggerStylesProps = ButtonStylesProps;
+export type PaperDialogTriggerStyles = ButtonStyles;
 
 export interface PaperDialogContentProps {
   children?: ReactNode;
-  styles?: PaperDialogContentStylesProps;
+  styles?: PaperDialogContentStyles;
 }
 
-export interface PaperDialogContentStylesProps {
+export interface PaperDialogContentStyles {
   self?: CSSProp;
 }
 

--- a/components/phonebox.stories.tsx
+++ b/components/phonebox.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { css } from "styled-components";
 import { COUNTRY_CODES } from "./../constants/countries";
-import { FieldLaneDropdownsOptionProps } from "./field-lane";
+import { FieldLaneDropdownsOption } from "./field-lane";
 import { CountryCodeProps, Phonebox } from "./phonebox";
 import { StatefulOnChangeType } from "./stateful-form";
 
@@ -104,7 +104,7 @@ export const WithDropdown: Story = {
       setValue((prev) => ({ ...prev, [name]: value }));
     };
 
-    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOptionProps[] = [
+    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOption[] = [
       {
         text: "On-site",
         value: "1",

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -25,7 +25,7 @@ import {
 import { COUNTRY_CODES } from "../constants/countries";
 import { AsYouType, CountryCode } from "libphonenumber-js/max";
 import styled, { css, CSSProp } from "styled-components";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { Figure } from "./figure";
 import { StatefulForm } from "./stateful-form";
 import { Searchbox } from "./searchbox";
@@ -56,12 +56,12 @@ interface BasePhoneboxProps {
   onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
   onBlur?: () => void;
   countryCodeValue?: CountryCodeProps;
-  styles?: PhoneboxStylesProps;
+  styles?: PhoneboxStyles;
   id?: string;
   required?: boolean;
 }
 
-export interface PhoneboxStylesProps {
+export interface PhoneboxStyles {
   self?: CSSProp;
   inputWrapperStyle?: CSSProp;
   toggleStyle?: CSSProp;
@@ -375,7 +375,7 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
 export interface PhoneboxProps
   extends Omit<BasePhoneboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "onChange"> {
-  styles?: PhoneboxStylesProps & FieldLaneStylesProps;
+  styles?: PhoneboxStyles & FieldLaneStyles;
 }
 
 const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(

--- a/components/pinbox.stories.tsx
+++ b/components/pinbox.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
-import { Pinbox, PinboxState } from "./pinbox";
+import { Pinbox, PinboxParts } from "./pinbox";
 import { StatefulOnChangeType } from "./stateful-form";
 
 const meta: Meta<typeof Pinbox> = {
@@ -94,7 +94,7 @@ export const Default: Story = {
   render: () => {
     const [value, setValue] = useState("");
 
-    const PARTS_INPUT: PinboxState[] = [
+    const PARTS_INPUT: PinboxParts[] = [
       { type: "static", text: "S" },
       { type: "alphanumeric" },
       { type: "digit" },
@@ -119,7 +119,7 @@ export const Masked: Story = {
   render: () => {
     const [value, setValue] = useState("");
 
-    const PARTS_INPUT: PinboxState[] = [
+    const PARTS_INPUT: PinboxParts[] = [
       { type: "static", text: "S" },
       { type: "alphanumeric" },
       { type: "alphanumeric" },
@@ -145,7 +145,7 @@ export const Disabled: Story = {
   render: () => {
     const [value, setValue] = useState("");
 
-    const PARTS_INPUT: PinboxState[] = [
+    const PARTS_INPUT: PinboxParts[] = [
       { type: "static", text: "S" },
       { type: "alphanumeric" },
       { type: "alphanumeric" },
@@ -172,7 +172,7 @@ export const Error: Story = {
   render: () => {
     const [value, setValue] = useState("");
 
-    const PARTS_INPUT: PinboxState[] = [
+    const PARTS_INPUT: PinboxParts[] = [
       { type: "static", text: "S" },
       { type: "alphanumeric" },
       { type: "alphanumeric" },

--- a/components/pinbox.tsx
+++ b/components/pinbox.tsx
@@ -6,9 +6,9 @@ import React, {
   useRef,
   useState,
 } from "react";
-import styled, { css } from "styled-components";
+import styled, { css, CSSProp } from "styled-components";
 import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { PinboxThemeConfig } from "./../theme";
 
@@ -19,20 +19,22 @@ interface BasePinboxProps {
   showError?: boolean;
   errorMessage?: string;
   masked?: boolean;
-  parts?: PinboxState[];
+  parts?: PinboxParts[];
   name?: string;
   onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
   onBlur?: () => void;
   value?: string;
   disabled?: boolean;
-  styles?: BasePinboxStylesProps;
   id?: string;
   required?: boolean;
+  styles?: BasePinboxStyles;
 }
 
-interface BasePinboxStylesProps {}
+interface BasePinboxStyles {
+  self?: CSSProp;
+}
 
-export interface PinboxState {
+export interface PinboxParts {
   type?: PinboxTypeState;
   text?: string;
 }
@@ -54,6 +56,7 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
       id,
       onBlur,
       required,
+      styles,
     },
     ref
   ) => {
@@ -405,6 +408,7 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
                 onChange={() => {}}
                 aria-label="pinbox-input"
                 $error={showError}
+                $style={styles?.self}
                 ref={(el: HTMLInputElement) => {
                   inputsRef.current[index] = el;
 
@@ -449,12 +453,12 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
   }
 );
 
-export type PinboxStylesProps = BasePinboxStylesProps & FieldLaneStylesProps;
+export type PinboxStyles = BasePinboxStyles & FieldLaneStyles;
 
 export interface PinboxProps
   extends Omit<BasePinboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns"> {
-  styles?: PinboxStylesProps;
+  styles?: PinboxStyles;
 }
 
 const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
@@ -586,6 +590,7 @@ const PinboxInput = styled.input<{
   $isStatic?: boolean;
   $isAnimate?: boolean;
   $theme: PinboxThemeConfig;
+  $style?: CSSProp;
 }>`
   ${({ $fontSize, $isStatic }) =>
     $isStatic
@@ -651,6 +656,8 @@ const PinboxInput = styled.input<{
             cursor: not-allowed;
           }
         `};
+
+  ${({ $style }) => $style}
 `;
 
 const switchInputBox = (type: PinboxTypeState) => {

--- a/components/radio.stories.tsx
+++ b/components/radio.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Radio, RadioOptionProps } from "./radio";
+import { Radio, RadioOption } from "./radio";
 import { ChangeEvent, ComponentProps, Fragment, useState } from "react";
 import { useArgs } from "@storybook/preview-api";
 import { css } from "styled-components";
@@ -94,7 +94,7 @@ export const Default: Story = {
     value: "comments",
   },
   render: (args) => {
-    const RADIO_OPTIONS: RadioOptionProps[] = [
+    const RADIO_OPTIONS: RadioOption[] = [
       {
         value: "comments",
         label: "Comments",
@@ -146,7 +146,7 @@ export const WithButton: Story = {
     value: "comments",
   },
   render: (args) => {
-    const RADIO_OPTIONS_WITH_ICON: RadioOptionProps[] = [
+    const RADIO_OPTIONS_WITH_ICON: RadioOption[] = [
       {
         value: "text",
         label: "Text",
@@ -210,7 +210,7 @@ export const WithButton: Story = {
   },
 };
 
-const DAILY_RADIO_OPTIONS: RadioOptionProps[] = [
+const DAILY_RADIO_OPTIONS: RadioOption[] = [
   {
     value: "daily",
     label: "Daily",
@@ -329,7 +329,7 @@ export const WithError: Story = {
 
 export const Disabled: Story = {
   render: () => {
-    const RADIO_OPTIONS: RadioOptionProps[] = [
+    const RADIO_OPTIONS: RadioOption[] = [
       {
         value: "email",
         label: "Email",

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -2,7 +2,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { ChangeEvent, InputHTMLAttributes } from "react";
 import { StatefulForm } from "./stateful-form";
 import { Figure, FigureProps } from "./figure";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { RadioThemeConfig } from "theme";
 
@@ -15,7 +15,7 @@ interface BaseRadioProps
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   name?: string;
   highlightOnChecked?: boolean;
-  styles?: BaseRadioStylesProps;
+  styles?: BaseRadioStyles;
   showError?: boolean;
   errorMessage?: string;
   mode?: "radio" | "button";
@@ -25,7 +25,7 @@ interface BaseRadioProps
 
 export type RadioIconProps = FigureProps;
 
-interface BaseRadioStylesProps {
+interface BaseRadioStyles {
   descriptionStyle?: CSSProp;
   self?: CSSProp;
   titleStyle?: CSSProp;
@@ -34,7 +34,7 @@ interface BaseRadioStylesProps {
   textWrapperStyle?: CSSProp;
 }
 
-export interface RadioOptionProps {
+export interface RadioOption {
   value?: string;
   label?: string;
   description?: string;
@@ -127,12 +127,12 @@ function BaseRadio({
   );
 }
 
-export type RadioStylesProps = BaseRadioStylesProps & FieldLaneStylesProps;
+export type RadioStyles = BaseRadioStyles & FieldLaneStyles;
 
 export interface RadioProps
   extends Omit<BaseRadioProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns"> {
-  styles?: RadioStylesProps;
+  styles?: RadioStyles;
 }
 
 function Radio({

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -6,6 +6,13 @@ import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { RadioThemeConfig } from "theme";
 
+export const RadioMode = {
+  Radio: "radio",
+  Button: "button",
+} as const;
+
+export type RadioMode = (typeof RadioMode)[keyof typeof RadioMode];
+
 interface BaseRadioProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "style"> {
   value?: string;
@@ -18,7 +25,7 @@ interface BaseRadioProps
   styles?: BaseRadioStyles;
   showError?: boolean;
   errorMessage?: string;
-  mode?: "radio" | "button";
+  mode?: RadioMode;
   helper?: string;
   icon?: RadioIconProps;
 }

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -27,10 +27,8 @@ interface BaseRadioProps
   errorMessage?: string;
   mode?: RadioMode;
   helper?: string;
-  icon?: RadioIconProps;
+  icon?: FigureProps;
 }
-
-export type RadioIconProps = FigureProps;
 
 interface BaseRadioStyles {
   descriptionStyle?: CSSProp;
@@ -45,7 +43,7 @@ export interface RadioOption {
   value?: string;
   label?: string;
   description?: string;
-  icon?: RadioIconProps;
+  icon?: FigureProps;
 }
 
 function BaseRadio({

--- a/components/rating.tsx
+++ b/components/rating.tsx
@@ -6,9 +6,9 @@ import { useTheme } from "./../theme/provider";
 import { RatingThemeConfig } from "./../theme";
 
 export const RatingSize = {
-  Sm: "sm",
-  Md: "md",
-  Lg: "lg",
+  Small: "sm",
+  Medium: "md",
+  Large: "lg",
 } as const;
 
 export type RatingSize = (typeof RatingSize)[keyof typeof RatingSize];

--- a/components/rating.tsx
+++ b/components/rating.tsx
@@ -1,22 +1,30 @@
 import { ChangeEvent, MouseEvent, useState } from "react";
 import styled, { css, CSSProp } from "styled-components";
 import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { RatingThemeConfig } from "./../theme";
+
+export const RatingSize = {
+  Sm: "sm",
+  Md: "md",
+  Lg: "lg",
+} as const;
+
+export type RatingSize = (typeof RatingSize)[keyof typeof RatingSize];
 
 interface BaseRatingProps {
   rating?: string;
   onChange?: (rating: ChangeEvent<HTMLInputElement>) => void;
   editable?: boolean;
   withLabel?: boolean;
-  size?: "sm" | "md" | "lg";
+  size?: RatingSize;
   disabled?: boolean;
   name?: string;
-  styles?: BaseRatingStylesProps;
+  styles?: BaseRatingStyles;
   id?: string;
 }
-interface BaseRatingStylesProps {
+interface BaseRatingStyles {
   containerStyle?: CSSProp;
   labelStyle?: CSSProp;
 }
@@ -161,12 +169,12 @@ function BaseRating({
   );
 }
 
-export type RatingStylesProps = BaseRatingStylesProps & FieldLaneStylesProps;
+export type RatingStyles = BaseRatingStyles & FieldLaneStyles;
 
 export interface RatingProps
   extends Omit<BaseRatingProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns"> {
-  styles?: RatingStylesProps;
+  styles?: RatingStyles;
 }
 
 function Rating({

--- a/components/rating.tsx
+++ b/components/rating.tsx
@@ -15,7 +15,7 @@ export type RatingSize = (typeof RatingSize)[keyof typeof RatingSize];
 
 interface BaseRatingProps {
   rating?: string;
-  onChange?: (rating: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
   editable?: boolean;
   withLabel?: boolean;
   size?: RatingSize;

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -30,20 +30,34 @@ export interface RichEditorProps {
   value?: string;
   onChange?: (value: string) => void;
   toolbarRightPanel?: ReactNode;
-  styles?: RichEditorStylesProps;
-  mode?: RichEditorModeState;
-  toolbarPosition?: RichEditorToolbarPositionState;
+  styles?: RichEditorStyles;
+  mode?: RichEditorMode;
+  toolbarPosition?: RichEditorToolbarPosition;
   autogrow?: boolean;
   height?: number;
 }
 
-export interface RichEditorStylesProps {
+export interface RichEditorStyles {
   editorStyle?: CSSProp;
   containerStyle?: CSSProp;
 }
 
-export type RichEditorToolbarPositionState = "top" | "bottom";
-export type RichEditorModeState = "view-only" | "page-editor" | "text-editor";
+export const RichEditorToolbarPosition = {
+  Top: "top",
+  Bottom: "bottom",
+} as const;
+
+export type RichEditorToolbarPosition =
+  (typeof RichEditorToolbarPosition)[keyof typeof RichEditorToolbarPosition];
+
+export const RichEditorMode = {
+  ViewOnly: "view-only",
+  PageEditor: "page-editor",
+  TextEditor: "text-editor",
+} as const;
+
+export type RichEditorMode =
+  (typeof RichEditorMode)[keyof typeof RichEditorMode];
 
 export interface RichEditorToolbarButtonProps {
   icon?: FigureProps;
@@ -51,10 +65,10 @@ export interface RichEditorToolbarButtonProps {
   children?: ReactNode;
   isOpen?: boolean;
   isActive?: boolean;
-  styles?: RichEditorToolbarButtonStylesProps;
+  styles?: RichEditorToolbarButtonStyles;
 }
 
-export interface RichEditorToolbarButtonStylesProps {
+export interface RichEditorToolbarButtonStyles {
   self?: CSSProp;
 }
 
@@ -1268,7 +1282,7 @@ function RichEditorToolbarButton({
 
 const Wrapper = styled.div<{
   $containerStyle?: CSSProp;
-  $mode?: RichEditorModeState;
+  $mode?: RichEditorMode;
   $theme: RichEditorThemeConfig;
 }>`
   ${({ $mode, $theme }) =>
@@ -1286,7 +1300,7 @@ const Wrapper = styled.div<{
 `;
 
 const ToolbarWrapper = styled.div<{
-  $toolbarPosition?: RichEditorToolbarPositionState;
+  $toolbarPosition?: RichEditorToolbarPosition;
 }>`
   position: absolute;
   width: 100%;
@@ -1302,7 +1316,7 @@ const ToolbarWrapper = styled.div<{
 `;
 
 const Toolbar = styled.div<{
-  $toolbarPosition?: RichEditorToolbarPositionState;
+  $toolbarPosition?: RichEditorToolbarPosition;
   $theme: RichEditorThemeConfig;
 }>`
   display: flex;
@@ -1347,7 +1361,7 @@ const ToolbarRightPanel = styled.div`
 `;
 
 const MenuWrapper = styled.div<{
-  $toolbarPosition?: RichEditorToolbarPositionState;
+  $toolbarPosition?: RichEditorToolbarPosition;
 }>`
   position: absolute;
   ${({ $toolbarPosition }) =>
@@ -1365,9 +1379,9 @@ const MenuWrapper = styled.div<{
 `;
 
 const EditorArea = styled.div<{
-  $toolbarPosition?: RichEditorToolbarPositionState;
+  $toolbarPosition?: RichEditorToolbarPosition;
   $editorStyle?: CSSProp;
-  $mode?: RichEditorModeState;
+  $mode?: RichEditorMode;
   $autogrow?: boolean;
   $height?: number;
   $theme: RichEditorThemeConfig;

--- a/components/searchbox.stories.tsx
+++ b/components/searchbox.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Searchbox, SearchboxResultMenuItemProps } from "./searchbox";
+import { Searchbox, SearchboxResultMenuItem } from "./searchbox";
 import { useArgs } from "@storybook/preview-api";
 import { ChangeEvent, useMemo, useState } from "react";
 import {
@@ -110,7 +110,7 @@ export const WithResultMenu: Story = {
     placeholder: "Search here...",
   },
   render: (args) => {
-    const PEOPLE_MENU: SearchboxResultMenuItemProps[] = [
+    const PEOPLE_MENU: SearchboxResultMenuItem[] = [
       {
         caption: "Adam Noto Hakarsa",
         icon: { image: RiUserSmileLine },

--- a/components/searchbox.tsx
+++ b/components/searchbox.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 import styled, { css, CSSProp } from "styled-components";
-import { Button, SubMenuButtonProps } from "./button";
+import { Button, ButtonSubMenu } from "./button";
 import { TipMenuItemProps } from "./tip-menu";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
@@ -19,21 +19,21 @@ export interface SearchboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "style"> {
   name?: string;
   value?: string;
-  onChange?: (data: ChangeEvent<HTMLInputElement>) => void;
-  styles?: SearchboxStylesProps;
-  resultMenu?: SearchboxResultMenuProps;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  styles?: SearchboxStyles;
+  resultMenu?: SearchboxResultMenu;
   showResultMenu?: boolean;
   safeAriaLabelSubMenu?: string[];
 }
 
-export interface SearchboxStylesProps {
+export interface SearchboxStyles {
   self?: CSSProp;
   containerStyle?: CSSProp;
   iconStyle?: CSSProp;
 }
 
-export type SearchboxResultMenuProps = (props: SubMenuButtonProps) => ReactNode;
-export type SearchboxResultMenuItemProps = TipMenuItemProps;
+export type SearchboxResultMenu = (props: ButtonSubMenu) => ReactNode;
+export type SearchboxResultMenuItem = TipMenuItemProps;
 
 const Searchbox = forwardRef<Omit<HTMLInputElement, "style">, SearchboxProps>(
   (

--- a/components/selectbox.stories.tsx
+++ b/components/selectbox.stories.tsx
@@ -1,5 +1,9 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { OptionProps, Selectbox, SelectboxSelectedOptions } from "./selectbox";
+import {
+  SelectboxOption,
+  Selectbox,
+  SelectboxSelectedOptions,
+} from "./selectbox";
 import { useState } from "react";
 
 const meta: Meta<typeof Selectbox> = {
@@ -195,7 +199,7 @@ export const Default: Story = {
   render: () => {
     const [value, setValue] = useState<SelectboxSelectedOptions>([]);
 
-    const SELECTBOX_DATA: OptionProps[] = [
+    const SELECTBOX_DATA: SelectboxOption[] = [
       {
         text: "Selectbox content default.",
         value: "1",
@@ -253,7 +257,7 @@ export const Clearable: Story = {
   render: () => {
     const [value, setValue] = useState<SelectboxSelectedOptions>([]);
 
-    const SELECTBOX_DATA: OptionProps[] = [
+    const SELECTBOX_DATA: SelectboxOption[] = [
       {
         text: "Selectbox content with clearable.",
         value: "1",

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -30,7 +30,7 @@ import {
 } from "@remixicon/react";
 import styled, { css, CSSProp } from "styled-components";
 import { isValidDateString } from "../lib/date";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { FigureProps } from "./figure";
 import { StatefulForm } from "./stateful-form";
 import { LoadingSpinner } from "./loading-spinner";
@@ -41,7 +41,7 @@ export type SelectboxSelectedOptions = number | string | number[] | string[];
 
 interface BaseSelectboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "children"> {
-  options?: OptionProps[];
+  options?: SelectboxOption[];
   selectedOptions?: SelectboxSelectedOptions;
   onChange?: (selectedOptions: SelectboxSelectedOptions) => void;
   placeholder?: string;
@@ -63,17 +63,17 @@ interface BaseSelectboxProps
   children?: (
     props: DrawerProps &
       InteractionModeProps & {
-        options: OptionProps[];
+        options: SelectboxOption[];
         handleKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
-        selectedOptionsLocal: OptionProps;
-        setSelectedOptionsLocal: (value: OptionProps) => void;
+        selectedOptionsLocal: SelectboxOption;
+        setSelectedOptionsLocal: (value: SelectboxOption) => void;
         hasInteracted?: boolean;
         setHasInteracted?: (value: boolean) => void;
         ref?: Ref<HTMLInputElement>;
-        setConfirmedValue?: (option: OptionProps | null) => void;
+        setConfirmedValue?: (option: SelectboxOption | null) => void;
       }
   ) => ReactNode;
-  styles?: SelectboxStylesProps;
+  styles?: SelectboxStyles;
   labels?: SelectboxLabelsProps;
 }
 
@@ -81,14 +81,12 @@ export interface SelectboxLabelsProps {
   loadingText?: string;
 }
 
-interface BaseSelectboxStylesProps {
+interface BaseSelectboxStyles {
   selectboxStyle?: CSSProp;
   self?: CSSProp;
 }
 
-export interface SelectboxStylesProps
-  extends FieldLaneStylesProps,
-    BaseSelectboxStylesProps {}
+export type SelectboxStyles = FieldLaneStyles & BaseSelectboxStyles;
 
 export interface DrawerProps extends InteractionModeProps {
   highlightedIndex: number | null;
@@ -110,7 +108,7 @@ interface InteractionModeProps {
   setInteractionMode: (props: "keyboard" | "mouse") => void;
 }
 
-export interface OptionProps {
+export interface SelectboxOption {
   text: string;
   render?: ReactNode;
   value: string | number;
@@ -210,7 +208,7 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
     };
 
     const [selectedOptionsLocal, setSelectedOptionsLocal] =
-      useState<OptionProps>(initialState);
+      useState<SelectboxOption>(initialState);
 
     const [isOpen, setIsOpen] = useState(false);
     const [highlightedIndex, setHighlightedIndex] = useState<number | null>(0);
@@ -221,9 +219,8 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
       "keyboard" | "mouse"
     >("mouse");
 
-    const [confirmedValue, setConfirmedValue] = useState<OptionProps | null>(
-      null
-    );
+    const [confirmedValue, setConfirmedValue] =
+      useState<SelectboxOption | null>(null);
 
     const inputRef = useRef<HTMLInputElement>(null);
     const listRef = useRef<(HTMLLIElement | null)[]>([]);
@@ -276,9 +273,9 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
     const justCommittedRef = useRef(false);
 
     const commitOrRevert = (
-      selectedOption?: OptionProps,
-      currentLocal: OptionProps = selectedOptionsLocal,
-      currentConfirmed: OptionProps | null = confirmedValue
+      selectedOption?: SelectboxOption,
+      currentLocal: SelectboxOption = selectedOptionsLocal,
+      currentConfirmed: SelectboxOption | null = confirmedValue
     ) => {
       if (selectedOption) {
         const val = String(selectedOption.value);
@@ -612,7 +609,7 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
 export interface SelectboxProps
   extends Omit<BaseSelectboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "actions" | "children"> {
-  styles?: SelectboxStylesProps;
+  styles?: SelectboxStyles;
 }
 
 const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -74,10 +74,10 @@ interface BaseSelectboxProps
       }
   ) => ReactNode;
   styles?: SelectboxStyles;
-  labels?: SelectboxLabelsProps;
+  labels?: SelectboxLabels;
 }
 
-export interface SelectboxLabelsProps {
+export interface SelectboxLabels {
   loadingText?: string;
 }
 

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -1,14 +1,22 @@
 import styled, { CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
 
+export const SeparatorTextFloat = {
+  Left: "left",
+  Right: "right",
+} as const;
+
+export type SeparatorTextFloat =
+  (typeof SeparatorTextFloat)[keyof typeof SeparatorTextFloat];
+
 export interface SeparatorProps {
   title?: string;
-  textFloat?: "left" | "right";
+  textFloat?: SeparatorTextFloat;
   depth?: string;
-  styles?: SeparatorStylesProps;
+  styles?: SeparatorStyles;
 }
 
-export interface SeparatorStylesProps {
+export interface SeparatorStyles {
   containerStyle?: CSSProp;
   titleStyle?: CSSProp;
   lineStyle?: CSSProp;

--- a/components/sidebar.stories.tsx
+++ b/components/sidebar.stories.tsx
@@ -63,7 +63,7 @@ const meta: Meta<typeof Sidebar> = {
     styles: {
       control: false,
       description: "Custom styles for sidebar containers.",
-      table: { type: { summary: "SidebarStylesProps" } },
+      table: { type: { summary: "SidebarStyles" } },
     },
   },
 };

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -10,11 +10,11 @@ import { useTheme } from "./../theme/provider";
 
 export interface SidebarProps {
   children?: ReactNode;
-  styles?: SidebarStylesProps;
+  styles?: SidebarStyles;
   position?: "left" | "right";
 }
 
-export interface SidebarStylesProps {
+export interface SidebarStyles {
   mobileStyle?: CSSProp;
   desktopStyle?: CSSProp;
 }
@@ -22,10 +22,10 @@ export interface SidebarStylesProps {
 export interface SidebarItemProps {
   isFixed?: boolean;
   children?: ReactNode;
-  styles?: SidebarItemStylesProps;
+  styles?: SidebarItemStyles;
 }
 
-export interface SidebarItemStylesProps {
+export interface SidebarItemStyles {
   self?: CSSProp;
 }
 

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -8,10 +8,18 @@ import { OverlayBlocker } from "./overlay-blocker";
 import { SidebarThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
 
+export const SidebarPosition = {
+  Left: "left",
+  Right: "right",
+} as const;
+
+export type SidebarPosition =
+  (typeof SidebarPosition)[keyof typeof SidebarPosition];
+
 export interface SidebarProps {
   children?: ReactNode;
   styles?: SidebarStyles;
-  position?: "left" | "right";
+  position?: SidebarPosition;
 }
 
 export interface SidebarStyles {

--- a/components/signbox.stories.tsx
+++ b/components/signbox.stories.tsx
@@ -3,7 +3,7 @@ import { useArgs } from "@storybook/preview-api";
 import { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { css } from "styled-components";
-import { FieldLaneDropdownsOptionProps } from "./field-lane";
+import { FieldLaneDropdownsOption } from "./field-lane";
 import { Signbox } from "./signbox";
 import { StatefulOnChangeType } from "./stateful-form";
 
@@ -117,7 +117,7 @@ export const WithDropdown: Story = {
       value: "",
     });
 
-    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOptionProps[] = [
+    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOption[] = [
       {
         text: "On-site",
         value: "1",

--- a/components/signbox.tsx
+++ b/components/signbox.tsx
@@ -1,7 +1,7 @@
 import { RiEraserLine } from "@remixicon/react";
 import React, { useRef, useEffect, ChangeEvent } from "react";
 import styled, { css, CSSProp } from "styled-components";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { SignboxThemeConfig } from "./../theme";
@@ -18,12 +18,12 @@ interface BaseSignboxProps {
   errorMessage?: string;
   height?: string;
   width?: string;
-  styles?: SignboxStylesProps;
+  styles?: SignboxStyles;
   helper?: string;
   id?: string;
 }
 
-export interface SignboxStylesProps {
+export interface SignboxStyles {
   self?: CSSProp;
 }
 
@@ -278,7 +278,7 @@ function BaseSignbox({
 export interface SignboxProps
   extends Omit<BaseSignboxProps, "styles" | "children">,
     Omit<FieldLaneProps, "styles" | "type" | "children"> {
-  styles?: SignboxStylesProps & FieldLaneStylesProps;
+  styles?: SignboxStyles & FieldLaneStyles;
 }
 
 function Signbox({

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -337,7 +337,7 @@ export const Default: Story = {
         required: true,
         disabled: !isFormValid,
         placeholder: "Enter text",
-        rowJustifyContent: "flex-end",
+        rowJustifyPosition: "flex-end",
       },
     ];
 
@@ -473,7 +473,7 @@ export const WithFrame: Story = {
         title: "Submit",
         type: "button",
         disabled: !isFormValid,
-        rowJustifyContent: "flex-end",
+        rowJustifyPosition: "flex-end",
       },
     ];
 
@@ -653,7 +653,7 @@ export const ConditionalElement: Story = {
           title: "Submit",
           type: "button",
           disabled: !isFormValid,
-          rowJustifyContent: "flex-end",
+          rowJustifyPosition: "flex-end",
         },
       ] as FormFieldGroup[];
     }, [formFields.compEffort, formFields.quantType, isFormValid]);
@@ -1479,7 +1479,7 @@ export const AllCase: Story = {
         type: "button",
         required: true,
         disabled: !isFormValid,
-        rowJustifyContent: "flex-end",
+        rowJustifyPosition: "flex-end",
       },
     ];
 

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -337,7 +337,7 @@ export const Default: Story = {
         required: true,
         disabled: !isFormValid,
         placeholder: "Enter text",
-        rowJustifyContent: "end",
+        rowJustifyContent: "flex-end",
       },
     ];
 
@@ -473,7 +473,7 @@ export const WithFrame: Story = {
         title: "Submit",
         type: "button",
         disabled: !isFormValid,
-        rowJustifyContent: "end",
+        rowJustifyContent: "flex-end",
       },
     ];
 
@@ -653,7 +653,7 @@ export const ConditionalElement: Story = {
           title: "Submit",
           type: "button",
           disabled: !isFormValid,
-          rowJustifyContent: "end",
+          rowJustifyContent: "flex-end",
         },
       ] as FormFieldGroup[];
     }, [formFields.compEffort, formFields.quantType, isFormValid]);
@@ -1479,7 +1479,7 @@ export const AllCase: Story = {
         type: "button",
         required: true,
         disabled: !isFormValid,
-        rowJustifyContent: "end",
+        rowJustifyContent: "flex-end",
       },
     ];
 

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -7,12 +7,9 @@ import { BadgeProps } from "./badge";
 import { Button } from "./button";
 import { CapsuleTab } from "./capsule";
 import { Card } from "./card";
-import {
-  OnCompleteFunctionProps,
-  OnFileDroppedFunctionProps,
-} from "./file-drop-box";
+import { OnCompleteFunction, OnFileDroppedFunction } from "./file-drop-box";
 import { Messagebox } from "./messagebox";
-import { CurrencyOption } from "./moneybox";
+import { MoneyboxCurrencyOption } from "./moneybox";
 import { CountryCodeProps } from "./phonebox";
 import { PinboxParts } from "./pinbox";
 import { SelectboxOption } from "./selectbox";
@@ -952,7 +949,7 @@ export const AllCase: Story = {
       },
     ];
 
-    const CURRENCY_OPTIONS: CurrencyOption[] = [
+    const CURRENCY_OPTIONS: MoneyboxCurrencyOption[] = [
       { id: "IDR", name: "Indonesian Rupiah", symbol: "Rp" },
       { id: "USD", name: "US Dollar", symbol: "$" },
       { id: "EUR", name: "Euro", symbol: "€" },
@@ -1202,7 +1199,7 @@ export const AllCase: Story = {
       files,
       setProgressLabel,
       succeed,
-    }: OnFileDroppedFunctionProps) => {
+    }: OnFileDroppedFunction) => {
       const file = files[0];
       setProgressLabel(`Uploading ${file.name}`);
 
@@ -1229,7 +1226,7 @@ export const AllCase: Story = {
       failedFiles,
       setProgressLabel,
       succeedFiles,
-    }: OnCompleteFunctionProps) => {
+    }: OnCompleteFunction) => {
       setValue((prev) => ({
         ...prev,
         file_drop_box: succeedFiles,

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -5,24 +5,24 @@ import { z } from "zod";
 import { COUNTRY_CODES } from "./../constants/countries";
 import { BadgeProps } from "./badge";
 import { Button } from "./button";
-import { CapsuleContentProps } from "./capsule";
+import { CapsuleTab } from "./capsule";
 import { Card } from "./card";
 import {
   OnCompleteFunctionProps,
   OnFileDroppedFunctionProps,
 } from "./file-drop-box";
 import { Messagebox } from "./messagebox";
-import { CurrencyOptionProps } from "./moneybox";
+import { CurrencyOption } from "./moneybox";
 import { CountryCodeProps } from "./phonebox";
-import { PinboxState } from "./pinbox";
-import { OptionProps } from "./selectbox";
+import { PinboxParts } from "./pinbox";
+import { SelectboxOption } from "./selectbox";
 import {
   FormFieldGroup,
   FormValueType,
   StatefulForm,
   StatefulOnChangeType,
 } from "./stateful-form";
-import { BodyThemeConfiguration } from "./../theme";
+import { BodyThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
 import { darkenColor, lightenColor } from "./../lib/color";
 
@@ -164,7 +164,7 @@ Custom styles for form components:
 - \`frameContainerStyle\`: CSS for frame containers.
 - \`frameTitleStyle\`: CSS for frame titles.
 `,
-      table: { type: { summary: "StatefulFormStylesProps" } },
+      table: { type: { summary: "StatefulFormStyles" } },
     },
   },
 };
@@ -194,7 +194,7 @@ export const Default: Story = {
       country_code: DEFAULT_COUNTRY_CODES,
     });
 
-    const SALUTATION_OPTIONS: OptionProps[] = [
+    const SALUTATION_OPTIONS: SelectboxOption[] = [
       { text: "Mr.", value: "1" },
       { text: "Mrs.", value: "2" },
       { text: "Ms.", value: "3" },
@@ -401,12 +401,12 @@ export const WithFrame: Story = {
       purpose: z.string().min(10, "Business purpose is required"),
     });
 
-    const MANAGER_NAME_OPTIONS: OptionProps[] = [
+    const MANAGER_NAME_OPTIONS: SelectboxOption[] = [
       { text: "Alim Naufal", value: "1" },
       { text: "Soekarno", value: "2" },
     ];
 
-    const DEPARTMENT_OPTIONS: OptionProps[] = [
+    const DEPARTMENT_OPTIONS: SelectboxOption[] = [
       { text: "HR", value: "1" },
       { text: "IT", value: "2" },
     ];
@@ -557,20 +557,20 @@ export const ConditionalElement: Story = {
       Fp32: 3,
     } as const;
 
-    const HOST_ARCHITECTURE_OPTIONS: OptionProps[] = [
+    const HOST_ARCHITECTURE_OPTIONS: SelectboxOption[] = [
       { value: String(HostArchitecture.x86), text: "x86" },
       { value: String(HostArchitecture.x64), text: "x64" },
       { value: String(HostArchitecture.ARM), text: "ARM" },
       { value: String(HostArchitecture.ARM64), text: "ARM64" },
     ];
 
-    const COMPILATION_TARGET_OPTIONS: OptionProps[] = [
+    const COMPILATION_TARGET_OPTIONS: SelectboxOption[] = [
       { value: String(CompilationTarget.Interpreter), text: "Interpreter" },
       { value: String(CompilationTarget.Simulator), text: "Simulator" },
       { value: String(CompilationTarget.IP), text: "IP" },
     ];
 
-    const COMPILATION_EFFORT_OPTIONS: OptionProps[] = [
+    const COMPILATION_EFFORT_OPTIONS: SelectboxOption[] = [
       {
         value: String(CompilationEffort.SimpleScheduling),
         text: "Simple scheduling",
@@ -585,7 +585,7 @@ export const ConditionalElement: Story = {
       },
     ];
 
-    const QUANTIZATION_TYPE_OPTIONS: OptionProps[] = [
+    const QUANTIZATION_TYPE_OPTIONS: SelectboxOption[] = [
       { value: String(Quantization.Int8), text: "INT8" },
       { value: String(Quantization.Bf16), text: "BF16" },
       { value: String(Quantization.Fp16), text: "FP16" },
@@ -832,7 +832,7 @@ const FormBody = styled.div`
 `;
 
 const Footer = styled.div<{
-  $theme?: BodyThemeConfiguration;
+  $theme?: BodyThemeConfig;
   $mode: "light" | "dark";
 }>`
   display: flex;
@@ -899,7 +899,7 @@ export const AllCase: Story = {
       throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
     }
 
-    const FRUIT_OPTIONS: OptionProps[] = [
+    const FRUIT_OPTIONS: SelectboxOption[] = [
       { text: "Apple", value: "1" },
       { text: "Banana", value: "2" },
       { text: "Orange", value: "3" },
@@ -952,7 +952,7 @@ export const AllCase: Story = {
       },
     ];
 
-    const CURRENCY_OPTIONS: CurrencyOptionProps[] = [
+    const CURRENCY_OPTIONS: CurrencyOption[] = [
       { id: "IDR", name: "Indonesian Rupiah", symbol: "Rp" },
       { id: "USD", name: "US Dollar", symbol: "$" },
       { id: "EUR", name: "Euro", symbol: "€" },
@@ -1025,7 +1025,7 @@ export const AllCase: Story = {
       pin: "",
     });
 
-    const CAPSULE_TABS: CapsuleContentProps[] = [
+    const CAPSULE_TABS: CapsuleTab[] = [
       {
         id: "paid",
         title: "Paid",
@@ -1036,7 +1036,7 @@ export const AllCase: Story = {
       },
     ];
 
-    const PARTS_INPUT: PinboxState[] = [
+    const PARTS_INPUT: PinboxParts[] = [
       {
         type: "static",
         text: "S",

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -130,25 +130,25 @@ export interface StatefulFormStyles {
 
 export type FormFieldGroup = FormFieldProps | FormFieldProps[];
 
-export const FormFieldRowJustifyContent = {
+export const FormFieldRowJustifyPosition = {
   Center: "center",
   Start: "flex-start",
   End: "flex-end",
   Between: "space-between",
 } as const;
 
-export type FormFieldRowJustifyContent =
-  (typeof FormFieldRowJustifyContent)[keyof typeof FormFieldRowJustifyContent];
+export type FormFieldRowJustifyPosition =
+  (typeof FormFieldRowJustifyPosition)[keyof typeof FormFieldRowJustifyPosition];
 
-export const FormFieldRowAlignItems = {
+export const FormFieldRowItemsAligment = {
   Center: "center",
   Start: "flex-start",
   End: "flex-end",
   Stretch: "stretch",
 } as const;
 
-export type FormFieldRowAlignItems =
-  (typeof FormFieldRowAlignItems)[keyof typeof FormFieldRowAlignItems];
+export type FormFieldRowItemsAligment =
+  (typeof FormFieldRowItemsAligment)[keyof typeof FormFieldRowItemsAligment];
 
 export interface FormFieldProps {
   name: string;
@@ -169,8 +169,8 @@ export interface FormFieldProps {
   labelGap?: FieldLaneProps["labelGap"];
   labelWidth?: FieldLaneProps["labelWidth"];
   disabled?: boolean;
-  rowJustifyContent?: FormFieldRowJustifyContent;
-  rowAlignItems?: FormFieldRowAlignItems;
+  rowJustifyPosition?: FormFieldRowJustifyPosition;
+  rowItemsAlignment?: FormFieldRowItemsAligment;
   onChange?: (e?: StatefulOnChangeType) => void;
   onClick?: (e?: React.MouseEvent) => void;
   textboxProps?: TextboxProps;
@@ -456,12 +456,12 @@ function FormFields<T extends FieldValues>({
         }
 
         const rowJustifiedContent = visibleFields.find(
-          (f) => f.rowJustifyContent
-        )?.rowJustifyContent;
+          (f) => f.rowJustifyPosition
+        )?.rowJustifyPosition;
 
         const rowAlignedItem = visibleFields.find(
-          (f) => f.rowAlignItems
-        )?.rowAlignItems;
+          (f) => f.rowItemsAlignment
+        )?.rowItemsAlignment;
 
         const withFrame = visibleFields.some((f) => f.type === "frame");
 

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -121,6 +121,26 @@ export interface StatefulFormStyles {
 
 export type FormFieldGroup = FormFieldProps | FormFieldProps[];
 
+export const FormFieldRowJustifyContent = {
+  Center: "center",
+  Start: "flex-start",
+  End: "flex-end",
+  Between: "space-between",
+} as const;
+
+export type FormFieldRowJustifyContent =
+  (typeof FormFieldRowJustifyContent)[keyof typeof FormFieldRowJustifyContent];
+
+export const FormFieldRowAlignItems = {
+  Center: "center",
+  Start: "flex-start",
+  End: "flex-end",
+  Stretch: "stretch",
+} as const;
+
+export type FormFieldRowAlignItems =
+  (typeof FormFieldRowAlignItems)[keyof typeof FormFieldRowAlignItems];
+
 export interface FormFieldProps {
   name: string;
   id?: string;
@@ -140,8 +160,8 @@ export interface FormFieldProps {
   labelGap?: FieldLaneProps["labelGap"];
   labelWidth?: FieldLaneProps["labelWidth"];
   disabled?: boolean;
-  rowJustifyContent?: "center" | "start" | "end" | "between";
-  rowAlignItems?: "center" | "start" | "end" | "between";
+  rowJustifyContent?: FormFieldRowJustifyContent;
+  rowAlignItems?: FormFieldRowAlignItems;
   onChange?: (e?: StatefulOnChangeType) => void;
   onClick?: (e?: React.MouseEvent) => void;
   textboxProps?: TextboxProps;
@@ -450,13 +470,7 @@ function FormFields<T extends FieldValues>({
               ${styles?.rowStyle}
               ${rowJustifiedContent &&
               css`
-                justify-content: ${rowJustifiedContent === "end"
-                  ? "flex-end"
-                  : rowJustifiedContent === "start"
-                    ? "flex-start"
-                    : rowJustifiedContent === "between"
-                      ? "space-between"
-                      : "center"};
+                justify-content: ${rowJustifiedContent};
               `};
 
               ${rowWithFrame &&
@@ -467,13 +481,7 @@ function FormFields<T extends FieldValues>({
 
               ${rowAlignedItem &&
               css`
-                align-items: ${rowAlignedItem === "end"
-                  ? "end"
-                  : rowAlignedItem === "start"
-                    ? "start"
-                    : rowAlignedItem === "between"
-                      ? "space-between"
-                      : "center"};
+                align-items: ${rowAlignedItem};
               `};
 
               ${rowStyleItem}

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -99,11 +99,20 @@ export const FormFieldType = {
 
 export type FormFieldType = (typeof FormFieldType)[keyof typeof FormFieldType];
 
+export const StatefulFormMode = {
+  OnChange: "onChange",
+  OnBlur: "onBlur",
+  OnSubmit: "onSubmit",
+} as const;
+
+export type StatefulFormMode =
+  (typeof StatefulFormMode)[keyof typeof StatefulFormMode];
+
 export interface StatefulFormProps<Z extends ZodTypeAny> {
   fields: FormFieldGroup[];
   formValues: TypeOf<Z>;
   validationSchema?: Z;
-  mode?: "onChange" | "onBlur" | "onSubmit";
+  mode?: StatefulFormMode;
   onValidityChange?: (e: boolean) => void;
   labelSize?: string;
   fieldSize?: string;

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -67,34 +67,37 @@ export type FormValueType =
   | string[]
   | number[];
 
-export type FormFieldType =
-  | "text"
-  | "message"
-  | "number"
-  | "email"
-  | "password"
-  | "textarea"
-  | "checkbox"
-  | "radio"
-  | "phone"
-  | "color"
-  | "file_drop_box"
-  | "file"
-  | "image"
-  | "signbox"
-  | "money"
-  | "date"
-  | "combo"
-  | "chips"
-  | "rating"
-  | "thumbfield"
-  | "toggle"
-  | "capsule"
-  | "time"
-  | "button"
-  | "pin"
-  | "frame"
-  | "custom";
+export const FormFieldType = {
+  Text: "text",
+  Message: "message",
+  Number: "number",
+  Email: "email",
+  Password: "password",
+  Textarea: "textarea",
+  Checkbox: "checkbox",
+  Radio: "radio",
+  Phone: "phone",
+  Color: "color",
+  FileDropBox: "file_drop_box",
+  File: "file",
+  Image: "image",
+  Signbox: "signbox",
+  Money: "money",
+  Date: "date",
+  Combo: "combo",
+  Chips: "chips",
+  Rating: "rating",
+  Thumbfield: "thumbfield",
+  Toggle: "toggle",
+  Capsule: "capsule",
+  Time: "time",
+  Button: "button",
+  Pin: "pin",
+  Frame: "frame",
+  Custom: "custom",
+} as const;
+
+export type FormFieldType = (typeof FormFieldType)[keyof typeof FormFieldType];
 
 export interface StatefulFormProps<Z extends ZodTypeAny> {
   fields: FormFieldGroup[];

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -106,10 +106,10 @@ export interface StatefulFormProps<Z extends ZodTypeAny> {
   fieldSize?: string;
   onChange?: (args: { currentState: any }) => void;
   autoFocusField?: string;
-  styles?: StatefulFormStylesProps;
+  styles?: StatefulFormStyles;
 }
 
-export interface StatefulFormStylesProps {
+export interface StatefulFormStyles {
   containerStyle?: CSSProp;
   rowStyle?: CSSProp;
   frameContainerStyle?: CSSProp;
@@ -379,7 +379,7 @@ interface FormFieldsProps<T extends FieldValues> {
   setValue?: UseFormSetValue<T>;
   onChange?: (name: keyof T, value: FormValueType) => void;
   autoFocusField?: string;
-  styles?: StatefulFormStylesProps;
+  styles?: StatefulFormStyles;
   rowWithFrame?: boolean;
 }
 

--- a/components/statusbar.stories.tsx
+++ b/components/statusbar.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react/*";
 import { Statusbar } from "./statusbar";
-import { CapsuleTab, CapsuleTabContentProps } from "./capsule-tab";
+import { CapsuleTab, CapsuleTabTab } from "./capsule-tab";
 import { Textbox } from "./textbox";
 import { ChangeEvent, useState } from "react";
 import {
@@ -295,7 +295,7 @@ export const ContainerizedClassicTheme: Story = {
       );
     };
 
-    const TABS_ITEMS: CapsuleTabContentProps[] = [
+    const TABS_ITEMS: CapsuleTabTab[] = [
       {
         id: "1",
         title: "Write",
@@ -495,7 +495,7 @@ export const ContainerizedModernTheme: Story = {
       );
     };
 
-    const TABS_ITEMS: CapsuleTabContentProps[] = [
+    const TABS_ITEMS: CapsuleTabTab[] = [
       {
         id: "1",
         title: "Write",

--- a/components/statusbar.stories.tsx
+++ b/components/statusbar.stories.tsx
@@ -74,7 +74,7 @@ const statusbarContent = {
   argTypes: {
     content: {
       description:
-        "Content object for the statusbar. Use \`left\` and \`right\` arrays of StatusbarItemProps to configure items.",
+        "Content object for the statusbar. Use \`left\` and \`right\` arrays of StatusbarItem to configure items.",
       control: false,
     },
     styles: {

--- a/components/statusbar.tsx
+++ b/components/statusbar.tsx
@@ -7,16 +7,16 @@ import { StatusbarThemeConfig } from "./../theme";
 
 export interface StatusbarProps {
   styles?: StatusbarStyles;
-  content?: StatusbarContentProps;
+  content?: StatusbarContent;
   activeBackgroundColor?: string;
   hoverBackgroundColor?: string;
   transparent?: boolean;
   size?: number;
 }
 
-export interface StatusbarContentProps {
-  left?: StatusbarItemProps[];
-  right?: StatusbarItemProps[];
+export interface StatusbarContent {
+  left?: StatusbarItem[];
+  right?: StatusbarItem[];
 }
 
 export interface StatusbarStyles {
@@ -69,7 +69,7 @@ function Statusbar({
 }
 
 const renderSection = (
-  items?: StatusbarItemProps[],
+  items?: StatusbarItem[],
   style?: CSSProp,
   itemStyle?: CSSProp,
   activeBackgroundColor?: string,
@@ -103,7 +103,7 @@ const renderSection = (
   );
 };
 
-export interface StatusbarItemProps {
+export interface StatusbarItem {
   text?: string;
   icon?: FigureProps;
   render?: ReactNode;
@@ -128,7 +128,7 @@ function StatusbarItem({
   size,
   width,
   transparent,
-}: StatusbarItemProps & {
+}: StatusbarItem & {
   activeBackgroundColor?: string;
   hoverBackgroundColor?: string;
   size?: number;

--- a/components/statusbar.tsx
+++ b/components/statusbar.tsx
@@ -6,7 +6,7 @@ import { useTheme } from "./../theme/provider";
 import { StatusbarThemeConfig } from "./../theme";
 
 export interface StatusbarProps {
-  styles?: StatusbarStylesProps;
+  styles?: StatusbarStyles;
   content?: StatusbarContentProps;
   activeBackgroundColor?: string;
   hoverBackgroundColor?: string;
@@ -19,7 +19,7 @@ export interface StatusbarContentProps {
   right?: StatusbarItemProps[];
 }
 
-export interface StatusbarStylesProps {
+export interface StatusbarStyles {
   self?: CSSProp;
   itemStyle?: CSSProp;
   leftWrapperStyle?: CSSProp;
@@ -108,12 +108,12 @@ export interface StatusbarItemProps {
   icon?: FigureProps;
   render?: ReactNode;
   button?: ButtonProps;
-  styles?: StatusbarItemStylesProps;
+  styles?: StatusbarItemStyles;
   width?: string;
   hidden?: boolean;
 }
 
-interface StatusbarItemStylesProps {
+interface StatusbarItemStyles {
   self?: CSSProp;
 }
 

--- a/components/stepline.stories.tsx
+++ b/components/stepline.stories.tsx
@@ -30,7 +30,7 @@ It supports icons, labels, collapsible tooltips, customizable styles, and click 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | \`children\` | ReactNode | — | Step components (\`Stepline.Item\`) to render inside the stepline. |
-| \`styles\` | SteplineStylesProps | — | Custom CSS styles for the wrapper. |
+| \`styles\` | SteplineStyles | — | Custom CSS styles for the wrapper. |
 | \`gap\` | number | 8 | Space in pixels between steps. |
 | \`collapsed\` | boolean | false | Collapses step labels into tooltips. |
 
@@ -45,7 +45,7 @@ It supports icons, labels, collapsible tooltips, customizable styles, and click 
 | \`variant\` | 'todo' \| 'current' \| 'completed' \| 'error' | 'todo' | Step visual variant affecting circle color and line color. |
 | \`active\` | boolean | false | Scale the outer circle to indicate active state. |
 | \`onClick\` | () => void | — | Callback when the step is clicked. |
-| \`styles\` | SteplineItemStylesProps | — | Custom styles for the item, outer/inner circle, and text wrapper. |
+| \`styles\` | SteplineItemStyles | — | Custom styles for the item, outer/inner circle, and text wrapper. |
 
 ---
 

--- a/components/stepline.tsx
+++ b/components/stepline.tsx
@@ -1,4 +1,4 @@
-import { SteplineItemState } from "./../constants/step-component-util";
+import { SteplineItem } from "./../constants/step-component-util";
 import { Children, cloneElement, isValidElement, ReactNode } from "react";
 import styled, { css } from "styled-components";
 import type { CSSProp } from "styled-components";
@@ -8,12 +8,12 @@ import { SteplineThemeConfig } from "./../theme";
 
 export interface SteplineProps {
   children?: ReactNode;
-  styles?: SteplineStylesProps;
+  styles?: SteplineStyles;
   gap?: number;
   collapsed?: boolean;
 }
 
-export interface SteplineStylesProps {
+export interface SteplineStyles {
   self?: CSSProp;
 }
 
@@ -32,7 +32,7 @@ function Stepline({ children, styles, gap, collapsed }: SteplineProps) {
       {childArray.map((child, index) => {
         if (
           !isValidElement<
-            SteplineItemState &
+            SteplineItem &
               Partial<{
                 hoveredIndex?: number | null;
               }>
@@ -125,12 +125,12 @@ const StepLine = styled.div<{
         : $theme?.line?.default || "#9ca3af"};
 `;
 
-export type SteplineItemProps = SteplineItemState &
+export type SteplineItemProps = SteplineItem &
   Partial<{
-    styles?: SteplineItemStylesProps;
+    styles?: SteplineItemStyles;
   }>;
 
-export interface SteplineItemStylesProps {
+export interface SteplineItemStyles {
   containerStyle?: CSSProp;
   outerCircleStyle?: CSSProp;
   innerCircleStyle?: CSSProp;

--- a/components/stepline.tsx
+++ b/components/stepline.tsx
@@ -1,4 +1,4 @@
-import { SteplineItem } from "./../constants/step-component-util";
+import { BaseSteplineItem } from "./../constants/step-component-util";
 import { Children, cloneElement, isValidElement, ReactNode } from "react";
 import styled, { css } from "styled-components";
 import type { CSSProp } from "styled-components";
@@ -32,7 +32,7 @@ function Stepline({ children, styles, gap, collapsed }: SteplineProps) {
       {childArray.map((child, index) => {
         if (
           !isValidElement<
-            SteplineItem &
+            BaseSteplineItem &
               Partial<{
                 hoveredIndex?: number | null;
               }>
@@ -125,7 +125,7 @@ const StepLine = styled.div<{
         : $theme?.line?.default || "#9ca3af"};
 `;
 
-export type SteplineItemProps = SteplineItem &
+export type SteplineItemProps = BaseSteplineItem &
   Partial<{
     styles?: SteplineItemStyles;
   }>;

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -1,10 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import {
-  ColumnTableProps,
-  SubMenuListTableProps,
-  Table,
-  TableActionsProps,
-} from "./table";
+import { TableColumn, TableSubMenuList, Table, TableAction } from "./table";
 import { useEffect, useMemo, useState } from "react";
 import {
   RiArrowDownSLine,
@@ -21,7 +16,7 @@ import {
 import { EmptySlate } from "./empty-slate";
 import { Button } from "./button";
 import { css } from "styled-components";
-import { CapsuleContentProps } from "./capsule";
+import { CapsuleTab } from "./capsule";
 import { List } from "./list";
 import { Card } from "./card";
 import { generateSentence } from "./../lib/text";
@@ -290,7 +285,7 @@ Each column includes:
     `,
       control: false,
       table: {
-        type: { summary: "ColumnTableProps[]" },
+        type: { summary: "TableColumn[]" },
       },
     },
 
@@ -304,7 +299,7 @@ Header-level actions displayed when rows are selected.
     `,
       control: false,
       table: {
-        type: { summary: "TableActionsProps[]" },
+        type: { summary: "TableAction[]" },
       },
     },
 
@@ -346,7 +341,7 @@ Used to define rows and grouping structure.
 Generates sorting menu for each column.
 
 \`\`\`ts
-(columnId: string) => SubMenuListTableProps[]
+(columnId: string) => TableSubMenuList[]
 \`\`\`
 
 - Used when \`sortable: true\` in column
@@ -355,7 +350,7 @@ Generates sorting menu for each column.
       control: false,
       table: {
         type: {
-          summary: "(columnId: string) => SubMenuListTableProps[]",
+          summary: "(columnId: string) => TableSubMenuList[]",
         },
       },
     },
@@ -463,7 +458,7 @@ Used to override default text (i18n, UX customization)
     `,
       control: false,
       table: {
-        type: { summary: "TableLabelsProps | null" },
+        type: { summary: "TableLabels | null" },
       },
     },
 
@@ -476,7 +471,7 @@ Summary row displayed at the bottom.
     `,
       control: false,
       table: {
-        type: { summary: "SummaryRowProps[]" },
+        type: { summary: "TableSummaryRow[]" },
       },
     },
 
@@ -496,7 +491,7 @@ All accept \`CSSProp\` (styled-components).
     `,
       control: false,
       table: {
-        type: { summary: "TableStylesProps" },
+        type: { summary: "TableStyles" },
       },
     },
   },
@@ -521,7 +516,7 @@ export const Default: Story = {
       );
     });
 
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "name",
         caption: "Name",
@@ -551,7 +546,7 @@ export const Default: Story = {
 
 export const Appendable: Story = {
   render: () => {
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "from",
         caption: "From",
@@ -684,7 +679,7 @@ export const Appendable: Story = {
 
     const TIP_MENU_ACTION = (
       columnCaption: "from" | "content"
-    ): SubMenuListTableProps[] => {
+    ): TableSubMenuList[] => {
       return [
         {
           caption: "Sort Ascending",
@@ -719,7 +714,7 @@ export const Appendable: Story = {
       ];
     };
 
-    const ROW_ACTION = (rowId: string): SubMenuListTableProps[] => {
+    const ROW_ACTION = (rowId: string): TableSubMenuList[] => {
       return [
         {
           caption: "Edit",
@@ -797,7 +792,7 @@ export const Appendable: Story = {
 
 export const WithOneAction: Story = {
   render: () => {
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "from",
         caption: "From",
@@ -930,7 +925,7 @@ export const WithOneAction: Story = {
 
     const TIP_MENU_ACTION = (
       columnCaption: "from" | "content"
-    ): SubMenuListTableProps[] => {
+    ): TableSubMenuList[] => {
       return [
         {
           caption: "Sort Ascending",
@@ -965,7 +960,7 @@ export const WithOneAction: Story = {
       ];
     };
 
-    const ROW_ACTION = (rowId: string): SubMenuListTableProps[] => {
+    const ROW_ACTION = (rowId: string): TableSubMenuList[] => {
       return [
         {
           caption: "Delete",
@@ -1114,7 +1109,7 @@ export const SortableWithPagination: Story = {
       setPagedRows(sorted);
     };
 
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "name",
         caption: "Name",
@@ -1127,9 +1122,7 @@ export const SortableWithPagination: Story = {
       },
     ];
 
-    const TIP_MENU_ACTION = (
-      columnCaption: string
-    ): SubMenuListTableProps[] => {
+    const TIP_MENU_ACTION = (columnCaption: string): TableSubMenuList[] => {
       const column = columnCaption.toLowerCase() as keyof (typeof rawRows)[0];
 
       return [
@@ -1236,7 +1229,7 @@ export const WithLoading: Story = {
         />
       );
     });
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "name",
         caption: "Name",
@@ -1270,7 +1263,7 @@ export const WithEmptySlate: Story = {
   render: () => {
     const emptyRows = [];
 
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "name",
         caption: "Name",
@@ -1403,7 +1396,7 @@ export const WithSummary: Story = {
     const [rows, setRows] = useState(TABLE_ITEMS);
     const [search, setSearch] = useState("");
 
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "itemId",
         caption: "Item ID",
@@ -1460,9 +1453,7 @@ export const WithSummary: Story = {
       setRows(sortedRows);
     };
 
-    const TIP_MENU_ACTION = (
-      columnCaption: string
-    ): SubMenuListTableProps[] => {
+    const TIP_MENU_ACTION = (columnCaption: string): TableSubMenuList[] => {
       const column = columnCaption as keyof (typeof TABLE_ITEMS)[0]["items"][0];
 
       return [
@@ -1499,7 +1490,7 @@ export const WithSummary: Story = {
       ];
     };
 
-    const ROW_ACTION = (rowId: string): SubMenuListTableProps[] => {
+    const ROW_ACTION = (rowId: string): TableSubMenuList[] => {
       return [
         {
           caption: "Edit",
@@ -1779,7 +1770,7 @@ export const WithRowGroup: Story = {
     });
     const [isFocus, setIsFocus] = useState(false);
 
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "title",
         caption: "Title",
@@ -1832,7 +1823,7 @@ export const WithRowGroup: Story = {
       setRows(sortedRows);
     };
 
-    const VIEW_MODES: CapsuleContentProps[] = [
+    const VIEW_MODES: CapsuleTab[] = [
       {
         id: "taken",
         title: "Taken",
@@ -1843,7 +1834,7 @@ export const WithRowGroup: Story = {
       },
     ];
 
-    const VIEW_MODES_WITH_ICON: CapsuleContentProps[] = [
+    const VIEW_MODES_WITH_ICON: CapsuleTab[] = [
       {
         id: "frontend",
         icon: {
@@ -1858,7 +1849,7 @@ export const WithRowGroup: Story = {
       },
     ];
 
-    const COPY_ACTIONS: SubMenuListTableProps[] = [
+    const COPY_ACTIONS: TableSubMenuList[] = [
       {
         caption: "Copy to parent",
         icon: {
@@ -1882,7 +1873,7 @@ export const WithRowGroup: Story = {
       },
     ];
 
-    const TOP_ACTIONS: TableActionsProps[] = [
+    const TOP_ACTIONS: TableAction[] = [
       {
         type: "capsule",
         capsuleProps: {
@@ -1943,9 +1934,7 @@ export const WithRowGroup: Story = {
       },
     ];
 
-    const TIP_MENU_ACTION = (
-      columnCaption: string
-    ): SubMenuListTableProps[] => {
+    const TIP_MENU_ACTION = (columnCaption: string): TableSubMenuList[] => {
       const column =
         columnCaption.toLowerCase() as keyof (typeof TABLE_ITEMS)[0]["items"][0];
 
@@ -1983,7 +1972,7 @@ export const WithRowGroup: Story = {
       ];
     };
 
-    const ROW_ACTION = (rowId: string): SubMenuListTableProps[] => {
+    const ROW_ACTION = (rowId: string): TableSubMenuList[] => {
       return [
         {
           caption: "Edit",
@@ -2258,7 +2247,7 @@ export const WithRowAppendix: Story = {
     const [rows, setRows] = useState(TABLE_ITEMS);
     const [search, setSearch] = useState("");
 
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "itemId",
         caption: "Item ID",
@@ -2315,9 +2304,7 @@ export const WithRowAppendix: Story = {
       setRows(sortedRows);
     };
 
-    const TIP_MENU_ACTION = (
-      columnCaption: string
-    ): SubMenuListTableProps[] => {
+    const TIP_MENU_ACTION = (columnCaption: string): TableSubMenuList[] => {
       const column = columnCaption as keyof (typeof TABLE_ITEMS)[0]["items"][0];
 
       return [
@@ -2354,7 +2341,7 @@ export const WithRowAppendix: Story = {
       ];
     };
 
-    const ROW_ACTION = (rowId: string): SubMenuListTableProps[] => {
+    const ROW_ACTION = (rowId: string): TableSubMenuList[] => {
       return [
         {
           caption: "Edit",
@@ -2608,7 +2595,7 @@ export const Draggable: Story = {
 
     const TYPES_DATA = ["HTTP", "HTTPS", "TCP", "UDP", "QUIC"];
 
-    const columnsDefault = (sortable?: boolean): ColumnTableProps[] => {
+    const columnsDefault = (sortable?: boolean): TableColumn[] => {
       let sortableValue = sortable;
       return [
         {
@@ -2708,7 +2695,7 @@ export const Draggable: Story = {
 
     const [selected, setSelected] = useState([]);
 
-    const columnsGroup: ColumnTableProps[] = [
+    const columnsGroup: TableColumn[] = [
       {
         id: "title",
         caption: "Title",
@@ -2829,7 +2816,7 @@ export const Draggable: Story = {
       }
     };
 
-    const COPY_ACTIONS: SubMenuListTableProps[] = [
+    const COPY_ACTIONS: TableSubMenuList[] = [
       {
         caption: "Copy to parent",
         icon: {
@@ -2853,7 +2840,7 @@ export const Draggable: Story = {
       },
     ];
 
-    const TOP_ACTIONS: TableActionsProps[] = [
+    const TOP_ACTIONS: TableAction[] = [
       {
         caption: "Delete",
         disabled: selected.length === 0,
@@ -2880,7 +2867,7 @@ export const Draggable: Story = {
       columnCaption: string,
       rowNumber?: number,
       category?: TableCategoryState
-    ): SubMenuListTableProps[] => {
+    ): TableSubMenuList[] => {
       const column =
         columnCaption.toLowerCase() as keyof (typeof TABLE_ITEMS_GROUPS)[0]["items"][0];
 
@@ -2933,7 +2920,7 @@ export const Draggable: Story = {
       ];
     };
 
-    const ROW_ACTION = (rowId: string): SubMenuListTableProps[] => {
+    const ROW_ACTION = (rowId: string): TableSubMenuList[] => {
       return [
         {
           caption: "Edit",

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -23,11 +23,7 @@ import {
 } from "@remixicon/react";
 import { AnimatePresence, motion } from "framer-motion";
 import styled, { css, CSSProp } from "styled-components";
-import {
-  Searchbox,
-  SearchboxProps,
-  SearchboxResultMenuProps,
-} from "./searchbox";
+import { Searchbox, SearchboxProps, SearchboxResultMenu } from "./searchbox";
 import { Capsule, CapsuleProps } from "./capsule";
 import ContextMenu from "./context-menu";
 import { ActionButton, ActionButtonProps } from "./action-button";
@@ -43,8 +39,16 @@ export interface TableColumn {
   id: string;
 }
 
+export const TableActionType = {
+  Button: "button",
+  Capsule: "capsule",
+} as const;
+
+export type TableActionType =
+  (typeof TableActionType)[keyof typeof TableActionType];
+
 export interface TableAction extends ActionButtonProps {
-  type?: "button" | "capsule";
+  type?: TableActionType;
   capsuleProps?: CapsuleProps;
 }
 
@@ -97,7 +101,7 @@ export interface TableLabels {
   pageNumberText?: string | number;
 }
 
-interface TableAlwaysShowDragIconProp {
+interface TableAlwaysShowDragIcon {
   alwaysShowDragIcon?: boolean;
 }
 
@@ -112,7 +116,7 @@ export interface SummaryRowStyles {
   self?: CSSProp;
 }
 
-export type TableResultMenuProps = SearchboxResultMenuProps;
+export type TableResultMenuProps = SearchboxResultMenu;
 
 const DnDContext = createContext<{
   dragItem: {
@@ -162,7 +166,7 @@ function Table({
   styles,
   alwaysShowDragIcon = true,
   searchbox,
-}: TableProps & TableAlwaysShowDragIconProp) {
+}: TableProps & TableAlwaysShowDragIcon) {
   const { currentTheme } = useTheme();
   const tableTheme = currentTheme.table;
 
@@ -242,7 +246,7 @@ function Table({
         setOpenRowId,
         alwaysShowDragIcon,
       } as TableRowGroupProps &
-        TableAlwaysShowDragIconProp & {
+        TableAlwaysShowDragIcon & {
           selectedData?: string[];
           handleSelect?: (data: string) => void;
           draggable?: boolean;
@@ -285,7 +289,7 @@ function Table({
             setDragItem(null);
           }
         },
-      } as TableRowProps & TableAlwaysShowDragIconProp);
+      } as TableRowProps & TableAlwaysShowDragIcon);
     }
 
     return null;
@@ -873,7 +877,7 @@ function TableRowGroup({
   const tableTheme = currentTheme.table;
 
   const { openRowId, setOpenRowId, alwaysShowDragIcon } =
-    props as TableAlwaysShowDragIconProp & TableRowOpenWithId;
+    props as TableAlwaysShowDragIcon & TableRowOpenWithId;
 
   const { dragItem, setDragItem, onDragged } = useContext(DnDContext);
 
@@ -914,7 +918,7 @@ function TableRowGroup({
           }
         },
       } as TableRowProps &
-        TableAlwaysShowDragIconProp & {
+        TableAlwaysShowDragIcon & {
           index?: number;
           onDropItem?: (position: number) => void;
           groupLength?: number;
@@ -1086,7 +1090,7 @@ function TableRow({
     isLast,
     index,
   } = props as TableRowOpenWithId &
-    TableAlwaysShowDragIconProp & {
+    TableAlwaysShowDragIcon & {
       index?: number;
       isSelected?: boolean;
       isLast?: boolean;

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -78,7 +78,7 @@ export interface TableProps {
   disablePreviousPageButton?: boolean;
   disableNextPageButton?: boolean;
   labels?: TableLabels;
-  sumRow?: TableSummaryRow[];
+  sumRow?: TableSummaryRowColumn[];
   styles?: TableStyles;
   searchbox?: TableSearchbox;
 }
@@ -105,7 +105,7 @@ interface TableAlwaysShowDragIcon {
   alwaysShowDragIcon?: boolean;
 }
 
-export interface TableSummaryRow {
+export interface TableSummaryRowColumn {
   span?: number;
   content?: ReactNode;
   bold?: boolean;

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -35,9 +35,7 @@ import { OverlayBlocker } from "./overlay-blocker";
 import { useTheme } from "./../theme/provider";
 import { TableThemeConfig } from "./../theme";
 
-export type RowData = (string | ReactNode)[];
-
-export interface ColumnTableProps {
+export interface TableColumn {
   caption: string;
   sortable?: boolean;
   styles?: { self?: CSSProp };
@@ -45,7 +43,7 @@ export interface ColumnTableProps {
   id: string;
 }
 
-export interface TableActionsProps extends ActionButtonProps {
+export interface TableAction extends ActionButtonProps {
   type?: "button" | "capsule";
   capsuleProps?: CapsuleProps;
 }
@@ -62,12 +60,12 @@ export interface TableProps {
     oldPosition: number;
     newPosition: number;
   }) => void;
-  actions?: TableActionsProps[];
-  columns: ColumnTableProps[];
+  actions?: TableAction[];
+  columns: TableColumn[];
   onItemsSelected?: (items: string[]) => void;
   children: ReactNode;
   isLoading?: boolean;
-  subMenuList?: (columnCaption: string) => SubMenuListTableProps[];
+  subMenuList?: (columnCaption: string) => TableSubMenuList[];
   emptySlate?: ReactNode;
   onLastRowReached?: () => void;
   showPagination?: boolean;
@@ -75,15 +73,17 @@ export interface TableProps {
   onPreviousPageRequested?: () => void;
   disablePreviousPageButton?: boolean;
   disableNextPageButton?: boolean;
-  labels?: TableLabelsProps;
-  sumRow?: SummaryRowProps[];
-  styles?: TableStylesProps;
-  searchbox?: SearchboxProps;
+  labels?: TableLabels;
+  sumRow?: TableSummaryRow[];
+  styles?: TableStyles;
+  searchbox?: TableSearchbox;
 }
 
-export type SubMenuListTableProps = TipMenuItemProps;
+type TableSearchbox = SearchboxProps;
 
-export interface TableStylesProps {
+export type TableSubMenuList = TipMenuItemProps;
+
+export interface TableStyles {
   containerStyle?: CSSProp;
   tableHeaderStyle?: CSSProp;
   tableBodyStyle?: CSSProp;
@@ -92,7 +92,7 @@ export interface TableStylesProps {
   totalSelectedItemTextStyle?: CSSProp;
 }
 
-export interface TableLabelsProps {
+export interface TableLabels {
   totalSelectedItemText?: ((count: number) => string) | null;
   pageNumberText?: string | number;
 }
@@ -101,14 +101,14 @@ interface TableAlwaysShowDragIconProp {
   alwaysShowDragIcon?: boolean;
 }
 
-export interface SummaryRowProps {
+export interface TableSummaryRow {
   span?: number;
   content?: ReactNode;
   bold?: boolean;
-  styles?: SummaryRowStylesProps;
+  styles?: SummaryRowStyles;
 }
 
-export interface SummaryRowStylesProps {
+export interface SummaryRowStyles {
   self?: CSSProp;
 }
 
@@ -135,7 +135,7 @@ const DnDContext = createContext<{
   setDragItem: () => {},
 });
 
-const TableColumnContext = createContext<ColumnTableProps[]>([]);
+const TableColumnContext = createContext<TableColumn[]>([]);
 const useTableColumns = () => useContext(TableColumnContext);
 
 function Table({
@@ -1019,13 +1019,17 @@ const RotatingIcon = styled.span<{ $isOpen?: boolean }>`
     `}
 `;
 
+type TableRowAction = TipMenuItemProps;
+
+export type TableRowContent = (string | ReactNode)[];
+
 export interface TableRowProps {
-  content?: RowData;
+  content?: TableRowContent;
   selectable?: boolean;
   handleSelect?: (data: string) => void;
   rowId?: string;
   children?: ReactNode;
-  actions?: (columnCaption: string) => TipMenuItemProps[];
+  actions?: (columnCaption: string) => TableRowAction[];
   onClick?: (args?: {
     toggleCheckbox: () => void;
     isFirstClick?: boolean;
@@ -1033,10 +1037,10 @@ export interface TableRowProps {
     close?: () => void;
   }) => void;
   groupId?: string;
-  styles?: TableRowStylesProps;
+  styles?: TableRowStyles;
 }
 
-export interface TableRowStylesProps {
+export interface TableRowStyles {
   containerStyle?: CSSProp;
   contentStyle?: CSSProp;
   rowStyle?: CSSProp;
@@ -1283,7 +1287,7 @@ function TableRow({
           (() => {
             const listActions = actions(`${rowId}`);
             const actionsWithIcons = listActions
-              ?.filter((action): action is TipMenuItemProps => Boolean(action))
+              ?.filter((action): action is TableRowAction => Boolean(action))
               .map((action) => ({
                 ...action,
                 icon: {

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -109,10 +109,10 @@ export interface TableSummaryRowColumn {
   span?: number;
   content?: ReactNode;
   bold?: boolean;
-  styles?: SummaryRowStyles;
+  styles?: TableSummaryRowColumnStyles;
 }
 
-export interface SummaryRowStyles {
+export interface TableSummaryRowColumnStyles {
   self?: CSSProp;
 }
 

--- a/components/textarea.stories.tsx
+++ b/components/textarea.stories.tsx
@@ -3,7 +3,7 @@ import { useArgs } from "@storybook/preview-api";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { css } from "styled-components";
-import { FieldLaneDropdownsOptionProps } from "./field-lane";
+import { FieldLaneDropdownsOption } from "./field-lane";
 import { StatefulOnChangeType } from "./stateful-form";
 import { Textarea, TextareaProps } from "./textarea";
 
@@ -95,7 +95,7 @@ const meta: Meta<typeof Textarea> = {
         "Array of action buttons rendered inside the input. Each action can have an icon, tooltip title, click handler, and optional disabled state.",
       table: {
         type: {
-          summary: "TextareaActionsProps[]",
+          summary: "Textareaaction[]",
           detail: `{
   title?: string;
   icon?: FigureProps;
@@ -202,7 +202,7 @@ export const WithDropdown: Story = {
       value: "",
     });
 
-    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOptionProps[] = [
+    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOption[] = [
       {
         text: "On-site",
         value: "1",

--- a/components/textarea.stories.tsx
+++ b/components/textarea.stories.tsx
@@ -95,7 +95,7 @@ const meta: Meta<typeof Textarea> = {
         "Array of action buttons rendered inside the input. Each action can have an icon, tooltip title, click handler, and optional disabled state.",
       table: {
         type: {
-          summary: "TextareaAction[]",
+          summary: "FieldLaneAction[]",
           detail: `{
   title?: string;
   icon?: FigureProps;

--- a/components/textarea.stories.tsx
+++ b/components/textarea.stories.tsx
@@ -95,7 +95,7 @@ const meta: Meta<typeof Textarea> = {
         "Array of action buttons rendered inside the input. Each action can have an icon, tooltip title, click handler, and optional disabled state.",
       table: {
         type: {
-          summary: "Textareaaction[]",
+          summary: "TextareaAction[]",
           detail: `{
   title?: string;
   icon?: FigureProps;

--- a/components/textarea.tsx
+++ b/components/textarea.tsx
@@ -26,7 +26,7 @@ interface BaseTextareaProps
   id?: string;
 }
 
-export type Textareaaction = FieldLaneAction;
+export type TextareaAction = FieldLaneAction;
 
 export interface TextareaStyles {
   self?: CSSProp;

--- a/components/textarea.tsx
+++ b/components/textarea.tsx
@@ -6,10 +6,10 @@ import {
 } from "react";
 import styled, { css, CSSProp } from "styled-components";
 import {
-  FieldLaneActionsProps,
+  FieldLaneAction,
   FieldLane,
   FieldLaneProps,
-  FieldLaneStylesProps,
+  FieldLaneStyles,
 } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
@@ -18,7 +18,7 @@ import { TextareaThemeConfig } from "./../theme";
 interface BaseTextareaProps
   extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "style"> {
   showError?: boolean;
-  styles?: TextareaStylesProps;
+  styles?: TextareaStyles;
   onChange?: (
     data: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => void;
@@ -26,9 +26,9 @@ interface BaseTextareaProps
   id?: string;
 }
 
-export type TextareaActionsProps = FieldLaneActionsProps;
+export type Textareaaction = FieldLaneAction;
 
-export interface TextareaStylesProps {
+export interface TextareaStyles {
   self?: CSSProp;
 }
 
@@ -67,7 +67,7 @@ const BaseTextarea = forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
 export interface TextareaProps
   extends Omit<BaseTextareaProps, "styles">,
     Omit<FieldLaneProps, "styles"> {
-  styles?: TextareaStylesProps & FieldLaneStylesProps;
+  styles?: TextareaStyles & FieldLaneStyles;
 }
 
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(

--- a/components/textarea.tsx
+++ b/components/textarea.tsx
@@ -5,12 +5,7 @@ import {
   forwardRef,
 } from "react";
 import styled, { css, CSSProp } from "styled-components";
-import {
-  FieldLaneAction,
-  FieldLane,
-  FieldLaneProps,
-  FieldLaneStyles,
-} from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { TextareaThemeConfig } from "./../theme";
@@ -25,8 +20,6 @@ interface BaseTextareaProps
   autogrow?: boolean;
   id?: string;
 }
-
-export type TextareaAction = FieldLaneAction;
 
 export interface TextareaStyles {
   self?: CSSProp;

--- a/components/textbox.stories.tsx
+++ b/components/textbox.stories.tsx
@@ -3,7 +3,7 @@ import { useArgs } from "@storybook/preview-api";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect, useState, type ChangeEvent } from "react";
 import { css } from "styled-components";
-import { FieldLaneDropdownsOptionProps } from "./field-lane";
+import { FieldLaneDropdownsOption } from "./field-lane";
 import { Textbox, TextboxProps } from "./textbox";
 
 const meta: Meta<typeof Textbox> = {
@@ -133,7 +133,7 @@ const meta: Meta<typeof Textbox> = {
         "Array of action buttons displayed inside the input. Each action can have icon, tooltip, click handler, and disabled state.",
       table: {
         type: {
-          summary: "TextboxActionsProps[]",
+          summary: "Textboxaction[]",
           detail: `{
   title?: string;
   icon?: FigureProps;
@@ -153,7 +153,7 @@ const meta: Meta<typeof Textbox> = {
         type: {
           summary: "FieldLaneDropdownProps[]",
           detail: `{
-  options?: FieldLaneDropdownsOptionProps[];
+  options?: FieldLaneDropdownsOption[];
   caption?: string;
   onChange?: (id: string) => void;
   width?: string;
@@ -175,7 +175,7 @@ const meta: Meta<typeof Textbox> = {
       description: "Custom styles for the input and container.",
       table: {
         type: {
-          summary: "TextboxStylesProps & FieldLaneStylesProps",
+          summary: "TextboxStyles & FieldLaneStyles",
           detail: `{
   self?: CSSProp;             // Styles applied to the input
   bodyStyle?: CSSProp;
@@ -280,7 +280,7 @@ export const WithDropdown: Story = {
       value: "",
     });
 
-    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOptionProps[] = [
+    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOption[] = [
       {
         text: "On-site",
         value: "1",

--- a/components/textbox.stories.tsx
+++ b/components/textbox.stories.tsx
@@ -151,7 +151,7 @@ const meta: Meta<typeof Textbox> = {
         "Dropdown configuration array supporting custom rendering, optional filtering, and selection options.",
       table: {
         type: {
-          summary: "FieldLaneDropdownProps[]",
+          summary: "FieldLaneDropdown[]",
           detail: `{
   options?: FieldLaneDropdownsOption[];
   caption?: string;

--- a/components/textbox.stories.tsx
+++ b/components/textbox.stories.tsx
@@ -133,7 +133,7 @@ const meta: Meta<typeof Textbox> = {
         "Array of action buttons displayed inside the input. Each action can have icon, tooltip, click handler, and disabled state.",
       table: {
         type: {
-          summary: "Textboxaction[]",
+          summary: "FieldLaneAction[]",
           detail: `{
   title?: string;
   icon?: FigureProps;

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -32,7 +32,7 @@ export interface TextboxStyles {
   self?: CSSProp;
 }
 
-export type TextareaActions = FieldLaneAction;
+export type TextboxActions = FieldLaneAction;
 
 const BaseTextbox = forwardRef<HTMLInputElement, BaseTextboxProps>(
   ({ showError, onChange, styles, type = "text", id, ...props }, ref) => {

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -32,7 +32,7 @@ export interface TextboxStyles {
   self?: CSSProp;
 }
 
-export type TextboxActions = FieldLaneAction;
+export type TextboxAction = FieldLaneAction;
 
 const BaseTextbox = forwardRef<HTMLInputElement, BaseTextboxProps>(
   ({ showError, onChange, styles, type = "text", id, ...props }, ref) => {

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -8,12 +8,7 @@ import {
 } from "react";
 import styled, { css, CSSProp } from "styled-components";
 import { Button } from "./button";
-import {
-  FieldLaneAction,
-  FieldLane,
-  FieldLaneProps,
-  FieldLaneStyles,
-} from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { TextboxThemeConfig } from "./../theme";
@@ -31,8 +26,6 @@ interface BaseTextboxProps
 export interface TextboxStyles {
   self?: CSSProp;
 }
-
-export type TextboxAction = FieldLaneAction;
 
 const BaseTextbox = forwardRef<HTMLInputElement, BaseTextboxProps>(
   ({ showError, onChange, styles, type = "text", id, ...props }, ref) => {

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -9,10 +9,10 @@ import {
 import styled, { css, CSSProp } from "styled-components";
 import { Button } from "./button";
 import {
-  FieldLaneActionsProps,
+  FieldLaneAction,
   FieldLane,
   FieldLaneProps,
-  FieldLaneStylesProps,
+  FieldLaneStyles,
 } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
@@ -25,14 +25,14 @@ interface BaseTextboxProps
   > {
   showError?: boolean;
   onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
-  styles?: TextboxStylesProps;
+  styles?: TextboxStyles;
 }
 
-export interface TextboxStylesProps {
+export interface TextboxStyles {
   self?: CSSProp;
 }
 
-export type TextareaActions = FieldLaneActionsProps;
+export type TextareaActions = FieldLaneAction;
 
 const BaseTextbox = forwardRef<HTMLInputElement, BaseTextboxProps>(
   ({ showError, onChange, styles, type = "text", id, ...props }, ref) => {
@@ -112,7 +112,7 @@ const BaseTextbox = forwardRef<HTMLInputElement, BaseTextboxProps>(
 export interface TextboxProps
   extends Omit<BaseTextboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "id" | "type"> {
-  styles?: TextboxStylesProps & FieldLaneStylesProps;
+  styles?: TextboxStyles & FieldLaneStyles;
 }
 
 const Textbox = forwardRef<HTMLInputElement, TextboxProps>(

--- a/components/thumb-field.tsx
+++ b/components/thumb-field.tsx
@@ -8,7 +8,7 @@ import {
 import { ChangeEvent, useRef, useState } from "react";
 import styled, { css, CSSProp } from "styled-components";
 import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { ThumbFieldThemeConfig } from "./../theme";
 
@@ -19,12 +19,12 @@ interface BaseThumbFieldProps {
   thumbsDownBackgroundColor?: string;
   disabled?: boolean;
   name?: string;
-  styles?: BaseThumbFieldStylesProps;
+  styles?: BaseThumbFieldStyles;
   id?: string;
   showError?: boolean;
 }
 
-interface BaseThumbFieldStylesProps {
+interface BaseThumbFieldStyles {
   triggerWrapperStyle?: CSSProp;
   triggerStyle?: CSSProp;
 }
@@ -135,13 +135,12 @@ function BaseThumbField({
   );
 }
 
-export type ThumbFieldStylesProps = BaseThumbFieldStylesProps &
-  FieldLaneStylesProps;
+export type ThumbFieldStyles = BaseThumbFieldStyles & FieldLaneStyles;
 
 export interface ThumbFieldProps
   extends Omit<BaseThumbFieldProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns"> {
-  styles?: ThumbFieldStylesProps;
+  styles?: ThumbFieldStyles;
 }
 
 function ThumbField({

--- a/components/thumb-field.tsx
+++ b/components/thumb-field.tsx
@@ -29,7 +29,13 @@ interface BaseThumbFieldStyles {
   triggerStyle?: CSSProp;
 }
 
-export type ThumbFieldValue = "up" | "down" | "blank";
+const ThumbFieldValue = {
+  Up: "up",
+  Down: "down",
+  Blank: "blank",
+} as const;
+
+type ThumbFieldValue = (typeof ThumbFieldValue)[keyof typeof ThumbFieldValue];
 
 function BaseThumbField({
   onChange,

--- a/components/timebox.stories.tsx
+++ b/components/timebox.stories.tsx
@@ -3,7 +3,7 @@ import { useArgs } from "@storybook/preview-api";
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChangeEvent, useEffect, useState } from "react";
 import { css } from "styled-components";
-import { FieldLaneDropdownsOptionProps } from "./field-lane";
+import { FieldLaneDropdownsOption } from "./field-lane";
 import { Timebox } from "./timebox";
 
 const meta: Meta<typeof Timebox> = {
@@ -172,7 +172,7 @@ export const WithDropdown: Story = {
       value: "",
     });
 
-    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOptionProps[] = [
+    const ATTENDANCE_OPTIONS: FieldLaneDropdownsOption[] = [
       {
         text: "On-site",
         value: "1",

--- a/components/timebox.tsx
+++ b/components/timebox.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 import styled, { css, CSSProp } from "styled-components";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { TimeboxThemeConfig } from "./../theme";
@@ -21,7 +21,7 @@ interface BaseTimeboxProps
   > {
   withSeconds?: boolean;
   editable?: boolean;
-  styles?: TimeboxStylesProps;
+  styles?: TimeboxStyles;
   showError?: boolean;
   value?: string;
   name?: string;
@@ -29,7 +29,7 @@ interface BaseTimeboxProps
   placeholder?: TimeboxPlaceholderProps;
 }
 
-export interface TimeboxStylesProps {
+export interface TimeboxStyles {
   self?: CSSProp;
   inputWrapperStyle?: CSSProp;
 }
@@ -379,7 +379,7 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
 export interface TimeboxProps
   extends Omit<BaseTimeboxProps, "styles" | "inputId">,
     Omit<FieldLaneProps, "styles" | "inputId" | "type"> {
-  styles?: TimeboxStylesProps & FieldLaneStylesProps;
+  styles?: TimeboxStyles & FieldLaneStyles;
 }
 
 const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(

--- a/components/timebox.tsx
+++ b/components/timebox.tsx
@@ -26,7 +26,7 @@ interface BaseTimeboxProps
   value?: string;
   name?: string;
   onKeyDown?: (e: KeyboardEvent<HTMLInputElement | HTMLDivElement>) => void;
-  placeholder?: TimeboxPlaceholderProps;
+  placeholder?: TimeboxPlaceholder;
 }
 
 export interface TimeboxStyles {
@@ -34,7 +34,7 @@ export interface TimeboxStyles {
   inputWrapperStyle?: CSSProp;
 }
 
-export interface TimeboxPlaceholderProps {
+export interface TimeboxPlaceholder {
   hour?: string;
   minute?: string;
   second?: string;

--- a/components/timeline.stories.tsx
+++ b/components/timeline.stories.tsx
@@ -35,7 +35,7 @@ It supports custom items (\`Timeline.Item\`), clickable states, variant-based co
 - \`subtitle\` (string): Secondary description or detail under the title.
 - \`sidenote\` (ReactNode): Optional content displayed beside the item.
 - \`variant\` (string): Status/variant of the item, affects colors. Options from \`TEXT_VARIANT_COLOR\`.
-- \`styles\` (TimelineItemStylesProps): Customize styling for item sub-elements.
+- \`styles\` (TimelineItemStyles): Customize styling for item sub-elements.
   - \`self\` – container wrapper
   - \`textWrapperStyle\` – wrapper for title & subtitle
   - \`titleStyle\` – title text

--- a/components/timeline.tsx
+++ b/components/timeline.tsx
@@ -5,7 +5,7 @@ import {
   ReactNode,
   useState,
 } from "react";
-import { SteplineItemState } from "./../constants/step-component-util";
+import { SteplineItem } from "./../constants/step-component-util";
 import styled, { css, CSSProp } from "styled-components";
 import { useTheme } from "../theme/provider";
 import { TimelineThemeConfig } from "../theme";
@@ -27,7 +27,7 @@ function Timeline({ children, isClickable = false }: TimelineProps) {
       {childArray.map((child, index) => {
         if (
           !isValidElement<
-            SteplineItemState &
+            SteplineItem &
               Partial<{
                 isClickable?: boolean;
               }>
@@ -122,7 +122,7 @@ const CircleWrapper = styled.div`
 const OuterCircle = styled.div<{
   $isHovered: boolean;
   $theme: TimelineThemeConfig;
-  $variant: SteplineItemState["variant"];
+  $variant: SteplineItem["variant"];
 }>`
   min-width: 0.5rem;
   min-height: 0.5rem;
@@ -150,7 +150,7 @@ const OuterCircle = styled.div<{
 `;
 
 const InnerCircle = styled.div<{
-  $variant: SteplineItemState["variant"];
+  $variant: SteplineItem["variant"];
   $theme: TimelineThemeConfig;
 }>`
   min-width: 0.5rem;
@@ -171,7 +171,7 @@ const Divider = styled.div<{
   $isLast: boolean;
   $line: "solid" | "dash" | "dot";
   $theme: TimelineThemeConfig;
-  $variant: SteplineItemState["variant"];
+  $variant: SteplineItem["variant"];
 }>`
   width: 1px;
   height: 100%;
@@ -217,14 +217,14 @@ const ContentWrapper = styled.div<{ $isLast: boolean }>`
     `}
 `;
 
-export type TimelineItemProps = SteplineItemState &
+export type TimelineItemProps = SteplineItem &
   Partial<{
     sidenote?: ReactNode;
     isClickable?: boolean;
-    styles?: TimelineItemStylesProps;
+    styles?: TimelineItemStyles;
   }>;
 
-export type TimelineItemStylesProps = SteplineItemState["styles"] & {
+export type TimelineItemStyles = SteplineItem["styles"] & {
   textWrapperStyle?: CSSProp;
   titleStyle?: CSSProp;
   subtitleStyle?: CSSProp;
@@ -268,7 +268,7 @@ function TimelineItem({
 }
 
 const TimelineContainer = styled.div<{
-  $variant: SteplineItemState["variant"];
+  $variant: SteplineItem["variant"];
   $theme: TimelineThemeConfig;
   $style?: CSSProp;
 }>`

--- a/components/timeline.tsx
+++ b/components/timeline.tsx
@@ -5,7 +5,7 @@ import {
   ReactNode,
   useState,
 } from "react";
-import { SteplineItem } from "./../constants/step-component-util";
+import { BaseSteplineItem } from "./../constants/step-component-util";
 import styled, { css, CSSProp } from "styled-components";
 import { useTheme } from "../theme/provider";
 import { TimelineThemeConfig } from "../theme";
@@ -27,7 +27,7 @@ function Timeline({ children, isClickable = false }: TimelineProps) {
       {childArray.map((child, index) => {
         if (
           !isValidElement<
-            SteplineItem &
+            BaseSteplineItem &
               Partial<{
                 isClickable?: boolean;
               }>
@@ -122,7 +122,7 @@ const CircleWrapper = styled.div`
 const OuterCircle = styled.div<{
   $isHovered: boolean;
   $theme: TimelineThemeConfig;
-  $variant: SteplineItem["variant"];
+  $variant: BaseSteplineItem["variant"];
 }>`
   min-width: 0.5rem;
   min-height: 0.5rem;
@@ -150,7 +150,7 @@ const OuterCircle = styled.div<{
 `;
 
 const InnerCircle = styled.div<{
-  $variant: SteplineItem["variant"];
+  $variant: BaseSteplineItem["variant"];
   $theme: TimelineThemeConfig;
 }>`
   min-width: 0.5rem;
@@ -171,7 +171,7 @@ const Divider = styled.div<{
   $isLast: boolean;
   $line: "solid" | "dash" | "dot";
   $theme: TimelineThemeConfig;
-  $variant: SteplineItem["variant"];
+  $variant: BaseSteplineItem["variant"];
 }>`
   width: 1px;
   height: 100%;
@@ -217,14 +217,14 @@ const ContentWrapper = styled.div<{ $isLast: boolean }>`
     `}
 `;
 
-export type TimelineItemProps = SteplineItem &
+export type TimelineItemProps = BaseSteplineItem &
   Partial<{
     sidenote?: ReactNode;
     isClickable?: boolean;
     styles?: TimelineItemStyles;
   }>;
 
-export type TimelineItemStyles = SteplineItem["styles"] & {
+export type TimelineItemStyles = BaseSteplineItem["styles"] & {
   textWrapperStyle?: CSSProp;
   titleStyle?: CSSProp;
   subtitleStyle?: CSSProp;
@@ -268,7 +268,7 @@ function TimelineItem({
 }
 
 const TimelineContainer = styled.div<{
-  $variant: SteplineItem["variant"];
+  $variant: BaseSteplineItem["variant"];
   $theme: TimelineThemeConfig;
   $style?: CSSProp;
 }>`

--- a/components/tip-menu.stories.tsx
+++ b/components/tip-menu.stories.tsx
@@ -13,9 +13,9 @@ import {
   RiEditLine,
   RiDeleteBinLine,
 } from "@remixicon/react";
-import { ModalDialog, ModalButtonProps } from "./modal-dialog";
+import { ModalDialog, ModalDialogButton } from "./modal-dialog";
 
-const BUTTONS: ModalButtonProps[] = [
+const BUTTONS: ModalDialogButton[] = [
   {
     id: "cancel",
     caption: "Cancel",

--- a/components/tip-menu.tsx
+++ b/components/tip-menu.tsx
@@ -7,18 +7,24 @@ import { Figure, FigureProps } from "./figure";
 import { useTheme } from "../theme/provider";
 import { TipMenuThemeConfig } from "./../theme";
 
-export type TipMenuItemVariantType = "sm" | "md";
+export const TipMenuVariant = {
+  Small: "sm",
+  Medium: "md",
+} as const;
+
+export type TipMenuVariant =
+  (typeof TipMenuVariant)[keyof typeof TipMenuVariant];
 
 export interface TipMenuProps {
   children?: ReactNode;
   subMenuList?: TipMenuItemProps[];
   setIsOpen?: () => void;
-  variant?: TipMenuItemVariantType;
+  variant?: TipMenuVariant;
   withFilter?: boolean;
-  styles?: TipMenuStylesProps;
+  styles?: TipMenuStyles;
 }
 
-export interface TipMenuStylesProps {
+export interface TipMenuStyles {
   self?: CSSProp;
 }
 
@@ -109,7 +115,7 @@ export interface TipMenuItemProps {
   icon?: FigureProps;
   onClick?: (e?: React.MouseEvent) => void;
   isDangerous?: boolean;
-  variant?: TipMenuItemVariantType;
+  variant?: TipMenuVariant;
   className?: string;
   hidden?: boolean;
 }
@@ -157,7 +163,7 @@ function TipMenuItem({
 
 const StyledTipMenuItem = styled.div<{
   $isDangerous: boolean;
-  $variant?: TipMenuItemVariantType;
+  $variant?: TipMenuVariant;
   $theme: TipMenuThemeConfig;
 }>`
   display: flex;

--- a/components/togglebox.stories.tsx
+++ b/components/togglebox.stories.tsx
@@ -289,7 +289,7 @@ export const WithIconAndLoading: Story = {
       if (args.checked) {
         setUpdateArgs({ isLoading: true });
         setTimeout(() => {
-          setUpdateArgs({ isLoading: "false" });
+          setUpdateArgs({ isLoading: false });
         }, 1200);
       }
     }, [args.checked]);
@@ -323,7 +323,7 @@ export const WithDescription: Story = {
       if (args.checked) {
         setUpdateArgs({ isLoading: true });
         setTimeout(() => {
-          setUpdateArgs({ isLoading: "false" });
+          setUpdateArgs({ isLoading: false });
         }, 1200);
       }
     }, [args.checked]);

--- a/components/togglebox.stories.tsx
+++ b/components/togglebox.stories.tsx
@@ -136,9 +136,9 @@ It integrates seamlessly with \`FieldLane\` for form layout and validation suppo
     },
     styles: {
       description:
-        "Custom styles for individual sub-elements of the togglebox. Accepts a ToggleboxStylesProps object.",
+        "Custom styles for individual sub-elements of the togglebox. Accepts a ToggleboxStyles object.",
       table: {
-        type: { summary: "ToggleboxStylesProps" },
+        type: { summary: "ToggleboxStyles" },
       },
       control: { type: "object" },
     },

--- a/components/togglebox.tsx
+++ b/components/togglebox.tsx
@@ -4,7 +4,7 @@ import { LoadingSpinner } from "./loading-spinner";
 import styled, { css, CSSProp } from "styled-components";
 import { StatefulForm } from "./stateful-form";
 import { Figure, FigureProps } from "./figure";
-import { FieldLane, FieldLaneProps, FieldLaneStylesProps } from "./field-lane";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { ToggleboxThemeConfig } from "./../theme";
 
@@ -18,10 +18,10 @@ interface BaseToggleboxProps
   label?: string;
   description?: string;
   size?: number;
-  styles?: BaseToggleboxStylesProps;
+  styles?: BaseToggleboxStyles;
 }
 
-interface BaseToggleboxStylesProps {
+interface BaseToggleboxStyles {
   descriptionStyle?: CSSProp;
   rowStyle?: CSSProp;
   textWrapperStyle?: CSSProp;
@@ -132,13 +132,12 @@ function BaseTogglebox({
   );
 }
 
-export type ToggleboxStylesProps = BaseToggleboxStylesProps &
-  FieldLaneStylesProps;
+export type ToggleboxStyles = BaseToggleboxStyles & FieldLaneStyles;
 
 export interface ToggleboxProps
   extends Omit<BaseToggleboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns"> {
-  styles?: ToggleboxStylesProps;
+  styles?: ToggleboxStyles;
 }
 
 function Togglebox({

--- a/components/toolbar.stories.tsx
+++ b/components/toolbar.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Toolbar, ToolbarSubMenuProps } from "./toolbar";
+import { Toolbar, ToolbarSubMenuList } from "./toolbar";
 import {
   RiSpam2Line,
   RiForbid2Line,
@@ -32,7 +32,7 @@ It is suitable for building rich action bars, tool panels, or context menus in a
 - 🏷 **Toolbar.Menu**: Each menu can have a caption, an icon, and an optional dropdown sub-menu.
 - 🔀 **Variants**: Supports \`default\`, \`primary\`, and \`danger\` modes for visual emphasis.
 - 🔄 **Interactive states**: Hover, active, focus-visible, and open states are styled out-of-the-box.
-- ⬆️⬇️ **Dropdown menus**: Sub-menu lists can be fully customized with \`ToolbarSubMenuProps\`.
+- ⬆️⬇️ **Dropdown menus**: Sub-menu lists can be fully customized with \`ToolbarSubMenuList\`.
 - ⚡ **Dynamic sizing**: Supports a \`big\` mode for larger icons and vertically-aligned content.
 - 🎨 **Styling flexibility**: Customize the container, trigger, toggle button, and dropdown via the \`styles\` prop.
 - 🧩 **Composable children**: Place any custom JSX or multiple \`Toolbar.Menu\` items inside a toolbar.
@@ -42,7 +42,7 @@ It is suitable for building rich action bars, tool panels, or context menus in a
 ### 📌 Usage
 
 \`\`\`tsx
-const subMenuList: ToolbarSubMenuProps[] = [
+const subMenuList: ToolbarSubMenuList[] = [
   { caption: "Edit", icon: { image: RiEditLine, color: "yellow" }, onClick: () => console.log("Edit mode") },
   { caption: "Delete", icon: { image: RiForbid2Line, color: "red" }, isDangerous: true, onClick: () => console.log("Deleted") },
 ];
@@ -126,7 +126,7 @@ type Story = StoryObj<typeof TipMenu>;
 
 export const Default: Story = {
   render: () => {
-    const subMenuList: ToolbarSubMenuProps[] = [
+    const subMenuList: ToolbarSubMenuList[] = [
       {
         caption: "Report Phishing",
         icon: {
@@ -247,7 +247,7 @@ export const Default: Story = {
 
 export const Big: Story = {
   render: () => {
-    const subMenuList: ToolbarSubMenuProps[] = [
+    const subMenuList: ToolbarSubMenuList[] = [
       {
         caption: "Report Phishing",
         icon: {

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -142,8 +142,8 @@ function Toolbar({ children, styles, big }: ToolbarProps) {
 export interface ToolbarMenuProps {
   caption?: string;
   icon?: FigureProps;
-  openedIcon?: ToolbarMenuIcon;
-  closedIcon?: ToolbarMenuIcon;
+  openedIcon?: FigureProps["image"];
+  closedIcon?: FigureProps["image"];
   subMenuList?: ToolbarSubMenuList[];
   isOpen?: boolean;
   setIsOpen?: (data?: boolean) => void;
@@ -152,8 +152,6 @@ export interface ToolbarMenuProps {
   variant?: ToolbarVariant;
   iconSize?: number;
 }
-
-type ToolbarMenuIcon = FigureProps["image"];
 
 export type ToolbarSubMenuList = TipMenuItemProps;
 

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -26,54 +26,35 @@ import { ToolbarThemeConfig } from "./../theme";
 export interface ToolbarProps {
   children: ReactNode;
   big?: boolean;
-  styles?: ToolbarStylesProps;
+  styles?: ToolbarStyles;
 }
 
-export interface ToolbarStylesProps {
+export interface ToolbarStyles {
   self?: CSSProp;
 }
 
-export interface ToolbarMenuProps {
-  caption?: string;
-  icon?: FigureProps;
-  openedIcon?: FigureProps["image"];
-  closedIcon?: FigureProps["image"];
-  subMenuList?: ToolbarSubMenuProps[];
-  isOpen?: boolean;
-  setIsOpen?: (data?: boolean) => void;
-  onClick?: () => void;
-  styles?: ToolbarMenuSylesProps;
-  variant?: ToolbarVariantType;
-  iconSize?: number;
-}
+export const ToolbarVariant = {
+  Default: "default",
+  Primary: "primary",
+  Danger: "danger",
+  Success: "success",
+  Transparent: "transparent",
+} as const;
 
-export type ToolbarSubMenuProps = TipMenuItemProps;
-
-export interface ToolbarMenuSylesProps {
-  dropdownStyle?: CSSProp;
-  containerStyle?: CSSProp;
-  triggerStyle?: CSSProp;
-  toggleActiveStyle?: CSSProp;
-}
-
-export type ToolbarVariantType =
-  | "default"
-  | "primary"
-  | "danger"
-  | "success"
-  | "transparent";
+export type ToolbarVariant =
+  (typeof ToolbarVariant)[keyof typeof ToolbarVariant];
 
 const useVariantToolbar = () => {
   const { currentTheme } = useTheme();
   const toolbarVariant = currentTheme?.toolbar ?? {};
 
-  const VARIANT_COLORS: Record<ToolbarVariantType, ToolbarThemeConfig> =
+  const VARIANT_COLORS: Record<ToolbarVariant, ToolbarThemeConfig> =
     Object.keys(toolbarVariant).reduce(
       (acc, key) => {
         const variant: ToolbarThemeConfig =
-          toolbarVariant[key as ToolbarVariantType];
+          toolbarVariant[key as ToolbarVariant];
         if (!variant) return acc;
-        acc[key as ToolbarVariantType] = {
+        acc[key as ToolbarVariant] = {
           backgroundColor: variant.backgroundColor,
           textColor: variant.textColor,
           borderColor: variant.borderColor,
@@ -84,7 +65,7 @@ const useVariantToolbar = () => {
         };
         return acc;
       },
-      {} as Record<ToolbarVariantType, ToolbarThemeConfig>
+      {} as Record<ToolbarVariant, ToolbarThemeConfig>
     );
 
   return { VARIANT_COLORS };
@@ -158,6 +139,31 @@ function Toolbar({ children, styles, big }: ToolbarProps) {
   );
 }
 
+export interface ToolbarMenuProps {
+  caption?: string;
+  icon?: FigureProps;
+  openedIcon?: ToolbarMenuIcon;
+  closedIcon?: ToolbarMenuIcon;
+  subMenuList?: ToolbarSubMenuList[];
+  isOpen?: boolean;
+  setIsOpen?: (data?: boolean) => void;
+  onClick?: () => void;
+  styles?: ToolbarMenuStyles;
+  variant?: ToolbarVariant;
+  iconSize?: number;
+}
+
+type ToolbarMenuIcon = FigureProps["image"];
+
+export type ToolbarSubMenuList = TipMenuItemProps;
+
+export interface ToolbarMenuStyles {
+  dropdownStyle?: CSSProp;
+  containerStyle?: CSSProp;
+  triggerStyle?: CSSProp;
+  toggleActiveStyle?: CSSProp;
+}
+
 function ToolbarMenu({
   caption,
   icon,
@@ -213,7 +219,7 @@ function ToolbarMenu({
   };
 
   const filteredSubMenuList =
-    subMenuList?.filter((menu): menu is ToolbarSubMenuProps => Boolean(menu)) ??
+    subMenuList?.filter((menu): menu is ToolbarSubMenuList => Boolean(menu)) ??
     [];
 
   const toolbarButtonStyle = (
@@ -375,7 +381,7 @@ const ToolbarContainer = styled.div`
 const MenuWrapper = styled.div<{
   $style?: CSSProp;
   $theme?: ToolbarThemeConfig;
-  $variant?: ToolbarVariantType;
+  $variant?: ToolbarVariant;
 }>`
   display: flex;
   align-items: center;

--- a/components/tooltip.stories.tsx
+++ b/components/tooltip.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Tooltip, TooltipProps } from "./tooltip";
-import { DialogPlacement } from "./../lib/floating-placement";
+import { Tooltip, TooltipProps, TooltipDialogPlacement } from "./tooltip";
 import { Button } from "./button";
 import { Badge } from "./badge";
 import {
@@ -255,7 +254,7 @@ export const Link: Story = {
 
 export const Positioning: Story = {
   render: () => {
-    const Content = ({ placement }: { placement: DialogPlacement }) => (
+    const Content = ({ placement }: { placement: TooltipDialogPlacement }) => (
       <Tooltip
         dialog={placement}
         showDialogOn="hover"

--- a/components/tooltip.stories.tsx
+++ b/components/tooltip.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Tooltip, TooltipDialogPlacement, TooltipProps } from "./tooltip";
+import { Tooltip, TooltipProps } from "./tooltip";
+import { DialogPlacement } from "./../lib/floating-placement";
 import { Button } from "./button";
 import { Badge } from "./badge";
 import {
@@ -254,7 +255,7 @@ export const Link: Story = {
 
 export const Positioning: Story = {
   render: () => {
-    const Content = ({ placement }: { placement: TooltipDialogPlacement }) => (
+    const Content = ({ placement }: { placement: DialogPlacement }) => (
       <Tooltip
         dialog={placement}
         showDialogOn="hover"

--- a/components/tooltip.stories.tsx
+++ b/components/tooltip.stories.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 import z from "zod";
 import { RiAddBoxLine, RiImage2Line } from "@remixicon/react";
 import { css } from "styled-components";
-import { OptionProps } from "./selectbox";
+import { SelectboxOption } from "./selectbox";
 import { useTheme } from "./../theme/provider";
 
 const meta: Meta<typeof Tooltip> = {
@@ -452,7 +452,7 @@ export const WithBadge: Story = {
     });
     const [isOpen, setIsOpen] = useState(false);
 
-    const EMPLOYEE_OPTIONS: OptionProps[] = [
+    const EMPLOYEE_OPTIONS: SelectboxOption[] = [
       { text: "Organization Owner", value: "1" },
       { text: "HR Manager", value: "2" },
       { text: "Member", value: "3" },

--- a/components/tooltip.tsx
+++ b/components/tooltip.tsx
@@ -23,6 +23,8 @@ import styled, { css, CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
 import { TooltipThemeConfig } from "./../theme";
 
+export type TooltipDialogPlacement = DialogPlacement;
+
 export const TooltipDialogPosition = {
   Hover: "hover",
   Click: "click",
@@ -36,7 +38,7 @@ export type TooltipProps = {
   children: ReactNode;
   showDialogOn?: TooltipDialogPosition;
   hideDialogOn?: TooltipDialogPosition;
-  dialogPlacement?: DialogPlacement;
+  dialogPlacement?: TooltipDialogPlacement;
   onVisibilityChange?: (open?: boolean) => void;
   safeAreaAriaLabels?: string[];
   showDelayPeriod?: number;

--- a/components/tooltip.tsx
+++ b/components/tooltip.tsx
@@ -25,11 +25,19 @@ import { TooltipThemeConfig } from "./../theme";
 
 export type TooltipDialogPlacement = DialogPlacement;
 
+export const TooltipDialogOn = {
+  Hover: "hover",
+  Click: "click",
+} as const;
+
+export type TooltipDialogOn =
+  (typeof TooltipDialogOn)[keyof typeof TooltipDialogOn];
+
 export type TooltipProps = {
   dialog: ReactNode;
   children: ReactNode;
-  showDialogOn?: "hover" | "click";
-  hideDialogOn?: "hover" | "click";
+  showDialogOn?: TooltipDialogOn;
+  hideDialogOn?: TooltipDialogOn;
   dialogPlacement?: TooltipDialogPlacement;
   onVisibilityChange?: (open?: boolean) => void;
   safeAreaAriaLabels?: string[];
@@ -214,11 +222,11 @@ const TooltipBase = forwardRef<TooltipRef, TooltipProps>(
 
 export interface TooltipContainerProps {
   placement?: Placement;
-  styles?: TooltipContainerStylesProps;
+  styles?: TooltipContainerStyles;
   dialog?: ReactNode;
 }
 
-export interface TooltipContainerStylesProps {
+export interface TooltipContainerStyles {
   drawerStyle?: CSSProp | ((placement?: Placement) => CSSProp);
   arrowStyle?: CSSProp | ((placement?: Placement) => CSSProp);
   spacerStyle?: CSSProp | ((placement?: Placement) => CSSProp);

--- a/components/tooltip.tsx
+++ b/components/tooltip.tsx
@@ -25,19 +25,19 @@ import { TooltipThemeConfig } from "./../theme";
 
 export type TooltipDialogPlacement = DialogPlacement;
 
-export const TooltipDialogOn = {
+export const TooltipDialogPosition = {
   Hover: "hover",
   Click: "click",
 } as const;
 
-export type TooltipDialogOn =
-  (typeof TooltipDialogOn)[keyof typeof TooltipDialogOn];
+export type TooltipDialogPosition =
+  (typeof TooltipDialogPosition)[keyof typeof TooltipDialogPosition];
 
 export type TooltipProps = {
   dialog: ReactNode;
   children: ReactNode;
-  showDialogOn?: TooltipDialogOn;
-  hideDialogOn?: TooltipDialogOn;
+  showDialogOn?: TooltipDialogPosition;
+  hideDialogOn?: TooltipDialogPosition;
   dialogPlacement?: TooltipDialogPlacement;
   onVisibilityChange?: (open?: boolean) => void;
   safeAreaAriaLabels?: string[];

--- a/components/tooltip.tsx
+++ b/components/tooltip.tsx
@@ -23,8 +23,6 @@ import styled, { css, CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
 import { TooltipThemeConfig } from "./../theme";
 
-export type TooltipDialogPlacement = DialogPlacement;
-
 export const TooltipDialogPosition = {
   Hover: "hover",
   Click: "click",
@@ -38,7 +36,7 @@ export type TooltipProps = {
   children: ReactNode;
   showDialogOn?: TooltipDialogPosition;
   hideDialogOn?: TooltipDialogPosition;
-  dialogPlacement?: TooltipDialogPlacement;
+  dialogPlacement?: DialogPlacement;
   onVisibilityChange?: (open?: boolean) => void;
   safeAreaAriaLabels?: string[];
   showDelayPeriod?: number;

--- a/components/treelist.stories.tsx
+++ b/components/treelist.stories.tsx
@@ -782,7 +782,6 @@ export const WithoutHeader: Story = {
           containerStyle: css`
             min-width: 300px;
             padding: 8px 8px 4px;
-            background-color: white;
           `,
         }}
         fields={DIVISION_EMPLOYEE_FIELDS}

--- a/components/treelist.stories.tsx
+++ b/components/treelist.stories.tsx
@@ -1,13 +1,13 @@
 import { Meta, StoryObj } from "@storybook/react";
 import {
   TreeList,
-  TreeListActionsProps,
-  TreeListContentActionsProps,
-  TreeListContentProps,
-  TreeListItemsActionsProps,
-  TreeListItemsProps,
+  TreeListAction,
+  TreeListContentAction,
+  TreeListContent,
+  TreeListItemAction,
+  TreeListItem,
   TreeListNode,
-  TreeListOnDraggedProps,
+  TreeListOnDragged,
 } from "./treelist";
 import {
   RiAddBoxLine,
@@ -27,7 +27,7 @@ import { Button } from "./button";
 import styled, { css } from "styled-components";
 import { useMemo, useState } from "react";
 import { Combobox } from "./combobox";
-import { OptionProps } from "./selectbox";
+import { SelectboxOption } from "./selectbox";
 import { FormFieldGroup, StatefulForm } from "./stateful-form";
 
 const meta: Meta<typeof TreeList> = {
@@ -103,7 +103,7 @@ export const Default: Story = {
       console.log("Clicked person:", props.item.caption);
     };
 
-    const TREE_LIST_DATA: TreeListContentProps[] = [
+    const TREE_LIST_DATA: TreeListContent[] = [
       {
         id: "member",
         caption: "Member of Technical Staff",
@@ -158,8 +158,7 @@ export const Default: Story = {
       return `${first} ${last}`;
     };
 
-    const [content, setContent] =
-      useState<TreeListContentProps[]>(TREE_LIST_DATA);
+    const [content, setContent] = useState<TreeListContent[]>(TREE_LIST_DATA);
 
     return (
       <TreeList
@@ -241,12 +240,12 @@ export const Default: Story = {
 export const Nested: Story = {
   render: () => {
     type UseTreeListControllerOptions = {
-      initialData: TreeListContentProps[];
+      initialData: TreeListContent[];
       defaultPrevented?: boolean;
       initialState?: "opened" | "closed";
     };
 
-    const HEADER_ACTIONS: TreeListContentActionsProps[] = [
+    const HEADER_ACTIONS: TreeListContentAction[] = [
       {
         caption: "New Folder",
         onClick: () => console.log("first"),
@@ -256,7 +255,7 @@ export const Nested: Story = {
       },
     ];
 
-    const TREE_LIST_DATA: TreeListContentProps[] = [
+    const TREE_LIST_DATA: TreeListContent[] = [
       {
         id: "home",
         caption: "Home",
@@ -311,15 +310,15 @@ export const Nested: Story = {
       const [groups, setGroups] = useState(initialData);
 
       function applyContent(
-        tree: TreeListContentProps[],
+        tree: TreeListContent[],
         defaultPrevented?: boolean,
         initialState?: "opened" | "closed"
-      ): TreeListContentProps[] {
+      ): TreeListContent[] {
         return tree.map((props) => {
           const hasChildren =
             Array.isArray(props.items) && props.items.length > 0;
 
-          let normalizedItems: TreeListItemsProps[] | undefined = undefined;
+          let normalizedItems: TreeListItem[] | undefined = undefined;
 
           if (hasChildren && props.items) {
             normalizedItems = props.items.map((item) => {
@@ -363,10 +362,10 @@ export const Nested: Story = {
       }
 
       function applyItemsRecursively(
-        items: TreeListItemsProps[],
+        items: TreeListItem[],
         defaultPrevented?: boolean,
         initialState?: "opened" | "closed"
-      ): TreeListItemsProps[] {
+      ): TreeListItem[] {
         return items.map((item) => {
           const hasChildren =
             Array.isArray(item.items) && item.items.length > 0;
@@ -460,7 +459,7 @@ export const Nested: Story = {
         id,
         newGroupId,
         newPosition,
-      }: TreeListOnDraggedProps) => {
+      }: TreeListOnDragged) => {
         const dragged = TreeList.findTreeListNode(groups, id);
 
         if (
@@ -591,7 +590,7 @@ export const WithActions: Story = {
       console.log("Clicked person:", props.item.caption);
     };
 
-    const ITEM_ACTIONS: TreeListItemsActionsProps[] = [
+    const ITEM_ACTIONS: TreeListItemAction[] = [
       {
         caption: "Edit",
         icon: { image: RiEdit2Line },
@@ -633,7 +632,7 @@ export const WithActions: Story = {
       return itemActions.slice(0, itemLength);
     }, [showItem]);
 
-    const TREE_LIST_DATA: TreeListContentProps[] = [
+    const TREE_LIST_DATA: TreeListContent[] = [
       {
         id: "member",
         caption: "Member of Technical Staff",
@@ -678,7 +677,7 @@ export const WithActions: Story = {
       },
     ];
 
-    const TREE_LIST_ACTIONS: TreeListActionsProps[] = [
+    const TREE_LIST_ACTIONS: TreeListAction[] = [
       {
         id: "discover",
         caption: "Discover",
@@ -697,7 +696,7 @@ export const WithActions: Story = {
       },
     ];
 
-    const SHOW_OPTIONS: OptionProps[] = [
+    const SHOW_OPTIONS: SelectboxOption[] = [
       { text: "1", value: "1" },
       { text: "2", value: "2" },
       { text: "3", value: "3" },
@@ -809,7 +808,7 @@ export const WithoutHeader: Story = {
       },
     ];
 
-    const TREE_LIST_ACTIONS: TreeListActionsProps[] = [
+    const TREE_LIST_ACTIONS: TreeListAction[] = [
       {
         id: "add-new-branch",
         icon: { image: RiAddBoxLine },
@@ -847,9 +846,9 @@ export const WithoutHeader: Story = {
 
 export const WithEmptySlate: Story = {
   render: () => {
-    const TREE_LIST_DATA: TreeListContentProps[] = [];
+    const TREE_LIST_DATA: TreeListContent[] = [];
 
-    const TREE_LIST_ACTIONS: TreeListActionsProps[] = [
+    const TREE_LIST_ACTIONS: TreeListAction[] = [
       {
         id: "discover",
         caption: "Discover",

--- a/components/treelist.tsx
+++ b/components/treelist.tsx
@@ -8,9 +8,9 @@ import React, {
 } from "react";
 import { RiArrowRightSLine, RiDraggable } from "@remixicon/react";
 import { motion, AnimatePresence } from "framer-motion";
-import ContextMenu, { ContextMenuActionsProps } from "./context-menu";
+import ContextMenu, { ContextMenuAction } from "./context-menu";
 import { LoadingSpinner } from "./loading-spinner";
-import { SubMenuButtonProps } from "./button";
+import { ButtonSubMenu } from "./button";
 import { Tooltip } from "./tooltip";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
@@ -21,29 +21,29 @@ export interface TreeListProps
     HTMLAttributes<HTMLDivElement>,
     "style" | "onChange" | "content"
   > {
-  content: TreeListContentProps[];
+  content: TreeListContent[];
   children?: ReactNode;
   emptySlate?: ReactNode;
   emptyItemSlate?: ReactNode | null;
   searchTerm?: string;
-  actions?: TreeListActionsProps[];
+  actions?: TreeListAction[];
   selectedItem?: string;
   onChange?: (id: string) => void;
-  onOpenChange?: (props?: TreeListOnOpenChangeProps) => void;
+  onOpenChange?: (props?: TreeListOnOpenChange) => void;
   showHierarchyLine?: boolean;
   collapsible?: boolean;
   draggable?: boolean;
   alwaysShowDragIcon?: boolean;
-  onDragged?: (props: TreeListOnDraggedProps) => void;
-  styles?: TreeListStylesProps;
+  onDragged?: (props: TreeListOnDragged) => void;
+  styles?: TreeListStyles;
 }
 
-export interface TreeListStylesProps {
+export interface TreeListStyles {
   containerStyle?: CSSProp;
   emptyItemSlateStyle?: CSSProp;
 }
 
-export interface TreeListOnDraggedProps {
+export interface TreeListOnDragged {
   id: string;
   oldGroupId: string;
   newGroupId: string;
@@ -51,7 +51,7 @@ export interface TreeListOnDraggedProps {
   newPosition: number;
 }
 
-export interface TreeListOnOpenChangeProps {
+export interface TreeListOnOpenChange {
   id?: string;
   isOpen?: boolean;
   setIsLoading?: (isLoading: boolean, caption?: string) => void;
@@ -59,60 +59,65 @@ export interface TreeListOnOpenChangeProps {
   setLastFetch?: (date: Date) => void;
 }
 
-type TreeListInitialState = "closed" | "opened";
+export const TreeListInitialState = {
+  Closed: "closed",
+  Opened: "opened",
+} as const;
 
-export interface TreeListContentProps {
+export type TreeListInitialState =
+  (typeof TreeListInitialState)[keyof typeof TreeListInitialState];
+
+export interface TreeListContent {
   id: string;
   caption?: string;
-  items?: TreeListItemsProps[];
+  items?: TreeListItem[];
   initialState?: TreeListInitialState;
-  actions?: TreeListContentActionsProps[];
+  actions?: TreeListContentAction[];
 }
 
-export interface TreeListContentActionsProps
-  extends Omit<ContextMenuActionsProps, "onClick"> {
+export interface TreeListContentAction
+  extends Omit<ContextMenuAction, "onClick"> {
   onClick?: (id?: string) => void;
 }
 
-export interface TreeListItemsProps {
+export interface TreeListItem {
   id: string;
   caption?: string;
   canContainChildren?: boolean;
-  onClick?: (props: TreeListItemsOnClickProps) => void;
-  actions?: TreeListItemsActionsProps[];
-  items?: TreeListItemsProps[];
+  onClick?: (props: TreeListItemOnClick) => void;
+  actions?: TreeListItemAction[];
+  items?: TreeListItem[];
   icon?: FigureProps["image"];
   iconOnActive?: FigureProps["image"];
   iconColor?: string;
   initialState?: TreeListInitialState;
 }
 
-export interface TreeListItemsActionsProps
-  extends Omit<ContextMenuActionsProps, "onClick"> {
+export interface TreeListItemAction extends Omit<ContextMenuAction, "onClick"> {
   onClick?: (id?: string) => void;
 }
 
-export interface TreeListItemsOnClickProps {
-  item?: TreeListItemsProps;
+export interface TreeListItemOnClick {
+  item?: TreeListItem;
   preventDefault?: () => void;
 }
 
-export interface TreeListActionsProps {
+export interface TreeListAction {
   id: string;
   caption?: string;
   onClick?: (props?: { setActive?: (prop: boolean) => void }) => void;
   icon?: FigureProps;
   styles?: { self?: CSSProp };
-  subMenu?: (props: SubMenuTreeListProps) => ReactNode;
+  subMenu?: (props: TreeListSubMenu) => ReactNode;
   hidden?: boolean;
 }
 
-type SubMenuTreeListProps = Omit<SubMenuButtonProps, "list">;
+type TreeListSubMenu = Omit<ButtonSubMenu, "list">;
 
 const DnDContext = createContext<{
   dragItem: {
     id: string;
-    item: TreeListItemsProps;
+    item: TreeListItem;
     oldGroupId: string;
     oldPosition: number;
   } | null;
@@ -602,7 +607,7 @@ function TreeListAction({
 }
 
 function collectAllItemIds(
-  items: TreeListItemsProps[],
+  items: TreeListItem[],
   initialState?: boolean,
   acc = {} as Record<string, boolean>
 ) {
@@ -623,7 +628,7 @@ function collectAllItemIds(
 }
 
 function findLevelById(
-  items: TreeListItemsProps[],
+  items: TreeListItem[],
   id: string,
   level = 0
 ): number | null {
@@ -637,7 +642,7 @@ function findLevelById(
   return null;
 }
 
-function findGroupOfItem(content: TreeListContentProps[], selectedId: string) {
+function findGroupOfItem(content: TreeListContent[], selectedId: string) {
   for (const group of content) {
     if (!group.items) continue;
     if (containsId(group.items, selectedId)) {
@@ -646,7 +651,7 @@ function findGroupOfItem(content: TreeListContentProps[], selectedId: string) {
   }
   return null;
 }
-function containsId(items: TreeListItemsProps[], id: string) {
+function containsId(items: TreeListItem[], id: string) {
   for (const item of items) {
     if (item.id === id) return true;
     if (item.items && containsId(item.items, id)) return true;
@@ -654,7 +659,7 @@ function containsId(items: TreeListItemsProps[], id: string) {
   return false;
 }
 
-interface TreeListItemComponent<T extends TreeListItemsProps> {
+interface TreeListItemComponent<T extends TreeListItem> {
   item: T;
   searchTerm?: string;
   onChange?: (item?: string) => void;
@@ -686,9 +691,9 @@ interface TreeListOpenWithId {
 }
 
 function findItemById(
-  items: TreeListItemsProps[] | undefined,
+  items: TreeListItem[] | undefined,
   id: string
-): TreeListItemsProps | undefined {
+): TreeListItem | undefined {
   if (!items) return;
 
   for (const item of items) {
@@ -701,7 +706,7 @@ function findItemById(
   return undefined;
 }
 
-export type TreeListNode = TreeListContentProps & Partial<TreeListItemsProps>;
+export type TreeListNode = TreeListContent & Partial<TreeListItem>;
 
 function findTreeListNode(
   nodes: TreeListNode[],
@@ -724,7 +729,7 @@ function hasChild(parent: TreeListNode, childId: string): boolean {
     (item) => item.id === childId || hasChild(item, childId)
   );
 }
-function TreeListItem<T extends TreeListItemsProps>({
+function TreeListItem<T extends TreeListItem>({
   item,
   isSelected,
   onChange,

--- a/components/treelist.tsx
+++ b/components/treelist.tsx
@@ -589,9 +589,12 @@ function TreeListAction({
   styles,
 }: TreeListActionInternalProps) {
   if (!onClick) onClick = () => {};
+  const { currentTheme } = useTheme();
+  const treeListTheme = currentTheme.treelist;
 
   return (
     <ActionItem
+      $theme={treeListTheme}
       $isActive={isActive}
       $isSelected={isSelected}
       role="button"
@@ -1252,6 +1255,7 @@ const ActionItem = styled.div<{
   $style?: CSSProp;
   $isSelected?: boolean;
   $isActive?: boolean;
+  $theme?: TreeListThemeConfig;
 }>`
   display: flex;
   flex-direction: row;
@@ -1266,20 +1270,20 @@ const ActionItem = styled.div<{
   min-height: 36px;
 
   &:hover {
-    background-color: #f5f5f5;
+    background-color: ${({ $theme }) => $theme?.hoverBackgroundColor};
   }
 
-  ${({ $isActive }) =>
+  ${({ $isActive, $theme }) =>
     $isActive &&
     css`
-      background-color: #f5f5f5;
+      background-color: ${$theme?.selectedBackgroundColor};
     `}
 
-  ${({ $isSelected }) =>
+  ${({ $isSelected, $theme }) =>
     $isSelected &&
     css`
-      background-color: #f5f5f5;
-      border-left: 3px solid #3b82f6;
+      background-color: ${$theme?.selectedBackgroundColor};
+      border-left: 3px solid ${$theme?.dividerHierarchySelectedColor};
     `}
   ${(props) => props.$style}
 `;

--- a/components/window.stories.tsx
+++ b/components/window.stories.tsx
@@ -143,7 +143,7 @@ export const Default: Story = {
             `,
           }}
         >
-          Up
+          Left
         </Window.Cell>
         <Window.Cell
           styles={{
@@ -153,7 +153,7 @@ export const Default: Story = {
             `,
           }}
         >
-          Down
+          Right
         </Window.Cell>
       </Window>
     );

--- a/components/window.stories.tsx
+++ b/components/window.stories.tsx
@@ -4,7 +4,7 @@ import { RiCloseFill } from "@remixicon/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { css } from "styled-components";
 import { Textarea } from "./textarea";
-import { ColumnTableProps, Table } from "./table";
+import { TableColumn, Table } from "./table";
 import { useTheme } from "./../theme/provider";
 
 const meta: Meta<typeof Window> = {
@@ -288,7 +288,7 @@ export const WithCellRef: Story = {
       );
     });
 
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "name",
         caption: "Name",

--- a/components/window.tsx
+++ b/components/window.tsx
@@ -52,11 +52,9 @@ export interface WindowCellStyles {
   self?: CSSProp;
 }
 
-export type WindowActionIcon = FigureProps;
-
 export interface WindowAction {
   onClick?: () => void;
-  icon?: WindowActionIcon;
+  icon?: FigureProps;
   styles?: WindowActionStyles;
   hidden?: boolean;
 }

--- a/components/window.tsx
+++ b/components/window.tsx
@@ -14,21 +14,29 @@ import {
   useState,
 } from "react";
 import styled, { css, CSSProp } from "styled-components";
-import { Button, ButtonStylesProps } from "./button";
+import { Button, ButtonStyles } from "./button";
 import { Figure, FigureProps } from "./figure";
 import { RiCloseLine } from "@remixicon/react";
 import { useTheme } from "./../theme/provider";
 
+export const WindowOrientation = {
+  Horizontal: "horizontal",
+  Vertical: "vertical",
+} as const;
+
+export type WindowOrientation =
+  (typeof WindowOrientation)[keyof typeof WindowOrientation];
+
 export interface WindowProps {
-  orientation?: "horizontal" | "vertical";
+  orientation?: WindowOrientation;
   children?: ReactNode;
   onResize?: () => void;
   onResizeComplete?: () => void;
   initialSizeRatio?: number[];
-  styles?: WindowStylesProps;
+  styles?: WindowStyles;
 }
 
-export interface WindowStylesProps {
+export interface WindowStyles {
   self?: CSSProp;
   dividerStyle?: CSSProp;
 }
@@ -36,22 +44,24 @@ export interface WindowStylesProps {
 export interface WindowCellProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "style"> {
   children?: ReactNode;
-  styles?: WindowCellStylesProps;
-  actions?: WindowActionProps[];
+  styles?: WindowCellStyles;
+  actions?: WindowAction[];
 }
 
-export interface WindowCellStylesProps {
+export interface WindowCellStyles {
   self?: CSSProp;
 }
 
-export interface WindowActionProps {
+export type WindowActionIcon = FigureProps;
+
+export interface WindowAction {
   onClick?: () => void;
-  icon?: FigureProps;
-  styles?: WindowActionStylesProps;
+  icon?: WindowActionIcon;
+  styles?: WindowActionStyles;
   hidden?: boolean;
 }
 
-export type WindowActionStylesProps = ButtonStylesProps;
+export type WindowActionStyles = ButtonStyles;
 
 function Window({
   orientation = "vertical",

--- a/constants/step-component-util.ts
+++ b/constants/step-component-util.ts
@@ -1,11 +1,29 @@
 import { ReactNode } from "react";
 import { CSSProp } from "styled-components";
 
-export interface SteplineItemState {
+export const SteplineVariant = {
+  Current: "current",
+  Todo: "todo",
+  Error: "error",
+  Completed: "completed",
+} as const;
+
+export type SteplineVariant =
+  (typeof SteplineVariant)[keyof typeof SteplineVariant];
+
+export const SteplineLine = {
+  Dash: "dash",
+  Dot: "dot",
+  Solid: "solid",
+} as const;
+
+export type SteplineLine = (typeof SteplineLine)[keyof typeof SteplineLine];
+
+export interface SteplineItem {
   title?: ReactNode;
   subtitle?: ReactNode;
-  variant?: "current" | "todo" | "error" | "completed";
-  line?: "dash" | "dot" | "solid";
+  variant?: SteplineVariant;
+  line?: SteplineLine;
   styles?: { self?: CSSProp };
   active?: boolean;
   onClick?: () => void;

--- a/constants/step-component-util.ts
+++ b/constants/step-component-util.ts
@@ -19,7 +19,7 @@ export const SteplineLine = {
 
 export type SteplineLine = (typeof SteplineLine)[keyof typeof SteplineLine];
 
-export interface SteplineItem {
+export interface BaseSteplineItem {
   title?: ReactNode;
   subtitle?: ReactNode;
   variant?: SteplineVariant;

--- a/lib/floating-placement.ts
+++ b/lib/floating-placement.ts
@@ -1,18 +1,25 @@
 import { Placement } from "@floating-ui/react";
 
+export const DialogPlacement = {
+  BottomLeft: "bottom-left",
+  BottomRight: "bottom-right",
+  BottomCenter: "bottom-center",
+
+  TopLeft: "top-left",
+  TopRight: "top-right",
+  TopCenter: "top-center",
+
+  LeftTop: "left-top",
+  LeftBottom: "left-bottom",
+  LeftCenter: "left-center",
+
+  RightTop: "right-top",
+  RightBottom: "right-bottom",
+  RightCenter: "right-center",
+} as const;
+
 export type DialogPlacement =
-  | "bottom-left"
-  | "bottom-right"
-  | "bottom-center"
-  | "top-left"
-  | "top-right"
-  | "top-center"
-  | "left-top"
-  | "left-bottom"
-  | "left-center"
-  | "right-top"
-  | "right-bottom"
-  | "right-center";
+  (typeof DialogPlacement)[keyof typeof DialogPlacement];
 
 export function getFloatingPlacement(placement: DialogPlacement): Placement {
   switch (placement) {

--- a/public/feed.xml
+++ b/public/feed.xml
@@ -498,7 +498,7 @@ Grouped Option
 ```ts
 {
   category: string;
-  options: OptionProps[];
+  options: SelectboxOption[];
   collapsible?: boolean;
   initialState?: "opened" | "closed";
 }
@@ -2085,7 +2085,7 @@ It supports icons, labels, collapsible tooltips, customizable styles, and click 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `children` | ReactNode | — | Step components (`Stepline.Item`) to render inside the stepline. |
-| `styles` | SteplineStylesProps | — | Custom CSS styles for the wrapper. |
+| `styles` | SteplineStyles | — | Custom CSS styles for the wrapper. |
 | `gap` | number | 8 | Space in pixels between steps. |
 | `collapsed` | boolean | false | Collapses step labels into tooltips. |
 
@@ -2099,7 +2099,7 @@ It supports icons, labels, collapsible tooltips, customizable styles, and click 
 | `variant` | 'todo' | 'current' | 'completed' | 'error' | 'todo' | Step visual variant affecting circle color and line color. |
 | `active` | boolean | false | Scale the outer circle to indicate active state. |
 | `onClick` | () => void | — | Callback when the step is clicked. |
-| `styles` | SteplineItemStylesProps | — | Custom styles for the item, outer/inner circle, and text wrapper. |
+| `styles` | SteplineItemStyles | — | Custom styles for the item, outer/inner circle, and text wrapper. |
 
 ---
 📌 Usage
@@ -2516,7 +2516,7 @@ It supports custom items (`Timeline.Item`), clickable states, variant-based colo
 - `subtitle` (string): Secondary description or detail under the title.
 - `sidenote` (ReactNode): Optional content displayed beside the item.
 - `variant` (string): Status/variant of the item, affects colors. Options from `TEXT_VARIANT_COLOR`.
-- `styles` (TimelineItemStylesProps): Customize styling for item sub-elements.
+- `styles` (TimelineItemStyles): Customize styling for item sub-elements.
   - `self` – container wrapper
   - `textWrapperStyle` – wrapper for title & subtitle
   - `titleStyle` – title text
@@ -2684,7 +2684,7 @@ It is suitable for building rich action bars, tool panels, or context menus in a
 - 🏷 **Toolbar.Menu**: Each menu can have a caption, an icon, and an optional dropdown sub-menu.
 - 🔀 **Variants**: Supports `default`, `primary`, and `danger` modes for visual emphasis.
 - 🔄 **Interactive states**: Hover, active, focus-visible, and open states are styled out-of-the-box.
-- ⬆️⬇️ **Dropdown menus**: Sub-menu lists can be fully customized with `ToolbarSubMenuProps`.
+- ⬆️⬇️ **Dropdown menus**: Sub-menu lists can be fully customized with `ToolbarSubMenuList`.
 - ⚡ **Dynamic sizing**: Supports a `big` mode for larger icons and vertically-aligned content.
 - 🎨 **Styling flexibility**: Customize the container, trigger, toggle button, and dropdown via the `styles` prop.
 - 🧩 **Composable children**: Place any custom JSX or multiple `Toolbar.Menu` items inside a toolbar.
@@ -2693,7 +2693,7 @@ It is suitable for building rich action bars, tool panels, or context menus in a
 📌 Usage
 
 ```tsx
-const subMenuList: ToolbarSubMenuProps[] = [
+const subMenuList: ToolbarSubMenuList[] = [
   { caption: "Edit", icon: { image: RiEditLine, color: "yellow" }, onClick: () => console.log("Edit mode") },
   { caption: "Delete", icon: { image: RiForbid2Line, color: "red" }, isDangerous: true, onClick: () => console.log("Deleted") },
 ];

--- a/test/component/action-button.cy.tsx
+++ b/test/component/action-button.cy.tsx
@@ -272,7 +272,7 @@ describe("ActionButton", () => {
 
         cy.findAllByLabelText("action-button")
           .eq(2)
-          .should("have.css", "background-color", "rgb(221, 221, 221)");
+          .should("have.css", "background-color", "rgb(236, 236, 236)");
       });
     });
 
@@ -364,11 +364,11 @@ describe("ActionButton", () => {
 
           cy.findAllByLabelText("action-button")
             .eq(2)
-            .should("have.css", "background-color", "rgb(221, 221, 221)");
+            .should("have.css", "background-color", "rgb(236, 236, 236)");
 
           cy.findAllByLabelText("button-toggle")
             .eq(0)
-            .should("have.css", "background-color", "rgb(221, 221, 221)");
+            .should("have.css", "background-color", "rgb(236, 236, 236)");
         });
       });
     });

--- a/test/component/action-button.cy.tsx
+++ b/test/component/action-button.cy.tsx
@@ -1,4 +1,4 @@
-import { NavTab, NavTabContentProps } from "./../../components/nav-tab";
+import { NavTab, NavTabTabProps } from "./../../components/nav-tab";
 import { Card } from "./../../components/card";
 import {
   RiAddBoxLine,
@@ -12,14 +12,10 @@ import {
   RiShieldLine,
   RiSpam2Line,
 } from "@remixicon/react";
-import { List, ListGroupContentProps } from "./../../components/list";
+import { List, ListGroupContent } from "./../../components/list";
 import { css } from "styled-components";
 import { TipMenuItemProps } from "./../../components/tip-menu";
-import {
-  ColumnTableProps,
-  Table,
-  TableActionsProps,
-} from "./../../components/table";
+import { TableColumn, Table, TableAction } from "./../../components/table";
 import { ReactNode } from "react";
 
 describe("ActionButton", () => {
@@ -771,7 +767,7 @@ describe("ActionButton", () => {
     context("when given pressed", () => {
       it("should render table button with pressed", () => {
         function TableComponent() {
-          const columns: ColumnTableProps[] = [
+          const columns: TableColumn[] = [
             {
               id: "name",
               caption: "Name",
@@ -824,7 +820,7 @@ describe("ActionButton", () => {
     context("when given className", () => {
       it("should render the class", () => {
         function TableComponent() {
-          const columns: ColumnTableProps[] = [
+          const columns: TableColumn[] = [
             {
               id: "name",
               caption: "Name",
@@ -876,7 +872,7 @@ describe("ActionButton", () => {
     context("when given variant", () => {
       it("should render button with variant", () => {
         function TableComponent() {
-          const columns: ColumnTableProps[] = [
+          const columns: TableColumn[] = [
             {
               id: "name",
               caption: "Name",
@@ -929,7 +925,7 @@ describe("ActionButton", () => {
       context("with caret", () => {
         it("should render button with 0px radius top-right and bottom-right", () => {
           function TableComponent() {
-            const columns: ColumnTableProps[] = [
+            const columns: TableColumn[] = [
               {
                 id: "name",
                 caption: "Name",
@@ -982,7 +978,7 @@ describe("ActionButton", () => {
       context("with self", () => {
         it("should render button with 6px radius top-right and bottom-right", () => {
           function TableComponent() {
-            const columns: ColumnTableProps[] = [
+            const columns: TableColumn[] = [
               {
                 id: "name",
                 caption: "Name",
@@ -1051,7 +1047,7 @@ describe("ActionButton", () => {
       context("when given variant", () => {
         it("should render button with variant", () => {
           function TableComponent() {
-            const columns: ColumnTableProps[] = [
+            const columns: TableColumn[] = [
               {
                 id: "name",
                 caption: "Name",
@@ -1107,7 +1103,7 @@ describe("ActionButton", () => {
   });
 });
 
-const LIST_GROUPS: ListGroupContentProps[] = [
+const LIST_GROUPS: ListGroupContent[] = [
   {
     id: "employees",
     title: "Employees",
@@ -1127,7 +1123,7 @@ const LIST_GROUPS: ListGroupContentProps[] = [
   },
 ];
 
-const TOP_ACTIONS: TableActionsProps[] = [
+const TOP_ACTIONS: TableAction[] = [
   {
     className: "table-delete-action",
     caption: "Delete",
@@ -1153,7 +1149,7 @@ const TOP_ACTIONS: TableActionsProps[] = [
   },
 ];
 
-const TABS_ITEMS: NavTabContentProps[] = [
+const TABS_ITEMS: NavTabTabProps[] = [
   {
     id: "1",
     title: "Write",

--- a/test/component/badge.cy.tsx
+++ b/test/component/badge.cy.tsx
@@ -1,5 +1,5 @@
 import { RiCheckLine, RiCloseLine } from "@remixicon/react";
-import { Badge, BadgeActionProps } from "./../../components/badge";
+import { Badge, BadgeAction } from "./../../components/badge";
 import { strToColor } from "./../../lib/code-color";
 
 describe("Badge", () => {
@@ -87,7 +87,7 @@ describe("Badge", () => {
   });
 
   context("with actions", () => {
-    const contentAction: BadgeActionProps[] = [
+    const contentAction: BadgeAction[] = [
       {
         icon: { image: RiCloseLine },
         onClick: () => {
@@ -97,7 +97,7 @@ describe("Badge", () => {
       },
     ];
 
-    const contentActions: BadgeActionProps[] = [
+    const contentActions: BadgeAction[] = [
       {
         icon: { image: RiCheckLine },
         onClick: () => {
@@ -114,7 +114,7 @@ describe("Badge", () => {
       },
     ];
 
-    const contentWithHiddenActions: BadgeActionProps[] = [
+    const contentWithHiddenActions: BadgeAction[] = [
       {
         hidden: true,
         icon: { image: RiCheckLine },

--- a/test/component/capsule-tab.cy.tsx
+++ b/test/component/capsule-tab.cy.tsx
@@ -1,13 +1,13 @@
 import { css } from "styled-components";
 import {
   CapsuleTab,
-  CapsuleTabContentProps,
-  CapsuleTabStylesProps,
+  CapsuleTabTab,
+  CapsuleTabStyles,
 } from "./../../components/capsule-tab";
 import { useState } from "react";
 
 describe("Capsule Tab", () => {
-  const TABS_ITEMS: CapsuleTabContentProps[] = [
+  const TABS_ITEMS: CapsuleTabTab[] = [
     { id: "1", title: "Write", content: "Write Tab" },
     { id: "2", title: "Review", content: "Review Tab" },
   ];
@@ -16,7 +16,7 @@ describe("Capsule Tab", () => {
     withCallback,
     styles,
   }: {
-    styles?: CapsuleTabStylesProps;
+    styles?: CapsuleTabStyles;
     withCallback?: boolean;
   }) {
     const [activeTab, setActiveTab] = useState("2");

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -1,10 +1,9 @@
 import {
   Combobox,
-  ComboboxActionProps,
-  ComboboxGroupedOptionProps,
-  ComboboxOptionProps,
+  ComboboxAction,
+  ComboboxOption,
   ComboboxProps,
-  ComboboxSingleOptionProps,
+  ComboboxSingleOption,
 } from "./../../components/combobox";
 import { Button } from "./../../components/button";
 import {
@@ -16,7 +15,7 @@ import {
 } from "@remixicon/react";
 import { useState } from "react";
 
-const FRUIT_OPTIONS: ComboboxSingleOptionProps[] = [
+const FRUIT_OPTIONS: ComboboxSingleOption[] = [
   { text: "Apple", value: "1" },
   { text: "Banana", value: "2" },
   { text: "Orange", value: "3" },
@@ -26,7 +25,7 @@ const FRUIT_OPTIONS: ComboboxSingleOptionProps[] = [
   { text: "Watermelon", value: "7" },
 ];
 
-const MIX_FRUIT_OPTIONS: ComboboxOptionProps[] = [
+const MIX_FRUIT_OPTIONS: ComboboxOption[] = [
   {
     category: "Sweet",
     options: [
@@ -318,7 +317,7 @@ describe("Combobox", () => {
     });
 
     context("initialState", () => {
-      const MIX_FRUIT_OPTIONS_WITH_INITIAL_OPENED: ComboboxOptionProps[] =
+      const MIX_FRUIT_OPTIONS_WITH_INITIAL_OPENED: ComboboxOption[] =
         MIX_FRUIT_OPTIONS.map((item) => {
           if ("category" in item && item.options) {
             return {
@@ -462,7 +461,7 @@ describe("Combobox", () => {
   });
 
   context("actions", () => {
-    const FRUIT_ACTIONS: ComboboxActionProps[] = [
+    const FRUIT_ACTIONS: ComboboxAction[] = [
       {
         title: "Add Fruit",
         onClick: () => {},

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -410,7 +410,7 @@ describe("Combobox", () => {
 
         cy.findByLabelText("circle")
           .parent()
-          .should("have.css", "background-color", "rgba(255, 255, 255, 0.6)");
+          .should("have.css", "background-color", "rgba(0, 0, 0, 0)");
       });
 
       it("should disabled the input component", () => {

--- a/test/component/context-menu.cy.tsx
+++ b/test/component/context-menu.cy.tsx
@@ -16,21 +16,17 @@ import {
 } from "@remixicon/react";
 import {
   List,
-  ListGroupContentProps,
-  ListItemActionProps,
+  ListGroupContent,
+  ListItemAction,
 } from "./../../components/list";
 import { css } from "styled-components";
 import {
-  SubMenuTreeList,
+  TreeListItemAction,
   TreeList,
-  TreeListContentProps,
+  TreeListContent,
 } from "./../../components/treelist";
-import {
-  ColumnTableProps,
-  SubMenuListTableProps,
-  Table,
-} from "./../../components/table";
-import { NavTab, SubMenuNavTab } from "./../../components/nav-tab";
+import { TableColumn, TableSubMenuList, Table } from "./../../components/table";
+import { NavTab, NavTabTabAction } from "./../../components/nav-tab";
 
 const checkMenuAlignment = () => {
   return cy
@@ -55,7 +51,7 @@ const checkMenuAlignment = () => {
 
 describe("context-menu", () => {
   context("when given in List component", () => {
-    const LIST_ACTION_ITEMS_PROPS = (id: string): ListItemActionProps[] => [
+    const LIST_ACTION_ITEMS_PROPS = (id: string): ListItemAction[] => [
       {
         caption: "Add",
         icon: { image: RiArrowRightSLine },
@@ -65,7 +61,7 @@ describe("context-menu", () => {
       },
     ];
 
-    const LIST_GROUPS: ListGroupContentProps[] = [
+    const LIST_GROUPS: ListGroupContent[] = [
       {
         id: "recent-content",
         title: "Recent Content",
@@ -75,20 +71,20 @@ describe("context-menu", () => {
             id: "messages",
             title: "Messages",
             subtitle: "Check your inbox",
-            leftIcon: RiMailFill,
+            icon: { image: RiMailFill },
             actions: LIST_ACTION_ITEMS_PROPS,
           },
           {
             id: "notifications",
             title: "Notifications",
             subtitle: "View Alerts",
-            leftIcon: RiNotification3Fill,
+            icon: { image: RiNotification3Fill },
           },
           {
             id: "calendar",
             title: "Calendar",
             subtitle: "Upcoming events",
-            leftIcon: RiCalendar2Fill,
+            icon: { image: RiCalendar2Fill },
           },
         ],
       },
@@ -101,26 +97,26 @@ describe("context-menu", () => {
             id: "home",
             title: "Home",
             subtitle: "Go to homepage",
-            leftIcon: RiHome2Fill,
+            icon: { image: RiHome2Fill },
             actions: LIST_ACTION_ITEMS_PROPS,
           },
           {
             id: "profile",
             title: "Profile",
             subtitle: "View your profile",
-            leftIcon: RiUser3Fill,
+            icon: { image: RiUser3Fill },
           },
           {
             id: "settings",
             title: "Settings",
             subtitle: "Adjust preferences",
-            leftIcon: RiSettings3Fill,
+            icon: { image: RiSettings3Fill },
           },
         ],
       },
     ];
 
-    const ROW_ACTIONS = (id: string): ListItemActionProps[] => [
+    const ROW_ACTIONS = (id: string): ListItemAction[] => [
       {
         className: "test-classname",
         caption: "Edit",
@@ -167,7 +163,7 @@ describe("context-menu", () => {
                     id={list.id}
                     groupId={group.id}
                     actions={ROW_ACTIONS}
-                    leftIcon={list.leftIcon}
+                    icon={list.icon}
                     subtitle={list.subtitle}
                     title={list.title}
                     selectedOptions={{
@@ -219,7 +215,7 @@ describe("context-menu", () => {
                     id={list.id}
                     groupId={group.id}
                     actions={ROW_ACTIONS}
-                    leftIcon={list.leftIcon}
+                    icon={list.icon}
                     subtitle={list.subtitle}
                     title={list.title}
                     selectedOptions={{
@@ -268,7 +264,7 @@ describe("context-menu", () => {
                     id={list.id}
                     groupId={group.id}
                     actions={ROW_ACTIONS}
-                    leftIcon={list.leftIcon}
+                    icon={list.icon}
                     subtitle={list.subtitle}
                     title={list.title}
                     selectedOptions={{
@@ -321,7 +317,7 @@ describe("context-menu", () => {
                       id={list.id}
                       groupId={group.id}
                       actions={ROW_ACTIONS}
-                      leftIcon={list.leftIcon}
+                      icon={list.icon}
                       subtitle={list.subtitle}
                       title={list.title}
                       selectedOptions={{
@@ -348,7 +344,7 @@ describe("context-menu", () => {
   });
 
   context("when given in TreeList component", () => {
-    const ITEM_ACTIONS: SubMenuTreeList[] = [
+    const ITEM_ACTIONS: TreeListItemAction[] = [
       {
         className: "editable-action-tip",
         caption: "Edit",
@@ -380,7 +376,7 @@ describe("context-menu", () => {
       },
     ];
 
-    const TREE_LIST_DATA: TreeListContentProps[] = [
+    const TREE_LIST_DATA: TreeListContent[] = [
       {
         id: "member",
         caption: "Member of Technical Staff",
@@ -530,7 +526,7 @@ describe("context-menu", () => {
   context("when given in Table component", () => {
     const TYPES_DATA = ["HTTP", "HTTPS", "TCP", "UDP", "QUIC"];
 
-    const ROW_ACTION = (rowId: string): SubMenuListTableProps[] => {
+    const ROW_ACTION = (rowId: string): TableSubMenuList[] => {
       return [
         {
           caption: "Edit",
@@ -562,7 +558,7 @@ describe("context-menu", () => {
       );
     });
 
-    const columns: ColumnTableProps[] = [
+    const columns: TableColumn[] = [
       {
         id: "name",
         caption: "Name",
@@ -684,7 +680,7 @@ describe("context-menu", () => {
   });
 
   context("when given in Navtab component", () => {
-    const SUB_MENU: SubMenuNavTab[] = [
+    const SUB_MENU: NavTabTabAction[] = [
       {
         caption: "Discover",
         onClick: () => {

--- a/test/component/crumb.cy.tsx
+++ b/test/component/crumb.cy.tsx
@@ -1,5 +1,4 @@
 import { Crumb } from "../../components/crumb";
-import { mount } from "cypress/react";
 
 describe("Crumb", () => {
   const CrumbData = [
@@ -17,7 +16,7 @@ describe("Crumb", () => {
   context("fontSize", () => {
     context("when a custom fontSize is provided", () => {
       it("renders the crumb links with the correct font size and calculates chevron size", () => {
-        mount(<Crumb fontSize={20}>{CrumbItems}</Crumb>);
+        cy.mount(<Crumb fontSize={20}>{CrumbItems}</Crumb>);
 
         cy.get("a").first().should("have.css", "font-size", "20px");
         cy.findByLabelText("crumb")
@@ -34,7 +33,7 @@ describe("Crumb", () => {
   context("maxShown", () => {
     context("when 1", () => {
       it("displays one ellipsis on the left and the last link on the right", () => {
-        mount(<Crumb maxShown={1}>{CrumbItems}</Crumb>);
+        cy.mount(<Crumb maxShown={1}>{CrumbItems}</Crumb>);
 
         cy.findByLabelText("ellipsis").should("exist");
         cy.contains("Contact").should("exist");
@@ -43,7 +42,7 @@ describe("Crumb", () => {
 
     context("when 2", () => {
       it("displays the first link on the left, one ellipsis in the middle, and the last link on the right", () => {
-        mount(<Crumb maxShown={2}>{CrumbItems}</Crumb>);
+        cy.mount(<Crumb maxShown={2}>{CrumbItems}</Crumb>);
 
         cy.contains("Home").should("exist");
         cy.findByLabelText("ellipsis").should("exist");
@@ -53,7 +52,7 @@ describe("Crumb", () => {
 
     context("when maxShown smaller than data", () => {
       it("displays the first link, one ellipsis in the middle, and 2 link from latest when not clicking the ellipsis", () => {
-        mount(<Crumb maxShown={3}>{CrumbItems}</Crumb>);
+        cy.mount(<Crumb maxShown={3}>{CrumbItems}</Crumb>);
 
         cy.contains("Home").should("exist");
         cy.contains("Service").should("exist");
@@ -61,7 +60,7 @@ describe("Crumb", () => {
       });
 
       it("displays all links and no ellipsis when clicking on the ellipsis", () => {
-        mount(<Crumb maxShown={5}>{CrumbItems}</Crumb>);
+        cy.mount(<Crumb maxShown={5}>{CrumbItems}</Crumb>);
 
         cy.contains("Home").should("exist");
         cy.contains("About").should("exist");
@@ -74,7 +73,7 @@ describe("Crumb", () => {
   context("arrowColor", () => {
     context("when not given", () => {
       it("renders with the default color", () => {
-        mount(<Crumb maxShown={4}>{CrumbItems}</Crumb>);
+        cy.mount(<Crumb maxShown={4}>{CrumbItems}</Crumb>);
 
         cy.findAllByLabelText("arrow-icon").each(($icon) => {
           cy.wrap($icon).should("have.css", "color", "rgb(156, 163, 175)");
@@ -84,7 +83,7 @@ describe("Crumb", () => {
 
     context("when given", () => {
       it("renders with the specified color", () => {
-        mount(
+        cy.mount(
           <Crumb arrowColor="red" maxShown={4}>
             {CrumbItems}
           </Crumb>
@@ -100,7 +99,7 @@ describe("Crumb", () => {
   context("lastTextColor", () => {
     context("when not given", () => {
       it("renders the last crumb with the default color", () => {
-        mount(<Crumb>{CrumbItems}</Crumb>);
+        cy.mount(<Crumb>{CrumbItems}</Crumb>);
 
         cy.get("a").last().should("have.css", "color", "rgb(0, 0, 0)");
       });
@@ -108,7 +107,7 @@ describe("Crumb", () => {
 
     context("when given", () => {
       it("renders the last crumb link with the specified color", () => {
-        mount(<Crumb lastTextColor="green">{CrumbItems}</Crumb>);
+        cy.mount(<Crumb lastTextColor="green">{CrumbItems}</Crumb>);
 
         cy.get("a").last().should("have.css", "color", "rgb(0, 128, 0)");
       });
@@ -118,7 +117,7 @@ describe("Crumb", () => {
   context("hoverColor", () => {
     context("when not given", () => {
       it("uses the default hover color", () => {
-        mount(<Crumb>{CrumbItems}</Crumb>);
+        cy.mount(<Crumb>{CrumbItems}</Crumb>);
 
         cy.get("a")
           .first()
@@ -129,7 +128,7 @@ describe("Crumb", () => {
 
     context("when given", () => {
       it("changes the color of the crumb link on hover", () => {
-        mount(<Crumb hoverColor="red">{CrumbItems}</Crumb>);
+        cy.mount(<Crumb hoverColor="red">{CrumbItems}</Crumb>);
 
         cy.get("a")
           .first()

--- a/test/component/datebox.cy.tsx
+++ b/test/component/datebox.cy.tsx
@@ -47,7 +47,7 @@ describe("Datebox", () => {
 
         cy.findByLabelText("circle")
           .parent()
-          .should("have.css", "background-color", "rgba(255, 255, 255, 0.6)");
+          .should("have.css", "background-color", "rgba(0, 0, 0, 0)");
       });
 
       it("should disabled the input component", () => {

--- a/test/component/file-drop-box.cy.tsx
+++ b/test/component/file-drop-box.cy.tsx
@@ -1,8 +1,8 @@
 import { css } from "styled-components";
 import {
   FileDropBox,
-  OnCompleteFunctionProps,
-  OnFileDroppedFunctionProps,
+  OnCompleteFunction,
+  OnFileDroppedFunction,
 } from "./../../components/file-drop-box";
 import { Table } from "./../../components/table";
 import { useState } from "react";
@@ -19,7 +19,7 @@ describe("FileDropBox", () => {
           files,
           setProgressLabel,
           succeed,
-        }: OnFileDroppedFunctionProps) => {
+        }: OnFileDroppedFunction) => {
           const file = files[0];
           setFiles((prev) => [...prev, file]);
           setProgressLabel(`Uploading ${file.name}`);
@@ -49,7 +49,7 @@ describe("FileDropBox", () => {
           succeedFiles,
           hideProgressLabel,
           showUploaderForm,
-        }: OnCompleteFunctionProps) => {
+        }: OnCompleteFunction) => {
           console.log(succeedFiles, "This is succeedFiles");
           console.log(failedFiles, "This is failedFiles");
           await setProgressLabel(
@@ -144,7 +144,7 @@ describe("FileDropBox", () => {
         files,
         setProgressLabel,
         succeed,
-      }: OnFileDroppedFunctionProps) => {
+      }: OnFileDroppedFunction) => {
         const file = files[0];
         setProgressLabel(`Uploading ${file.name}`);
 
@@ -172,7 +172,7 @@ describe("FileDropBox", () => {
         setProgressLabel,
         succeedFiles,
         hideProgressLabel,
-      }: OnCompleteFunctionProps) => {
+      }: OnCompleteFunction) => {
         console.log(succeedFiles, "This is succeedFiles");
         console.log(failedFiles, "This is failedFiles");
         await setProgressLabel(
@@ -208,7 +208,7 @@ describe("FileDropBox", () => {
           files,
           setProgressLabel,
           succeed,
-        }: OnFileDroppedFunctionProps) => {
+        }: OnFileDroppedFunction) => {
           const file = files[0];
           setProgressLabel(`Uploading ${file.name}`);
 
@@ -237,7 +237,7 @@ describe("FileDropBox", () => {
           succeedFiles,
           hideProgressLabel,
           showUploaderForm,
-        }: OnCompleteFunctionProps) => {
+        }: OnCompleteFunction) => {
           console.log(succeedFiles, "This is succeedFiles");
           console.log(failedFiles, "This is failedFiles");
           await setProgressLabel(
@@ -292,7 +292,7 @@ describe("FileDropBox", () => {
         files,
         setProgressLabel,
         succeed,
-      }: OnFileDroppedFunctionProps) => {
+      }: OnFileDroppedFunction) => {
         const file = files[0];
         setProgressLabel(`Uploading ${file.name}`);
 
@@ -319,7 +319,7 @@ describe("FileDropBox", () => {
         failedFiles,
         setProgressLabel,
         succeedFiles,
-      }: OnCompleteFunctionProps) => {
+      }: OnCompleteFunction) => {
         console.log(succeedFiles, "This is succeedFiles");
         console.log(failedFiles, "This is failedFiles");
         await setProgressLabel(
@@ -365,7 +365,7 @@ describe("FileDropBox", () => {
         files,
         setProgressLabel,
         succeed,
-      }: OnFileDroppedFunctionProps) => {
+      }: OnFileDroppedFunction) => {
         const file = files[0];
         setProgressLabel(`Uploading ${file.name}`);
 
@@ -392,7 +392,7 @@ describe("FileDropBox", () => {
         failedFiles,
         setProgressLabel,
         succeedFiles,
-      }: OnCompleteFunctionProps) => {
+      }: OnCompleteFunction) => {
         console.log(failedFiles, "This is failedFiles");
         await setProgressLabel(
           `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`

--- a/test/component/list.cy.tsx
+++ b/test/component/list.cy.tsx
@@ -12,10 +12,10 @@ import {
 } from "@remixicon/react";
 import {
   List,
-  ListGroupActionsProps,
-  ListGroupContentProps,
+  ListGroupaction,
+  ListGroupContent,
   ListGroupProps,
-  ListItemActionProps,
+  ListItemAction,
   ListItemProps,
   ListProps,
 } from "./../../components/list";
@@ -55,7 +55,7 @@ describe("List", () => {
     },
   ];
 
-  const LIST_GROUPS_OPENABLE: ListGroupContentProps[] = [
+  const LIST_GROUPS_OPENABLE: ListGroupContent[] = [
     {
       id: "recent-content",
       title: "Recent Content",
@@ -129,7 +129,7 @@ describe("List", () => {
       groupOpenerBehavior?: ListProps["groupOpenerBehavior"];
       groupProps?: Omit<ListGroupProps, "id" | "children" | "title">;
     }) {
-      const ACTIONS_GROUPS: ListGroupActionsProps[] = [
+      const ACTIONS_GROUPS: ListGroupaction[] = [
         {
           caption: "Refresh",
           onClick: (id: string) => {
@@ -287,7 +287,7 @@ describe("List", () => {
 
   context("colors in the List.Item level", () => {
     function ListItemWithColors() {
-      const ACTIONS_GROUPS: ListGroupActionsProps[] = [
+      const ACTIONS_GROUPS: ListGroupaction[] = [
         {
           caption: "Refresh",
           onClick: (id: string) => {
@@ -1057,7 +1057,7 @@ describe("List", () => {
 
   context("group", () => {
     context("titleStyle", () => {
-      const LIST_GROUPS_WITH_TITLE_STYLE: ListGroupContentProps[] = [
+      const LIST_GROUPS_WITH_TITLE_STYLE: ListGroupContent[] = [
         {
           id: "recent-content",
           title: "Recent Content",
@@ -1168,7 +1168,7 @@ describe("List", () => {
     });
 
     context("subtitleStyle", () => {
-      const LIST_GROUPS_WITH_SUBTITLE_STYLE: ListGroupContentProps[] = [
+      const LIST_GROUPS_WITH_SUBTITLE_STYLE: ListGroupContent[] = [
         {
           id: "recent-content",
           title: "Recent Content",
@@ -1277,7 +1277,7 @@ describe("List", () => {
     });
 
     context("when items is empty", () => {
-      const LIST_GROUPS_WITH_EMPTY: ListGroupContentProps[] = [
+      const LIST_GROUPS_WITH_EMPTY: ListGroupContent[] = [
         {
           id: "recent-content",
           title: "Recent Content",
@@ -1408,7 +1408,7 @@ describe("List", () => {
         />
       );
 
-      const LIST_GROUPS: ListGroupContentProps[] = [
+      const LIST_GROUPS: ListGroupContent[] = [
         {
           id: "recent-content",
           title: "Recent Content",
@@ -1571,7 +1571,7 @@ describe("List", () => {
         />
       );
 
-      const ACTIONS_GROUPS: ListGroupActionsProps[] = [
+      const ACTIONS_GROUPS: ListGroupaction[] = [
         {
           caption: "Add",
           onClick: (id: string) => {
@@ -1580,7 +1580,7 @@ describe("List", () => {
         },
       ];
 
-      const LIST_GROUPS: ListGroupContentProps[] = [
+      const LIST_GROUPS: ListGroupContent[] = [
         {
           id: "recent-content",
           title: "Recent Content",
@@ -1739,7 +1739,7 @@ describe("List", () => {
 
   context("actions", () => {
     context("when given in the list", () => {
-      const LIST_ACTION_ITEMS_PROPS = (id: string): ListItemActionProps[] => [
+      const LIST_ACTION_ITEMS_PROPS = (id: string): ListItemAction[] => [
         {
           caption: "Add",
           icon: { image: RiArrowRightSLine },
@@ -1757,7 +1757,7 @@ describe("List", () => {
         },
       ];
 
-      const LIST_GROUPS: ListGroupContentProps[] = [
+      const LIST_GROUPS: ListGroupContent[] = [
         {
           id: "recent-content",
           title: "Recent Content",
@@ -2048,7 +2048,7 @@ describe("List", () => {
     });
 
     context("when given in the group", () => {
-      const ACTIONS_GROUPS: ListGroupActionsProps[] = [
+      const ACTIONS_GROUPS: ListGroupaction[] = [
         {
           caption: "Add",
           onClick: (id: string) => {
@@ -2064,7 +2064,7 @@ describe("List", () => {
         },
       ];
 
-      const LIST_GROUPS: ListGroupContentProps[] = [
+      const LIST_GROUPS: ListGroupContent[] = [
         {
           id: "recent-content",
           title: "Recent Content",
@@ -2204,7 +2204,7 @@ describe("List", () => {
         />
       );
 
-      const ACTIONS_GROUPS: ListGroupActionsProps[] = [
+      const ACTIONS_GROUPS: ListGroupaction[] = [
         {
           caption: "Add",
           onClick: (id: string) => {
@@ -2213,7 +2213,7 @@ describe("List", () => {
         },
       ];
 
-      const LIST_GROUPS: ListGroupContentProps[] = [
+      const LIST_GROUPS: ListGroupContent[] = [
         {
           id: "recent-content",
           title: "Recent Content",
@@ -2396,7 +2396,7 @@ describe("List", () => {
         leftSideContent?: number;
       };
 
-      type TestListGroup = Omit<ListGroupContentProps, "items"> & {
+      type TestListGroup = Omit<ListGroupContent, "items"> & {
         items: TestListItem[];
       };
 
@@ -3156,7 +3156,7 @@ describe("List", () => {
     });
 
     context("without children", () => {
-      const LIST_GROUPS_OPENABLE_WITHOUT_CHILDREN: ListGroupContentProps[] = [
+      const LIST_GROUPS_OPENABLE_WITHOUT_CHILDREN: ListGroupContent[] = [
         {
           id: "recent-content",
           title: "Recent Content",
@@ -3385,7 +3385,7 @@ describe("List", () => {
         </div>
       );
     };
-    const LIST_GROUPS_OPENABLE: ListGroupContentProps[] = [
+    const LIST_GROUPS_OPENABLE: ListGroupContent[] = [
       {
         id: "recent-content",
         title: "Recent Content",

--- a/test/component/moneybox.cy.tsx
+++ b/test/component/moneybox.cy.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useState } from "react";
 import {
-  CurrencyOptionProps,
+  MoneyboxCurrencyOption,
   Moneybox,
   MoneyboxProps,
 } from "./../../components/moneybox";
@@ -64,7 +64,7 @@ describe("Moneybox", () => {
   });
 
   context("editableCurrency", () => {
-    const CURRENCY_OPTIONS: CurrencyOptionProps[] = [
+    const CURRENCY_OPTIONS: MoneyboxCurrencyOption[] = [
       { id: "IDR", name: "Indonesian Rupiah", symbol: "Rp" },
       { id: "USD", name: "US Dollar", symbol: "$" },
       { id: "EUR", name: "Euro", symbol: "€" },

--- a/test/component/nav-tab.cy.tsx
+++ b/test/component/nav-tab.cy.tsx
@@ -2,7 +2,7 @@ import {
   ReviewTabContent,
   WriteTabContent,
 } from "./../../components/nav-tab.stories";
-import { NavTab, NavTabContentProps } from "./../../components/nav-tab";
+import { NavTab, NavTabTabProps } from "./../../components/nav-tab";
 import { Button } from "./../../components/button";
 import { css } from "styled-components";
 import {
@@ -550,7 +550,7 @@ describe("NavTab", () => {
   });
 });
 
-const TABS_ITEMS: NavTabContentProps[] = [
+const TABS_ITEMS: NavTabTabProps[] = [
   {
     id: "1",
     title: "Write",

--- a/test/component/pinbox.cy.tsx
+++ b/test/component/pinbox.cy.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Pinbox, PinboxProps, PinboxState } from "./../../components/pinbox";
+import { Pinbox, PinboxProps, PinboxParts } from "./../../components/pinbox";
 
 describe("Pinbox", () => {
   function ProductPinbox(props: PinboxProps) {
@@ -212,7 +212,7 @@ describe("Pinbox", () => {
   });
 });
 
-const PARTS_INPUT: PinboxState[] = [
+const PARTS_INPUT: PinboxParts[] = [
   { type: "static", text: "S" },
   { type: "alphanumeric" },
   { type: "alphanumeric" },
@@ -221,7 +221,7 @@ const PARTS_INPUT: PinboxState[] = [
   { type: "alphanumeric" },
 ];
 
-const MIX_PARTS_INPUT: PinboxState[] = [
+const MIX_PARTS_INPUT: PinboxParts[] = [
   { type: "static", text: "S" },
   { type: "alphanumeric" },
   { type: "digit" },

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -21,7 +21,7 @@ describe("RichEditor", () => {
         cy.findAllByLabelText("rich-editor-content").should(
           "have.css",
           "height",
-          "509px"
+          "472px"
         );
       });
     });
@@ -39,7 +39,7 @@ describe("RichEditor", () => {
         cy.findAllByLabelText("rich-editor-content").should(
           "have.css",
           "height",
-          "509px"
+          "472px"
         );
       });
 
@@ -52,14 +52,14 @@ describe("RichEditor", () => {
             />
           );
           cy.findAllByLabelText("rich-editor-content")
-            .should("have.css", "height", "509px")
+            .should("have.css", "height", "472px")
             .click()
             .type("{enter}{enter}{enter}");
 
           cy.findAllByLabelText("rich-editor-content").should(
             "have.css",
             "height",
-            "581px"
+            "544px"
           );
         });
       });

--- a/test/component/searchbox.cy.tsx
+++ b/test/component/searchbox.cy.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import {
   Searchbox,
   SearchboxProps,
-  SearchboxResultMenuItemProps,
+  SearchboxResultMenuItem,
 } from "./../../components/searchbox";
 import {
   RiUserLine,
@@ -59,7 +59,7 @@ describe("Searchbox", () => {
 
   context("resultMenu", () => {
     context("list", () => {
-      const PEOPLE_MENU: SearchboxResultMenuItemProps[] = [
+      const PEOPLE_MENU: SearchboxResultMenuItem[] = [
         {
           caption: "Adam Noto Hakarsa",
           icon: { image: RiUserSmileLine },

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -9,18 +9,18 @@ import { COUNTRY_CODES } from "./../../constants/countries";
 import { Boxbar } from "./../../components/boxbar";
 import { Badge, BadgeProps } from "./../../components/badge";
 import { css } from "styled-components";
-import { OptionProps } from "./../../components/selectbox";
-import { CapsuleContentProps } from "./../../components/capsule";
+import { SelectboxOption } from "./../../components/selectbox";
+import { CapsuleTab } from "./../../components/capsule";
 import { useMemo, useState } from "react";
 import {
-  OnCompleteFunctionProps,
+  OnCompleteFunction,
   FileDropBox,
-  OnFileDroppedFunctionProps,
+  OnFileDroppedFunction,
 } from "./../../components/file-drop-box";
 import { Table } from "./../../components/table";
 import { RiDeleteBin2Fill } from "@remixicon/react";
 import z from "zod";
-import { PinboxState } from "./../../components/pinbox";
+import { PinboxParts } from "./../../components/pinbox";
 
 const DEFAULT_COUNTRY_CODES = (() => {
   const code =
@@ -30,7 +30,7 @@ const DEFAULT_COUNTRY_CODES = (() => {
   return code;
 })();
 
-const FRUIT_OPTIONS: OptionProps[] = [
+const FRUIT_OPTIONS: SelectboxOption[] = [
   { text: "Apple", value: "1" },
   { text: "Banana", value: "2" },
   { text: "Orange", value: "3" },
@@ -55,12 +55,12 @@ const MONTH_NAMES = [
   { text: "DEC", value: "12" },
 ];
 
-const CAPSULE_TABS: CapsuleContentProps[] = [
+const CAPSULE_TABS: CapsuleTab[] = [
   { id: "paid", title: "Paid" },
   { id: "unpaid", title: "Unpaid" },
 ];
 
-const PARTS_INPUT: PinboxState[] = [
+const PARTS_INPUT: PinboxParts[] = [
   { type: "static", text: "S" },
   { type: "alphanumeric" },
   { type: "digit" },
@@ -680,20 +680,20 @@ describe("StatefulForm", () => {
         Fp32: 3,
       } as const;
 
-      const HOST_ARCHITECTURE_OPTIONS: OptionProps[] = [
+      const HOST_ARCHITECTURE_OPTIONS: SelectboxOption[] = [
         { value: String(HostArchitecture.x86), text: "x86" },
         { value: String(HostArchitecture.x64), text: "x64" },
         { value: String(HostArchitecture.ARM), text: "ARM" },
         { value: String(HostArchitecture.ARM64), text: "ARM64" },
       ];
 
-      const COMPILATION_TARGET_OPTIONS: OptionProps[] = [
+      const COMPILATION_TARGET_OPTIONS: SelectboxOption[] = [
         { value: String(CompilationTarget.Interpreter), text: "Interpreter" },
         { value: String(CompilationTarget.Simulator), text: "Simulator" },
         { value: String(CompilationTarget.IP), text: "IP" },
       ];
 
-      const COMPILATION_EFFORT_OPTIONS: OptionProps[] = [
+      const COMPILATION_EFFORT_OPTIONS: SelectboxOption[] = [
         {
           value: String(CompilationEffort.SimpleScheduling),
           text: "Simple scheduling",
@@ -708,7 +708,7 @@ describe("StatefulForm", () => {
         },
       ];
 
-      const QUANTIZATION_TYPE_OPTIONS: OptionProps[] = [
+      const QUANTIZATION_TYPE_OPTIONS: SelectboxOption[] = [
         { value: String(Quantization.Int8), text: "INT8" },
         { value: String(Quantization.Bf16), text: "BF16" },
         { value: String(Quantization.Fp16), text: "FP16" },
@@ -1558,7 +1558,7 @@ describe("StatefulForm", () => {
         files,
         setProgressLabel,
         succeed,
-      }: OnFileDroppedFunctionProps) => {
+      }: OnFileDroppedFunction) => {
         const file = files[0];
         setValue((prev) => ({ ...prev, files: [...prev.files, file] }));
         setProgressLabel(`Uploading ${file.name}`);
@@ -1588,7 +1588,7 @@ describe("StatefulForm", () => {
         succeedFiles,
         hideProgressLabel,
         showUploaderForm,
-      }: OnCompleteFunctionProps) => {
+      }: OnCompleteFunction) => {
         console.log(succeedFiles, "This is succeedFiles");
         console.log(failedFiles, "This is failedFiles");
         await setProgressLabel(

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -500,7 +500,7 @@ describe("StatefulForm", () => {
           title: "Submit",
           type: "button",
           disabled: !isFormValid,
-          rowJustifyContent: "flex-end",
+          rowJustifyPosition: "flex-end",
         },
       ];
 
@@ -1707,7 +1707,7 @@ describe("StatefulForm", () => {
           type: "button",
           required: false,
           disabled: !isFormValid,
-          rowJustifyContent: "flex-end",
+          rowJustifyPosition: "flex-end",
         },
       ];
 
@@ -2308,7 +2308,7 @@ describe("StatefulForm", () => {
         required: true,
         placeholder: "Enter text",
         width: "15%",
-        rowJustifyContent: "flex-end",
+        rowJustifyPosition: "flex-end",
       },
     ];
 

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -500,7 +500,7 @@ describe("StatefulForm", () => {
           title: "Submit",
           type: "button",
           disabled: !isFormValid,
-          rowJustifyContent: "end",
+          rowJustifyContent: "flex-end",
         },
       ];
 
@@ -1707,7 +1707,7 @@ describe("StatefulForm", () => {
           type: "button",
           required: false,
           disabled: !isFormValid,
-          rowJustifyContent: "end",
+          rowJustifyContent: "flex-end",
         },
       ];
 
@@ -2308,7 +2308,7 @@ describe("StatefulForm", () => {
         required: true,
         placeholder: "Enter text",
         width: "15%",
-        rowJustifyContent: "end",
+        rowJustifyContent: "flex-end",
       },
     ];
 

--- a/test/component/statusbar.cy.tsx
+++ b/test/component/statusbar.cy.tsx
@@ -244,7 +244,7 @@ describe("Statusbar", () => {
         cy.findAllByLabelText("statusbar-button")
           .eq(0)
           .should("exist")
-          .and("have.css", "background-color", "rgb(236, 236, 236)");
+          .and("have.css", "background-color", "rgb(221, 221, 221)");
 
         cy.findByLabelText("statusbar-wrapper").should(
           "have.css",
@@ -260,7 +260,7 @@ describe("Statusbar", () => {
         cy.findAllByLabelText("statusbar-button")
           .eq(0)
           .should("exist")
-          .and("have.css", "border-color", "rgb(0, 0, 0)");
+          .and("have.css", "border-color", "rgb(17, 17, 17)");
 
         cy.findByLabelText("statusbar-wrapper")
           .should("have.css", "border-width", "0px")
@@ -303,7 +303,7 @@ describe("Statusbar", () => {
         cy.findAllByLabelText("statusbar-button")
           .eq(0)
           .should("exist")
-          .and("have.css", "background-color", "rgb(236, 236, 236)");
+          .and("have.css", "background-color", "rgb(221, 221, 221)");
 
         cy.findAllByLabelText("statusbar-button")
           .eq(0)
@@ -318,7 +318,7 @@ describe("Statusbar", () => {
         cy.findAllByLabelText("statusbar-button")
           .eq(2)
           .should("exist")
-          .and("have.css", "background-color", "rgb(236, 236, 236)");
+          .and("have.css", "background-color", "rgb(221, 221, 221)");
 
         cy.findAllByLabelText("statusbar-button")
           .eq(2)
@@ -506,7 +506,7 @@ describe("Statusbar", () => {
 
         cy.findByLabelText("statusbar-button")
           .should("exist")
-          .and("have.css", "background-color", "rgb(236, 236, 236)");
+          .and("have.css", "background-color", "rgb(221, 221, 221)");
       });
 
       context("when given hidden", () => {

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -1516,7 +1516,6 @@ describe("Table", () => {
       const DEFAULT_TOP_ACTIONS: TableActionsProps[] = [
         {
           caption: "Copy",
-          icon: { image: RiArrowUpSLine },
           onClick: () => {
             console.log("Copy clicked");
           },
@@ -1567,11 +1566,7 @@ describe("Table", () => {
 
         cy.findByText("Copy").click();
 
-        cy.wait(100);
-        cy.get("@consoleLog").should(
-          "not.have.been.calledWith",
-          "Copy clicked"
-        );
+        cy.findByText("Report Phishing").should("exist");
       });
     });
 

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -9,16 +9,16 @@ import {
   RiSpam2Line,
 } from "@remixicon/react";
 import {
-  ColumnTableProps,
-  SubMenuListTableProps,
+  TableColumn,
+  TableSubMenuList,
   Table,
-  TableActionsProps,
+  TableAction,
   TableProps,
   TableRowProps,
 } from "./../../components/table";
 import { TipMenuItemProps } from "./../../components/tip-menu";
 import { css } from "styled-components";
-import { CapsuleContentProps } from "./../../components/capsule";
+import { CapsuleTab } from "./../../components/capsule";
 import { Button } from "./../../components/button";
 import { Card } from "./../../components/card";
 import { useState } from "react";
@@ -31,7 +31,7 @@ interface TableItemProps {
 }
 
 describe("Table", () => {
-  const columnsBasic: ColumnTableProps[] = [
+  const columnsBasic: TableColumn[] = [
     {
       id: "name",
       caption: "Name",
@@ -44,7 +44,7 @@ describe("Table", () => {
     },
   ];
 
-  const VIEW_MODES: CapsuleContentProps[] = [
+  const VIEW_MODES: CapsuleTab[] = [
     {
       id: "new",
       title: "New",
@@ -428,7 +428,7 @@ describe("Table", () => {
       };
     }
 
-    const DEFAULT_TOP_ACTIONS: TableActionsProps[] = [
+    const DEFAULT_TOP_ACTIONS: TableAction[] = [
       {
         caption: "Copy",
         icon: { image: RiArrowUpSLine },
@@ -824,7 +824,7 @@ describe("Table", () => {
     },
   ];
 
-  const TOP_ACTIONS: TableActionsProps[] = [
+  const TOP_ACTIONS: TableAction[] = [
     {
       caption: "Delete",
       icon: { image: RiDeleteBin2Line },
@@ -841,7 +841,7 @@ describe("Table", () => {
     },
   ];
 
-  const columns: ColumnTableProps[] = [
+  const columns: TableColumn[] = [
     {
       id: "title",
       caption: "Title",
@@ -876,7 +876,7 @@ describe("Table", () => {
     ];
   };
 
-  const ROW_ACTIONS = (rowId: string): SubMenuListTableProps[] => {
+  const ROW_ACTIONS = (rowId: string): TableSubMenuList[] => {
     return [
       {
         caption: "Edit",
@@ -1287,7 +1287,7 @@ describe("Table", () => {
   context("with selectable", () => {
     context("checkbox style", () => {
       it("renders with transparent wrapper", () => {
-        const columns: ColumnTableProps[] = [
+        const columns: TableColumn[] = [
           {
             id: "name",
             caption: "Name",
@@ -1338,7 +1338,7 @@ describe("Table", () => {
 
     context("when initialize", () => {
       it("renders content with checked value", () => {
-        const columns: ColumnTableProps[] = [
+        const columns: TableColumn[] = [
           {
             id: "name",
             caption: "Name",
@@ -1442,7 +1442,7 @@ describe("Table", () => {
 
   context("with top actions", () => {
     context("when given default", () => {
-      const DEFAULT_TOP_ACTIONS: TableActionsProps[] = [
+      const DEFAULT_TOP_ACTIONS: TableAction[] = [
         {
           caption: "Copy",
           icon: { image: RiArrowUpSLine },
@@ -1513,7 +1513,7 @@ describe("Table", () => {
         },
       ];
 
-      const DEFAULT_TOP_ACTIONS: TableActionsProps[] = [
+      const DEFAULT_TOP_ACTIONS: TableAction[] = [
         {
           caption: "Copy",
           onClick: () => {
@@ -1571,7 +1571,7 @@ describe("Table", () => {
     });
 
     context("when given capsule", () => {
-      const VIEW_MODES: CapsuleContentProps[] = [
+      const VIEW_MODES: CapsuleTab[] = [
         {
           id: "new",
           title: "New",
@@ -1582,7 +1582,7 @@ describe("Table", () => {
         },
       ];
 
-      const DEFAULT_TOP_ACTIONS: TableActionsProps[] = [
+      const DEFAULT_TOP_ACTIONS: TableAction[] = [
         {
           type: "capsule",
           capsuleProps: {
@@ -1633,7 +1633,7 @@ describe("Table", () => {
       });
 
       context("when given only with icon", () => {
-        const VIEW_MODES_WITH_ICON: CapsuleContentProps[] = [
+        const VIEW_MODES_WITH_ICON: CapsuleTab[] = [
           {
             id: "frontend",
             icon: {
@@ -1648,7 +1648,7 @@ describe("Table", () => {
           },
         ];
 
-        const DEFAULT_TOP_ACTIONS: TableActionsProps[] = [
+        const DEFAULT_TOP_ACTIONS: TableAction[] = [
           {
             type: "capsule",
             capsuleProps: {
@@ -1923,7 +1923,7 @@ describe("Table", () => {
     function TableWithRowActions({
       actions,
     }: {
-      actions?: (columnCaption: string) => SubMenuListTableProps[];
+      actions?: (columnCaption: string) => TableSubMenuList[];
     }) {
       return (
         <Table

--- a/test/component/tip-menu.cy.tsx
+++ b/test/component/tip-menu.cy.tsx
@@ -91,7 +91,7 @@ describe("TipMenu", () => {
       cy.mount(<TipMenu subMenuList={TIP_MENU_ITEMS} />);
       cy.findAllByLabelText("tip-menu-item")
         .eq(2)
-        .should("have.css", "background-color", "rgb(239, 68, 68)");
+        .should("have.css", "background-color", "rgb(206, 55, 93)");
     });
   });
 
@@ -111,7 +111,7 @@ describe("TipMenu", () => {
         .eq(2)
         .realHover()
         .wait(200)
-        .should("have.css", "background-color", "rgb(231, 31, 41)");
+        .should("have.css", "background-color", "rgb(161, 47, 75)");
     });
   });
 

--- a/test/component/toolbar.cy.tsx
+++ b/test/component/toolbar.cy.tsx
@@ -161,7 +161,7 @@ describe("Toolbar", () => {
             cy.wrap($button).should(
               "have.css",
               "background-color",
-              "rgb(232, 232, 232)"
+              "rgb(207, 207, 207)"
             );
           });
       });
@@ -220,7 +220,7 @@ describe("Toolbar", () => {
         cy.findByLabelText("toolbar-menu-toggle")
           .realHover()
           .wait(300)
-          .should("have.css", "background-color", "rgb(245, 245, 245)");
+          .should("have.css", "background-color", "rgb(226, 226, 226)");
       });
     });
   });

--- a/test/component/toolbar.cy.tsx
+++ b/test/component/toolbar.cy.tsx
@@ -1,5 +1,5 @@
 import { css } from "styled-components";
-import { Toolbar, ToolbarSubMenuProps } from "./../../components/toolbar";
+import { Toolbar, ToolbarSubMenuList } from "./../../components/toolbar";
 import {
   RiSpam2Line,
   RiForbid2Line,
@@ -14,7 +14,7 @@ import {
 } from "@remixicon/react";
 
 describe("Toolbar", () => {
-  const TIP_MENU_ITEMS: ToolbarSubMenuProps[] = [
+  const TIP_MENU_ITEMS: ToolbarSubMenuList[] = [
     {
       caption: "Report Phishing",
       icon: { image: RiSpam2Line, color: "blue" },

--- a/test/component/tooltip.cy.tsx
+++ b/test/component/tooltip.cy.tsx
@@ -1,11 +1,10 @@
-import { DialogPlacement } from "./../../lib/floating-placement";
 import { Badge } from "./../../components/badge";
-import { Tooltip } from "./../../components/tooltip";
+import { Tooltip, TooltipDialogPlacement } from "./../../components/tooltip";
 import { css } from "styled-components";
 
 describe("Tooltip", () => {
   context("dialogPlacement", () => {
-    const ALL_PLACEMENTS: DialogPlacement[] = [
+    const ALL_PLACEMENTS: TooltipDialogPlacement[] = [
       "top-left",
       "top-center",
       "top-right",

--- a/test/component/tooltip.cy.tsx
+++ b/test/component/tooltip.cy.tsx
@@ -1,10 +1,11 @@
+import { DialogPlacement } from "./../../lib/floating-placement";
 import { Badge } from "./../../components/badge";
-import { Tooltip, TooltipDialogPlacement } from "./../../components/tooltip";
+import { Tooltip } from "./../../components/tooltip";
 import { css } from "styled-components";
 
 describe("Tooltip", () => {
   context("dialogPlacement", () => {
-    const ALL_PLACEMENTS: TooltipDialogPlacement[] = [
+    const ALL_PLACEMENTS: DialogPlacement[] = [
       "top-left",
       "top-center",
       "top-right",

--- a/test/component/treelist.cy.tsx
+++ b/test/component/treelist.cy.tsx
@@ -1,9 +1,9 @@
 import {
   TreeList,
-  TreeListActionsProps,
-  TreeListContentActionsProps,
-  TreeListContentProps,
-  TreeListItemsActionsProps,
+  TreeListAction,
+  TreeListContentAction,
+  TreeListContent,
+  TreeListItemAction,
 } from "./../../components/treelist";
 import {
   RiAddBoxLine,
@@ -17,7 +17,7 @@ import { StatefulForm } from "./../../components/stateful-form";
 
 describe("Treelist", () => {
   context("common behavior", () => {
-    let TREE_LIST_DATA: TreeListContentProps[];
+    let TREE_LIST_DATA: TreeListContent[];
 
     beforeEach(() => {
       const setPerson = cy.stub().as("setPerson");
@@ -116,12 +116,12 @@ describe("Treelist", () => {
   });
 
   context("actions", () => {
-    let TREE_LIST_DATA: TreeListContentProps[];
+    let TREE_LIST_DATA: TreeListContent[];
 
     beforeEach(() => {
       const setPerson = cy.stub().as("setPerson");
 
-      const HEADER_ACTIONS: TreeListContentActionsProps[] = [
+      const HEADER_ACTIONS: TreeListContentAction[] = [
         {
           caption: "New File",
           onClick: () => console.log("add new file in this group"),
@@ -131,7 +131,7 @@ describe("Treelist", () => {
         },
       ];
 
-      const ITEMS_ACTIONS: TreeListItemsActionsProps[] = [
+      const ITEMS_ACTIONS: TreeListItemAction[] = [
         {
           caption: "Delete",
           onClick: () => console.log("delete this list"),
@@ -283,7 +283,7 @@ describe("Treelist", () => {
     });
 
     context("when given actions in the main level", () => {
-      let TREE_LIST_ACTIONS: TreeListActionsProps[];
+      let TREE_LIST_ACTIONS: TreeListAction[];
 
       beforeEach(() => {
         const onDiscover = cy.stub().as("onDiscover");
@@ -351,7 +351,7 @@ describe("Treelist", () => {
 
       context("with subMenu", () => {
         context("with show", () => {
-          const TREE_LIST_ACTIONS_WITH_RENDER: TreeListActionsProps[] = [
+          const TREE_LIST_ACTIONS_WITH_RENDER: TreeListAction[] = [
             {
               id: "add-new-branch",
               icon: { image: RiAddBoxLine },
@@ -404,7 +404,7 @@ describe("Treelist", () => {
         });
 
         context("with render", () => {
-          const TREE_LIST_ACTIONS_WITH_RENDER: TreeListActionsProps[] = [
+          const TREE_LIST_ACTIONS_WITH_RENDER: TreeListAction[] = [
             {
               id: "add-new-branch",
               icon: { image: RiAddBoxLine },
@@ -507,7 +507,7 @@ describe("Treelist", () => {
   });
 
   context("alwaysShowDragIcon", () => {
-    let TREE_LIST_DATA: TreeListContentProps[];
+    let TREE_LIST_DATA: TreeListContent[];
 
     beforeEach(() => {
       const setPerson = cy.stub().as("setPerson");
@@ -600,7 +600,7 @@ describe("Treelist", () => {
   });
 
   context("initialState", () => {
-    let TREE_LIST_DATA: TreeListContentProps[];
+    let TREE_LIST_DATA: TreeListContent[];
 
     beforeEach(() => {
       const setPerson = cy.stub().as("setPerson");
@@ -645,7 +645,7 @@ describe("Treelist", () => {
   });
 
   context("selectedItem", () => {
-    let TREE_LIST_DATA: TreeListContentProps[];
+    let TREE_LIST_DATA: TreeListContent[];
 
     beforeEach(() => {
       const setPerson = cy.stub().as("setPerson");
@@ -690,7 +690,7 @@ describe("Treelist", () => {
   });
 
   context("caption", () => {
-    let TREE_LIST_DATA: TreeListContentProps[];
+    let TREE_LIST_DATA: TreeListContent[];
 
     beforeEach(() => {
       const setPerson = cy.stub().as("setPerson");
@@ -732,7 +732,7 @@ describe("Treelist", () => {
   });
 
   context("collapsible", () => {
-    let TREE_LIST_DATA: TreeListContentProps[];
+    let TREE_LIST_DATA: TreeListContent[];
 
     beforeEach(() => {
       const setPerson = cy.stub().as("setPerson");

--- a/test/e2e/button.cy.ts
+++ b/test/e2e/button.cy.ts
@@ -64,16 +64,16 @@ describe("Button", () => {
           border: "rgb(66, 163, 64)",
           hoverBg: "rgb(66, 163, 64)",
         },
-        default: { bg: "rgb(236, 236, 236)", color: "rgb(0, 0, 0)" },
+        default: { bg: "rgb(221, 221, 221)", color: "rgb(17, 17, 17)" },
         primary: { bg: "rgb(86, 154, 236)", color: "rgb(255, 255, 255)" },
         danger: { bg: "rgb(206, 55, 93)", color: "rgb(255, 255, 255)" },
-        secondary: { bg: "rgb(221, 221, 221)", color: "rgb(17, 17, 17)" },
+        secondary: { bg: "rgb(236, 236, 236)", color: "rgb(17, 17, 17)" },
         ghost: { bg: "rgba(0, 0, 0, 0)", color: "rgb(17, 17, 17)" },
-        transparent: { bg: "rgba(0, 0, 0, 0)", color: "rgb(0, 0, 0)" },
+        transparent: { bg: "rgba(0, 0, 0, 0)", color: "rgb(17, 17, 17)" },
         success: { bg: "rgb(66, 163, 64)", color: "rgb(255, 255, 255)" },
       };
 
-      cy.visit(getIdContent("controls-button--all-variants"));
+      cy.visit(getIdContent("controls-button--default"));
 
       Object.entries(VARIANT_STYLES).forEach(([variant, style]) => {
         const exactRegex = new RegExp(`^${variant}$`, "i");
@@ -115,7 +115,7 @@ describe("Button", () => {
       );
 
       cy.findByRole("button", { name: /Button/i })
-        .should("have.css", "background-color", "rgb(236, 236, 236)")
+        .should("have.css", "background-color", "rgb(221, 221, 221)")
         .and("have.css", "opacity", "0.6")
         .and("have.css", "pointer-events", "none");
     });

--- a/test/e2e/frame.cy.ts
+++ b/test/e2e/frame.cy.ts
@@ -1,26 +1,18 @@
 import { getIdContent } from "test/support/commands";
 
-context("Frame Component", () => {
-  describe("Default", () => {
+describe("Frame", () => {
+  context("Default", () => {
     it("Renders inner content", () => {
       cy.visit(getIdContent("stage-frame--default"));
       cy.contains("This is inside the frame.").should("exist");
     });
   });
 
-  describe("With Title", () => {
+  context("With Title", () => {
     it("Renders title and content", () => {
       cy.visit(getIdContent("stage-frame--with-title"));
       cy.contains("Frame Title").should("exist");
       cy.contains("This frame has a title.").should("exist");
-    });
-  });
-
-  describe("Custom", () => {
-    it("Renders custom title and background", () => {
-      cy.visit(getIdContent("stage-frame--custom"));
-      cy.contains("Frame w/ Class").should("exist");
-      cy.contains("This frame has a custom background color.").should("exist");
     });
   });
 });

--- a/test/e2e/pagination.cy.ts
+++ b/test/e2e/pagination.cy.ts
@@ -15,7 +15,7 @@ describe("Pagination", () => {
             .click();
           cy.findAllByLabelText("pagination-button")
             .eq(1)
-            .should("have.css", "border", "1px solid rgb(243, 244, 246)");
+            .should("have.css", "border", "1px solid rgb(209, 213, 219)");
           cy.findAllByLabelText("pagination-button")
             .eq(2)
             .should("have.css", "border", "1px solid rgb(97, 169, 249)");
@@ -30,7 +30,7 @@ describe("Pagination", () => {
             .click({ force: true });
           cy.findAllByLabelText("pagination-button")
             .eq(0)
-            .should("have.css", "border", "1px solid rgb(243, 244, 246)")
+            .should("have.css", "border", "1px solid rgb(209, 213, 219)")
             .and("have.css", "opacity", "0.3");
           cy.findAllByLabelText("pagination-button")
             .eq(1)
@@ -46,7 +46,7 @@ describe("Pagination", () => {
           .should("have.css", "border", "1px solid rgb(97, 169, 249)");
         cy.findAllByLabelText("pagination-button")
           .eq(2)
-          .should("have.css", "border", "1px solid rgb(243, 244, 246)");
+          .should("have.css", "border", "1px solid rgb(209, 213, 219)");
 
         cy.findAllByLabelText("pagination-button")
           .eq(6)
@@ -55,7 +55,7 @@ describe("Pagination", () => {
 
         cy.findAllByLabelText("pagination-button")
           .eq(1)
-          .should("have.css", "border", "1px solid rgb(243, 244, 246)");
+          .should("have.css", "border", "1px solid rgb(209, 213, 219)");
         cy.findAllByLabelText("pagination-button")
           .eq(2)
           .should("have.css", "border", "1px solid rgb(97, 169, 249)");
@@ -100,7 +100,7 @@ describe("Pagination", () => {
           cy.findByPlaceholderText("1").should(
             "have.css",
             "border",
-            "1px solid rgb(243, 244, 246)"
+            "1px solid rgb(209, 213, 219)"
           );
         });
       });
@@ -129,12 +129,12 @@ describe("Pagination", () => {
 
           cy.findByPlaceholderText("1")
             .trigger("mouseover")
-            .should("have.css", "border", "1px solid rgb(243, 244, 246)")
+            .should("have.css", "border", "1px solid rgb(209, 213, 219)")
             .trigger("mouseout");
           cy.findByPlaceholderText("1").should(
             "have.css",
             "border",
-            "1px solid rgb(243, 244, 246)"
+            "1px solid rgb(209, 213, 219)"
           );
         });
       });

--- a/test/e2e/pinbox.cy.ts
+++ b/test/e2e/pinbox.cy.ts
@@ -244,7 +244,7 @@ describe("Pinbox", () => {
           cy.findAllByLabelText("pinbox-input").eq(data).should("be.disabled");
           cy.findAllByLabelText("pinbox-input")
             .eq(data)
-            .should("have.css", "background-color", "rgb(249, 250, 251)");
+            .should("have.css", "background-color", "rgb(255, 255, 255)");
           cy.findAllByLabelText("pinbox-input")
             .eq(data)
             .should("have.css", "opacity", "0.6");
@@ -267,7 +267,7 @@ describe("Pinbox", () => {
 
         cy.findAllByLabelText("pinbox-input")
           .eq(1)
-          .should("have.css", "border-color", "rgb(248, 113, 113)");
+          .should("have.css", "border-color", "rgb(239, 68, 68)");
         cy.findAllByLabelText("pinbox-input")
           .eq(1)
           .should("have.css", "color", "rgb(153, 27, 27)");

--- a/test/e2e/rich-editor.cy.ts
+++ b/test/e2e/rich-editor.cy.ts
@@ -21,7 +21,7 @@ describe("RichEditor", () => {
         cy.findByLabelText("toolbar-content").should("have.css", "top", "0px");
         cy.findByRole("textbox")
           .should("have.css", "min-height", "200px")
-          .and("have.css", "padding-top", "45px");
+          .and("have.css", "padding-top", "8px");
       });
     });
 
@@ -37,7 +37,7 @@ describe("RichEditor", () => {
         );
         cy.findByRole("textbox")
           .should("have.css", "min-height", "200px")
-          .and("have.css", "padding-bottom", "45px");
+          .and("have.css", "padding-bottom", "8px");
       });
     });
   });
@@ -134,7 +134,7 @@ describe("RichEditor", () => {
         cy.findByLabelText("toolbar-content").should("have.css", "top", "0px");
         cy.findByRole("textbox")
           .should("have.css", "min-height", "200px")
-          .and("have.css", "padding-top", "45px");
+          .and("have.css", "padding-top", "8px");
       });
     });
 
@@ -149,10 +149,10 @@ describe("RichEditor", () => {
           .and("not.have.css", "box-shadow", "0 1px 4px -3px #5b5b5b");
         cy.findByRole("textbox")
           .should("have.css", "min-height", "800px")
-          .and("have.css", "padding-top", "45px");
+          .and("have.css", "padding-top", "8px");
         cy.findByRole("textbox")
           .should("have.css", "max-height", "800px")
-          .and("have.css", "padding-top", "45px");
+          .and("have.css", "padding-top", "8px");
       });
     });
 

--- a/test/e2e/table.cy.ts
+++ b/test/e2e/table.cy.ts
@@ -125,10 +125,12 @@ describe("Table Component", () => {
 
     context("when click content", () => {
       it("should render checked", () => {
-        cy.findByText("Load Balancer 1").click();
         cy.get("input[type=checkbox]").eq(1).should("be.checked");
-        cy.findAllByText("HTTPS").eq(0).click();
+        cy.findByText("Load Balancer 1").click();
+        cy.get("input[type=checkbox]").eq(1).should("not.be.checked");
         cy.get("input[type=checkbox]").eq(2).should("be.checked");
+        cy.findAllByText("HTTPS").eq(0).click();
+        cy.get("input[type=checkbox]").eq(2).should("not.be.checked");
       });
     });
   });

--- a/test/e2e/togglebox.cy.ts
+++ b/test/e2e/togglebox.cy.ts
@@ -35,7 +35,6 @@ describe("Togglebox", () => {
     it("should show loading state (circle) after toggle", () => {
       onClickToggle();
       cy.get("input[type=checkbox]").should("be.checked");
-
       cy.findByLabelText("circle", { timeout: 1500 }).should("exist");
     });
   });
@@ -55,8 +54,9 @@ describe("Togglebox", () => {
         onClickToggle();
         cy.get("input[type=checkbox]").should("be.checked");
 
-        cy.findByLabelText("circle", { timeout: 1500 }).should("exist");
-        cy.findByLabelText("circle", { timeout: 1500 }).should("not.exist");
+        cy.findByLabelText("circle").should("exist");
+        cy.wait(2000);
+        cy.findByLabelText("circle").should("not.exist");
       });
     });
   });

--- a/test/support/component.tsx
+++ b/test/support/component.tsx
@@ -1,15 +1,39 @@
 import "./../../shared.css";
-import { mount } from "cypress/react";
+import { mount, MountOptions } from "cypress/react";
 import "./commands";
 import "@testing-library/cypress/add-commands";
 import "cypress-real-events";
+import { ThemeProvider } from "./../../theme/provider";
+import { themes } from "./../../theme/mode";
+import { ReactNode } from "react";
 
-Cypress.Commands.add("mount", mount);
+type CustomMountOptions = MountOptions & {
+  mode?: "light" | "dark";
+};
+
+const mountWithTheme = (
+  component: React.ReactNode,
+  options: CustomMountOptions = {}
+) => {
+  const { mode = "light" } = options;
+
+  return mount(
+    <ThemeProvider themes={themes} mode={mode}>
+      <div data-theme={mode}>{component}</div>
+    </ThemeProvider>,
+    options
+  );
+};
+
+Cypress.Commands.add("mount", mountWithTheme);
 
 declare global {
   namespace Cypress {
     interface Chainable {
-      mount: typeof mount;
+      mount(
+        component: ReactNode,
+        options?: CustomMountOptions
+      ): Cypress.Chainable;
     }
   }
 }

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -1,7 +1,7 @@
 import { MessageboxVariantState } from "./../components/messagebox";
 import { ButtonVariants } from "./../components/button";
 import { ToolbarVariant } from "./../components/toolbar";
-import { SteplineItem } from "./../constants/step-component-util";
+import { BaseSteplineItem } from "./../constants/step-component-util";
 
 export type ThemeMode = "light" | "dark";
 
@@ -356,6 +356,7 @@ export interface ListThemeConfig extends BodyThemeConfig {
   badgeTextColor?: string;
   badgeBackgroundColor?: string;
   badgeBorderColor?: string;
+  maxItemTextColor?: string;
 }
 
 // loading-skeleton.tsx
@@ -569,9 +570,9 @@ export interface SidebarThemeConfig extends BodyThemeConfig {
 
 // stepline.tsx
 export interface SteplineThemeConfig {
-  outerCircle: Record<SteplineItem["variant"], string>;
-  innerCircle: Record<SteplineItem["variant"], string>;
-  text: Record<SteplineItem["variant"], string>;
+  outerCircle: Record<BaseSteplineItem["variant"], string>;
+  innerCircle: Record<BaseSteplineItem["variant"], string>;
+  text: Record<BaseSteplineItem["variant"], string>;
   line?: {
     default: string;
     completed: string;

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -1,4 +1,4 @@
-import { MessageboxVariantState } from "./../components/messagebox";
+import { MessageboxVariant } from "./../components/messagebox";
 import { ButtonVariants } from "./../components/button";
 import { ToolbarVariant } from "./../components/toolbar";
 import { BaseSteplineItem } from "./../constants/step-component-util";
@@ -378,7 +378,7 @@ export interface MessageboxVariantTheme
 }
 
 export type MessageboxThemeConfig = {
-  [K in MessageboxVariantState]: MessageboxVariantTheme;
+  [K in MessageboxVariant]: MessageboxVariantTheme;
 };
 
 // moneybox.tsx

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -1,7 +1,7 @@
 import { MessageboxVariantState } from "./../components/messagebox";
 import { ButtonVariants } from "./../components/button";
-import { ToolbarVariantType } from "./../components/toolbar";
-import { SteplineItemState } from "./../constants/step-component-util";
+import { ToolbarVariant } from "./../components/toolbar";
+import { SteplineItem } from "./../constants/step-component-util";
 
 export type ThemeMode = "light" | "dark";
 
@@ -569,9 +569,9 @@ export interface SidebarThemeConfig extends BodyThemeConfig {
 
 // stepline.tsx
 export interface SteplineThemeConfig {
-  outerCircle: Record<SteplineItemState["variant"], string>;
-  innerCircle: Record<SteplineItemState["variant"], string>;
-  text: Record<SteplineItemState["variant"], string>;
+  outerCircle: Record<SteplineItem["variant"], string>;
+  innerCircle: Record<SteplineItem["variant"], string>;
+  text: Record<SteplineItem["variant"], string>;
   line?: {
     default: string;
     completed: string;
@@ -782,7 +782,7 @@ export interface AppTheme {
   tipmenu: TipMenuThemeConfig;
   timebox: TimeboxThemeConfig;
   togglebox: ToggleboxThemeConfig;
-  toolbar: Record<ToolbarVariantType, ToolbarThemeConfig>;
+  toolbar: Record<ToolbarVariant, ToolbarThemeConfig>;
   tooltip: TooltipThemeConfig;
   treelist: TreeListThemeConfig;
   window: WindowThemeConfig;

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1,4 +1,4 @@
-import { ToolbarVariantType } from "./../../components/toolbar";
+import { ToolbarVariant } from "./../../components/toolbar";
 import { ButtonVariants } from "./../../components/button";
 import {
   ActionButtonThemeConfig,
@@ -1569,10 +1569,10 @@ export function createToggleboxTheme(
 
 // toolbar.tsx
 export function createToolbarTheme(
-  baseButton: Record<ToolbarVariantType, ToolbarThemeConfig>,
-  customVariants: Partial<Record<ToolbarVariantType, ToolbarThemeConfig>> = {}
-): Record<ToolbarVariantType, ToolbarThemeConfig> {
-  const variants: Record<ToolbarVariantType, ToolbarThemeConfig> = {
+  baseButton: Record<ToolbarVariant, ToolbarThemeConfig>,
+  customVariants: Partial<Record<ToolbarVariant, ToolbarThemeConfig>> = {}
+): Record<ToolbarVariant, ToolbarThemeConfig> {
+  const variants: Record<ToolbarVariant, ToolbarThemeConfig> = {
     default: {
       ...baseButton?.default,
       hoverBackgroundColor:

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -193,7 +193,7 @@ export function createBoxbarTheme(
 
 // button.tsx
 export function createButtonTheme(
-  body: BodyThemeConfig,
+  body: BodyThemeConfig = {},
   customVariants: Partial<
     Record<ButtonVariants["variant"], ButtonThemeConfig>
   > = {}
@@ -201,7 +201,7 @@ export function createButtonTheme(
   const variants: Record<string, ButtonThemeConfig> = {
     default: {
       backgroundColor: "#dddddd",
-      textColor: "black",
+      textColor: body.textColor || "rgb(17, 17, 17)",
       hoverBackgroundColor: "#e2e2e2",
       activeBackgroundColor: "#cfcfcf",
       textDecoration: "none",
@@ -233,7 +233,7 @@ export function createButtonTheme(
     },
     secondary: {
       backgroundColor: "#ececec",
-      textColor: body.textColor,
+      textColor: body.textColor || "rgb(17, 17, 17)",
       hoverBackgroundColor: "#cccccc",
       activeBackgroundColor: "#b3b3b3",
       focusBackgroundColor: "#B4B4B480",
@@ -241,7 +241,7 @@ export function createButtonTheme(
     },
     ghost: {
       backgroundColor: "transparent",
-      textColor: body.textColor,
+      textColor: body.textColor || "rgb(17, 17, 17)",
       hoverBackgroundColor: "#f3f3f3",
       activeBackgroundColor: "#eaeaea",
       focusBackgroundColor: "#00000033",
@@ -258,7 +258,7 @@ export function createButtonTheme(
     },
     transparent: {
       backgroundColor: "transparent",
-      textColor: body.textColor,
+      textColor: body.textColor || "rgb(17, 17, 17)",
       hoverBackgroundColor: "#e2e2e2",
       activeBackgroundColor: "#cfcfcf",
       focusBackgroundColor: "#cfcfcf",
@@ -1444,9 +1444,9 @@ export function createTableTheme(
     headerBackgroundColor: "linear-gradient(to bottom, #f0f0f0, #e4e4e4)",
     headerBorderColor: "rgb(229, 231, 235)",
 
-    rowGroupBackgroundColor: "white",
+    rowGroupBackgroundColor: "rgb(249, 250, 251)",
 
-    rowBackgroundColor: "white",
+    rowBackgroundColor: "rgb(249, 250, 251)",
     rowBorderColor: "#e5e7eb",
     rowSubtitleTextColor: "#1f2937",
     rowHoverBackgroundColor: "#e7f2fc",

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -840,12 +840,13 @@ export function createListTheme(
     hoverTextColor: body.textColor,
     badgeBackgroundColor: "#488cac",
     borderColor: "#d1d5db",
-    mutedTextColor: "#6b7280",
     dragLineColor: "#3b82f6",
     emptyHoverBackgroundColor: "#dbeafe",
     badgeTextColor: "white",
     badgeBorderColor: "#d1d5db",
     toggleBackgroundColor: "#c1d6f1",
+    mutedTextColor: "#6b7280",
+    maxItemTextColor: "rgb(97, 97, 97)",
   };
 
   return {

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -462,6 +462,7 @@ const darkList = createListTheme(darkBody, {
   badgeBorderColor: "#3f3f46",
   toggleBackgroundColor: "#1e3a5f",
   hoverTextColor: "#111111",
+  maxItemTextColor: "#9ca3af",
 });
 
 const darkLoadingSkeleton = createLoadingSkeletonTheme({

--- a/theme/mode/light.ts
+++ b/theme/mode/light.ts
@@ -85,7 +85,7 @@ const lightBadge = createBadgeTheme(lightBody);
 
 const lightBoxbar = createBoxbarTheme(lightBody);
 
-const lightButton = createButtonTheme(lightBody);
+const lightButton = createButtonTheme();
 
 const lightButtonTipMenuContainer = createTipMenuContainerTheme(lightBody);
 


### PR DESCRIPTION
Description:
We have NavTabContentProps where it has actions of type SubMenuNavTaband subitems of type NavTabSubItemsContentProps.

Let's reevaluate our interface naming convention, throughout all of our components. Let's have this rule:

If the interface name is X, the props interface to X is called XProps. So NavTab -> NavTabProps.

If inside that XProps there is a field/item which need custom class, use this format: XFieldNameProps. For example, take a look below.

```tsx
export interface NavTabProps {
  tabs?: NavTabContentProps[]; // Must be: NavTabTabProps[]
  actions?: NavTabActionsProps[]; // Must be: NavTabActionProps[]
  active?: boolean; // it is OK
  styles?: NavTabStylesProps; // Must be NavTabStyleProps, or just NavTabStyles
}

// DO NOT use plural ie NavTabTabsProps[] but singular NavTabTabProps[]
// the Props is plural, makes sense because containing a lot of properties,
// but the Tab is singular, because it is describing a single tab, not applicable
// to all the teb. That's why it's an array.
```

Another bad example. If the actions are "sub menu" then subitems is not sub menu? Why is actions "sub menu" but subitems are not "sub menu" if anything, subitems should be sub menu. Anyway, yeah, you can see that the naming is confusing. The name of the field is good, but the name of the class is very abstract and confusing — you will not know them just by looking at it, without looking at its usage.

Image you are not the one developing Coneto. When you see/heard the class/type "SubMenuNavTab" do you honestly think that it would be about action? NO, NEVER. I wouldn't. Only that I need to see the field name actions then I know the type is for navtab actions. This means, the field name is clear, but the class name is NOT clear, not self-describing.

```tsx
export interface NavTabContentProps {
  actions?: SubMenuNavTab[]; // WHAAAAT? very NON-STANDARD :D text for example: TextboxActionsProps
  subItems?: NavTabSubItemsContentProps[]; // WAIT WHAT?
  hidden?: boolean;
}

// To fix: rename SubMenuNavTab to: NavTabAction[]
// To fix: rename NavTabSubItemsContentProps[] (OMG SO LONG)
//         and an inconsistent naming, to: NavTabSubItem[]
```

Styles interface should be called: XStyles, so for NavTab it should be NavTabStyles, no need Props.

If the field has the word list or array, for example subMenuList, then the name of the interface is still singular, XSubMenuProps but the use is with []. X is the name of the component (ie: TipMenu).

```tsx
export interface TipMenuProps {
  subMenuList?: TipMenuSubMenuProps[];
}

// why? because List is already represented with the []
// let's say you want to define numberArray:

let numberArray: number[]

// right? NOT:

let numberArray: NumberArray[] // OR:
let numberArray: NumberArrays[] // BUT THIS IS CORRECT TOO:
let numberArray: NumberArray // however, why not just number[] ?

// as you can see, the "list" or "array" in the name
// is enough to represent with just []
```

Allow a little inconsistency, ie icon is using FigureProps not IconProps, that's ok. But most of the time, follow the ruling above. If not sure, let's discuss. IF YOU MAKE AN EXCEPTION/SKIP, please discuss. If not sure please discuss, I might miss not writing some rule.

Type like TipMenuItemVariantType must follow the same naming convention/technique above: XFieldName (without Type or Props).

```tsx
export type TipMenuItemVariantType = "sm" | "md";

export interface TipMenuProps {
  variant?: TipMenuItemVariantType;
}
```

For that, please rename TipMenuItemVariantType to: TipMenuVariant is clear, succinct, and enough. Also, please create the enum, so, the correct fix to that is like this:

```tsx
export const TipMenuVariant = {
  Small: "sm",
  Medium: "md",
}

export type TipMenuVariant =
  (typeof TipMenuVariant)[keyof typeof TipMenuVariant]

// by doing this, user can do TipMenuVariant.Small, or also
// just put "sm" as the value directly will be just as valid
```

Source:
[[Improvement] SYST-597: Standardizing interface and field names](https://linear.app/systatum/issue/SYST-597/standardizing-interface-and-field-names)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself