### PR TITLE
[Improvement] SYST-589: Rename `Togglebox` to just `Toggle`

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -7,7 +7,7 @@ import { RiCloseLine } from "@remixicon/react";
 import { HTMLAttributes, ReactNode } from "react";
 import styled, { css, CSSProp } from "styled-components";
 import { ActionButton, ActionButtonProps } from "./action-button";
-import { Togglebox } from "./togglebox";
+import { Toggle } from "./toggle";
 import { AnimatePresence, motion } from "framer-motion";
 import { useTheme } from "./../theme/provider";
 import { CardThemeConfig } from "./../theme";
@@ -140,7 +140,7 @@ function Card({
                   <ActionButton key={index} {...props} />
                 ))}
               {toggleable && (
-                <Togglebox
+                <Toggle
                   styles={{
                     bodyStyle: css`
                       min-height: 0;

--- a/components/list.stories.tsx
+++ b/components/list.stories.tsx
@@ -1856,7 +1856,7 @@ export const CustomOpener: Story = {
                 title={group.title}
                 actions={ACTIONS_GROUPS}
                 rightSideContent={group.rightSideContent}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item

--- a/components/list.tsx
+++ b/components/list.tsx
@@ -24,7 +24,7 @@ import { Searchbox, SearchboxStyles } from "./searchbox";
 import { AnimatePresence, motion } from "framer-motion";
 import { LoadingSpinner } from "./loading-spinner";
 import { Checkbox } from "./checkbox";
-import { Togglebox } from "./togglebox";
+import { Toggle } from "./toggle";
 import styled, { css, CSSProp } from "styled-components";
 import ContextMenu, { ContextMenuAction } from "./context-menu";
 import { ActionButton, ActionButtonProps } from "./action-button";
@@ -382,7 +382,7 @@ export interface ListGroupaction extends Omit<ActionButtonProps, "onClick"> {
 
 export const ListGroupOpenerStyle = {
   Chevron: "chevron",
-  ToggleBox: "togglebox",
+  Toggle: "toggle",
   None: "none",
 } as const;
 
@@ -562,8 +562,8 @@ function ListGroup({
               }}
               size={18}
             />
-          ) : openerStyle === "togglebox" ? (
-            <Togglebox
+          ) : openerStyle === "toggle" ? (
+            <Toggle
               styles={{
                 containerStyle: css`
                   width: fit-content;

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -984,7 +984,7 @@ export const AllCase: Story = {
       money: string;
       phone: string;
       thumb_field: boolean;
-      togglebox: boolean;
+      toggle: boolean;
       signature: string;
       capsule: string;
       country_code?: CountryCodeProps;
@@ -1014,7 +1014,7 @@ export const AllCase: Story = {
       money: "",
       phone: "",
       thumb_field: false,
-      togglebox: false,
+      toggle: false,
       signature: "",
       capsule: "",
       country_code: DEFAULT_COUNTRY_CODES,
@@ -1159,7 +1159,7 @@ export const AllCase: Story = {
       phone: z.string().min(8, "Phone number must be 8 digits").optional(),
       rating: z.string().optional(),
       thumb_field: z.boolean(),
-      togglebox: z.boolean(),
+      toggle: z.boolean(),
       capsule: z.string().max(4, "Paid is required"),
       pin: z.string().min(4, "Pinbox does not follow the acceptable format"),
       country_code: z
@@ -1429,8 +1429,8 @@ export const AllCase: Story = {
         helper: "This field allows you to select a thumbs-up or down value",
       },
       {
-        name: "togglebox",
-        title: "Togglebox",
+        name: "toggle",
+        title: "Toggle",
         type: "toggle",
         placeholder: "Toggle",
         required: true,

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -33,7 +33,7 @@ import { Textarea, TextareaProps } from "./textarea";
 import styled, { css, CSSProp } from "styled-components";
 import { Rating, RatingProps } from "./rating";
 import { ThumbField, ThumbFieldProps } from "./thumb-field";
-import { Togglebox, ToggleboxProps } from "./togglebox";
+import { Toggle, ToggleProps } from "./toggle";
 import { Capsule, CapsuleProps } from "./capsule";
 import { Timebox, TimeboxProps } from "./timebox";
 import { Button, ButtonProps } from "./button";
@@ -189,7 +189,7 @@ export interface FormFieldProps {
   chipsProps?: ChipsProps;
   ratingProps?: RatingProps;
   thumbFieldProps?: ThumbFieldProps;
-  toggleboxProps?: ToggleboxProps;
+  toggleProps?: ToggleProps;
   capsuleProps?: CapsuleProps;
   timeboxProps?: TimeboxProps;
   buttonProps?: ButtonProps;
@@ -1894,7 +1894,7 @@ function FormFields<T extends FieldValues>({
                   control={control}
                   name={field.name as Path<T>}
                   render={({ field: controllerField }) => (
-                    <Togglebox
+                    <Toggle
                       id={field.id}
                       name={controllerField.name}
                       labelGap={field.labelGap}
@@ -1920,35 +1920,35 @@ function FormFields<T extends FieldValues>({
                           | undefined
                       }
                       disabled={field.disabled}
-                      {...field.toggleboxProps}
+                      {...field.toggleProps}
                       title={field.title}
                       label={field.placeholder}
                       styles={{
-                        ...field.toggleboxProps?.styles,
+                        ...field.toggleProps?.styles,
                         titleStyle: css`
                           ${labelSize &&
                           css`
                             font-size: ${labelSize};
                           `}
-                          ${field.toggleboxProps?.styles?.titleStyle}
+                          ${field.toggleProps?.styles?.titleStyle}
                         `,
                         labelStyle: css`
                           ${labelSize &&
                           css`
                             font-size: ${labelSize};
                           `}
-                          ${field.toggleboxProps?.styles?.labelStyle}
+                          ${field.toggleProps?.styles?.labelStyle}
                         `,
                         containerStyle: css`
                           ${field.width &&
                           css`
                             width: ${field.width};
                           `}
-                          ${field.toggleboxProps?.styles?.containerStyle}
+                          ${field.toggleProps?.styles?.containerStyle}
                         `,
                         controlStyle: css`
                           min-height: 34px;
-                          ${field.toggleboxProps?.styles?.controlStyle}
+                          ${field.toggleProps?.styles?.controlStyle}
                         `,
                         bodyStyle: css`
                           ${!field.title &&
@@ -1958,7 +1958,7 @@ function FormFields<T extends FieldValues>({
                             justify-content: end;
                           `}
 
-                          ${field.toggleboxProps?.styles?.bodyStyle}
+                          ${field.toggleProps?.styles?.bodyStyle}
                         `,
                       }}
                     />

--- a/components/toggle.stories.tsx
+++ b/components/toggle.stories.tsx
@@ -1,19 +1,19 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Togglebox } from "./togglebox";
+import { Toggle } from "./toggle";
 import { useEffect } from "react";
 import * as RemixIcons from "@remixicon/react";
 import { useArgs } from "@storybook/preview-api";
 import { css } from "styled-components";
 
-const meta: Meta<typeof Togglebox> = {
-  title: "Input Elements/Togglebox",
-  component: Togglebox,
+const meta: Meta<typeof Toggle> = {
+  title: "Input Elements/Toggle",
+  component: Toggle,
   tags: ["autodocs"],
   parameters: {
     docs: {
       description: {
         component: `
-Togglebox is a flexible toggle switch component for React, designed for binary on/off states. 
+Toggle is a flexible toggle switch component for React, designed for binary on/off states. 
 It supports icons, loading states, custom sizes, labels, descriptions, and full styling control. 
 It integrates seamlessly with \`FieldLane\` for form layout and validation support.
 
@@ -33,7 +33,7 @@ It integrates seamlessly with \`FieldLane\` for form layout and validation suppo
 ### 📌 Usage
 
 \`\`\`tsx
-<Togglebox
+<Toggle
   checked={true}
   label="Enable notifications"
   description="Receive email updates for new activity"
@@ -50,7 +50,7 @@ It integrates seamlessly with \`FieldLane\` for form layout and validation suppo
 />
 
 {/* Integration with FieldLane and validation */}
-<Togglebox
+<Toggle
   title="Enable dark mode"
   label="Dark Mode"
   showError={true}
@@ -136,15 +136,15 @@ It integrates seamlessly with \`FieldLane\` for form layout and validation suppo
     },
     styles: {
       description:
-        "Custom styles for individual sub-elements of the togglebox. Accepts a ToggleboxStyles object.",
+        "Custom styles for individual sub-elements of the toggle. Accepts a ToggleStyles object.",
       table: {
-        type: { summary: "ToggleboxStyles" },
+        type: { summary: "ToggleStyles" },
       },
       control: { type: "object" },
     },
     disabled: {
       control: "boolean",
-      description: "Disables the togglebox, preventing interaction.",
+      description: "Disables the toggle, preventing interaction.",
       defaultValue: false,
       table: {
         type: { summary: "boolean" },
@@ -241,7 +241,7 @@ It integrates seamlessly with \`FieldLane\` for form layout and validation suppo
 
 export default meta;
 
-type Story = StoryObj<typeof Togglebox>;
+type Story = StoryObj<typeof Toggle>;
 
 export const Default: Story = {
   args: {
@@ -251,7 +251,7 @@ export const Default: Story = {
     const [, setUpdateArgs] = useArgs();
 
     return (
-      <Togglebox
+      <Toggle
         {...args}
         onChange={(e) => setUpdateArgs({ checked: e.target.checked })}
       />
@@ -268,7 +268,7 @@ export const WithIcon: Story = {
     const [, setUpdateArgs] = useArgs();
 
     return (
-      <Togglebox
+      <Toggle
         {...args}
         onChange={(e) => setUpdateArgs({ checked: e.target.checked })}
       />
@@ -295,7 +295,7 @@ export const WithIconAndLoading: Story = {
     }, [args.checked]);
 
     return (
-      <Togglebox
+      <Toggle
         {...args}
         onChange={(e) => setUpdateArgs({ checked: e.target.checked })}
       />
@@ -329,7 +329,7 @@ export const WithDescription: Story = {
     }, [args.checked]);
 
     return (
-      <Togglebox
+      <Toggle
         {...args}
         onChange={(e) => setUpdateArgs({ checked: e.target.checked })}
       />
@@ -344,7 +344,7 @@ export const WithError: Story = {
     isLoading: false,
     showError: true,
     label: "With Error",
-    errorMessage: "Must add value on togglebox",
+    errorMessage: "Must add value on toggle",
   },
   render: (args) => {
     const [, setUpdateArgs] = useArgs();
@@ -359,7 +359,7 @@ export const WithError: Story = {
     }, [args.checked]);
 
     return (
-      <Togglebox
+      <Toggle
         {...args}
         showError={!args.checked}
         onChange={(e) => setUpdateArgs({ checked: e.target.checked })}

--- a/components/toggle.tsx
+++ b/components/toggle.tsx
@@ -5,10 +5,10 @@ import styled, { css, CSSProp } from "styled-components";
 import { StatefulForm } from "./stateful-form";
 import { Figure, FigureProps } from "./figure";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { useTheme } from "./../theme/provider";
-import { ToggleboxThemeConfig } from "./../theme";
+import { useTheme } from "../theme/provider";
+import { ToggleThemeConfig } from "../theme";
 
-interface BaseToggleboxProps
+interface BaseToggleProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "style"> {
   checked?: boolean;
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
@@ -18,10 +18,10 @@ interface BaseToggleboxProps
   label?: string;
   description?: string;
   size?: number;
-  styles?: BaseToggleboxStyles;
+  styles?: BaseToggleStyles;
 }
 
-interface BaseToggleboxStyles {
+interface BaseToggleStyles {
   descriptionStyle?: CSSProp;
   rowStyle?: CSSProp;
   textWrapperStyle?: CSSProp;
@@ -30,7 +30,7 @@ interface BaseToggleboxStyles {
   titleStyle?: CSSProp;
 }
 
-function BaseTogglebox({
+function BaseToggle({
   name,
   checked = false,
   onChange,
@@ -43,25 +43,25 @@ function BaseTogglebox({
   id,
   disabled,
   ...props
-}: BaseToggleboxProps) {
+}: BaseToggleProps) {
   const { currentTheme } = useTheme();
-  const toggleboxTheme = currentTheme.togglebox;
+  const toggleTheme = currentTheme.toggle;
 
   const { heightWrapper, widthWrapper, thumbShift, iconSize } =
-    getToggleboxSize(size);
+    getToggleSize(size);
 
   return (
-    <ToggleboxWrapper
-      $theme={toggleboxTheme}
+    <ToggleWrapper
+      $theme={toggleTheme}
       $disabled={disabled}
       $style={styles?.rowStyle}
-      aria-label="togglebox-row-wrapper"
+      aria-label="toggle-row-wrapper"
     >
       <StyledLabel
         animate={{ opacity: 1, scale: 1 }}
         exit={{ opacity: 0, scale: 0.8 }}
         transition={{ duration: 0.2 }}
-        aria-label="togglebox-wrapper"
+        aria-label="toggle-wrapper"
         style={{
           width: widthWrapper,
           height: heightWrapper,
@@ -71,7 +71,7 @@ function BaseTogglebox({
       >
         <StyledInput
           {...props}
-          aria-label="togglebox-input"
+          aria-label="toggle-input"
           id={id}
           name={name}
           type="checkbox"
@@ -79,10 +79,10 @@ function BaseTogglebox({
           disabled={disabled}
           onChange={onChange}
         />
-        <ToggleBackground $checked={checked} $theme={toggleboxTheme} />
+        <ToggleBackground $checked={checked} $theme={toggleTheme} />
         <ToggleButton
-          $theme={toggleboxTheme}
-          aria-label="togglebox-thumb"
+          $theme={toggleTheme}
+          aria-label="toggle-thumb"
           transition={{ type: "spring", stiffness: 700, damping: 30 }}
           animate={{
             x: checked ? thumbShift : 0,
@@ -98,7 +98,7 @@ function BaseTogglebox({
             icon && (
               <Figure
                 {...icon}
-                aria-label="togglebox-icon"
+                aria-label="toggle-icon"
                 size={icon?.size ?? iconSize}
               />
             )
@@ -107,9 +107,9 @@ function BaseTogglebox({
       </StyledLabel>
 
       {(label || description) && (
-        <ToggleboxTextWrapper
+        <ToggleTextWrapper
           $style={styles?.textWrapperStyle}
-          aria-label="togglebox-text-wrapper"
+          aria-label="toggle-text-wrapper"
         >
           {label && (
             <StatefulForm.Label
@@ -119,28 +119,25 @@ function BaseTogglebox({
             />
           )}
           {description && (
-            <Description
-              $theme={toggleboxTheme}
-              $style={styles?.descriptionStyle}
-            >
+            <Description $theme={toggleTheme} $style={styles?.descriptionStyle}>
               {description}
             </Description>
           )}
-        </ToggleboxTextWrapper>
+        </ToggleTextWrapper>
       )}
-    </ToggleboxWrapper>
+    </ToggleWrapper>
   );
 }
 
-export type ToggleboxStyles = BaseToggleboxStyles & FieldLaneStyles;
+export type ToggleStyles = BaseToggleStyles & FieldLaneStyles;
 
-export interface ToggleboxProps
-  extends Omit<BaseToggleboxProps, "styles">,
+export interface ToggleProps
+  extends Omit<BaseToggleProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns"> {
-  styles?: ToggleboxStyles;
+  styles?: ToggleStyles;
 }
 
-function Togglebox({
+function Toggle({
   label,
   showError,
   styles,
@@ -156,9 +153,9 @@ function Togglebox({
   labelWidth,
   labelPosition,
   ...rest
-}: ToggleboxProps) {
+}: ToggleProps) {
   const inputId = StatefulForm.sanitizeId({
-    prefix: "togglebox",
+    prefix: "toggle",
     name,
     id,
   });
@@ -168,7 +165,7 @@ function Togglebox({
     controlStyle,
     containerStyle,
     titleStyle,
-    ...toggleboxStyles
+    ...toggleStyles
   } = styles ?? {};
 
   return (
@@ -196,10 +193,10 @@ function Togglebox({
         labelStyle: titleStyle,
       }}
     >
-      <BaseTogglebox
+      <BaseToggle
         {...rest}
         id={inputId}
-        styles={toggleboxStyles}
+        styles={toggleStyles}
         disabled={disabled}
         label={label}
         description={description}
@@ -208,7 +205,7 @@ function Togglebox({
   );
 }
 
-const getToggleboxSize = (size: number) => {
+const getToggleSize = (size: number) => {
   const widthWrapper = size * 2;
   const heightWrapper = size * 1;
   const thumbShift = size * 1.02;
@@ -222,10 +219,10 @@ const getToggleboxSize = (size: number) => {
   };
 };
 
-const ToggleboxWrapper = styled.div<{
+const ToggleWrapper = styled.div<{
   $style?: CSSProp;
   $disabled?: boolean;
-  $theme?: ToggleboxThemeConfig;
+  $theme?: ToggleThemeConfig;
 }>`
   display: flex;
   flex-direction: row;
@@ -247,7 +244,7 @@ const ToggleboxWrapper = styled.div<{
   ${({ $style }) => $style}
 `;
 
-const ToggleboxTextWrapper = styled.div<{ $style?: CSSProp }>`
+const ToggleTextWrapper = styled.div<{ $style?: CSSProp }>`
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -272,7 +269,7 @@ const StyledInput = styled.input`
 
 const ToggleBackground = styled.div<{
   $checked: boolean;
-  $theme?: ToggleboxThemeConfig;
+  $theme?: ToggleThemeConfig;
 }>`
   width: 100%;
   height: 100%;
@@ -285,7 +282,7 @@ const ToggleBackground = styled.div<{
 `;
 
 const ToggleButton = styled(motion.div)<{
-  $theme?: ToggleboxThemeConfig;
+  $theme?: ToggleThemeConfig;
 }>`
   position: absolute;
   top: 0;
@@ -300,7 +297,7 @@ const ToggleButton = styled(motion.div)<{
 
 const Description = styled.span<{
   $style?: CSSProp;
-  $theme?: ToggleboxThemeConfig;
+  $theme?: ToggleThemeConfig;
 }>`
   font-size: 12px;
   width: 100%;
@@ -308,4 +305,4 @@ const Description = styled.span<{
   ${({ $style }) => $style}
 `;
 
-export { Togglebox };
+export { Toggle };

--- a/package.json
+++ b/package.json
@@ -249,9 +249,9 @@
       "import": "./dist/components/tip-menu.js",
       "types": "./dist/components/tip-menu.d.ts"
     },
-    "./togglebox": {
-      "import": "./dist/components/togglebox.js",
-      "types": "./dist/components/togglebox.d.ts"
+    "./toggle": {
+      "import": "./dist/components/toggle.js",
+      "types": "./dist/components/toggle.d.ts"
     },
     "./toolbar": {
       "import": "./dist/components/toolbar.js",

--- a/public/feed.xml
+++ b/public/feed.xml
@@ -2611,10 +2611,10 @@ It is commonly used for action menus, context menus, or inline tips.
     
 
       <item>
-        <title>Togglebox - Coneto React UI</title>
-        <link>https://coneto.systatum.com/?path=/docs/input-elements-togglebox</link>
+        <title>Toggle - Coneto React UI</title>
+        <link>https://coneto.systatum.com/?path=/docs/input-elements-toggle</link>
         <guid>41c70b9d483cd078443744764438467123470c00</guid>
-        <description><![CDATA[Togglebox is a flexible toggle switch component for React, designed for binary on/off states. 
+        <description><![CDATA[Toggle is a flexible toggle switch component for React, designed for binary on/off states. 
 It supports icons, loading states, custom sizes, labels, descriptions, and full styling control. 
 It integrates seamlessly with `FieldLane` for form layout and validation support.
 
@@ -2632,7 +2632,7 @@ It integrates seamlessly with `FieldLane` for form layout and validation support
 📌 Usage
 
 ```tsx
-<Togglebox
+<Toggle
   checked={true}
   label="Enable notifications"
   description="Receive email updates for new activity"
@@ -2649,7 +2649,7 @@ It integrates seamlessly with `FieldLane` for form layout and validation support
 />
 
 {/* Integration with FieldLane and validation */}
-<Togglebox
+<Toggle
   title="Enable dark mode"
   label="Dark Mode"
   showError={true}

--- a/test/component/card.cy.tsx
+++ b/test/component/card.cy.tsx
@@ -38,14 +38,14 @@ describe("Card", () => {
 
   context("toggleable", () => {
     context("when given", () => {
-      it("renders the card using togglebox", () => {
+      it("renders the card using toggle", () => {
         cy.mount(<ProductCard toggleable />);
-        cy.findByLabelText("togglebox-wrapper").should("exist");
+        cy.findByLabelText("toggle-wrapper").should("exist");
       });
 
       it("renders with height by 24px (by default)", () => {
         cy.mount(<ProductCard toggleable />);
-        cy.findByLabelText("togglebox-wrapper")
+        cy.findByLabelText("toggle-wrapper")
           .should("exist")
           .should("have.css", "height", "24px");
       });
@@ -54,7 +54,7 @@ describe("Card", () => {
         it("should collapsing the card content", () => {
           cy.mount(<ProductCard toggleable />);
           cy.findByLabelText("card-content").should("exist");
-          cy.findByLabelText("togglebox-wrapper").should("exist").click();
+          cy.findByLabelText("toggle-wrapper").should("exist").click();
           cy.findByLabelText("card-content").should("not.exist");
         });
       });
@@ -68,7 +68,7 @@ describe("Card", () => {
           );
           cy.findByLabelText("card-content").should("exist");
           cy.findByLabelText("card-footer").should("exist");
-          cy.findByLabelText("togglebox-wrapper").should("exist").click();
+          cy.findByLabelText("toggle-wrapper").should("exist").click();
           cy.findByLabelText("card-content").should("not.exist");
           cy.findByLabelText("card-footer").should("not.exist");
         });

--- a/test/component/context-menu.cy.tsx
+++ b/test/component/context-menu.cy.tsx
@@ -155,7 +155,7 @@ describe("context-menu", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -207,7 +207,7 @@ describe("context-menu", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -256,7 +256,7 @@ describe("context-menu", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -309,7 +309,7 @@ describe("context-menu", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item

--- a/test/component/list.cy.tsx
+++ b/test/component/list.cy.tsx
@@ -489,7 +489,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -549,7 +549,7 @@ describe("List", () => {
                     title={group.title}
                     subtitle={group.subtitle}
                     actions={group.actions}
-                    openerStyle="togglebox"
+                    openerStyle="toggle"
                   >
                     {group.items.map((list, i) => (
                       <List.Item
@@ -626,7 +626,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -678,7 +678,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -731,7 +731,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -779,7 +779,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -827,7 +827,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -879,7 +879,7 @@ describe("List", () => {
               title={group.title}
               subtitle={group.subtitle}
               actions={group.actions}
-              openerStyle="togglebox"
+              openerStyle="toggle"
             >
               {group.items.map((list, i) => (
                 <List.Item
@@ -929,7 +929,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -981,7 +981,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -1028,7 +1028,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -1136,7 +1136,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                   styles={group.styles}
                 >
                   {group.items.map((list, i) => (
@@ -1247,7 +1247,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -1314,7 +1314,7 @@ describe("List", () => {
                   subtitle={group.subtitle}
                   actions={group.actions}
                   emptySlate={"This content is not available"}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -1363,7 +1363,7 @@ describe("List", () => {
                     actions={group.actions}
                     emptySlate={"This content is not available"}
                     styles={group.styles}
-                    openerStyle="togglebox"
+                    openerStyle="toggle"
                   >
                     {group.items.map((list, i) => (
                       <List.Item
@@ -1484,7 +1484,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -1528,7 +1528,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -1652,7 +1652,7 @@ describe("List", () => {
                 id={group.id}
                 title={group.title}
                 subtitle={group.subtitle}
-                openerStyle="togglebox"
+                openerStyle="toggle"
                 actions={ACTIONS_GROUPS}
                 rightSideContent={RIGHT_SIDE_CONTENT}
               >
@@ -1697,7 +1697,7 @@ describe("List", () => {
                   id={group.id}
                   title={group.title}
                   subtitle={group.subtitle}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                   actions={ACTIONS_GROUPS}
                   rightSideContent={RIGHT_SIDE_CONTENT}
                 >
@@ -1832,7 +1832,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -1882,7 +1882,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -1933,7 +1933,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -1994,7 +1994,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -2138,7 +2138,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -2291,7 +2291,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -2336,7 +2336,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -2438,7 +2438,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -2495,7 +2495,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -2555,7 +2555,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -2616,7 +2616,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -2671,7 +2671,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -2726,7 +2726,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -2780,7 +2780,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -2845,7 +2845,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -2915,7 +2915,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -2971,7 +2971,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -3026,7 +3026,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -3089,7 +3089,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -3207,7 +3207,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item
@@ -3260,7 +3260,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -3327,7 +3327,7 @@ describe("List", () => {
                   title={group.title}
                   subtitle={group.subtitle}
                   actions={group.actions}
-                  openerStyle="togglebox"
+                  openerStyle="toggle"
                 >
                   {group.items.map((list, i) => (
                     <List.Item
@@ -3423,7 +3423,7 @@ describe("List", () => {
                 title={group.title}
                 subtitle={group.subtitle}
                 actions={group.actions}
-                openerStyle="togglebox"
+                openerStyle="toggle"
               >
                 {group.items.map((list, i) => (
                   <List.Item

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -106,7 +106,7 @@ const TYPE_TO_ID_PREFIX: Record<FormFieldType, string> = {
   combo: "combobox",
   rating: "rating",
   thumbfield: "thumbfield",
-  toggle: "togglebox",
+  toggle: "toggle",
   capsule: "capsule",
   time: "timebox",
   button: "button",
@@ -137,7 +137,7 @@ const allValue = {
   money: "",
   phone: "",
   thumb_field: false,
-  togglebox: false,
+  toggle: false,
   signature: "",
   capsule: "",
   country_code: DEFAULT_COUNTRY_CODES,
@@ -291,8 +291,8 @@ const ALL_INPUT: FormFieldGroup[] = [
     required: true,
   },
   {
-    name: "togglebox",
-    title: "Togglebox",
+    name: "toggle",
+    title: "Toggle",
     type: "toggle",
     required: true,
   },
@@ -2522,8 +2522,8 @@ describe("StatefulForm", () => {
 
         flattenFields(INPUT_WITH_WIDTH).forEach((prop) => {
           if (prop.name === "country_code") return;
-          if (prop.name === "togglebox") {
-            cy.findByLabelText("togglebox-row-wrapper").then(($el) => {
+          if (prop.name === "toggle") {
+            cy.findByLabelText("toggle-row-wrapper").then(($el) => {
               const width = $el.width();
               expect(width).to.be.closeTo(222.5, 10);
             });

--- a/test/component/toggle.cy.tsx
+++ b/test/component/toggle.cy.tsx
@@ -1,11 +1,11 @@
 import { Ri24HoursFill } from "@remixicon/react";
-import { Togglebox } from "./../../components/togglebox";
+import { Toggle } from "../../components/toggle";
 
-describe("Togglebox", () => {
+describe("Toggle", () => {
   context("with size", () => {
     it("render with calculate icon, wrapper, and thumb-shift value", () => {
       cy.mount(
-        <Togglebox size={30} icon={{ image: Ri24HoursFill }} checked={true} />
+        <Toggle size={30} icon={{ image: Ri24HoursFill }} checked={true} />
       );
       const size = 30;
       const widthWrapper = size * 2;
@@ -13,11 +13,11 @@ describe("Togglebox", () => {
       const thumbShift = size * 1.02;
       const iconSize = size * 0.6;
 
-      cy.findByLabelText("togglebox-wrapper").each(($wrapper) => {
+      cy.findByLabelText("toggle-wrapper").each(($wrapper) => {
         expect($wrapper.width()).to.eq(widthWrapper);
         expect($wrapper.height()).to.eq(heightWrapper);
       });
-      cy.findByLabelText("togglebox-icon").each(($icon) => {
+      cy.findByLabelText("toggle-icon").each(($icon) => {
         expect($icon.width()).to.eq(iconSize);
         expect($icon.height()).to.eq(iconSize);
       });
@@ -26,7 +26,7 @@ describe("Togglebox", () => {
 
       // make sure of the matrix when use of 2d transformation
       // matrix(scaleX, skewY, skewX, scaleY, translateX, translateY)
-      cy.findByLabelText("togglebox-thumb")
+      cy.findByLabelText("toggle-thumb")
         .should("exist")
         .invoke("css", "transform")
         .then((transform) => {
@@ -46,13 +46,13 @@ describe("Togglebox", () => {
   context("with description", () => {
     it("render with align center", () => {
       cy.mount(
-        <Togglebox
+        <Toggle
           label="Click and load"
           description="Click and you will see a loading icon"
           checked={true}
         />
       );
-      cy.findByLabelText("togglebox-row-wrapper")
+      cy.findByLabelText("toggle-row-wrapper")
         .should("have.css", "flex-direction", "row")
         .and("have.css", "align-items", "center");
     });

--- a/test/e2e/list.cy.ts
+++ b/test/e2e/list.cy.ts
@@ -61,7 +61,7 @@ describe("List", () => {
       });
     });
 
-    context("with togglebox opener", () => {
+    context("with toggle opener", () => {
       beforeEach(() => {
         cy.visit(getIdContent("content-list--custom-opener"));
       });
@@ -74,11 +74,11 @@ describe("List", () => {
       });
 
       it("renders with fit-content (48px)", () => {
-        cy.findAllByLabelText("togglebox-wrapper")
+        cy.findAllByLabelText("toggle-wrapper")
           .eq(0)
           .should("have.css", "width", "48px");
 
-        cy.findAllByLabelText("togglebox-wrapper")
+        cy.findAllByLabelText("toggle-wrapper")
           .eq(0)
           .then(($el) => {
             const width = $el[0].getBoundingClientRect().width;
@@ -87,11 +87,11 @@ describe("List", () => {
       });
 
       context("when given actions", () => {
-        it("renders correct spacing between togglebox and action", () => {
+        it("renders correct spacing between toggle and action", () => {
           cy.findAllByLabelText("action-button")
             .eq(0)
             .then(($action) => {
-              cy.findAllByLabelText("togglebox-wrapper").then(($toggle) => {
+              cy.findAllByLabelText("toggle-wrapper").then(($toggle) => {
                 const a = $action[0].getBoundingClientRect();
                 const t = $toggle[0].getBoundingClientRect();
 
@@ -106,7 +106,7 @@ describe("List", () => {
       context("when clicking", () => {
         it("renders collapsed the content", () => {
           cy.contains("Messages").should("be.visible");
-          cy.findAllByLabelText("togglebox-thumb").eq(0).click();
+          cy.findAllByLabelText("toggle-thumb").eq(0).click();
           cy.contains("Messages").should("not.be.visible");
         });
       });

--- a/test/e2e/toggle.cy.ts
+++ b/test/e2e/toggle.cy.ts
@@ -1,11 +1,11 @@
 import { getIdContent } from "test/support/commands";
 
-describe("Togglebox", () => {
-  const onClickToggle = () => cy.findByLabelText("togglebox-wrapper").click();
+describe("Toggle", () => {
+  const onClickToggle = () => cy.findByLabelText("toggle-wrapper").click();
 
   context("Default", () => {
     beforeEach(() => {
-      cy.visit(getIdContent("input-elements-togglebox--default"));
+      cy.visit(getIdContent("input-elements-toggle--default"));
     });
 
     it("should toggle checkbox state on click", () => {
@@ -16,7 +16,7 @@ describe("Togglebox", () => {
 
   context("with icon", () => {
     beforeEach(() => {
-      cy.visit(getIdContent("input-elements-togglebox--with-icon"));
+      cy.visit(getIdContent("input-elements-toggle--with-icon"));
     });
 
     context("when clicking", () => {
@@ -29,7 +29,7 @@ describe("Togglebox", () => {
 
   context("with icon and loading", () => {
     beforeEach(() => {
-      cy.visit(getIdContent("input-elements-togglebox--with-icon-and-loading"));
+      cy.visit(getIdContent("input-elements-toggle--with-icon-and-loading"));
     });
 
     it("should show loading state (circle) after toggle", () => {
@@ -41,7 +41,7 @@ describe("Togglebox", () => {
 
   context("with description", () => {
     beforeEach(() => {
-      cy.visit(getIdContent("input-elements-togglebox--with-description"));
+      cy.visit(getIdContent("input-elements-toggle--with-description"));
     });
 
     it("should render label and description", () => {
@@ -63,18 +63,18 @@ describe("Togglebox", () => {
 
   context("with error", () => {
     beforeEach(() => {
-      cy.visit(getIdContent("input-elements-togglebox--with-error"));
+      cy.visit(getIdContent("input-elements-toggle--with-error"));
     });
 
     it("should show error message", () => {
-      cy.findByText("Must add value on togglebox").should("exist");
+      cy.findByText("Must add value on toggle").should("exist");
     });
 
     context("when clicking", () => {
       it("should hide error message", () => {
         onClickToggle();
         cy.get("input[type=checkbox]").should("be.checked");
-        cy.findByText("Must add value on togglebox").should("not.exist");
+        cy.findByText("Must add value on toggle").should("not.exist");
       });
     });
   });

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -672,8 +672,8 @@ export interface ThumbFieldThemeConfig {
   disabledOpacity?: number;
 }
 
-// togglebox.tsx
-export interface ToggleboxThemeConfig extends BodyThemeConfig {
+// toggle.tsx
+export interface ToggleThemeConfig extends BodyThemeConfig {
   checkedBackgroundColor?: string;
   thumbColor?: string;
   descriptionColor?: string;
@@ -786,7 +786,7 @@ export interface AppTheme {
   timeline: TimelineThemeConfig;
   tipmenu: TipMenuThemeConfig;
   timebox: TimeboxThemeConfig;
-  togglebox: ToggleboxThemeConfig;
+  toggle: ToggleThemeConfig;
   toolbar: Record<ToolbarVariant, ToolbarThemeConfig>;
   tooltip: TooltipThemeConfig;
   treelist: TreeListThemeConfig;

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -61,7 +61,7 @@ import {
   TimelineThemeConfig,
   TipMenuContainerThemeConfig,
   TipMenuThemeConfig,
-  ToggleboxThemeConfig,
+  ToggleThemeConfig,
   ToolbarThemeConfig,
   TooltipThemeConfig,
   TreeListThemeConfig,
@@ -1550,12 +1550,12 @@ export function createTipMenuTheme(
   };
 }
 
-// togglebox.tsx
-export function createToggleboxTheme(
+// toggle.tsx
+export function createToggleTheme(
   body: BodyThemeConfig,
-  custom: Partial<ToggleboxThemeConfig> = {}
-): ToggleboxThemeConfig {
-  const defaultTheme: ToggleboxThemeConfig = {
+  custom: Partial<ToggleThemeConfig> = {}
+): ToggleThemeConfig {
+  const defaultTheme: ToggleThemeConfig = {
     backgroundColor: "#D1D5DB",
     checkedBackgroundColor: "#61A9F9",
     thumbColor: "#ffffff",

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -60,7 +60,7 @@ import {
   createTimelineTheme,
   createTipMenuContainerTheme,
   createTipMenuTheme,
-  createToggleboxTheme,
+  createToggleTheme,
   createToolbarTheme,
   createTreeListTheme,
   createWindowTheme,
@@ -727,7 +727,7 @@ const darkThumbField = createThumbFieldTheme(darkBody, {
   errorColor: "#f87171",
 });
 
-const darkTogglebox = createToggleboxTheme(darkBody, {
+const darkToggle = createToggleTheme(darkBody, {
   backgroundColor: "rgb(80, 80, 80)",
   checkedBackgroundColor: darkButton?.primary?.hoverBackgroundColor,
   thumbColor: "#f5f5f5",
@@ -834,7 +834,7 @@ export const darkTheme: AppTheme = {
   timeline: darkTimeline,
   tipmenu: darkTipMenu,
   thumbField: darkThumbField,
-  togglebox: darkTogglebox,
+  toggle: darkToggle,
   toolbar: darkToolbar,
   tooltip: darkTooltip,
   treelist: darkTreeList,

--- a/theme/mode/light.ts
+++ b/theme/mode/light.ts
@@ -60,7 +60,7 @@ import {
   createTimelineTheme,
   createTipMenuContainerTheme,
   createTipMenuTheme,
-  createToggleboxTheme,
+  createToggleTheme,
   createToolbarTheme,
   createTreeListTheme,
   createWindowTheme,
@@ -207,7 +207,7 @@ const lightTipMenu = createTipMenuTheme(lightBody, {
   dangerousActiveBackgroundColor: lightButton.danger.activeBackgroundColor,
 });
 
-const lightTogglebox = createToggleboxTheme(lightBody);
+const lightToggle = createToggleTheme(lightBody);
 
 const lightToolbar = createToolbarTheme({
   default: lightButton.default,
@@ -288,7 +288,7 @@ export const lightTheme: AppTheme = {
   timeline: lightTimeline,
   tipmenu: lightTipMenu,
   thumbField: lightThumbField,
-  togglebox: lightTogglebox,
+  toggle: lightToggle,
   toolbar: lightToolbar,
   tooltip: lightTooltip,
   treelist: lightTreeList,


### PR DESCRIPTION
Description:
This pull request renames the component from `Togglebox` to `Toggle`, since its appearance does not resemble a box.

Source:
[[Improvement] SYST-589: Rename "Togglebox" to just "Toggle"](https://linear.app/systatum/issue/SYST-589/rename-togglebox-to-just-toggle)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself