### PR TITLE
[Bug] SYST-602: Allow rendering `Keynote` even if there's not `keyLabels`

### DIFF
--- a/components/keynote.tsx
+++ b/components/keynote.tsx
@@ -35,13 +35,13 @@ function Keynote<T extends Record<string, unknown>>({
   renderer,
   styles,
 }: KeynoteProps<T>) {
-  const shouldRenderFromData = data && keys && keyLabels;
+  const shouldRenderFromData = data && keys;
 
   return (
     <KeynoteWrapper aria-label="keynote-wrapper" $style={styles?.self}>
       {shouldRenderFromData
         ? keys?.map((key, index) => {
-            const keyLabel = keyLabels[index] ?? String(key);
+            const keyLabel = keyLabels?.[index] ?? String(key);
             const value = data[key];
             const renderFn = renderer?.[key];
 

--- a/test/component/keynote.cy.tsx
+++ b/test/component/keynote.cy.tsx
@@ -3,6 +3,46 @@ import { Keynote, KeynoteStyles } from "./../../components/keynote";
 
 describe("Keynote", () => {
   context("rendered condition", () => {
+    context("when not given keyLabels", () => {
+      it("should still rendered with key", () => {
+        const data = {
+          modelType: "MXQ83700F3",
+          requestCreatedBy: "adam@systatum.com",
+          lastSynced: "2025-06-20",
+          createdOn: "2025-06-19",
+          desc: "Backup unit installed on site",
+        };
+
+        cy.mount(
+          <Keynote
+            data={data}
+            keys={[
+              "modelType",
+              "requestCreatedBy",
+              "lastSynced",
+              "createdOn",
+              "desc",
+            ]}
+          />
+        );
+
+        const expectedValue = [
+          "modelType",
+          "requestCreatedBy",
+          "lastSynced",
+          "createdOn",
+          "desc",
+        ];
+
+        expectedValue.map((value) => {
+          cy.findByText(value).should("exist");
+        });
+        Object.values(data).map((value) => {
+          cy.findByText(value).should("exist");
+        });
+      });
+    });
+
     context("when keyLabels is less than the key", () => {
       it("should rendered with key", () => {
         const data = {


### PR DESCRIPTION
Description:
This pull request fixes the `Keynote` component logic for the `keyLabels` condition. Previously, when `keylabels` is not provided, all label values were handled incorrectly. It also ensures the component always renders as usual with `key` content.

```tsx
<Keynote
  data={details}
  keys={["version", "osVersion"]}
/>
```

Source:
[[Bug] SYST-602: Allow rendering `Keynote` even if there's not `keyLabels`](https://linear.app/systatum/issue/SYST-602/allow-rendering-keynote-even-if-theres-not-keylabels)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself