### PR TITLE
[Improvement] SYST-571: Change KeynoteProps for T to extends object

### DIFF
--- a/components/keynote.tsx
+++ b/components/keynote.tsx
@@ -2,9 +2,11 @@ import { Children, isValidElement, ReactNode } from "react";
 import styled, { CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
 
-export interface KeynoteProps<T extends Record<string, ReactNode>> {
+export type KeynoteKeys<T> = Extract<keyof T, string>;
+
+export interface KeynoteProps<T extends object> {
   data?: T;
-  keys?: (keyof T)[];
+  keys?: KeynoteKeys<T>[];
   keyLabels?: string[];
   children?: ReactNode;
   styles?: KeynoteStyles;
@@ -26,7 +28,7 @@ export interface KeynotePointStyles {
   rowValueStyle?: CSSProp;
 }
 
-function Keynote<T extends Record<string, ReactNode>>({
+function Keynote<T extends object>({
   data,
   keys,
   keyLabels,
@@ -52,7 +54,7 @@ function Keynote<T extends Record<string, ReactNode>>({
                 key={String(key)}
                 label={keyLabel}
               >
-                {value ?? "-"}
+                {renderValue(value)}
               </KeynotePoint>
             );
           })
@@ -61,6 +63,32 @@ function Keynote<T extends Record<string, ReactNode>>({
           )}
     </KeynoteWrapper>
   );
+}
+
+function renderValue(value: unknown): ReactNode {
+  if (value == null) return "-";
+
+  if (value instanceof Date) {
+    return value.toLocaleDateString();
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+
+  if (isValidElement(value)) {
+    return value;
+  }
+
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+
+  return "-";
 }
 
 function KeynotePoint({ label, children, styles }: KeynotePointProps) {

--- a/test/component/keynote.cy.tsx
+++ b/test/component/keynote.cy.tsx
@@ -98,7 +98,7 @@ describe("Keynote", () => {
       });
     });
 
-    context("when given typeof number", () => {
+    context("when given typeof string", () => {
       it("should still rendered normally", () => {
         Object.values(data).map((value) => {
           if (typeof value === "string") {

--- a/test/component/keynote.cy.tsx
+++ b/test/component/keynote.cy.tsx
@@ -2,6 +2,100 @@ import { css } from "styled-components";
 import { Keynote, KeynoteStyles } from "./../../components/keynote";
 
 describe("Keynote", () => {
+  context("data", () => {
+    interface BenchmarkRecord {
+      id: number;
+      userId: number;
+      compilationId: number;
+      cpuOps: number;
+      cpuReorder: number;
+      dnaIP: number;
+      e2eNoSetInput: number;
+      pcieDMA: number;
+      setInput: number;
+      createdAt: Date;
+      updatedAt: Date;
+    }
+
+    const data: BenchmarkRecord = {
+      id: 1,
+      userId: 101,
+      compilationId: 5001,
+      cpuOps: 1200,
+      cpuReorder: 300,
+      dnaIP: 450,
+      e2eNoSetInput: 200,
+      pcieDMA: 800,
+      setInput: 150,
+      createdAt: new Date("2025-06-19"),
+      updatedAt: new Date("2025-06-20"),
+    };
+
+    const keys: (keyof BenchmarkRecord)[] = [
+      "id",
+      "userId",
+      "compilationId",
+      "cpuOps",
+      "cpuReorder",
+      "dnaIP",
+      "e2eNoSetInput",
+      "pcieDMA",
+      "setInput",
+      "createdAt",
+      "updatedAt",
+    ];
+
+    const keyLabels: Record<keyof BenchmarkRecord, string> = {
+      id: "ID",
+      userId: "User ID",
+      compilationId: "Compilation ID",
+      cpuOps: "CPU Ops",
+      cpuReorder: "CPU Reorder",
+      dnaIP: "DNA IP",
+      e2eNoSetInput: "E2E No Set Input",
+      pcieDMA: "PCIe DMA",
+      setInput: "Set Input",
+      createdAt: "Created At",
+      updatedAt: "Updated At",
+    };
+
+    context("when given typeof number", () => {
+      it("should still rendered normally", () => {
+        cy.mount(
+          <Keynote
+            data={data}
+            keys={keys}
+            keyLabels={keys?.map((key) => keyLabels[key])}
+          />
+        );
+
+        Object.values(data).map((value) => {
+          if (typeof value === "number") {
+            cy.findByText(value).should("exist");
+          }
+        });
+      });
+    });
+
+    context("when given typeof date", () => {
+      it("should convert to local date string", () => {
+        cy.mount(
+          <Keynote
+            data={data}
+            keys={keys}
+            keyLabels={keys?.map((key) => keyLabels[key])}
+          />
+        );
+
+        Object.values(data).map((value) => {
+          if (value instanceof Date) {
+            cy.findByText(value?.toLocaleDateString()).should("exist");
+          }
+        });
+      });
+    });
+  });
+
   context("rendered condition", () => {
     context("when not given keyLabels", () => {
       it("should still rendered with key", () => {

--- a/test/component/keynote.cy.tsx
+++ b/test/component/keynote.cy.tsx
@@ -66,7 +66,7 @@ describe("Keynote", () => {
       );
     });
 
-    context("when given typeof number", () => {
+    context("when given a number", () => {
       it("should still rendered normally", () => {
         Object.values(data).map((value) => {
           if (typeof value === "number") {
@@ -76,8 +76,8 @@ describe("Keynote", () => {
       });
     });
 
-    context("when given typeof boolean", () => {
-      context("when given with true", () => {
+    context("when given boolean", () => {
+      context("when it's true", () => {
         it("renders the text with 'true' text", () => {
           Object.values(data).map((value) => {
             if (typeof value === "boolean") {
@@ -87,7 +87,7 @@ describe("Keynote", () => {
         });
       });
 
-      context("when given with false", () => {
+      context("when it's false", () => {
         it("renders the text with 'false' text", () => {
           Object.values(data).map((value) => {
             if (typeof value === "boolean") {
@@ -98,7 +98,7 @@ describe("Keynote", () => {
       });
     });
 
-    context("when given typeof string", () => {
+    context("when given string", () => {
       it("should still rendered normally", () => {
         Object.values(data).map((value) => {
           if (typeof value === "string") {
@@ -108,8 +108,8 @@ describe("Keynote", () => {
       });
     });
 
-    context("when given typeof object", () => {
-      it("renders the object in the text", () => {
+    context("when given object", () => {
+      it("renders the object JSON representation", () => {
         Object.values(data).map((value) => {
           if (typeof value === "object") {
             cy.findByText('{"mode":"benchmark"}').should("exist");
@@ -118,7 +118,7 @@ describe("Keynote", () => {
       });
     });
 
-    context("when given typeof React Element", () => {
+    context("when given React Element", () => {
       it("should render the element", () => {
         cy.findByLabelText("test")
           .should("exist")
@@ -127,7 +127,7 @@ describe("Keynote", () => {
       });
     });
 
-    context("when given typeof date", () => {
+    context("when given date", () => {
       it("should convert to local date string", () => {
         Object.values(data).map((value) => {
           if (value instanceof Date) {

--- a/test/component/keynote.cy.tsx
+++ b/test/component/keynote.cy.tsx
@@ -1,74 +1,73 @@
 import { css } from "styled-components";
 import { Keynote, KeynoteStyles } from "./../../components/keynote";
+import { ReactNode } from "react";
 
 describe("Keynote", () => {
   context("data", () => {
-    interface BenchmarkRecord {
-      id: number;
-      userId: number;
-      compilationId: number;
-      cpuOps: number;
-      cpuReorder: number;
-      dnaIP: number;
-      e2eNoSetInput: number;
-      pcieDMA: number;
-      setInput: number;
-      createdAt: Date;
-      updatedAt: Date;
+    interface KeynoteValueSample {
+      numberValue: number;
+      dateValue: Date;
+      booleanTrueValue: boolean;
+      booleanFalseValue: boolean;
+      objectValue: Record<string, unknown>;
+      nullValue: null;
+      undefinedValue?: undefined;
+      reactNode: ReactNode;
     }
 
-    const data: BenchmarkRecord = {
-      id: 1,
-      userId: 101,
-      compilationId: 5001,
-      cpuOps: 1200,
-      cpuReorder: 300,
-      dnaIP: 450,
-      e2eNoSetInput: 200,
-      pcieDMA: 800,
-      setInput: 150,
-      createdAt: new Date("2025-06-19"),
-      updatedAt: new Date("2025-06-20"),
+    const data: KeynoteValueSample = {
+      numberValue: 1200,
+      dateValue: new Date("2025-06-19"),
+      booleanTrueValue: true,
+      booleanFalseValue: false,
+      objectValue: { mode: "benchmark" },
+      nullValue: null,
+      undefinedValue: undefined,
+      reactNode: (
+        <div
+          aria-label="test"
+          style={{
+            backgroundColor: "red",
+          }}
+        >
+          Test the element
+        </div>
+      ),
     };
 
-    const keys: (keyof BenchmarkRecord)[] = [
-      "id",
-      "userId",
-      "compilationId",
-      "cpuOps",
-      "cpuReorder",
-      "dnaIP",
-      "e2eNoSetInput",
-      "pcieDMA",
-      "setInput",
-      "createdAt",
-      "updatedAt",
+    const keys: (keyof KeynoteValueSample)[] = [
+      "numberValue",
+      "dateValue",
+      "booleanTrueValue",
+      "booleanFalseValue",
+      "objectValue",
+      "nullValue",
+      "undefinedValue",
+      "reactNode",
     ];
 
-    const keyLabels: Record<keyof BenchmarkRecord, string> = {
-      id: "ID",
-      userId: "User ID",
-      compilationId: "Compilation ID",
-      cpuOps: "CPU Ops",
-      cpuReorder: "CPU Reorder",
-      dnaIP: "DNA IP",
-      e2eNoSetInput: "E2E No Set Input",
-      pcieDMA: "PCIe DMA",
-      setInput: "Set Input",
-      createdAt: "Created At",
-      updatedAt: "Updated At",
+    const keyLabels: Record<keyof KeynoteValueSample, string> = {
+      numberValue: "Number",
+      dateValue: "Date",
+      booleanTrueValue: "Boolean (true)",
+      booleanFalseValue: "Boolean (false)",
+      objectValue: "Object",
+      nullValue: "Null",
+      undefinedValue: "Undefined",
+      reactNode: "ReactNode",
     };
+    beforeEach(() => {
+      cy.mount(
+        <Keynote
+          data={data}
+          keys={keys}
+          keyLabels={keys?.map((key) => keyLabels[key])}
+        />
+      );
+    });
 
     context("when given typeof number", () => {
       it("should still rendered normally", () => {
-        cy.mount(
-          <Keynote
-            data={data}
-            keys={keys}
-            keyLabels={keys?.map((key) => keyLabels[key])}
-          />
-        );
-
         Object.values(data).map((value) => {
           if (typeof value === "number") {
             cy.findByText(value).should("exist");
@@ -77,19 +76,82 @@ describe("Keynote", () => {
       });
     });
 
+    context("when given typeof boolean", () => {
+      context("when given with true", () => {
+        it("renders the text with 'true' text", () => {
+          Object.values(data).map((value) => {
+            if (typeof value === "boolean") {
+              cy.findByText("true").should("exist");
+            }
+          });
+        });
+      });
+
+      context("when given with false", () => {
+        it("renders the text with 'false' text", () => {
+          Object.values(data).map((value) => {
+            if (typeof value === "boolean") {
+              cy.findByText("false").should("exist");
+            }
+          });
+        });
+      });
+    });
+
+    context("when given typeof number", () => {
+      it("should still rendered normally", () => {
+        Object.values(data).map((value) => {
+          if (typeof value === "string") {
+            cy.findByText(value).should("exist");
+          }
+        });
+      });
+    });
+
+    context("when given typeof object", () => {
+      it("renders the object in the text", () => {
+        Object.values(data).map((value) => {
+          if (typeof value === "object") {
+            cy.findByText('{"mode":"benchmark"}').should("exist");
+          }
+        });
+      });
+    });
+
+    context("when given typeof React Element", () => {
+      it("should render the element", () => {
+        cy.findByLabelText("test")
+          .should("exist")
+          .and("have.text", "Test the element")
+          .and("have.css", "background-color", "rgb(255, 0, 0)");
+      });
+    });
+
     context("when given typeof date", () => {
       it("should convert to local date string", () => {
-        cy.mount(
-          <Keynote
-            data={data}
-            keys={keys}
-            keyLabels={keys?.map((key) => keyLabels[key])}
-          />
-        );
-
         Object.values(data).map((value) => {
           if (value instanceof Date) {
             cy.findByText(value?.toLocaleDateString()).should("exist");
+          }
+        });
+      });
+    });
+
+    context("when given undefined", () => {
+      it("should convert to '-' text", () => {
+        Object.values(data).map((value) => {
+          if (typeof value === undefined) {
+            cy.findByText("-").should("exist");
+          }
+        });
+      });
+    });
+
+    context("when given null", () => {
+      it("should convert to '-' text", () => {
+        Object.values(data).map((value) => {
+          if (typeof value === null) {
+            cy.findByText("-").should("exist");
           }
         });
       });


### PR DESCRIPTION
Description:
This pull request to improves the `Keynote` component to support flexible value types in `data`, including `Date`, `number`, `string`, `boolean`, `object`, and `ReactNode`.
Value are automatically normalized before rendering:
- `Date` values are formatted using `toLocaleDateString()`
- `number` and `string` are rendered directly as `strings`
- `boolean` values are converted to `true` / `false` with string
- `object` values are stringified using `JSON.stringify`
- `null` or `undefined` values are displayed as "-"
This makes the `Keynote` component more robust and removes the need for manual value formatting before passing data.
 
Source:
[[Improvement] SYST-571: Change KeynoteProps for T to extends object](https://linear.app/systatum/issue/SYST-571/change-keynoteprops-for-t-to-extends-object)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself