### PR TITLE
[Improvement] SYST-576: Add `width` to `TextArea`

### DIFF
--- a/components/textarea.stories.tsx
+++ b/components/textarea.stories.tsx
@@ -144,12 +144,6 @@ export const Default: Story = {
     placeholder: "Type your message...",
     value: "",
     rows: 3,
-    styles: {
-      self: css`
-        min-width: 400px;
-        max-width: 400px;
-      `,
-    },
   },
   render: (args: TextareaProps) => {
     const [, setUpdateArgs] = useArgs();
@@ -161,7 +155,14 @@ export const Default: Story = {
       }
     };
 
-    return <Textarea {...args} value={args.value} onChange={handleChange} />;
+    return (
+      <Textarea
+        {...args}
+        width={400}
+        value={args.value}
+        onChange={handleChange}
+      />
+    );
   },
 };
 
@@ -173,12 +174,6 @@ export const Autogrow: Story = {
     placeholder: "Type your message...",
     value: "",
     rows: 3,
-    styles: {
-      self: css`
-        min-width: 400px;
-        max-width: 400px;
-      `,
-    },
   },
   render: (args: TextareaProps) => {
     const [, setUpdateArgs] = useArgs();
@@ -190,7 +185,14 @@ export const Autogrow: Story = {
       }
     };
 
-    return <Textarea {...args} value={args.value} onChange={handleChange} />;
+    return (
+      <Textarea
+        {...args}
+        width={400}
+        value={args.value}
+        onChange={handleChange}
+      />
+    );
   },
 };
 
@@ -232,6 +234,7 @@ export const WithDropdown: Story = {
         onChange={(e) =>
           setValue((prev) => ({ ...prev, value: e.target.value }))
         }
+        width={400}
         dropdowns={[
           {
             width: "150px",
@@ -257,11 +260,6 @@ export const WithDropdown: Story = {
             withFilter: true,
           },
         ]}
-        styles={{
-          self: css`
-            min-width: 300px;
-          `,
-        }}
       />
     );
   },
@@ -276,12 +274,6 @@ export const WithErrorMessage: Story = {
     value: "",
     showError: true,
     errorMessage: "This field is required",
-    styles: {
-      self: css`
-        min-width: 400px;
-        max-width: 400px;
-      `,
-    },
   },
   render: (args: TextareaProps) => {
     const [, setUpdateArgs] = useArgs();
@@ -293,6 +285,13 @@ export const WithErrorMessage: Story = {
       }
     };
 
-    return <Textarea {...args} value={args.value} onChange={handleChange} />;
+    return (
+      <Textarea
+        {...args}
+        width={400}
+        value={args.value}
+        onChange={handleChange}
+      />
+    );
   },
 };

--- a/components/textarea.tsx
+++ b/components/textarea.tsx
@@ -19,6 +19,7 @@ interface BaseTextareaProps
   ) => void;
   autogrow?: boolean;
   id?: string;
+  width?: string | number;
 }
 
 export interface TextareaStyles {
@@ -26,12 +27,16 @@ export interface TextareaStyles {
 }
 
 const BaseTextarea = forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
-  ({ id, showError, rows, onChange, autogrow, styles, ...props }, ref) => {
+  (
+    { id, showError, rows, onChange, autogrow, styles, width, ...props },
+    ref
+  ) => {
     const { currentTheme } = useTheme();
     const textareaTheme = currentTheme?.textarea;
 
     return (
       <TextareaInput
+        $width={width}
         $theme={textareaTheme}
         $disabled={props?.disabled}
         $autogrow={autogrow}
@@ -86,6 +91,14 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       id: props.id,
     });
 
+    const {
+      bodyStyle,
+      containerStyle,
+      controlStyle,
+      labelStyle,
+      self: textareaStyles,
+    } = styles ?? {};
+
     return (
       <FieldLane
         id={inputId}
@@ -102,10 +115,10 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         disabled={disabled}
         required={rest.required}
         styles={{
-          bodyStyle: styles?.bodyStyle,
-          controlStyle: styles?.controlStyle,
-          containerStyle: styles?.containerStyle,
-          labelStyle: styles?.labelStyle,
+          bodyStyle,
+          controlStyle,
+          containerStyle,
+          labelStyle,
         }}
       >
         <BaseTextarea
@@ -121,7 +134,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                 border-bottom-left-radius: 0px;
               `}
 
-              ${styles?.self}
+              ${textareaStyles}
             `,
           }}
           ref={ref}
@@ -137,6 +150,7 @@ const TextareaInput = styled.textarea<{
   $autogrow?: boolean;
   $disabled?: boolean;
   $theme?: TextareaThemeConfig;
+  $width?: string | number;
 }>`
   border-radius: 2px;
   font-size: 0.75rem;
@@ -178,7 +192,7 @@ const TextareaInput = styled.textarea<{
       : css`
           overflow-y: auto;
           resize: vertical;
-        `}
+        `};
 
   &::-webkit-scrollbar {
     width: 6px;
@@ -207,7 +221,13 @@ const TextareaInput = styled.textarea<{
             border-color: ${$theme?.focusedBorderColor || "#61a9f9"};
             box-shadow: 0 0 0 1px ${$theme?.focusedBorderColor || "#61a9f9"};
           }
-        `}
+        `};
+
+  ${({ $width }) =>
+    $width &&
+    css`
+      width: ${typeof $width === "number" ? `${$width}px` : $width};
+    `}
 
   ${({ $style }) => $style}
 `;

--- a/test/component/textarea.cy.tsx
+++ b/test/component/textarea.cy.tsx
@@ -26,6 +26,16 @@ describe("Textarea", () => {
     );
   }
 
+  context("width", () => {
+    context("when given 250px", () => {
+      it("should have the correct width", () => {
+        cy.mount(<ProductTextarea width={250} />);
+
+        cy.get("#textarea").should("have.css", "width", "250px");
+      });
+    });
+  });
+
   context("onChange", () => {
     context("when given", () => {
       it("should change the value", () => {


### PR DESCRIPTION
Description:
This pull request introduces a `width` prop in the `Textarea` component to simplify width customization and improve flexibility in element usage. 

Source:
[[Improvement] SYST-576: Add `width` to `TextArea`](https://linear.app/systatum/issue/SYST-576/add-width-to-textarea)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself