### PR TITLE
[Bug] SYST-603: Make Keynote value able to accept weird and long text

### DIFF
--- a/components/keynote.stories.tsx
+++ b/components/keynote.stories.tsx
@@ -104,7 +104,7 @@ export const Default: Story = {
       requestCreatedBy: "adam@systatum.com",
       lastSynced: "2025-06-20",
       createdOn: "2025-06-19",
-      desc: "Backup unit installed on site",
+      desc: "/home/alim.naufal@systatum.local/Documents/works/mydb-studio-system/winamp/node_modules/.pnpm/electron@40.1.0/node_modules/electron/dist/electron,--no-sandbox,dist-electron/electron/main.js",
     };
 
     return (

--- a/components/keynote.stories.tsx
+++ b/components/keynote.stories.tsx
@@ -104,7 +104,9 @@ export const Default: Story = {
       requestCreatedBy: "adam@systatum.com",
       lastSynced: "2025-06-20",
       createdOn: "2025-06-19",
-      desc: "/home/alim.naufal@systatum.local/Documents/works/mydb-studio-system/winamp/node_modules/.pnpm/electron@40.1.0/node_modules/electron/dist/electron,--no-sandbox,dist-electron/electron/main.js",
+      desc: "Backup unit installed on site",
+      execPath:
+        "/home/alim.naufal@systatum.local/Documents/works/mydb-studio-system/winamp/node_modules/.pnpm/electron@40.1.0/node_modules/electron/dist/electron,--no-sandbox,dist-electron/electron/main.js",
     };
 
     return (
@@ -116,6 +118,7 @@ export const Default: Story = {
           "lastSynced",
           "createdOn",
           "desc",
+          "execPath",
         ]}
         keyLabels={[
           "Model Type",
@@ -123,6 +126,7 @@ export const Default: Story = {
           "Last Synced",
           "Created On",
           "Description",
+          "Execution Path",
         ]}
       />
     );

--- a/components/keynote.tsx
+++ b/components/keynote.tsx
@@ -136,6 +136,12 @@ const Value = styled.span<{
   width: 70%;
   font-size: 14px;
   text-align: end;
+  overflow: clip;
+  user-select: text;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+
   color: ${({ $color }) => $color};
 
   ${({ $style }) => $style}

--- a/test/component/keynote.cy.tsx
+++ b/test/component/keynote.cy.tsx
@@ -126,7 +126,7 @@ describe("Keynote", () => {
         requestCreatedBy: "adam@systatum.com",
         lastSynced: "2025-06-20",
         createdOn: "2025-06-19",
-        desc: "Backup unit installed on site",
+        desc: "/home/alim.naufal@systatum.local/Documents/works/mydb-studio-system/winamp/node_modules/.pnpm/electron@40.1.0/node_modules/electron/dist/electron,--no-sandbox,dist-electron/electron/main.js",
       };
 
       return (
@@ -212,6 +212,23 @@ describe("Keynote", () => {
     });
 
     context("value label", () => {
+      it("renders text wrapping styles correctly", () => {
+        cy.mount(<ProductKeyNote />);
+
+        cy.findAllByLabelText("keynote-point-value").each(($el) => {
+          cy.wrap($el)
+            .should("have.css", "font-size", "14px")
+            .and("have.css", "white-space", "normal")
+            .and("have.css", "overflow-wrap", "anywhere")
+            .and("have.css", "word-break")
+            .and((wordBreak) => {
+              expect(["break-word", "break-all", "normal"]).to.include(
+                wordBreak
+              );
+            });
+        });
+      });
+
       it("renders with 14px and width 70%", () => {
         cy.mount(<ProductKeyNote />);
 


### PR DESCRIPTION
Description:
This pull request fixes the `keynote` component at the value level to support long text content. It ensures that text wraps correctly without breaking the layout and stays consistently aligned to the end.

Source:
[[Bug] SYST-603: Make Keynote value able to accept weird and long text](https://linear.app/systatum/issue/SYST-603/make-keynote-value-able-to-accept-weird-and-long-text)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself