### PR TITLE
[Improvement] SYST-598: Name refactor on NavTab

### DIFF
--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -33,9 +33,10 @@ export interface NavTabStyles {
   contentStyle?: CSSProp;
   containerStyle?: CSSProp;
   containerBoxStyle?: CSSProp;
-  containerRowStyle?: CSSProp;
   containerActionsStyle?: CSSProp;
-  boxStyle?: CSSProp;
+  tabStyle?: CSSProp;
+  barStyle?: CSSProp;
+  underscoreStyle?: CSSProp;
 }
 
 export interface NavTabAction extends ActionButtonProps {
@@ -66,8 +67,12 @@ export interface NavTabSubItem {
   onClick?: () => void;
   content?: ReactNode;
   hidden?: boolean;
+  styles?: NavTabSubItemStyles;
 }
 
+export interface NavTabSubItemStyles {
+  self?: CSSProp;
+}
 export interface NavTabTabAction extends Omit<TipMenuItemProps, "onClick"> {
   onClick: (id?: string) => void;
 }
@@ -178,18 +183,19 @@ function NavTab({
   );
 
   return (
-    <NavTabWrapper $containerStyle={styles?.containerStyle}>
-      <NavTabRowWrapper $theme={navTheme} $style={styles?.containerRowStyle}>
-        <NavTabHeader
-          aria-label="nav-tab-wrapper"
+    <NavTabContainer $style={styles?.containerStyle}>
+      <NavTabBar $theme={navTheme} $style={styles?.barStyle}>
+        <NavTabTabsSection
+          aria-label="nav-tab-tabs-sections"
           $style={styles?.containerBoxStyle}
           ref={containerRef}
           $theme={navTheme}
         >
-          <NavTabList
-            aria-label="nav-tab-list"
+          <NavTabUnderscore
+            aria-label="nav-tab-underscore"
             $activeColor={activeColor}
             $theme={navTheme}
+            $style={styles?.underscoreStyle}
             initial={{
               left: 0,
               width: 0,
@@ -253,9 +259,10 @@ function NavTab({
                       tab.subItems
                         ?.filter((item) => !item?.hidden)
                         ?.map((item, idx) => (
-                          <NavTabItem
+                          <NavTabTab
                             key={idx}
                             $theme={navTheme}
+                            $style={item?.styles?.self}
                             onClick={() => {
                               if (item.content) {
                                 setSelectedLocal(item.id);
@@ -274,17 +281,17 @@ function NavTab({
                           >
                             {item.icon && <Figure {...item.icon} />}
                             {item.caption}
-                          </NavTabItem>
+                          </NavTabTab>
                         ))}
                   </>
                 }
               >
-                <NavTabItem
+                <NavTabTab
                   $theme={navTheme}
                   key={tab.id}
                   $size={size}
-                  aria-label="nav-tab-item"
-                  $boxStyle={styles?.boxStyle}
+                  aria-label="nav-tab-tab"
+                  $style={styles?.tabStyle}
                   ref={setTabRef(index)}
                   role="tab"
                   onClick={(e) => {
@@ -372,14 +379,14 @@ function NavTab({
                         />
                       );
                     })()}
-                </NavTabItem>
+                </NavTabTab>
               </Tooltip>
             );
           })}
-        </NavTabHeader>
+        </NavTabTabsSection>
 
         {actions && (
-          <NavTabHeader
+          <NavTabTabsSection
             aria-label="nav-tab-actions-wrapper"
             $actions={!!actions}
             $theme={navTheme}
@@ -412,9 +419,9 @@ function NavTab({
                   />
                 );
               })}
-          </NavTabHeader>
+          </NavTabTabsSection>
         )}
-      </NavTabRowWrapper>
+      </NavTabBar>
 
       <NavContent $contentStyle={styles?.contentStyle}>
         {filteredTabs.map((tab, index) => {
@@ -429,12 +436,12 @@ function NavTab({
         })}
         {children}
       </NavContent>
-    </NavTabWrapper>
+    </NavTabContainer>
   );
 }
 
-const NavTabWrapper = styled.div<{
-  $containerStyle?: CSSProp;
+const NavTabContainer = styled.div<{
+  $style?: CSSProp;
 }>`
   width: 100%;
   height: 100%;
@@ -444,10 +451,10 @@ const NavTabWrapper = styled.div<{
   font-size: 14px;
   top: 0;
 
-  ${({ $containerStyle }) => $containerStyle}
+  ${({ $style }) => $style}
 `;
 
-const NavTabHeader = styled.div<{
+const NavTabTabsSection = styled.div<{
   $style?: CSSProp;
   $actions?: boolean;
   $theme: NavTabThemeConfig;
@@ -469,7 +476,7 @@ const NavTabHeader = styled.div<{
   ${({ $style }) => $style}
 `;
 
-const NavTabRowWrapper = styled.div<{
+const NavTabBar = styled.div<{
   $style?: CSSProp;
   $theme?: NavTabThemeConfig;
 }>`
@@ -488,9 +495,10 @@ const NavTabRowWrapper = styled.div<{
   ${({ $style }) => $style}
 `;
 
-const NavTabList = styled(motion.div)<{
+const NavTabUnderscore = styled(motion.div)<{
   $activeColor?: string;
   $theme?: NavTabThemeConfig;
+  $style?: CSSProp;
 }>`
   position: absolute;
   bottom: 0;
@@ -500,11 +508,13 @@ const NavTabList = styled(motion.div)<{
   pointer-events: none;
   background-color: ${({ $activeColor, $theme }) =>
     $activeColor ?? $theme?.indicatorColor};
+
+  ${({ $style }) => $style}
 `;
 
-const NavTabItem = styled.div<{
+const NavTabTab = styled.div<{
   $selected?: boolean;
-  $boxStyle?: CSSProp;
+  $style?: CSSProp;
   $isHovered?: boolean;
   $isAction?: boolean;
   $subMenu?: boolean;
@@ -583,7 +593,7 @@ const NavTabItem = styled.div<{
     box-shadow: ${({ $theme }) => $theme.activeInsetShadow};
   }
 
-  ${({ $boxStyle }) => $boxStyle};
+  ${({ $style }) => $style};
 `;
 
 const NavContent = styled.div<{ $contentStyle?: CSSProp }>`

--- a/test/component/nav-tab.cy.tsx
+++ b/test/component/nav-tab.cy.tsx
@@ -30,7 +30,7 @@ describe("NavTab", () => {
     context("when given hidden", () => {
       it("renders without hidden tab", () => {
         cy.mount(<NavTab tabs={TABS_ITEMS} activeTab={"2"} />);
-        cy.findAllByLabelText("nav-tab-item").should("have.length", 2);
+        cy.findAllByLabelText("nav-tab-tab").should("have.length", 2);
         cy.findByText("Write").should("exist");
         cy.findByText("Review").should("exist");
         cy.findByText("Empty").should("not.exist");
@@ -76,7 +76,7 @@ describe("NavTab", () => {
       it("should not render the hidden tab in the navigation", () => {
         cy.mount(<NavTabWithHidden hidden={true} />);
 
-        cy.findAllByLabelText("nav-tab-item").should("have.length", 1);
+        cy.findAllByLabelText("nav-tab-tab").should("have.length", 1);
       });
 
       context("when given active tab", () => {
@@ -104,7 +104,7 @@ describe("NavTab", () => {
           cy.findByText("Write tab content").should("not.exist");
 
           // Click visible tab (Write)
-          cy.findAllByLabelText("nav-tab-item").eq(0).click();
+          cy.findAllByLabelText("nav-tab-tab").eq(0).click();
           cy.findByText("Review tab content").should("not.exist");
           cy.findByText("Write tab content").should("exist");
 
@@ -120,7 +120,7 @@ describe("NavTab", () => {
       it("should render all tabs normally", () => {
         cy.mount(<NavTabWithHidden hidden={false} />);
 
-        cy.findAllByLabelText("nav-tab-item").should("have.length", 2);
+        cy.findAllByLabelText("nav-tab-tab").should("have.length", 2);
       });
     });
 
@@ -128,7 +128,7 @@ describe("NavTab", () => {
       it("should render all tabs normally", () => {
         cy.mount(<NavTabWithHidden />);
 
-        cy.findAllByLabelText("nav-tab-item").should("have.length", 2);
+        cy.findAllByLabelText("nav-tab-tab").should("have.length", 2);
       });
     });
   });
@@ -190,7 +190,7 @@ describe("NavTab", () => {
           />
         );
 
-        cy.findAllByLabelText("nav-tab-item")
+        cy.findAllByLabelText("nav-tab-tab")
           .eq(0)
           .should("have.css", "height", "35px");
         cy.findAllByLabelText("action-button")
@@ -210,7 +210,7 @@ describe("NavTab", () => {
           />
         );
 
-        cy.findAllByLabelText("nav-tab-item")
+        cy.findAllByLabelText("nav-tab-tab")
           .eq(0)
           .should("have.css", "height", "45px");
         cy.findAllByLabelText("action-button")
@@ -225,7 +225,7 @@ describe("NavTab", () => {
           <NavTab actions={ACTION_BUTTON} tabs={TABS_ITEMS} activeTab={"2"} />
         );
 
-        cy.findAllByLabelText("nav-tab-item")
+        cy.findAllByLabelText("nav-tab-tab")
           .eq(0)
           .should("have.css", "height", "45px");
         cy.findAllByLabelText("action-button")
@@ -243,11 +243,11 @@ describe("NavTab", () => {
           "This tab is meant to review the content that has been submitted. It includes multiple paragraphs to simulate a longer layout."
         ).should("be.visible");
 
-        cy.findAllByLabelText("nav-tab-item")
+        cy.findAllByLabelText("nav-tab-tab")
           .eq(1)
           .should("have.css", "background-color", "rgba(243, 244, 246, 0.5)");
 
-        cy.findAllByLabelText("nav-tab-list")
+        cy.findAllByLabelText("nav-tab-underscore")
           .eq(0)
           .should("have.css", "background-color", "rgb(59, 130, 246)")
           .and("have.css", "opacity", "1");
@@ -262,11 +262,11 @@ describe("NavTab", () => {
           cy.findByText(text).should("not.exist")
         );
 
-        cy.findAllByLabelText("nav-tab-item")
+        cy.findAllByLabelText("nav-tab-tab")
           .eq(1)
           .should("have.css", "background-color", "rgba(0, 0, 0, 0)");
 
-        cy.findAllByLabelText("nav-tab-list")
+        cy.findAllByLabelText("nav-tab-underscore")
           .eq(0)
           .should("have.css", "background-color", "rgb(59, 130, 246)")
           .and("have.css", "opacity", "0");
@@ -281,11 +281,11 @@ describe("NavTab", () => {
           cy.findByText(text).should("not.exist")
         );
 
-        cy.findAllByLabelText("nav-tab-item")
+        cy.findAllByLabelText("nav-tab-tab")
           .eq(1)
           .should("have.css", "background-color", "rgba(0, 0, 0, 0)");
 
-        cy.findAllByLabelText("nav-tab-list")
+        cy.findAllByLabelText("nav-tab-underscore")
           .eq(0)
           .should("have.css", "background-color", "rgb(59, 130, 246)")
           .and("have.css", "opacity", "0");
@@ -488,7 +488,7 @@ describe("NavTab", () => {
         cy.mount(
           <NavTab tabs={TABS_ITEMS} activeTab={"2"} activeColor="red" />
         );
-        cy.findByLabelText("nav-tab-list").should(
+        cy.findByLabelText("nav-tab-underscore").should(
           "have.css",
           "background-color",
           "rgb(255, 0, 0)"
@@ -505,7 +505,7 @@ describe("NavTab", () => {
             tabs={TABS_ITEMS}
             activeTab={"2"}
             styles={{
-              boxStyle: css`
+              tabStyle: css`
                 padding: 20px;
                 color: red;
               `,
@@ -513,7 +513,7 @@ describe("NavTab", () => {
           />
         );
         cy.wait(200);
-        cy.findAllByLabelText("nav-tab-item")
+        cy.findAllByLabelText("nav-tab-tab")
           .eq(0)
           .should("have.css", "padding", "20px")
           .and("have.css", "color", "rgb(255, 0, 0)");
@@ -529,7 +529,7 @@ describe("NavTab", () => {
             tabs={TABS_ITEMS}
             activeTab={"2"}
             styles={{
-              boxStyle: css`
+              tabStyle: css`
                 padding: 20px;
                 background-color: white;
               `,


### PR DESCRIPTION
Description:
This pull request updates the `elements` in the `NavTab` component to a more appropriate and descriptive name.  

Source:
[[Improvement] SYST-598: Name refactor on NavTab](https://linear.app/systatum/issue/SYST-598/name-refactor-on-navtab)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself