### PR TITLE
[Improvement] SYST-631: Create `Helper` component on `Content`

### DIFF
--- a/components/helper.stories.tsx
+++ b/components/helper.stories.tsx
@@ -47,3 +47,9 @@ export const Default: Story = {
     return <Helper value="Default Value" />;
   },
 };
+
+export const WithCustomDelay: Story = {
+  render: () => {
+    return <Helper value="Custom Delay Value" showDelayPeriod={1500} />;
+  },
+};

--- a/components/helper.stories.tsx
+++ b/components/helper.stories.tsx
@@ -50,6 +50,6 @@ export const Default: Story = {
 
 export const WithCustomDelay: Story = {
   render: () => {
-    return <Helper value="Custom Delay Value" showDelayPeriod={1500} />;
+    return <Helper value="Custom Delay Value 1500ms" showDelayPeriod={1500} />;
   },
 };

--- a/components/helper.stories.tsx
+++ b/components/helper.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { Helper } from "./helper";
+
+const meta: Meta<typeof Helper> = {
+  title: "Content/Helper",
+  component: Helper,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Helper>;
+
+export const Default: Story = {
+  render: () => {
+    return <Helper value="Default Value" />;
+  },
+};

--- a/components/helper.stories.tsx
+++ b/components/helper.stories.tsx
@@ -5,6 +5,37 @@ const meta: Meta<typeof Helper> = {
   title: "Content/Helper",
   component: Helper,
   tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+**Helper** is a lightweight tooltip trigger component used to display contextual help or additional information via an icon.
+
+---
+
+### ✨ Features
+- 💡 **Tooltip display**: Shows contextual information when hovering over the helper icon.
+- ⏱ **Delay support**: Includes a configurable delay before showing the tooltip (\`showDelayPeriod\`).
+- 🎯 **Smart positioning**: Adjusts tooltip arrow alignment based on placement.
+- 🧩 **Composable**: Built on top of the \`Tooltip\` component for flexibility and consistency.
+- 🎨 **Customizable styles**: Supports style overrides for container and arrow via the \`styles\` prop.
+
+---
+
+### 📌 Usage
+
+\`\`\`tsx
+<Helper value="This field is required and must be unique." />
+\`\`\`
+
+- The \`value\` prop defines the content shown inside the tooltip.
+- Displays an information icon that users can hover to reveal the message.
+- Ideal for form fields, labels, or any UI that needs extra explanation without cluttering the layout.
+- Uses a default hover delay of 400ms to improve user experience.
+`,
+      },
+    },
+  },
 };
 
 export default meta;

--- a/components/helper.tsx
+++ b/components/helper.tsx
@@ -2,7 +2,12 @@ import { css } from "styled-components";
 import { Tooltip } from "./tooltip";
 import { RiInformationLine } from "@remixicon/react";
 
-function Helper({ value }: { value: string }) {
+export interface HelperProps {
+  value: string;
+  showDelayPeriod?: number;
+}
+
+function Helper({ value, showDelayPeriod = 400 }: HelperProps) {
   return (
     <Tooltip
       styles={{
@@ -20,7 +25,7 @@ function Helper({ value }: { value: string }) {
           `}
         `,
       }}
-      showDelayPeriod={400}
+      showDelayPeriod={showDelayPeriod}
       dialog={value}
     >
       <RiInformationLine

--- a/components/helper.tsx
+++ b/components/helper.tsx
@@ -2,7 +2,7 @@ import { css } from "styled-components";
 import { Tooltip } from "./tooltip";
 import { RiInformationLine } from "@remixicon/react";
 
-export default function Helper({ value }: { value: string }) {
+function Helper({ value }: { value: string }) {
   return (
     <Tooltip
       styles={{
@@ -32,3 +32,5 @@ export default function Helper({ value }: { value: string }) {
     </Tooltip>
   );
 }
+
+export { Helper };

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -38,7 +38,7 @@ import { Capsule, CapsuleProps } from "./capsule";
 import { Timebox, TimeboxProps } from "./timebox";
 import { Button, ButtonProps } from "./button";
 import { Radio, RadioProps } from "./radio";
-import Helper from "./helper";
+import { Helper } from "./helper";
 import { FigureProps } from "./figure";
 import { Pinbox, PinboxProps } from "./pinbox";
 import { FieldLaneProps } from "./field-lane";

--- a/scripts/generate-export.cjs
+++ b/scripts/generate-export.cjs
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const IGNORED_COMPONENT_FILES = ["context-menu", "action-button", "helper"];
+const IGNORED_COMPONENT_FILES = ["context-menu", "action-button"];
 
 function getFlatExportsFrom(dirPath, baseDistPath) {
   const abs = path.join(process.cwd(), dirPath);

--- a/test/component/helper.cy.tsx
+++ b/test/component/helper.cy.tsx
@@ -1,0 +1,24 @@
+import { Helper } from "./../../components/helper";
+
+describe("Helper", () => {
+  const value = "This is a helper tooltip";
+  const mountHelper = () => {
+    cy.mount(<Helper value={value} />);
+    cy.get("svg").should("exist");
+  };
+
+  beforeEach(() => {
+    mountHelper();
+  });
+  it("should render icon", () => {
+    // render the helper icon;
+  });
+
+  context("when hovering the icon", () => {
+    it("should show dialog on hover", () => {
+      cy.get("svg").trigger("mouseover");
+      cy.wait(400);
+      cy.contains(value).should("be.visible");
+    });
+  });
+});


### PR DESCRIPTION
Description:
This pull request introduces a new story for the `helper` component to demonstrate how it works.

Source:
[[Improvement] SYST-631: Create `Helper` component on `Content`
](https://linear.app/systatum/issue/SYST-631/create-helper-component-on-content)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself