### PR TITLE
[Bug] SYST-637: Allow using coneto without `<Theme>` and should use light by default

### DIFF
--- a/components/Dark mode.mdx
+++ b/components/Dark mode.mdx
@@ -16,17 +16,17 @@ instead of UI maintenance.
 Dark mode is enabled through the `Theme` provider. Set the `mode` to `"dark"`.
 
 ```tsx
-import { Theme, ThemeMode } from "@systatum/coneto/theme"
-import { Buton } from "@systatum/coneto/components/button"
+import { Theme, ThemeMode } from "@systatum/coneto/theme";
+import { Button } from "@systatum/coneto/button";
 
 function App() {
-  const mode: ThemeMode = "dark"
+  const mode: ThemeMode = "dark";
 
   return (
     <Theme mode={mode}>
-      <Button title="Save" />
+      <Button>Save</Button>
     </Theme>
-  )
+  );
 }
 ```
 
@@ -42,8 +42,6 @@ dark mode, it automatically gets the right background, text color, and hover or 
 states. Switch to light mode, and it adapts instantly without changing any props. That
 means way less conditional styling and no duplicated code.
 
-
-
 ## Theming and future extension
 
 Right now, we support two modes: light and dark. They work consistently across all
@@ -51,4 +49,3 @@ component categories. In the future, we plan to add other color schemes and let 
 define your own themes easily. That means you'll be able to use brand-specific design
 tokens or build your own custom color system. And the best part? You won't need to change
 how you use existing components when we add those features.
-

--- a/test/component/theme-provider.cy.tsx
+++ b/test/component/theme-provider.cy.tsx
@@ -1,0 +1,40 @@
+import { Button } from "./../../components/button";
+
+describe("ThemeProvider", () => {
+  context("when using cy.mount (with provider)", () => {
+    it("should apply with theme", () => {
+      cy.mount(<Button aria-label="test-button">Test Button</Button>);
+      cy.findByLabelText("test-button").should(
+        "have.css",
+        "background-color",
+        "rgb(221, 221, 221)"
+      );
+    });
+
+    context("when given dark mode", () => {
+      it("renders default button in dark mode (rgb(47, 47, 47))", () => {
+        cy.mount(<Button aria-label="test-button">Test Button</Button>, {
+          mode: "dark",
+        });
+        cy.findByLabelText("test-button").should(
+          "have.css",
+          "background-color",
+          "rgb(47, 47, 47)"
+        );
+      });
+    });
+  });
+
+  context("when using cy.mountWithoutTheme", () => {
+    it("still renders element with light theme", () => {
+      cy.mountWithoutTheme(
+        <Button aria-label="test-button">Test Button</Button>
+      );
+      cy.findByLabelText("test-button").should(
+        "have.css",
+        "background-color",
+        "rgb(221, 221, 221)"
+      );
+    });
+  });
+});

--- a/test/support/component.tsx
+++ b/test/support/component.tsx
@@ -26,6 +26,7 @@ const mountWithTheme = (
 };
 
 Cypress.Commands.add("mount", mountWithTheme);
+Cypress.Commands.add("mountWithoutTheme", mount);
 
 declare global {
   namespace Cypress {
@@ -34,6 +35,7 @@ declare global {
         component: ReactNode,
         options?: CustomMountOptions
       ): Cypress.Chainable;
+      mountWithoutTheme(component: ReactNode): Cypress.Chainable;
     }
   }
 }

--- a/theme/provider.tsx
+++ b/theme/provider.tsx
@@ -12,6 +12,7 @@ interface ThemeContextValue {
 
 const ThemeContext = createContext<ThemeContextValue>({
   mode: "light",
+  themes: themes,
 });
 
 export function useThemeMode() {


### PR DESCRIPTION
Description:
This pull request fixes an issue where components break when `ThemeProvider` is not provided,  causing properties to be undefined. By default, components should fall back to the light theme. It also ensures the components works correctly even without `ThemeProvider` in the user code.

<img width="578" height="210" alt="image (9)" src="https://github.com/user-attachments/assets/e0ad507e-b7ca-44c2-8356-e89444b8d96c" />

Source:
[[Bug] SYST-637: Allow using coneto without `<Theme>` and should use light by default](https://linear.app/systatum/issue/SYST-637/allow-using-coneto-without-theme-and-should-use-light-by-default)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself