### PR TITLE
[Improvement] SYST-629: Add `disabled` on the `StatefulForm` to set disable on the whole form fields

### DIFF
--- a/components/file-drop-box.tsx
+++ b/components/file-drop-box.tsx
@@ -275,7 +275,16 @@ function FileDropBox({
           labelWidth={labelWidth}
           labelPosition={labelPosition}
           required={required}
-          styles={{ self: styles?.labelStyle }}
+          disabled={disabled}
+          styles={{
+            self: css`
+              color: ${disabled
+                ? fileDropBoxTheme?.disabledTextColor
+                : fileDropBoxTheme?.textColor};
+
+              ${styles?.labelStyle};
+            `,
+          }}
           helper={helper}
           label={label}
         />

--- a/components/file-drop-box.tsx
+++ b/components/file-drop-box.tsx
@@ -190,10 +190,22 @@ function FileDropBox({
       $isDragging={isDragging}
       $progress={progress}
       aria-label="file-drop-box-area"
-      onClick={!disabled && handleBrowseClick}
-      onDrop={!disabled && handleDrop}
-      onDragOver={!disabled && handleDragOver}
-      onDragLeave={!disabled && handleDragLeave}
+      onClick={(e) => {
+        if (disabled) return;
+        handleBrowseClick();
+      }}
+      onDrop={(e) => {
+        if (disabled) return;
+        handleDrop(e);
+      }}
+      onDragOver={(e) => {
+        if (disabled) return;
+        handleDragOver(e);
+      }}
+      onDragLeave={(e) => {
+        if (disabled) return;
+        handleDragLeave();
+      }}
     >
       {progress === "loading" && currentIndex !== null ? (
         <ProgressContainer $theme={fileDropBoxTheme}>

--- a/components/file-input-box.tsx
+++ b/components/file-input-box.tsx
@@ -100,10 +100,22 @@ function BaseFileInputBox({
       $style={styles?.self}
       $isDragging={!disabled && isDragging}
       $hasFile={selectedFiles.length > 0}
-      onClick={!disabled && handleBrowseClick}
-      onDrop={!disabled && handleDrop}
-      onDragOver={!disabled && handleDragOver}
-      onDragLeave={!disabled && handleDragLeave}
+      onClick={() => {
+        if (disabled) return;
+        handleBrowseClick();
+      }}
+      onDrop={(e) => {
+        if (disabled) return;
+        handleDrop(e);
+      }}
+      onDragOver={(e) => {
+        if (disabled) return;
+        handleDragOver(e);
+      }}
+      onDragLeave={(e) => {
+        if (disabled) return;
+        handleDragLeave();
+      }}
       aria-label="file-input-box-wrapper"
       $disabled={disabled}
       $isError={showError}

--- a/components/signbox.tsx
+++ b/components/signbox.tsx
@@ -288,7 +288,7 @@ function BaseSignbox({
             clearCanvas(e);
           }}
           disabled={disabled}
-          variant="transparent"
+          variant="ghost"
           icon={{
             image: RiEraserLine,
             size: 16,

--- a/components/signbox.tsx
+++ b/components/signbox.tsx
@@ -47,7 +47,7 @@ function BaseSignbox({
   const lastPoint = useRef<{ x: number; y: number } | null>(null);
 
   const valueRef = useRef(value);
-
+  console.log(disabled);
   useEffect(() => {
     valueRef.current = value;
   }, [value]);
@@ -165,13 +165,11 @@ function BaseSignbox({
   };
 
   const startDrawing = (e: MouseEvent | TouchEvent) => {
-    if (disabled) return;
     isDrawing.current = true;
     lastPoint.current = getCoordinates(e);
   };
 
   const draw = (e: MouseEvent | TouchEvent) => {
-    if (disabled) return;
     if (!isDrawing.current) return;
 
     const ctx = canvasRef.current?.getContext("2d");
@@ -201,13 +199,11 @@ function BaseSignbox({
   };
 
   const stopDrawing = () => {
-    if (disabled) return;
     isDrawing.current = false;
     lastPoint.current = null;
   };
 
   const clearCanvas = (e?: React.MouseEvent) => {
-    if (disabled) return;
     e?.stopPropagation();
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext("2d");
@@ -226,7 +222,6 @@ function BaseSignbox({
 
   return (
     <SignatureWrapper
-      $disabled={disabled}
       aria-label="signbox-canvas"
       $theme={signboxTheme}
       $error={showError}
@@ -234,17 +229,39 @@ function BaseSignbox({
       $height={height}
       $width={width}
       $cursor={cursor}
+      $disabled={disabled}
     >
       <SignatureCanvas
         ref={canvasRef}
         id={id}
-        onMouseDown={(e) => startDrawing(e.nativeEvent)}
-        onMouseMove={(e) => draw(e.nativeEvent)}
-        onMouseUp={stopDrawing}
-        onMouseLeave={stopDrawing}
-        onTouchStart={(e) => startDrawing(e.nativeEvent)}
-        onTouchMove={(e) => draw(e.nativeEvent)}
-        onTouchEnd={stopDrawing}
+        onMouseDown={(e) => {
+          if (disabled) return;
+          startDrawing(e.nativeEvent);
+        }}
+        onMouseMove={(e) => {
+          if (disabled) return;
+          draw(e.nativeEvent);
+        }}
+        onMouseUp={() => {
+          if (disabled) return;
+          stopDrawing();
+        }}
+        onMouseLeave={() => {
+          if (disabled) return;
+          stopDrawing();
+        }}
+        onTouchStart={(e) => {
+          if (disabled) return;
+          startDrawing(e.nativeEvent);
+        }}
+        onTouchMove={(e) => {
+          if (disabled) return;
+          draw(e.nativeEvent);
+        }}
+        onTouchEnd={() => {
+          if (disabled) return;
+          stopDrawing();
+        }}
       />
       {clearable && (
         <Button
@@ -257,13 +274,20 @@ function BaseSignbox({
             self: css`
               height: 22px;
               width: 22px;
-              cursor: pointer;
               padding: 2px;
               border-radius: 2px;
+              &:disabled {
+                background-color: transparent;
+                box-shadow: none;
+              }
             `,
           }}
           aria-label="signbox-clearable"
-          onClick={(e) => clearCanvas(e)}
+          onClick={(e) => {
+            if (disabled) return;
+            clearCanvas(e);
+          }}
+          disabled={disabled}
           variant="transparent"
           icon={{
             image: RiEraserLine,

--- a/components/signbox.tsx
+++ b/components/signbox.tsx
@@ -47,7 +47,7 @@ function BaseSignbox({
   const lastPoint = useRef<{ x: number; y: number } | null>(null);
 
   const valueRef = useRef(value);
-  console.log(disabled);
+
   useEffect(() => {
     valueRef.current = value;
   }, [value]);

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -1740,7 +1740,13 @@ export const AllCaseDisabled: Story = {
         moneyProps: {
           separator: "dot",
           editableCurrency: true,
-          currencyOptions: [],
+          currencyOptions: [
+            {
+              id: "USD",
+              name: "US Dollar",
+              symbol: "$",
+            },
+          ],
           currency: value.currency,
         },
       },

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -1484,119 +1484,30 @@ export const AllCase: Story = {
     ];
 
     return (
-      <div
-        style={{
-          marginLeft: "auto",
-          marginRight: "auto",
-          display: "flex",
-          width: "100%",
-          flexDirection: "column",
-          gap: "0.5rem",
-          paddingTop: "1rem",
-          paddingBottom: "1rem",
-          maxWidth: "500px",
-        }}
-      >
-        <StatefulForm
-          onChange={({ currentState }) => {
-            const { chips, ...rest } = currentState;
-            void chips;
+      <StatefulForm
+        onChange={({ currentState }) => {
+          const { chips, ...rest } = currentState;
+          void chips;
 
-            setValue((prev) => ({
-              ...prev,
-              ...rest,
-            }));
-          }}
-          onValidityChange={setIsFormValid}
-          labelSize="14px"
-          fieldSize="14px"
-          fields={FIELDS}
-          formValues={value}
-          validationSchema={schema}
-          mode="onChange"
-        />
-      </div>
+          setValue((prev) => ({
+            ...prev,
+            ...rest,
+          }));
+        }}
+        onValidityChange={setIsFormValid}
+        labelSize="14px"
+        fieldSize="14px"
+        fields={FIELDS}
+        formValues={value}
+        validationSchema={schema}
+        mode="onChange"
+      />
     );
   },
 };
 
 export const AllCaseDisabled: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false);
-    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-      (data) => data.id === "US" || COUNTRY_CODES[206]
-    );
-
-    if (!DEFAULT_COUNTRY_CODES) {
-      throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
-    }
-
-    const FRUIT_OPTIONS: SelectboxOption[] = [
-      { text: "Apple", value: "1" },
-      { text: "Banana", value: "2" },
-      { text: "Orange", value: "3" },
-      { text: "Grape", value: "4" },
-      { text: "Pineapple", value: "5" },
-      { text: "Strawberry", value: "6" },
-      { text: "Watermelon", value: "7" },
-    ];
-
-    const BADGE_OPTIONS: BadgeProps[] = [
-      {
-        id: "1",
-        caption: "Anime",
-      },
-      {
-        id: "2",
-        caption: "Manga",
-      },
-      {
-        id: "3",
-        caption: "Comics",
-      },
-      {
-        id: "4",
-        caption: "Movies",
-      },
-      {
-        id: "5",
-        caption: "Podcasts",
-      },
-      {
-        id: "6",
-        caption: "TV Shows",
-      },
-      {
-        id: "7",
-        caption: "Novels",
-      },
-      {
-        id: "8",
-        caption: "Music",
-      },
-      {
-        id: "9",
-        caption: "Games",
-      },
-      {
-        id: "10",
-        caption: "Webtoons",
-      },
-    ];
-
-    const CURRENCY_OPTIONS: MoneyboxCurrencyOption[] = [
-      { id: "IDR", name: "Indonesian Rupiah", symbol: "Rp" },
-      { id: "USD", name: "US Dollar", symbol: "$" },
-      { id: "EUR", name: "Euro", symbol: "€" },
-      { id: "JPY", name: "Japanese Yen", symbol: "¥" },
-      { id: "GBP", name: "British Pound", symbol: "£" },
-      { id: "SGD", name: "Singapore Dollar", symbol: "$" },
-      { id: "AUD", name: "Australian Dollar", symbol: "$" },
-      { id: "MYR", name: "Malaysian Ringgit", symbol: "RM" },
-      { id: "KRW", name: "South Korean Won", symbol: "₩" },
-      { id: "CNY", name: "Chinese Yuan", symbol: "¥" },
-    ];
-
     interface AllCaseValueProps {
       text: string;
       time: string;
@@ -1652,7 +1563,7 @@ export const AllCaseDisabled: Story = {
       togglebox: false,
       signature: "",
       capsule: "",
-      country_code: DEFAULT_COUNTRY_CODES,
+      country_code: undefined,
       currency: "USD",
       pin: "",
     });
@@ -1689,203 +1600,6 @@ export const AllCaseDisabled: Story = {
       {
         type: "alphabet",
       },
-    ];
-
-    const handleOptionClicked = (badge: BadgeProps) => {
-      const isAlreadySelected = value.chips.selectedOptions.some(
-        (data) => data.id === badge.id
-      );
-
-      setValue((prev) => ({
-        ...prev,
-        chips: {
-          ...prev.chips,
-          selectedOptions: isAlreadySelected
-            ? prev.chips.selectedOptions.filter((data) => data.id !== badge.id)
-            : [...prev.chips.selectedOptions, badge],
-        },
-      }));
-    };
-
-    const badgeSchema = z.object({
-      id: z.string().optional(),
-      metadata: z.record(z.unknown()).optional(),
-      variant: z.string().optional(),
-      withCircle: z.boolean().optional(),
-      caption: z.string().optional(),
-      backgroundColor: z.string().optional(),
-      textColor: z.string().optional(),
-      circleColor: z.string().optional(),
-    });
-
-    const schema = z.object({
-      text: z.string().min(3, "Text must be at least 3 characters"),
-      email: z.string().email("Please enter a valid email address"),
-      time: z.string().optional(),
-      number: z.string().refine((val) => val === "" || !isNaN(Number(val)), {
-        message: "Number must be numeric",
-      }),
-      password: z.string().min(6, "Password must be at least 6 characters"),
-      textarea: z.string().min(10, "Text must be at least 10 characters"),
-      check: z.boolean(),
-      chips: z.object({
-        searchText: z.string().optional(),
-        selectedOptions: z.array(badgeSchema).optional(),
-      }),
-      color: z.string().min(4, "Color is required"),
-      combo: z
-        .array(z.string().min(1, "Choose one"))
-        .min(1, "Combo must have at least one item")
-        .refine(
-          (arr) =>
-            arr.every((val) =>
-              FRUIT_OPTIONS.some((opt) => {
-                return opt.value === val;
-              })
-            ),
-          "Invalid value in combo"
-        ),
-      date: z.array(
-        z
-          .string()
-          .nonempty("Choose your date")
-          .refine(
-            (val) =>
-              /^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/\d{4}$/.test(val),
-            {
-              message: "Invalid date",
-            }
-          )
-      ),
-      file_drop_box: z.any().optional(),
-      file: z
-        .preprocess((value) => {
-          if (value instanceof FileList) return Array.from(value);
-          if (Array.isArray(value)) return value;
-          return [];
-        }, z.array(z.any()))
-        .refine((files) => files.length > 0, {
-          message: "At least one file is required",
-        })
-        .refine((files) => files.every((file) => file.type === "image/jpeg"), {
-          message: "Only JPEG files are allowed",
-        })
-        .refine(
-          (files) => files.every((file) => file.size <= 5 * 1024 * 1024),
-          {
-            message: "Each file must be 5MB or less",
-          }
-        ),
-      image: z
-        .any()
-        .refine(
-          (file) => {
-            return file?.type === "image/jpeg";
-          },
-          {
-            message: "Only JPEG file are allowed",
-          }
-        )
-        .refine((file) => file?.size <= 5 * 1024 * 1024, {
-          message: "File size must be 5MB or less",
-        }),
-      money: z.string().optional(),
-      signature: z.string().min(1, "Signature is required"),
-      phone: z.string().min(8, "Phone number must be 8 digits").optional(),
-      rating: z.string().optional(),
-      thumb_field: z.boolean(),
-      togglebox: z.boolean(),
-      capsule: z.string().max(4, "Paid is required"),
-      pin: z.string().min(4, "Pinbox does not follow the acceptable format"),
-      country_code: z
-        .object({
-          id: z.string(),
-          name: z.string(),
-          flag: z.string(),
-          code: z.string(),
-        })
-        .optional(),
-    });
-
-    const onChangeForm = (e?: StatefulOnChangeType) => {
-      if (e && "target" in e) {
-        const target = e.target;
-        const { name, value } = target;
-
-        let updatedValue: FormValueType = value;
-
-        if (target instanceof HTMLInputElement && target.type === "checkbox") {
-          updatedValue = target.checked;
-        }
-
-        if (target.name === "chips") {
-          setValue((prev) => ({
-            ...prev,
-            chips: { ...prev.chips, ["searchText"]: String(updatedValue) },
-          }));
-        } else {
-          setValue((prev) => ({ ...prev, [name]: updatedValue }));
-        }
-      }
-    };
-
-    const onFileDropped = async ({
-      error,
-      files,
-      setProgressLabel,
-      succeed,
-    }: OnFileDroppedFunction) => {
-      const file = files[0];
-      setProgressLabel(`Uploading ${file.name}`);
-
-      return new Promise<void>((resolve) => {
-        let progress = 0;
-        const interval = setInterval(() => {
-          progress += 20;
-
-          if (progress >= 100) {
-            clearInterval(interval);
-            if (file === null) {
-              error(file, `file ${files[0].name} is not uploaded`);
-            } else {
-              succeed(file);
-            }
-            setProgressLabel(`Uploaded ${files[0].name}`);
-            resolve();
-          }
-        }, 300);
-      });
-    };
-
-    const onComplete = ({
-      failedFiles,
-      setProgressLabel,
-      succeedFiles,
-    }: OnCompleteFunction) => {
-      setValue((prev) => ({
-        ...prev,
-        file_drop_box: succeedFiles,
-      }));
-      console.log(succeedFiles, "This is succeedFiles");
-      console.log(failedFiles, "This is failedFiles");
-      setProgressLabel(
-        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`
-      );
-    };
-
-    const MONTH_NAMES = [
-      { text: "JAN", value: "1" },
-      { text: "FEB", value: "2" },
-      { text: "MAR", value: "3" },
-      { text: "APR", value: "4" },
-      { text: "MAY", value: "5" },
-      { text: "JUN", value: "6" },
-      { text: "JUL", value: "7" },
-      { text: "AUG", value: "8" },
-      { text: "SEP", value: "9" },
-      { text: "OCT", value: "10" },
-      { text: "NOV", value: "11" },
-      { text: "DEC", value: "12" },
     ];
 
     const FIELDS: FormFieldGroup[] = [
@@ -1978,7 +1692,7 @@ export const AllCaseDisabled: Story = {
         placeholder: "Select a fruit...",
         helper: "This field allows you to select one or more options",
         comboboxProps: {
-          options: FRUIT_OPTIONS,
+          options: [],
         },
       },
       {
@@ -1989,7 +1703,7 @@ export const AllCaseDisabled: Story = {
         placeholder: "Select a date",
         helper: "This field allows you to select a date",
         dateProps: {
-          monthNames: MONTH_NAMES,
+          monthNames: [],
         },
       },
       {
@@ -1998,10 +1712,6 @@ export const AllCaseDisabled: Story = {
         type: "file_drop_box",
         required: true,
         helper: "This field allows you to upload files via drag and drop",
-        fileDropBoxProps: {
-          onComplete,
-          onFileDropped,
-        },
       },
       {
         name: "file",
@@ -2030,7 +1740,7 @@ export const AllCaseDisabled: Story = {
         moneyProps: {
           separator: "dot",
           editableCurrency: true,
-          currencyOptions: CURRENCY_OPTIONS,
+          currencyOptions: [],
           currency: value.currency,
         },
       },
@@ -2078,25 +1788,10 @@ export const AllCaseDisabled: Story = {
         required: false,
         helper: "This field allows you to select multiple items",
         chipsProps: {
-          options: BADGE_OPTIONS,
-          styles: {
-            chipStyle: css`
-              width: 100%;
-              gap: 0.5rem;
-              border-color: transparent;
-            `,
-            chipContainerStyle: css`
-              gap: 4px;
-            `,
-            chipsDrawerStyle: css`
-              min-width: 250px;
-            `,
-          },
-          onOptionClicked: handleOptionClicked,
+          options: [],
           selectedOptions: value.chips.selectedOptions,
           inputValue: value.chips.searchText,
         },
-        onChange: onChangeForm,
       },
       {
         name: "capsule",
@@ -2118,39 +1813,23 @@ export const AllCaseDisabled: Story = {
     ];
 
     return (
-      <div
-        style={{
-          marginLeft: "auto",
-          marginRight: "auto",
-          display: "flex",
-          width: "100%",
-          flexDirection: "column",
-          gap: "0.5rem",
-          paddingTop: "1rem",
-          paddingBottom: "1rem",
-          maxWidth: "500px",
-        }}
-      >
-        <StatefulForm
-          disabled
-          onChange={({ currentState }) => {
-            const { chips, ...rest } = currentState;
-            void chips;
+      <StatefulForm
+        disabled
+        onChange={({ currentState }) => {
+          const { chips, ...rest } = currentState;
+          void chips;
 
-            setValue((prev) => ({
-              ...prev,
-              ...rest,
-            }));
-          }}
-          onValidityChange={setIsFormValid}
-          labelSize="14px"
-          fieldSize="14px"
-          fields={FIELDS}
-          formValues={value}
-          validationSchema={schema}
-          mode="onChange"
-        />
-      </div>
+          setValue((prev) => ({
+            ...prev,
+            ...rest,
+          }));
+        }}
+        labelSize="14px"
+        fieldSize="14px"
+        fields={FIELDS}
+        formValues={value}
+        mode="onChange"
+      />
     );
   },
 };

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -1485,6 +1485,16 @@ export const AllCase: Story = {
 
     return (
       <StatefulForm
+        styles={{
+          containerStyle: css`
+            margin-left: auto;
+            margin-right: auto;
+            display: flex;
+            width: 100%;
+            padding: 1rem;
+            max-width: 500px;
+          `,
+        }}
         onChange={({ currentState }) => {
           const { chips, ...rest } = currentState;
           void chips;
@@ -1820,6 +1830,16 @@ export const AllCaseDisabled: Story = {
 
     return (
       <StatefulForm
+        styles={{
+          containerStyle: css`
+            margin-left: auto;
+            margin-right: auto;
+            display: flex;
+            width: 100%;
+            padding: 1rem;
+            max-width: 500px;
+          `,
+        }}
         disabled
         onChange={({ currentState }) => {
           const { chips, ...rest } = currentState;

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -1519,3 +1519,638 @@ export const AllCase: Story = {
     );
   },
 };
+
+export const AllCaseDisabled: Story = {
+  render: () => {
+    const [isFormValid, setIsFormValid] = useState(false);
+    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
+      (data) => data.id === "US" || COUNTRY_CODES[206]
+    );
+
+    if (!DEFAULT_COUNTRY_CODES) {
+      throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
+    }
+
+    const FRUIT_OPTIONS: SelectboxOption[] = [
+      { text: "Apple", value: "1" },
+      { text: "Banana", value: "2" },
+      { text: "Orange", value: "3" },
+      { text: "Grape", value: "4" },
+      { text: "Pineapple", value: "5" },
+      { text: "Strawberry", value: "6" },
+      { text: "Watermelon", value: "7" },
+    ];
+
+    const BADGE_OPTIONS: BadgeProps[] = [
+      {
+        id: "1",
+        caption: "Anime",
+      },
+      {
+        id: "2",
+        caption: "Manga",
+      },
+      {
+        id: "3",
+        caption: "Comics",
+      },
+      {
+        id: "4",
+        caption: "Movies",
+      },
+      {
+        id: "5",
+        caption: "Podcasts",
+      },
+      {
+        id: "6",
+        caption: "TV Shows",
+      },
+      {
+        id: "7",
+        caption: "Novels",
+      },
+      {
+        id: "8",
+        caption: "Music",
+      },
+      {
+        id: "9",
+        caption: "Games",
+      },
+      {
+        id: "10",
+        caption: "Webtoons",
+      },
+    ];
+
+    const CURRENCY_OPTIONS: MoneyboxCurrencyOption[] = [
+      { id: "IDR", name: "Indonesian Rupiah", symbol: "Rp" },
+      { id: "USD", name: "US Dollar", symbol: "$" },
+      { id: "EUR", name: "Euro", symbol: "€" },
+      { id: "JPY", name: "Japanese Yen", symbol: "¥" },
+      { id: "GBP", name: "British Pound", symbol: "£" },
+      { id: "SGD", name: "Singapore Dollar", symbol: "$" },
+      { id: "AUD", name: "Australian Dollar", symbol: "$" },
+      { id: "MYR", name: "Malaysian Ringgit", symbol: "RM" },
+      { id: "KRW", name: "South Korean Won", symbol: "₩" },
+      { id: "CNY", name: "Chinese Yuan", symbol: "¥" },
+    ];
+
+    interface AllCaseValueProps {
+      text: string;
+      time: string;
+      email: string;
+      number: string;
+      password: string;
+      textarea: string;
+      rating: string;
+      check: boolean;
+      chips?: {
+        searchText: string;
+        selectedOptions: BadgeProps[];
+      };
+      color: string;
+      combo: string[];
+      date: string[];
+      file_drop_box?: File[];
+      file: File[] | undefined;
+      image: File | undefined;
+      money: string;
+      phone: string;
+      thumb_field: boolean;
+      togglebox: boolean;
+      signature: string;
+      capsule: string;
+      country_code?: CountryCodeProps;
+      currency: string;
+      pin: string;
+    }
+
+    const [value, setValue] = useState<AllCaseValueProps>({
+      text: "",
+      time: "",
+      email: "",
+      number: "",
+      password: "",
+      textarea: "",
+      rating: "",
+      check: false,
+      chips: {
+        searchText: "",
+        selectedOptions: [],
+      },
+      color: "",
+      combo: [],
+      date: [""],
+      file_drop_box: [] as File[],
+      file: undefined,
+      image: undefined,
+      money: "",
+      phone: "",
+      thumb_field: false,
+      togglebox: false,
+      signature: "",
+      capsule: "",
+      country_code: DEFAULT_COUNTRY_CODES,
+      currency: "USD",
+      pin: "",
+    });
+
+    const CAPSULE_TABS: CapsuleTab[] = [
+      {
+        id: "paid",
+        title: "Paid",
+      },
+      {
+        id: "unpaid",
+        title: "Unpaid",
+      },
+    ];
+
+    const PARTS_INPUT: PinboxParts[] = [
+      {
+        type: "static",
+        text: "S",
+      },
+      {
+        type: "alphanumeric",
+      },
+      {
+        type: "digit",
+      },
+      {
+        type: "alphabet",
+      },
+      {
+        type: "static",
+        text: "-",
+      },
+      {
+        type: "alphabet",
+      },
+    ];
+
+    const handleOptionClicked = (badge: BadgeProps) => {
+      const isAlreadySelected = value.chips.selectedOptions.some(
+        (data) => data.id === badge.id
+      );
+
+      setValue((prev) => ({
+        ...prev,
+        chips: {
+          ...prev.chips,
+          selectedOptions: isAlreadySelected
+            ? prev.chips.selectedOptions.filter((data) => data.id !== badge.id)
+            : [...prev.chips.selectedOptions, badge],
+        },
+      }));
+    };
+
+    const badgeSchema = z.object({
+      id: z.string().optional(),
+      metadata: z.record(z.unknown()).optional(),
+      variant: z.string().optional(),
+      withCircle: z.boolean().optional(),
+      caption: z.string().optional(),
+      backgroundColor: z.string().optional(),
+      textColor: z.string().optional(),
+      circleColor: z.string().optional(),
+    });
+
+    const schema = z.object({
+      text: z.string().min(3, "Text must be at least 3 characters"),
+      email: z.string().email("Please enter a valid email address"),
+      time: z.string().optional(),
+      number: z.string().refine((val) => val === "" || !isNaN(Number(val)), {
+        message: "Number must be numeric",
+      }),
+      password: z.string().min(6, "Password must be at least 6 characters"),
+      textarea: z.string().min(10, "Text must be at least 10 characters"),
+      check: z.boolean(),
+      chips: z.object({
+        searchText: z.string().optional(),
+        selectedOptions: z.array(badgeSchema).optional(),
+      }),
+      color: z.string().min(4, "Color is required"),
+      combo: z
+        .array(z.string().min(1, "Choose one"))
+        .min(1, "Combo must have at least one item")
+        .refine(
+          (arr) =>
+            arr.every((val) =>
+              FRUIT_OPTIONS.some((opt) => {
+                return opt.value === val;
+              })
+            ),
+          "Invalid value in combo"
+        ),
+      date: z.array(
+        z
+          .string()
+          .nonempty("Choose your date")
+          .refine(
+            (val) =>
+              /^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/\d{4}$/.test(val),
+            {
+              message: "Invalid date",
+            }
+          )
+      ),
+      file_drop_box: z.any().optional(),
+      file: z
+        .preprocess((value) => {
+          if (value instanceof FileList) return Array.from(value);
+          if (Array.isArray(value)) return value;
+          return [];
+        }, z.array(z.any()))
+        .refine((files) => files.length > 0, {
+          message: "At least one file is required",
+        })
+        .refine((files) => files.every((file) => file.type === "image/jpeg"), {
+          message: "Only JPEG files are allowed",
+        })
+        .refine(
+          (files) => files.every((file) => file.size <= 5 * 1024 * 1024),
+          {
+            message: "Each file must be 5MB or less",
+          }
+        ),
+      image: z
+        .any()
+        .refine(
+          (file) => {
+            return file?.type === "image/jpeg";
+          },
+          {
+            message: "Only JPEG file are allowed",
+          }
+        )
+        .refine((file) => file?.size <= 5 * 1024 * 1024, {
+          message: "File size must be 5MB or less",
+        }),
+      money: z.string().optional(),
+      signature: z.string().min(1, "Signature is required"),
+      phone: z.string().min(8, "Phone number must be 8 digits").optional(),
+      rating: z.string().optional(),
+      thumb_field: z.boolean(),
+      togglebox: z.boolean(),
+      capsule: z.string().max(4, "Paid is required"),
+      pin: z.string().min(4, "Pinbox does not follow the acceptable format"),
+      country_code: z
+        .object({
+          id: z.string(),
+          name: z.string(),
+          flag: z.string(),
+          code: z.string(),
+        })
+        .optional(),
+    });
+
+    const onChangeForm = (e?: StatefulOnChangeType) => {
+      if (e && "target" in e) {
+        const target = e.target;
+        const { name, value } = target;
+
+        let updatedValue: FormValueType = value;
+
+        if (target instanceof HTMLInputElement && target.type === "checkbox") {
+          updatedValue = target.checked;
+        }
+
+        if (target.name === "chips") {
+          setValue((prev) => ({
+            ...prev,
+            chips: { ...prev.chips, ["searchText"]: String(updatedValue) },
+          }));
+        } else {
+          setValue((prev) => ({ ...prev, [name]: updatedValue }));
+        }
+      }
+    };
+
+    const onFileDropped = async ({
+      error,
+      files,
+      setProgressLabel,
+      succeed,
+    }: OnFileDroppedFunction) => {
+      const file = files[0];
+      setProgressLabel(`Uploading ${file.name}`);
+
+      return new Promise<void>((resolve) => {
+        let progress = 0;
+        const interval = setInterval(() => {
+          progress += 20;
+
+          if (progress >= 100) {
+            clearInterval(interval);
+            if (file === null) {
+              error(file, `file ${files[0].name} is not uploaded`);
+            } else {
+              succeed(file);
+            }
+            setProgressLabel(`Uploaded ${files[0].name}`);
+            resolve();
+          }
+        }, 300);
+      });
+    };
+
+    const onComplete = ({
+      failedFiles,
+      setProgressLabel,
+      succeedFiles,
+    }: OnCompleteFunction) => {
+      setValue((prev) => ({
+        ...prev,
+        file_drop_box: succeedFiles,
+      }));
+      console.log(succeedFiles, "This is succeedFiles");
+      console.log(failedFiles, "This is failedFiles");
+      setProgressLabel(
+        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`
+      );
+    };
+
+    const MONTH_NAMES = [
+      { text: "JAN", value: "1" },
+      { text: "FEB", value: "2" },
+      { text: "MAR", value: "3" },
+      { text: "APR", value: "4" },
+      { text: "MAY", value: "5" },
+      { text: "JUN", value: "6" },
+      { text: "JUL", value: "7" },
+      { text: "AUG", value: "8" },
+      { text: "SEP", value: "9" },
+      { text: "OCT", value: "10" },
+      { text: "NOV", value: "11" },
+      { text: "DEC", value: "12" },
+    ];
+
+    const FIELDS: FormFieldGroup[] = [
+      {
+        name: "text",
+        title: "Text",
+        type: "text",
+        required: true,
+        placeholder: "Enter text",
+        helper: "This field is used to enter a single line of text",
+      },
+      {
+        name: "email",
+        title: "Email",
+        type: "email",
+        required: true,
+        placeholder: "Enter email address",
+        helper: "This field is used to enter an email address",
+      },
+      {
+        name: "time",
+        title: "Time",
+        type: "time",
+        required: true,
+        placeholder: "Enter time",
+        helper: "This field allows you to select a time",
+      },
+      {
+        name: "number",
+        title: "Number",
+        type: "number",
+        required: true,
+        placeholder: "Enter number",
+        helper: "This field only accepts numeric values",
+      },
+      {
+        name: "password",
+        title: "Password",
+        type: "password",
+        required: true,
+        placeholder: "Enter password",
+        helper: "This field is used to enter a secure password",
+      },
+      {
+        name: "textarea",
+        title: "Textarea",
+        type: "textarea",
+        rows: 3,
+        required: true,
+        placeholder: "Enter text here",
+        helper: "This field allows you to enter multiple lines of text",
+      },
+      {
+        name: "pin",
+        title: "Pin",
+        type: "pin",
+        required: true,
+        helper: "This pinbox allows you to enter your PIN code.",
+        pinboxProps: {
+          parts: PARTS_INPUT,
+        },
+      },
+      {
+        name: "check",
+        title: "Checkbox",
+        placeholder: "Check",
+        type: "checkbox",
+        helper: "This checkbox allows you to toggle a boolean value",
+      },
+      {
+        name: "radio",
+        title: "Radio",
+        placeholder: "Radio",
+        type: "radio",
+        helper: "This radio allows you to select one option",
+      },
+      {
+        name: "color",
+        title: "Color",
+        type: "color",
+        required: true,
+        placeholder: "Enter the color here",
+        helper: "This field allows you to pick or input a color value",
+      },
+      {
+        name: "combo",
+        title: "Combo",
+        type: "combo",
+        required: true,
+        placeholder: "Select a fruit...",
+        helper: "This field allows you to select one or more options",
+        comboboxProps: {
+          options: FRUIT_OPTIONS,
+        },
+      },
+      {
+        name: "date",
+        title: "Date",
+        type: "date",
+        required: true,
+        placeholder: "Select a date",
+        helper: "This field allows you to select a date",
+        dateProps: {
+          monthNames: MONTH_NAMES,
+        },
+      },
+      {
+        name: "file_drop_box",
+        title: "File Drop Box",
+        type: "file_drop_box",
+        required: true,
+        helper: "This field allows you to upload files via drag and drop",
+        fileDropBoxProps: {
+          onComplete,
+          onFileDropped,
+        },
+      },
+      {
+        name: "file",
+        title: "File",
+        type: "file",
+        required: true,
+        helper: "This field allows you to upload one or more files",
+        fileInputBoxProps: {
+          accept: "image/jpeg",
+        },
+      },
+      {
+        name: "image",
+        title: "Image",
+        type: "image",
+        required: true,
+        helper: "This field allows you to upload and preview an image",
+      },
+      {
+        name: "money",
+        title: "Money",
+        type: "money",
+        required: true,
+        placeholder: "Enter amount",
+        helper: "This field is used to input a monetary value",
+        moneyProps: {
+          separator: "dot",
+          editableCurrency: true,
+          currencyOptions: CURRENCY_OPTIONS,
+          currency: value.currency,
+        },
+      },
+      {
+        name: "phone",
+        title: "Phone",
+        type: "phone",
+        required: true,
+        placeholder: "Enter phone number",
+        helper: "This field allows you to enter a phone number",
+      },
+      {
+        name: "signature",
+        title: "Signature",
+        type: "signbox",
+        required: true,
+        helper: "This field allows you to draw a signature",
+      },
+      {
+        name: "rating",
+        title: "Rating",
+        type: "rating",
+        required: true,
+        helper: "This field allows you to provide a rating",
+      },
+      {
+        name: "thumb_field",
+        title: "Thumb Field",
+        type: "thumbfield",
+        required: true,
+        helper: "This field allows you to select a thumbs-up or down value",
+      },
+      {
+        name: "togglebox",
+        title: "Togglebox",
+        type: "toggle",
+        placeholder: "Toggle",
+        required: true,
+        helper: "This field allows you to toggle a boolean state",
+      },
+      {
+        name: "chips",
+        title: "Chips",
+        type: "chips",
+        required: false,
+        helper: "This field allows you to select multiple items",
+        chipsProps: {
+          options: BADGE_OPTIONS,
+          styles: {
+            chipStyle: css`
+              width: 100%;
+              gap: 0.5rem;
+              border-color: transparent;
+            `,
+            chipContainerStyle: css`
+              gap: 4px;
+            `,
+            chipsDrawerStyle: css`
+              min-width: 250px;
+            `,
+          },
+          onOptionClicked: handleOptionClicked,
+          selectedOptions: value.chips.selectedOptions,
+          inputValue: value.chips.searchText,
+        },
+        onChange: onChangeForm,
+      },
+      {
+        name: "capsule",
+        title: "Monetary Value",
+        type: "capsule",
+        required: true,
+        helper: "This field allows you to switch between monetary options",
+        capsuleProps: {
+          tabs: CAPSULE_TABS,
+        },
+      },
+      {
+        name: "text",
+        title: "Save",
+        type: "button",
+        required: true,
+        rowJustifyPosition: "flex-end",
+      },
+    ];
+
+    return (
+      <div
+        style={{
+          marginLeft: "auto",
+          marginRight: "auto",
+          display: "flex",
+          width: "100%",
+          flexDirection: "column",
+          gap: "0.5rem",
+          paddingTop: "1rem",
+          paddingBottom: "1rem",
+          maxWidth: "500px",
+        }}
+      >
+        <StatefulForm
+          disabled
+          onChange={({ currentState }) => {
+            const { chips, ...rest } = currentState;
+            void chips;
+
+            setValue((prev) => ({
+              ...prev,
+              ...rest,
+            }));
+          }}
+          onValidityChange={setIsFormValid}
+          labelSize="14px"
+          fieldSize="14px"
+          fields={FIELDS}
+          formValues={value}
+          validationSchema={schema}
+          mode="onChange"
+        />
+      </div>
+    );
+  },
+};

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -119,6 +119,7 @@ export interface StatefulFormProps<Z extends ZodTypeAny> {
   onChange?: (args: { currentState: any }) => void;
   autoFocusField?: string;
   styles?: StatefulFormStyles;
+  disabled?: boolean;
 }
 
 export interface StatefulFormStyles {
@@ -208,6 +209,7 @@ function StatefulForm<Z extends ZodTypeAny>({
   onChange,
   styles,
   autoFocusField,
+  disabled,
 }: StatefulFormProps<Z>) {
   const handleFieldChange = (name: keyof TypeOf<Z>, value: FormValueType) => {
     onChange?.({ currentState: { [name]: value } });
@@ -333,6 +335,7 @@ function StatefulForm<Z extends ZodTypeAny>({
         fieldSize={fieldSize}
         control={control}
         fields={fields}
+        disabled={disabled}
         formValues={formValues}
         register={register}
         errors={errors}
@@ -413,6 +416,7 @@ interface FormFieldsProps<T extends FieldValues> {
   autoFocusField?: string;
   styles?: StatefulFormStyles;
   rowWithFrame?: boolean;
+  disabled?: boolean;
 }
 
 function FormFields<T extends FieldValues>({
@@ -429,6 +433,7 @@ function FormFields<T extends FieldValues>({
   styles,
   autoFocusField,
   rowWithFrame,
+  disabled,
 }: FormFieldsProps<T>) {
   const { currentTheme } = useTheme();
   const statefulFormTheme = currentTheme?.statefulForm;
@@ -532,6 +537,7 @@ function FormFields<T extends FieldValues>({
                         setValue={setValue}
                         onChange={onChange}
                         autoFocusField={autoFocusField}
+                        disabled={disabled}
                         styles={styles}
                         shouldShowError={shouldShowError}
                         rowWithFrame={true}
@@ -579,7 +585,7 @@ function FormFields<T extends FieldValues>({
                   errorMessage={
                     errors[field.name as keyof T]?.message as string | undefined
                   }
-                  disabled={field.disabled}
+                  disabled={field.disabled || disabled}
                   {...field.textboxProps}
                   styles={{
                     ...field.textboxProps?.styles,
@@ -652,7 +658,7 @@ function FormFields<T extends FieldValues>({
                           | string
                           | undefined
                       }
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       {...field.pinboxProps}
                       styles={{
                         ...field.pinboxProps?.styles,
@@ -729,7 +735,7 @@ function FormFields<T extends FieldValues>({
                       field.onClick(e);
                     }
                   }}
-                  disabled={field.disabled}
+                  disabled={field.disabled || disabled}
                 >
                   {field.icon && (
                     <field.icon size={fieldSize ? parseInt(fieldSize) : 16} />
@@ -762,7 +768,7 @@ function FormFields<T extends FieldValues>({
                   errorMessage={
                     errors[field.name as keyof T]?.message as string | undefined
                   }
-                  disabled={field.disabled}
+                  disabled={field.disabled || disabled}
                   {...field.timeboxProps}
                   styles={{
                     ...field.timeboxProps?.styles,
@@ -850,7 +856,7 @@ function FormFields<T extends FieldValues>({
                   errorMessage={
                     errors[field.name as keyof T]?.message as string | undefined
                   }
-                  disabled={field.disabled}
+                  disabled={field.disabled || disabled}
                   {...field.textareaProps}
                   styles={{
                     ...field.textareaProps?.styles,
@@ -925,7 +931,7 @@ function FormFields<T extends FieldValues>({
                         }
                         field.onChange?.(e);
                       }}
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       {...field.checkboxProps}
                       styles={{
                         ...field.checkboxProps?.styles,
@@ -1021,7 +1027,7 @@ function FormFields<T extends FieldValues>({
                         }
                         field.onChange?.(e);
                       }}
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       {...field.radioProps}
                       styles={{
                         ...field.radioProps?.styles,
@@ -1115,7 +1121,7 @@ function FormFields<T extends FieldValues>({
                           | string
                           | undefined
                       }
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       {...field.phoneboxProps}
                       styles={{
                         ...field.phoneboxProps?.styles,
@@ -1186,7 +1192,7 @@ function FormFields<T extends FieldValues>({
                       }}
                       showError={shouldShowError(field.name)}
                       errorMessage={fieldState.error?.message}
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       {...field.colorboxProps}
                       styles={{
                         ...field.colorboxProps?.styles,
@@ -1237,7 +1243,7 @@ function FormFields<T extends FieldValues>({
                   helper={field.helper}
                   name={field.name}
                   required={field.required}
-                  disabled={field.disabled}
+                  disabled={field.disabled || disabled}
                   {...register(field.name as Path<T>, {
                     onChange: (e) => {
                       if (field.onChange) {
@@ -1280,7 +1286,7 @@ function FormFields<T extends FieldValues>({
                   showError={shouldShowError(field.name)}
                   helper={field.helper}
                   name={field.name}
-                  disabled={field.disabled}
+                  disabled={field.disabled || disabled}
                   errorMessage={
                     errors[field.name as keyof T]?.message as string | undefined
                   }
@@ -1369,7 +1375,7 @@ function FormFields<T extends FieldValues>({
                     }
                   }}
                   label={field.title}
-                  disabled={field.disabled}
+                  disabled={field.disabled || disabled}
                   required={field.required}
                   {...register(field.name as Path<T>, {
                     onChange: (e) => {
@@ -1441,7 +1447,7 @@ function FormFields<T extends FieldValues>({
                   errorMessage={
                     errors[field.name as keyof T]?.message as string | undefined
                   }
-                  disabled={field.disabled}
+                  disabled={field.disabled || disabled}
                   {...field.signboxProps}
                   styles={{
                     ...field.signboxProps?.styles,
@@ -1493,7 +1499,7 @@ function FormFields<T extends FieldValues>({
                       placeholder={field.placeholder}
                       value={rhf.value ?? ""}
                       required={field.required}
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       onChange={(e) => {
                         const { name, value } = e.target;
 
@@ -1597,7 +1603,7 @@ function FormFields<T extends FieldValues>({
                       }}
                       placeholder={field.placeholder}
                       selectedDates={controllerField.value}
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       {...field.dateProps}
                       styles={{
                         ...field?.dateProps?.styles,
@@ -1677,7 +1683,7 @@ function FormFields<T extends FieldValues>({
                         }
                       }}
                       selectedOptions={controllerField.value}
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       {...field.comboboxProps}
                       strict={field?.comboboxProps?.strict ?? true}
                       styles={{
@@ -1732,7 +1738,7 @@ function FormFields<T extends FieldValues>({
                       labelPosition={field.labelPosition}
                       required={field.required}
                       filterPlaceholder={field.placeholder}
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       inputValue={controllerField.value}
                       setInputValue={(e) => {
                         controllerField?.onChange(e);
@@ -1794,7 +1800,7 @@ function FormFields<T extends FieldValues>({
                       }}
                       showError={!!fieldState.error}
                       errorMessage={fieldState.error?.message}
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       {...field.ratingProps}
                       styles={{
                         ...field.ratingProps?.styles,
@@ -1859,7 +1865,7 @@ function FormFields<T extends FieldValues>({
                           | string
                           | undefined
                       }
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       {...field.thumbFieldProps}
                       styles={{
                         ...field.thumbFieldProps?.styles,
@@ -1919,7 +1925,7 @@ function FormFields<T extends FieldValues>({
                           | string
                           | undefined
                       }
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       {...field.toggleboxProps}
                       title={field.title}
                       label={field.placeholder}
@@ -1980,7 +1986,7 @@ function FormFields<T extends FieldValues>({
                       required={field.required}
                       activeTab={controllerField.value}
                       helper={field.helper}
-                      disabled={field.disabled}
+                      disabled={field.disabled || disabled}
                       onTabChange={(e) => {
                         const inputValueEvent = {
                           target: { name: field.name, value: e },

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -212,6 +212,7 @@ function StatefulForm<Z extends ZodTypeAny>({
   disabled,
 }: StatefulFormProps<Z>) {
   const handleFieldChange = (name: keyof TypeOf<Z>, value: FormValueType) => {
+    if (disabled) return;
     onChange?.({ currentState: { [name]: value } });
   };
 

--- a/components/togglebox.tsx
+++ b/components/togglebox.tsx
@@ -58,6 +58,7 @@ function BaseTogglebox({
       aria-label="togglebox-row-wrapper"
     >
       <StyledLabel
+        $disabled={disabled}
         animate={{ opacity: 1, scale: 1 }}
         exit={{ opacity: 0, scale: 0.8 }}
         transition={{ duration: 0.2 }}
@@ -77,7 +78,12 @@ function BaseTogglebox({
           type="checkbox"
           checked={checked}
           disabled={disabled}
-          onChange={onChange}
+          onChange={(e) => {
+            if (disabled) return;
+            if (onChange) {
+              onChange(e);
+            }
+          }}
         />
         <ToggleBackground $checked={checked} $theme={toggleboxTheme} />
         <ToggleButton
@@ -113,6 +119,7 @@ function BaseTogglebox({
         >
           {label && (
             <StatefulForm.Label
+              disabled={disabled}
               htmlFor={disabled ? null : id}
               styles={{ self: styles?.labelStyle }}
               label={label}
@@ -147,7 +154,6 @@ function Togglebox({
   errorMessage,
   actions,
   helper,
-  disabled,
   name,
   id,
   title,
@@ -155,6 +161,7 @@ function Togglebox({
   labelGap,
   labelWidth,
   labelPosition,
+  disabled,
   ...rest
 }: ToggleboxProps) {
   const inputId = StatefulForm.sanitizeId({
@@ -241,7 +248,6 @@ const ToggleboxWrapper = styled.div<{
       cursor: not-allowed;
       opacity: ${$theme?.disabledOpacity ?? 0.5};
       user-select: none;
-      pointer-events: none;
     `};
 
   ${({ $style }) => $style}
@@ -255,12 +261,19 @@ const ToggleboxTextWrapper = styled.div<{ $style?: CSSProp }>`
   ${({ $style }) => $style}
 `;
 
-const StyledLabel = styled(motion.label)`
+const StyledLabel = styled(motion.label)<{ $disabled?: boolean }>`
   position: relative;
   display: flex;
   flex-direction: row;
   align-items: center;
   cursor: pointer;
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+      pointer-events: none;
+    `}
 `;
 
 const StyledInput = styled.input`

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -836,7 +836,7 @@ describe("StatefulForm", () => {
           .and("have.css", "user-select", "none");
       });
 
-      context("when add interaction", () => {
+      context("when trying to interact", () => {
         it("should not change value", () => {
           const onChange = cy.spy().as("onChange");
           cy.mount(

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -812,29 +812,16 @@ describe("StatefulForm", () => {
   });
 
   context("disabled", () => {
-    const INPUT_WITH_DISABLED: FormFieldGroup[] = ALL_INPUT.map((group) =>
-      Array.isArray(group)
-        ? group.map((item) => ({
-            ...item,
-            disabled: true,
-          }))
-        : {
-            ...group,
-            disabled: true,
-          }
-    );
-    context("when given true", () => {
+    context("when given by parent", () => {
       it("should render with cursor not-allowed and user-select none", () => {
+        const onChange = cy.spy().as("onChange");
         cy.mount(
           <StatefulForm
-            fields={INPUT_WITH_DISABLED}
+            fields={ALL_INPUT}
             formValues={allValue}
+            disabled={true}
             mode="onChange"
-            styles={{
-              containerStyle: css`
-                width: 480px;
-              `,
-            }}
+            onChange={onChange}
           />
         );
 
@@ -848,22 +835,85 @@ describe("StatefulForm", () => {
           .should("have.css", "cursor", "not-allowed")
           .and("have.css", "user-select", "none");
       });
+
+      context("when add interaction", () => {
+        it("should not change value", () => {
+          const onChange = cy.spy().as("onChange");
+          cy.mount(
+            <StatefulForm
+              fields={ALL_INPUT}
+              formValues={allValue}
+              disabled={true}
+              mode="onChange"
+              onChange={onChange}
+            />
+          );
+
+          cy.get("input, textarea, [role='radio'], [role='checkbox']").each(
+            ($el) => {
+              cy.wrap($el).should("be.disabled").click({ force: true });
+            }
+          );
+
+          cy.get("@onChange").should("not.have.been.called");
+        });
+      });
     });
 
-    it("should renders with disabled each input", () => {
-      cy.mount(
-        <StatefulForm
-          fields={INPUT_WITH_DISABLED}
-          formValues={allValue}
-          mode="onChange"
-        />
+    context("when given by per field", () => {
+      const INPUT_WITH_DISABLED: FormFieldGroup[] = ALL_INPUT.map((group) =>
+        Array.isArray(group)
+          ? group.map((item) => ({
+              ...item,
+              disabled: true,
+            }))
+          : {
+              ...group,
+              disabled: true,
+            }
       );
+      context("when given true", () => {
+        it("should render with cursor not-allowed and user-select none", () => {
+          cy.mount(
+            <StatefulForm
+              fields={INPUT_WITH_DISABLED}
+              formValues={allValue}
+              mode="onChange"
+              styles={{
+                containerStyle: css`
+                  width: 480px;
+                `,
+              }}
+            />
+          );
 
-      cy.get("input, textarea, [role='radio'], [role='checkbox']").each(
-        ($el) => {
-          cy.wrap($el).should("be.disabled");
-        }
-      );
+          cy.findAllByLabelText("field-lane-wrapper")
+            .should("have.css", "cursor", "not-allowed")
+            .and("have.css", "user-select", "none");
+          cy.findAllByLabelText("chip-input")
+            .should("have.css", "cursor", "not-allowed")
+            .and("have.css", "user-select", "none");
+          cy.findAllByLabelText("file-drop-box-container")
+            .should("have.css", "cursor", "not-allowed")
+            .and("have.css", "user-select", "none");
+        });
+      });
+
+      it("should renders with disabled each input", () => {
+        cy.mount(
+          <StatefulForm
+            fields={INPUT_WITH_DISABLED}
+            formValues={allValue}
+            mode="onChange"
+          />
+        );
+
+        cy.get("input, textarea, [role='radio'], [role='checkbox']").each(
+          ($el) => {
+            cy.wrap($el).should("be.disabled");
+          }
+        );
+      });
     });
   });
 


### PR DESCRIPTION
Description:
This pull request Introduces a `disabled` prop to the `StatefulForm`, allowing all input elements to be `disabled`. It also adds a story titled "All Case Disabled" to demonstrate how all inputs appear in the `disabled` mode.

Source:
[[Improvement] SYST-629: Add `disabled` on the `StatefulForm` to set disable on the whole form fields](https://linear.app/systatum/issue/SYST-629/add-disabled-on-the-statefulform-to-set-disable-on-the-whole-form)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself