### PR TITLE
[Improvement] SYST-568: Remove "Transparent" button

### DIFF
--- a/components/button.stories.tsx
+++ b/components/button.stories.tsx
@@ -283,7 +283,6 @@ export const Default: Story = {
       "danger",
       "secondary",
       "ghost",
-      "transparent",
       "success",
     ] as const;
 
@@ -317,7 +316,6 @@ export const Pressed: Story = {
       "danger",
       "secondary",
       "ghost",
-      "transparent",
       "success",
     ] as const;
 

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -29,7 +29,6 @@ export const ButtonVariant = {
   Danger: "danger",
   Secondary: "secondary",
   Ghost: "ghost",
-  Transparent: "transparent",
   Success: "success",
   OutlineDefault: "outline-default",
   OutlineSuccess: "outline-success",

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -581,7 +581,7 @@ function BaseCalendar({
             }}
           >
             <Button
-              variant="transparent"
+              variant="ghost"
               styles={{
                 self: css`
                   width: fit-content;
@@ -650,7 +650,7 @@ function BaseCalendar({
             </div>
 
             <Button
-              variant="transparent"
+              variant="ghost"
               styles={{
                 containerStyle: css`
                   cursor: pointer;
@@ -686,7 +686,7 @@ function BaseCalendar({
             }}
           >
             <Button
-              variant="transparent"
+              variant="ghost"
               styles={{
                 containerStyle: css`
                   cursor: pointer;
@@ -711,7 +711,7 @@ function BaseCalendar({
             />
 
             <Button
-              variant="transparent"
+              variant="ghost"
               styles={{
                 containerStyle: css`
                   cursor: pointer;

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -242,7 +242,7 @@ function Dialog({
 
         {closable && (
           <Button
-            variant="transparent"
+            variant="ghost"
             onClick={() => closeDialog()}
             aria-label="close-dialog"
             styles={{

--- a/components/file-input-box.tsx
+++ b/components/file-input-box.tsx
@@ -114,7 +114,7 @@ function BaseFileInputBox({
             <FileItem key={index}>
               <Button
                 aria-label="delete-button"
-                variant="transparent"
+                variant="ghost"
                 styles={{
                   containerStyle: css`
                     cursor: pointer;

--- a/components/messagebox.tsx
+++ b/components/messagebox.tsx
@@ -114,7 +114,7 @@ function Messagebox({
       </Content>
       {closable && (
         <Button
-          variant="transparent"
+          variant="ghost"
           styles={{
             containerStyle: css`
               position: absolute;

--- a/components/signbox.tsx
+++ b/components/signbox.tsx
@@ -264,7 +264,7 @@ function BaseSignbox({
           }}
           aria-label="signbox-clearable"
           onClick={(e) => clearCanvas(e)}
-          variant="transparent"
+          variant="ghost"
           icon={{
             image: RiEraserLine,
             size: 16,

--- a/components/statusbar.tsx
+++ b/components/statusbar.tsx
@@ -147,11 +147,7 @@ function StatusbarItem({
           size: button?.icon?.size ? button?.icon?.size : size,
         }}
         variant={
-          button?.variant
-            ? button?.variant
-            : transparent
-              ? "transparent"
-              : "default"
+          button?.variant ? button?.variant : transparent ? "ghost" : "default"
         }
         tipMenuSize={button?.tipMenuSize ?? "sm"}
         activeBackgroundColor={

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -499,7 +499,7 @@ function Table({
                           subMenuList={
                             subMenuList ? subMenuList(col.id) : undefined
                           }
-                          variant="transparent"
+                          variant="ghost"
                         />
                       </Toolbar>
                     )}

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -38,7 +38,7 @@ export const ToolbarVariant = {
   Primary: "primary",
   Danger: "danger",
   Success: "success",
-  Transparent: "transparent",
+  Ghost: "ghost",
 } as const;
 
 export type ToolbarVariant =
@@ -394,7 +394,7 @@ const MenuWrapper = styled.div<{
 
   border: 1px solid
     ${({ $theme, $variant }) =>
-      $variant === "transparent"
+      $variant === "ghost"
         ? "transparent"
         : ($theme?.hoverBackgroundColor ?? "transparent")};
 

--- a/components/window.tsx
+++ b/components/window.tsx
@@ -292,7 +292,7 @@ const WindowCell = forwardRef<HTMLDivElement, WindowCellProps>(
           <ActionContainer>
             {filteredActions.map((action, index) => (
               <Button
-                variant="transparent"
+                variant="ghost"
                 key={index}
                 aria-label="window-button"
                 onClick={() => {

--- a/test/component/button.cy.tsx
+++ b/test/component/button.cy.tsx
@@ -116,7 +116,6 @@ describe("Button", () => {
         { variant: "danger", icon: { image: RiStarLine } },
         { variant: "secondary", icon: { image: RiAddLine } },
         { variant: "ghost", icon: { image: RiSearchLine } },
-        { variant: "transparent", icon: { image: RiHeartLine } },
         { variant: "success", icon: { image: RiStarLine } },
       ];
 
@@ -158,7 +157,6 @@ describe("Button", () => {
         "danger",
         "secondary",
         "ghost",
-        "transparent",
         "success",
       ] as const;
 

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1614,11 +1614,11 @@ export function createToolbarTheme(
       focusBackgroundColor:
         baseButton?.success?.focusBackgroundColor ?? "#2FE62080",
     },
-    transparent: {
-      ...baseButton?.transparent,
-      hoverBackgroundColor: baseButton?.transparent?.hoverBackgroundColor,
-      activeBackgroundColor: baseButton?.transparent?.activeBackgroundColor,
-      focusBackgroundColor: baseButton?.transparent?.focusBackgroundColor,
+    ghost: {
+      ...baseButton?.ghost,
+      hoverBackgroundColor: baseButton?.ghost?.hoverBackgroundColor,
+      activeBackgroundColor: baseButton?.ghost?.activeBackgroundColor,
+      focusBackgroundColor: baseButton?.ghost?.focusBackgroundColor,
     },
   };
 

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -189,14 +189,7 @@ const darkButton = createButtonTheme(darkBody, {
     textDecoration: "underline",
     dividerColor: "#48398dbf",
   },
-  transparent: {
-    backgroundColor: "transparent",
-    textColor: darkBody.textColor,
-    hoverBackgroundColor: "#363636",
-    activeBackgroundColor: "#1f1f1f",
-    focusBackgroundColor: "#ffffff20",
-    dividerColor: "#363636",
-  },
+
   "outline-default": {
     backgroundColor: "transparent",
     textColor: "#a3a3a3",
@@ -741,7 +734,7 @@ const darkToolbar = createToolbarTheme({
   default: darkButton.default,
   primary: darkButton.primary,
   danger: darkButton.danger,
-  transparent: darkButton.transparent,
+  ghost: darkButton.ghost,
   success: darkButton.success,
 });
 

--- a/theme/mode/light.ts
+++ b/theme/mode/light.ts
@@ -213,7 +213,7 @@ const lightToolbar = createToolbarTheme({
   default: lightButton.default,
   primary: lightButton.primary,
   danger: lightButton.danger,
-  transparent: lightButton.transparent,
+  ghost: lightButton.ghost,
   success: lightButton.success,
 });
 


### PR DESCRIPTION
Description:
This pull request removes the `transparent` variant from the `Button` component, as the `transparent` appearance is already represented by the `ghost` variant. It also updates related component to use the `ghost` variant during the migration.

Source:
[[Improvement] SYST-568: Remove "Transparent" button](https://linear.app/systatum/issue/SYST-568/remove-transparent-button)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself