### PR TITLE
[Improvement] SYST-638: Coloring update (again)

### DIFF
--- a/components/table.tsx
+++ b/components/table.tsx
@@ -511,6 +511,7 @@ function Table({
             {rowChildren.length > 0 ? (
               <TableBody
                 ref={tableBodyRef}
+                $theme={tableTheme}
                 aria-label="table-body"
                 $style={styles?.tableBodyStyle}
               >
@@ -773,7 +774,7 @@ const TableHeader = styled.div<{
   ${({ $style }) => $style}
 `;
 
-const TableBody = styled.div<{ $style?: CSSProp }>`
+const TableBody = styled.div<{ $style?: CSSProp; $theme: TableThemeConfig }>`
   display: flex;
   flex-direction: column;
   overflow: auto;
@@ -787,15 +788,17 @@ const TableBody = styled.div<{ $style?: CSSProp }>`
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: rgba(145, 142, 142, 0.3);
+    background-color: ${({ $theme }) => $theme?.scrollbarThumbColor};
     border-radius: 2px;
   }
 
   &::-webkit-scrollbar-track {
-    background: rgba(168, 167, 167, 0.1);
+    background: ${({ $theme }) => $theme?.scrollbarTrackColor};
   }
 
-  ${({ $style }) => $style}
+  background-color: ${({ $theme }) => $theme?.backgroundColor};
+
+  ${({ $style }) => $style};
 `;
 
 const TableSummary = styled.div<{

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -596,8 +596,7 @@ export interface StatefulFormThemeConfig
 }
 
 // table.tsx
-export interface TableThemeConfig {
-  textColor?: string;
+export interface TableThemeConfig extends Omit<BodyThemeConfig, "borderColor"> {
   boxShadow?: string;
 
   headerActionBackgroundColor?: string;
@@ -620,6 +619,9 @@ export interface TableThemeConfig {
   summaryBorderColor?: string;
 
   toggleRowBackgroundColor?: string;
+
+  scrollbarThumbColor?: string;
+  scrollbarTrackColor?: string;
 }
 
 // timebox.tsx

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1439,6 +1439,7 @@ export function createTableTheme(
 ): TableThemeConfig {
   const defaultTheme: TableThemeConfig = {
     textColor: body.textColor || "#111827",
+    backgroundColor: body?.backgroundColor,
     boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
 
     headerActionBackgroundColor: "linear-gradient(to bottom, #fbf9f9, #f0f0f0)",
@@ -1460,6 +1461,9 @@ export function createTableTheme(
 
     summaryBackgroundColor: "linear-gradient(to bottom, #f0f0f0, #e4e4e4)",
     summaryBorderColor: "#d1d5db",
+
+    scrollbarThumbColor: "rgba(145, 142, 142, 0.3)",
+    scrollbarTrackColor: "rgba(168, 167, 167, 0.1)",
 
     toggleRowBackgroundColor: "#d4d4d4",
   };

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -666,7 +666,6 @@ const darkStepline = createSteplineTheme(darkBody, darkButton, {
 });
 
 const darkTable = createTableTheme(darkBody, {
-  textColor: darkBody.textColor,
   boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
 
   headerActionBackgroundColor:
@@ -689,6 +688,9 @@ const darkTable = createTableTheme(darkBody, {
 
   summaryBackgroundColor: "linear-gradient(#29282b, #323232)",
   summaryBorderColor: "rgb(39, 39, 48)",
+
+  scrollbarThumbColor: "rgba(255, 255, 255, 0.2)",
+  scrollbarTrackColor: "rgba(255, 255, 255, 0.1)",
 
   toggleRowBackgroundColor: "#374151",
 });

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -69,7 +69,7 @@ import {
 
 // Dark
 const darkBody = createBodyTheme({
-  backgroundColor: "#111",
+  backgroundColor: "#1f2023",
   textColor: "#caced4",
   borderColor: "#4b5563",
 });


### PR DESCRIPTION
Description:
This pull request updates the background on the color when using with `#111` to `#1f2023` and the attribute `aria-label` for`table-body` should be use with `body's` background-color.

Source:
[[Improvement] SYST-638: Coloring update (again)](https://linear.app/systatum/issue/SYST-638/coloring-update-again)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself