### PR TITLE
[Improvement] SYST-628: Standardize `choice-group` coloring

### DIFF
--- a/components/checkbox.tsx
+++ b/components/checkbox.tsx
@@ -250,6 +250,10 @@ const InputWrapper = styled.label<{
   display: flex;
   flex-direction: column;
   font-size: 12px;
+
+  padding: ${({ $highlight }) => ($highlight ? "12px" : "0")};
+  cursor: ${({ $highlight }) => ($highlight ? "pointer" : "default")};
+
   background-color: ${({
     $highlight,
     $checked,
@@ -260,8 +264,6 @@ const InputWrapper = styled.label<{
       ? ($highlightBackgroundColor ?? $backgroundColor ?? "#DBEAFE")
       : "transparent"};
 
-  padding: ${({ $highlight }) => ($highlight ? "12px" : "0")};
-  cursor: ${({ $highlight }) => ($highlight ? "pointer" : "default")};
   transition: background-color 0.2s;
 
   &:hover {
@@ -269,10 +271,16 @@ const InputWrapper = styled.label<{
       $highlight,
       $highlightHoverColor,
       $highlightBackgroundColor,
-    }) =>
-      $highlight
-        ? ($highlightHoverColor ?? $highlightBackgroundColor ?? "#E7F2FC")
-        : "none"};
+      $checked,
+    }) => {
+      if ($highlight && $checked) {
+        return $highlightBackgroundColor ?? "#E7F2FC";
+      } else if ($highlight) {
+        return $highlightHoverColor;
+      } else {
+        return "transparent";
+      }
+    }};
   }
 
   ${({ $disabled }) =>

--- a/components/checkbox.tsx
+++ b/components/checkbox.tsx
@@ -8,6 +8,7 @@ import {
 import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
+import { CheckboxThemeConfig } from "./../theme";
 
 type WithoutStyle<T> = Omit<T, "style">;
 
@@ -75,10 +76,7 @@ function BaseCheckbox({
       $checked={isChecked}
       $style={styles?.inputWrapperStyle}
       $disabled={props.disabled}
-      $backgroundColor={checkboxTheme?.backgroundColor}
-      $checkedBorderColor={checkboxTheme?.checkedBorderColor}
-      $highlightBackgroundColor={checkboxTheme?.highlightBackgroundColor}
-      $highlightHoverColor={checkboxTheme?.highlightHoverColor}
+      $theme={checkboxTheme}
     >
       <InputContainer aria-label="input-container-checkbox">
         <CheckboxBox
@@ -239,10 +237,7 @@ const InputWrapper = styled.label<{
   $hasDescription: boolean;
   $highlight: boolean;
   $checked: boolean;
-  $backgroundColor?: string;
-  $highlightBackgroundColor?: string;
-  $highlightHoverColor?: string;
-  $checkedBorderColor?: string;
+  $theme: CheckboxThemeConfig;
   $style?: CSSProp;
   $disabled?: boolean;
 }>`
@@ -254,29 +249,21 @@ const InputWrapper = styled.label<{
   padding: ${({ $highlight }) => ($highlight ? "12px" : "0")};
   cursor: ${({ $highlight }) => ($highlight ? "pointer" : "default")};
 
-  background-color: ${({
-    $highlight,
-    $checked,
-    $backgroundColor,
-    $highlightBackgroundColor,
-  }) =>
+  background-color: ${({ $highlight, $checked, $theme }) =>
     $highlight && $checked
-      ? ($highlightBackgroundColor ?? $backgroundColor ?? "#DBEAFE")
+      ? ($theme?.highlightCheckedBackgroundColor ??
+        $theme?.backgroundColor ??
+        "#DBEAFE")
       : "transparent"};
 
   transition: background-color 0.2s;
 
   &:hover {
-    background-color: ${({
-      $highlight,
-      $highlightHoverColor,
-      $highlightBackgroundColor,
-      $checked,
-    }) => {
+    background-color: ${({ $highlight, $theme, $checked }) => {
       if ($highlight && $checked) {
-        return $highlightBackgroundColor ?? "#E7F2FC";
+        return $theme?.highlightCheckedBackgroundColor ?? "#E7F2FC";
       } else if ($highlight) {
-        return $highlightHoverColor;
+        return $theme?.highlightHoverBackgroundColor;
       } else {
         return "transparent";
       }

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -268,10 +268,10 @@ const Label = styled.label<{
             : "transparent"};
 
     background-color: ${({ $highlight, $checked, $theme }) => {
-      if ($highlight) {
-        return $checked
-          ? $theme?.highlightBackgroundColor
-          : $theme?.highlightBackgroundColor || $theme?.backgroundColor;
+      if ($highlight && $checked) {
+        return $theme?.highlightCheckedBackgroundColor;
+      } else if ($highlight) {
+        return $theme?.highlightBackgroundColor || $theme?.backgroundColor;
       }
       return $theme?.backgroundColor;
     }};

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -156,8 +156,8 @@ export interface CheckboxThemeConfig
   iconColor?: string;
   labelColor?: string;
   descriptionColor?: string;
-  highlightBackgroundColor?: string;
-  highlightHoverColor?: string;
+  highlightCheckedBackgroundColor?: string;
+  highlightHoverBackgroundColor?: string;
 }
 
 // combobox.tsx

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -484,8 +484,8 @@ export function createCheckboxTheme(
     iconColor: "#ffffff",
     labelColor: body.textColor,
     descriptionColor: "#4b5563",
-    highlightBackgroundColor: "#DBEAFE",
-    highlightHoverColor: "#E7F2FC",
+    highlightCheckedBackgroundColor: "#DBEAFE",
+    highlightHoverBackgroundColor: "#E7F2FC",
   };
 
   return {
@@ -1115,9 +1115,9 @@ export function createRadioTheme(
     iconColor: "#ffffff",
     textColor: body.textColor,
     descriptionColor: "#4b5563",
-    highlightBackgroundColor: "#DBEAFE",
+    highlightBackgroundColor: "#E7F2FC",
     highlightBorderColor: "#e5e7eb",
-    highlightCheckedBackgroundColor: "#E7F2FC",
+    highlightCheckedBackgroundColor: "#DBEAFE",
     highlightCheckedBorderColor: "#e5e7eb",
   };
 

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -329,8 +329,8 @@ const darkCheckbox = createCheckboxTheme(darkBody, {
   iconColor: "#f9fafb",
   labelColor: "#f9fafb",
   descriptionColor: "#d1d5db",
-  highlightBackgroundColor: "#2563EB33",
-  highlightHoverColor: "#2563EB55",
+  highlightCheckedBackgroundColor: "#2563EB33",
+  highlightHoverBackgroundColor: "#2563EB55",
 });
 
 const darkColorbox = createColorboxTheme(darkBody, darkFieldLane);


### PR DESCRIPTION
Description:
This pull request updates the `choice-group` component behavior so that hovering over a selected item does not change its background color.

Source:
[[Improvement] SYST-628: Standardize choice group coloring](https://linear.app/systatum/issue/SYST-628/standardize-choice-group-coloring)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself