### PR TITLE
[Bug] SYST-627: Fix combobox coloring bug

### DIFF
--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -504,6 +504,9 @@ function ComboboxDrawer({
             setHasInteracted(false);
           }
 
+          requestAnimationFrame(() => {
+            setHighlightedIndex(null);
+          });
           onClick?.();
         }}
         onMouseMove={() => {

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -755,25 +755,18 @@ const listItemRowStyle = ({
     }
   `}
 
+  ${shouldHighlight &&
+  css`
+    background-color: ${theme.highlightBackgroundColor};
+    color: ${theme.textColor};
+  `};
+
   ${isSelected &&
   !multiple &&
   css`
     font-weight: 600;
     background-color: ${theme.selectedBackgroundColor};
     color: ${theme.selectedTextColor};
-    &:hover {
-      color: ${theme.textColor};
-    }
-  `};
-
-  ${shouldHighlight &&
-  css`
-    background-color: ${theme.highlightBackgroundColor};
-    color: ${theme.textColor};
-
-    &:hover {
-      background-color: ${theme.highlightBackgroundColor};
-    }
   `};
 `;
 

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -554,6 +554,7 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
         )}
 
         <IconWrapper
+          $isLoading={isLoading}
           aria-label="selectbox-opener"
           onClick={async () => {
             await setIsOpen((prev) => {
@@ -726,7 +727,6 @@ const Container = styled.div<{
     css`
       user-select: none;
       pointer-events: none;
-      opacity: 0.5;
     `};
 
   ${({ $disabled }) =>
@@ -837,12 +837,18 @@ const Divider = styled.span<{
   border-right: 1px solid ${({ $theme }) => $theme.dividerColor || "#9ca3af"};
 `;
 
-const IconWrapper = styled.div`
+const IconWrapper = styled.div<{ $isLoading?: boolean }>`
   position: absolute;
   top: 50%;
   right: 8px;
   transform: translateY(-50%);
   cursor: pointer;
+
+  ${({ $isLoading }) =>
+    $isLoading &&
+    css`
+      opacity: 0.5;
+    `}
 `;
 
 export { Selectbox };

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -379,6 +379,10 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           justCommittedRef.current = true;
           commitOrRevert(selectedOption, selectedOptionsLocal, confirmedValue);
         }
+
+        requestAnimationFrame(() => {
+          setHighlightedIndex(null);
+        });
       }
 
       if (e.key === "Escape") {
@@ -393,6 +397,10 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
         if (!isOpen) {
           inputRef.current?.blur();
         }
+
+        requestAnimationFrame(() => {
+          setHighlightedIndex(null);
+        });
       }
     };
 

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -102,6 +102,69 @@ describe("Combobox", () => {
     );
   }
 
+  context("style", () => {
+    it("should render the height with 34px", () => {
+      cy.mount(
+        <ProductCombobox options={null} placeholder="Select a fruit..." />
+      );
+
+      cy.findByPlaceholderText("Select a fruit...").should(
+        "have.css",
+        "height",
+        "34px"
+      );
+    });
+
+    context("when selected the value", () => {
+      context("when clicking arrow", () => {
+        it("should highlight selected option (rgb(97, 169, 249))", () => {
+          cy.mount(
+            <ProductCombobox
+              options={FRUIT_OPTIONS}
+              placeholder="Select a fruit..."
+            />
+          );
+          cy.findByPlaceholderText("Select a fruit...").type("Banana");
+          cy.findByRole("option", { name: "Banana" }).click();
+          cy.findByPlaceholderText("Select a fruit...").should(
+            "have.value",
+            "Banana"
+          );
+
+          cy.findByLabelText("selectbox-opener").click();
+          cy.wait(500);
+          cy.findAllByLabelText("list-item-row")
+            .eq(1)
+            .should("have.css", "background-color", "rgb(97, 169, 249)");
+        });
+      });
+
+      context("when pressing arrow up/arrow down", () => {
+        it("should highlight selected option (rgb(97, 169, 249))", () => {
+          cy.mount(
+            <ProductCombobox
+              options={FRUIT_OPTIONS}
+              placeholder="Select a fruit..."
+            />
+          );
+          cy.findByPlaceholderText("Select a fruit...").type("Banana");
+          cy.findByRole("option", { name: "Banana" }).click();
+          cy.findByPlaceholderText("Select a fruit...").should(
+            "have.value",
+            "Banana"
+          );
+
+          cy.findByPlaceholderText("Select a fruit...").type("{uparrow}");
+
+          cy.wait(500);
+          cy.findAllByLabelText("list-item-row")
+            .eq(1)
+            .should("have.css", "background-color", "rgb(97, 169, 249)");
+        });
+      });
+    });
+  });
+
   context("common behavior", () => {
     const selectApple = (props = {}) => {
       cy.window().then((win) => {
@@ -443,20 +506,6 @@ describe("Combobox", () => {
 
         cy.findByLabelText("circle").should("not.exist");
       });
-    });
-  });
-
-  context("style", () => {
-    it("should render the height with 34px", () => {
-      cy.mount(
-        <ProductCombobox options={null} placeholder="Select a fruit..." />
-      );
-
-      cy.findByPlaceholderText("Select a fruit...").should(
-        "have.css",
-        "height",
-        "34px"
-      );
     });
   });
 

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -116,21 +116,45 @@ describe("Combobox", () => {
     });
 
     context("when selected the value", () => {
+      const firstSelection = () => {
+        cy.mount(
+          <ProductCombobox
+            options={FRUIT_OPTIONS}
+            placeholder="Select a fruit..."
+          />
+        );
+        cy.findByPlaceholderText("Select a fruit...").type("Banana");
+        cy.findByRole("option", { name: "Banana" }).click();
+        cy.findByPlaceholderText("Select a fruit...").should(
+          "have.value",
+          "Banana"
+        );
+      };
+
+      beforeEach(() => {
+        firstSelection();
+      });
+
+      it("should display the selected value", () => {
+        // selection in beforeEach
+      });
+
+      context("when hovering the selected option", () => {
+        it("still highlight with selected option (rgb(97, 169, 249))", () => {
+          cy.findByLabelText("selectbox-opener").click();
+          cy.wait(500);
+
+          // hovering the selected option
+          cy.findAllByLabelText("list-item-row").eq(1).trigger("mouseover");
+
+          cy.findAllByLabelText("list-item-row")
+            .eq(1)
+            .should("have.css", "background-color", "rgb(97, 169, 249)");
+        });
+      });
+
       context("when clicking arrow", () => {
         it("should highlight selected option (rgb(97, 169, 249))", () => {
-          cy.mount(
-            <ProductCombobox
-              options={FRUIT_OPTIONS}
-              placeholder="Select a fruit..."
-            />
-          );
-          cy.findByPlaceholderText("Select a fruit...").type("Banana");
-          cy.findByRole("option", { name: "Banana" }).click();
-          cy.findByPlaceholderText("Select a fruit...").should(
-            "have.value",
-            "Banana"
-          );
-
           cy.findByLabelText("selectbox-opener").click();
           cy.wait(500);
           cy.findAllByLabelText("list-item-row")
@@ -141,19 +165,6 @@ describe("Combobox", () => {
 
       context("when pressing arrow up/arrow down", () => {
         it("should highlight selected option (rgb(97, 169, 249))", () => {
-          cy.mount(
-            <ProductCombobox
-              options={FRUIT_OPTIONS}
-              placeholder="Select a fruit..."
-            />
-          );
-          cy.findByPlaceholderText("Select a fruit...").type("Banana");
-          cy.findByRole("option", { name: "Banana" }).click();
-          cy.findByPlaceholderText("Select a fruit...").should(
-            "have.value",
-            "Banana"
-          );
-
           cy.findByPlaceholderText("Select a fruit...").type("{uparrow}");
 
           cy.wait(500);


### PR DESCRIPTION
Description:
This pull request fixes the `highlighting` of the `selected` item in the drawer when re-opened via the `selectbox` or `arrow`. It also ensures consistent coloring across interactions (clicking, pressing).  

Source:
[[Bug] SYST-627: Fix combobox coloring bug](https://linear.app/systatum/issue/SYST-627/fix-combobox-coloring-bug)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself