### PR TITLE
[Feature] SYST-626: Allow overriding icons on `PaperDialog`

### DIFF
--- a/components/paper-dialog.stories.tsx
+++ b/components/paper-dialog.stories.tsx
@@ -8,7 +8,13 @@ import { COUNTRY_CODES } from "./../constants/countries";
 import { css } from "styled-components";
 import { Card } from "./card";
 import { TableColumn, TableSubMenuList, Table } from "./table";
-import { RiAddBoxLine, RiDeleteBin2Line, RiEdit2Line } from "@remixicon/react";
+import {
+  RiAddBoxLine,
+  RiCheckLine,
+  RiDeleteBin2Line,
+  RiEdit2Line,
+  RiSubtractLine,
+} from "@remixicon/react";
 
 const meta: Meta<typeof PaperDialog> = {
   title: "Stage/PaperDialog",
@@ -42,9 +48,22 @@ const meta: Meta<typeof PaperDialog> = {
 </PaperDialog>
 \`\`\`
 
+### 🎨 Custom Icons
+You can override the default control icons (e.g. close and restore) by passing custom icon components:
+
+\`\`\`tsx
+<PaperDialog
+  icons={{
+    closeIcon: { image: RiCloseLine },
+    restoreIcon: { image: RiSubtractLine }
+  }}
+/>
+\`\`\`
+
 ### 📝 Notes
 - Always include both \`PaperDialog.Trigger\` and \`PaperDialog.Content\` as children.
 - Use \`styles\` prop to override default styles.
+- Use the \`icons\` prop to override default icons.
         `,
       },
     },
@@ -64,6 +83,19 @@ const meta: Meta<typeof PaperDialog> = {
       description:
         "Width of the dialog. If not provided, min-width defaults to 92vw",
       control: { type: "text" },
+    },
+    icons: {
+      description: `
+Customize the dialog control icons.
+
+- \`closeIcon\`: Icon used for closing the dialog
+- \`restoreIcon\`: Icon used for toggling minimized/restored state
+
+Each icon accepts:
+- \`image\`: React component (icon)
+- \`size\`: Icon size (optional)
+      `,
+      control: false,
     },
     children: {
       description:
@@ -238,6 +270,68 @@ export const Default: Story = {
                 </Button>
               </div>
             </div>
+          </PaperDialog.Content>
+        </PaperDialog>
+      </div>
+    );
+  },
+};
+
+export const CustomIcon: Story = {
+  render: () => {
+    const dialogRef = useRef<PaperDialogRef>(null);
+
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "8px",
+        }}
+      >
+        <Button onClick={() => dialogRef.current?.openDialog()}>Open</Button>
+        <Button onClick={() => dialogRef.current?.closeDialog()}>Close</Button>
+
+        <PaperDialog
+          closable={true}
+          width="35vw"
+          icons={{
+            closeIcon: {
+              image: RiCheckLine,
+            },
+            restoreIcon: {
+              image: RiSubtractLine,
+            },
+          }}
+          ref={dialogRef}
+        >
+          <PaperDialog.Content
+            styles={{
+              self: {
+                padding: "36px",
+                gap: "16px",
+              },
+            }}
+          >
+            <h2 style={{ fontSize: "24px", fontWeight: "bold" }}>
+              Dialog with Custom Icons
+            </h2>
+
+            <p style={{ fontSize: "14px", color: "#4B5563" }}>
+              This dialog demonstrates how to customize the close and restore
+              icons using the <code>icons</code> prop.
+            </p>
+
+            <p style={{ fontSize: "14px", color: "#4B5563" }}>
+              You can replace the default icons with any icon component to
+              better match your application’s design or interaction needs.
+            </p>
+
+            <p style={{ fontSize: "14px", color: "#4B5563" }}>
+              In this example, the close action uses a check icon, while the
+              restore action uses a subtract icon for a more customized
+              appearance.
+            </p>
           </PaperDialog.Content>
         </PaperDialog>
       </div>

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -48,6 +48,12 @@ export interface PaperDialogProps {
   width?: string;
   styles?: PaperDialogStyles;
   onClosed?: () => void;
+  icons?: PaperDialogIcons;
+}
+
+export interface PaperDialogIcons {
+  closeIcon?: FigureProps;
+  restoreIcon?: FigureProps;
 }
 
 export interface PaperDialogStyles {
@@ -82,7 +88,15 @@ export interface PaperDialogRef {
 
 const PaperDialogBase = forwardRef<PaperDialogRef, PaperDialogProps>(
   (
-    { position = "right", children, closable = true, width, styles, onClosed },
+    {
+      position = "right",
+      children,
+      closable = true,
+      width,
+      styles,
+      onClosed,
+      icons,
+    },
     ref
   ) => {
     const { currentTheme } = useTheme();
@@ -204,7 +218,11 @@ const PaperDialogBase = forwardRef<PaperDialogRef, PaperDialogProps>(
                       }
                     }}
                   >
-                    <RiCloseLine size={20} />
+                    <Figure
+                      {...icons?.closeIcon}
+                      image={icons?.closeIcon?.image ?? RiCloseLine}
+                      size={icons?.closeIcon?.size ?? 18}
+                    />
                   </IconButton>
                 </CloseButtonWrapper>
               )}
@@ -223,29 +241,23 @@ const PaperDialogBase = forwardRef<PaperDialogRef, PaperDialogProps>(
                     )
                   }
                 >
-                  {isLeft ? (
-                    <RiArrowRightSLine
-                      style={{
-                        transition: "transform 0.5s ease-in-out",
-                        transform:
-                          dialogState === "restored"
-                            ? "rotate(180deg)"
-                            : "rotate(0deg)",
-                      }}
-                      size={20}
-                    />
-                  ) : (
-                    <RiArrowLeftSLine
-                      style={{
-                        transition: "transform 0.5s ease-in-out",
-                        transform:
-                          dialogState === "restored"
-                            ? "rotate(180deg)"
-                            : "rotate(0deg)",
-                      }}
-                      size={20}
-                    />
-                  )}
+                  <Figure
+                    {...icons?.restoreIcon}
+                    image={
+                      icons?.restoreIcon?.image ??
+                      (isLeft ? RiArrowRightSLine : RiArrowLeftSLine)
+                    }
+                    size={icons?.restoreIcon?.size ?? 18}
+                    styles={{
+                      self: css`
+                        display: flex;
+                        transition: transform 0.5s ease-in-out;
+                        transform: ${dialogState === "restored"
+                          ? "rotate(180deg)"
+                          : "rotate(0deg)"};
+                      `,
+                    }}
+                  />
                 </IconButton>
               </MinimizeButtonWrapper>
 

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -210,7 +210,7 @@ const PaperDialogBase = forwardRef<PaperDialogRef, PaperDialogProps>(
                   <IconButton
                     $theme={paperDialogTheme}
                     $isLeft={isLeft}
-                    aria-label="button-close"
+                    aria-label="paper-dialog-toggle-close"
                     onClick={() => {
                       setDialogState("closed");
                       if (onClosed) {
@@ -220,6 +220,7 @@ const PaperDialogBase = forwardRef<PaperDialogRef, PaperDialogProps>(
                   >
                     <Figure
                       {...icons?.closeIcon}
+                      aria-label="paper-dialog-close-icon"
                       image={icons?.closeIcon?.image ?? RiCloseLine}
                       size={icons?.closeIcon?.size ?? 18}
                     />
@@ -234,7 +235,7 @@ const PaperDialogBase = forwardRef<PaperDialogRef, PaperDialogProps>(
                 <IconButton
                   $theme={paperDialogTheme}
                   $isLeft={isLeft}
-                  aria-label="paper-dialog-toggle"
+                  aria-label="paper-dialog-toggle-restore"
                   onClick={() =>
                     handleToggleDrawer(
                       dialogState === "minimized" ? "restored" : "minimized"
@@ -247,6 +248,7 @@ const PaperDialogBase = forwardRef<PaperDialogRef, PaperDialogProps>(
                       icons?.restoreIcon?.image ??
                       (isLeft ? RiArrowRightSLine : RiArrowLeftSLine)
                     }
+                    aria-label="paper-dialog-restore-icon"
                     size={icons?.restoreIcon?.size ?? 18}
                     styles={{
                       self: css`

--- a/test/component/paper-dialog.cy.tsx
+++ b/test/component/paper-dialog.cy.tsx
@@ -7,6 +7,7 @@ import {
 } from "./../../components/paper-dialog";
 import { ReactNode, useRef } from "react";
 import { generateSentence } from "./../../lib/text";
+import { Ri4kLine } from "@remixicon/react";
 
 describe("PaperDialog", () => {
   function ProductPaperDialog(
@@ -56,6 +57,101 @@ describe("PaperDialog", () => {
       </div>
     );
   }
+
+  context("icons", () => {
+    context("restore icon", () => {
+      context("when not given", () => {
+        it("should renders with arrow icon (default)", () => {
+          cy.mount(
+            <ProductPaperDialog
+              onClosed={() => {
+                console.log("the modal is closed");
+              }}
+            />
+          );
+
+          cy.findAllByRole("button").eq(0).should("exist").click();
+
+          cy.findByLabelText("paper-dialog-restore-icon")
+            .find("path")
+            .invoke("attr", "d")
+            .should("include", "M10.8284");
+          // The default restore icon is has #M10.8284
+        });
+      });
+
+      context("when given another icon", () => {
+        it("should changes with customize icon", () => {
+          cy.mount(
+            <ProductPaperDialog
+              onClosed={() => {
+                console.log("the modal is closed");
+              }}
+              icons={{
+                restoreIcon: {
+                  image: Ri4kLine,
+                },
+              }}
+            />
+          );
+
+          cy.findAllByRole("button").eq(0).should("exist").click();
+
+          cy.findByLabelText("paper-dialog-restore-icon")
+            .find("path")
+            .invoke("attr", "d")
+            .should("not.include", "M10.8284");
+          // The default restore icon is has #M10.8284
+        });
+      });
+    });
+
+    context("close icon", () => {
+      context("when not given", () => {
+        it("should renders with close icon (default)", () => {
+          cy.mount(
+            <ProductPaperDialog
+              onClosed={() => {
+                console.log("the modal is closed");
+              }}
+            />
+          );
+
+          cy.findAllByRole("button").eq(0).should("exist").click();
+
+          cy.findByLabelText("paper-dialog-close-icon")
+            .find("path")
+            .invoke("attr", "d")
+            .should("include", "M11.9997");
+        });
+      });
+
+      context("when given another icon", () => {
+        it("should changes with customize icon", () => {
+          cy.mount(
+            <ProductPaperDialog
+              onClosed={() => {
+                console.log("the modal is closed");
+              }}
+              icons={{
+                closeIcon: {
+                  image: Ri4kLine,
+                },
+              }}
+            />
+          );
+
+          cy.findAllByRole("button").eq(0).should("exist").click();
+
+          cy.findByLabelText("paper-dialog-close-icon")
+            .find("path")
+            .invoke("attr", "d")
+            .should("not.include", "M11.9997");
+          // The default close icon is has #M11.9997
+        });
+      });
+    });
+  });
 
   context("onClosed", () => {
     context("when pressing escape", () => {

--- a/test/e2e/paper-dialog.cy.ts
+++ b/test/e2e/paper-dialog.cy.ts
@@ -24,7 +24,7 @@ describe("PaperDialog", () => {
         cy.findByLabelText("paper-dialog-wrapper").then(($drawer) => {
           const drawerRect = $drawer[0].getBoundingClientRect();
 
-          cy.findByLabelText("paper-dialog-toggle").then(($tab) => {
+          cy.findByLabelText("paper-dialog-toggle-restore").then(($tab) => {
             const tabRect = $tab[0].getBoundingClientRect();
 
             const isLeft = drawerRect.left === 0;
@@ -52,7 +52,7 @@ describe("PaperDialog", () => {
 
       cy.findByText("Add New Employee").should("exist");
 
-      cy.findByLabelText("button-close").click();
+      cy.findByLabelText("paper-dialog-toggle-close").click();
       cy.findByText("Add New Employee").should("not.exist");
     });
   });


### PR DESCRIPTION
Description:
This pull request introduces an `icons` prop to supports customization between `close` and `restore` icon. It also ensures that works correctly when given in that 

Source:
[[Feature] SYST-626: Allow overriding icons on `PaperDialog`](https://linear.app/systatum/issue/SYST-626/allow-overriding-icons-on-paperdialog)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself