### PR TITLE
[Feature] SYST-634: Allow defining action to a combobox option

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -234,12 +234,13 @@ function Button({
       $variant={variant}
     >
       <BaseButton
-        onClick={(e) => {
+        onMouseDown={(e) => {
           if (onClick && showSubMenuOn === "caret") {
             onClick(e);
           }
-          if (subMenu && showSubMenuOn === "self") {
+          if (onClick && subMenu && showSubMenuOn === "self") {
             e.stopPropagation();
+            e.preventDefault();
             setIsOpen(!isOpen);
           } else {
             setIsOpen(false);

--- a/components/combobox.stories.tsx
+++ b/components/combobox.stories.tsx
@@ -6,6 +6,7 @@ import {
   ComboboxOption,
   ComboboxSingleOption,
   ComboboxDropdownOption,
+  ComboboxItemAction,
 } from "./combobox";
 import { SelectboxSelectedOptions } from "./selectbox";
 import { RiAddLine } from "@remixicon/react";
@@ -348,14 +349,36 @@ export const WithActions: Story = {
   render: () => {
     const [value, setValue] = useState<SelectboxSelectedOptions>("");
 
+    const OPTION_ACTIONS = (id: string): ComboboxItemAction[] => [
+      {
+        caption: "Run",
+        onClick: () => {
+          console.log(`run this ${id}`);
+        },
+      },
+      {
+        caption: "Delete",
+        onClick: () => {
+          console.log(`delete this ${id}`);
+        },
+        icon: { image: RemixIcons.RiDeleteBack2Line },
+      },
+      {
+        onClick: () => {
+          console.log(`delete this ${id}`);
+        },
+        icon: { image: RemixIcons.RiFileCopyLine },
+      },
+    ];
+
     const FRUIT_OPTIONS: ComboboxSingleOption[] = [
-      { text: "Apple", value: "1" },
-      { text: "Banana", value: "2" },
-      { text: "Orange", value: "3" },
-      { text: "Grape", value: "4" },
-      { text: "Pineapple", value: "5" },
-      { text: "Strawberry", value: "6" },
-      { text: "Watermelon", value: "7" },
+      { text: "Apple", value: "1", actions: OPTION_ACTIONS },
+      { text: "Banana", value: "2", actions: OPTION_ACTIONS },
+      { text: "Orange", value: "3", actions: OPTION_ACTIONS },
+      { text: "Grape", value: "4", actions: OPTION_ACTIONS },
+      { text: "Pineapple", value: "5", actions: OPTION_ACTIONS },
+      { text: "Strawberry", value: "6", actions: OPTION_ACTIONS },
+      { text: "Watermelon", value: "7", actions: OPTION_ACTIONS },
     ];
 
     const FRUIT_ACTIONS: ComboboxAction[] = [

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -57,7 +57,7 @@ export const ComboboxGroupInitialState = {
 export type ComboboxGroupInitialState =
   (typeof ComboboxGroupInitialState)[keyof typeof ComboboxGroupInitialState];
 
-export interface ComboboxGroupedOption extends ComboboxActionOption {
+export interface ComboboxGroupedOption {
   category?: string;
   options?: ComboboxSingleOption[];
   collapsible?: boolean;

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -19,7 +19,7 @@ import {
   SelectboxStyles,
 } from "./selectbox";
 import styled, { css, CSSProp } from "styled-components";
-import { List, ListItemStyles } from "./list";
+import { List, ListItemAction, ListItemStyles } from "./list";
 import { FieldLaneDropdownOption, FieldLaneProps } from "./field-lane";
 import { Figure, FigureProps } from "./figure";
 import { StatefulForm } from "./stateful-form";
@@ -57,7 +57,7 @@ export const ComboboxGroupInitialState = {
 export type ComboboxGroupInitialState =
   (typeof ComboboxGroupInitialState)[keyof typeof ComboboxGroupInitialState];
 
-export interface ComboboxGroupedOption {
+export interface ComboboxGroupedOption extends ComboboxActionOption {
   category?: string;
   options?: ComboboxSingleOption[];
   collapsible?: boolean;
@@ -65,7 +65,12 @@ export interface ComboboxGroupedOption {
   initialState?: ComboboxGroupInitialState;
 }
 
-export type ComboboxSingleOption = SelectboxOption;
+export type ComboboxSingleOption = SelectboxOption & ComboboxActionOption;
+export interface ComboboxActionOption {
+  actions?: (id?: string) => ComboboxItemAction[];
+}
+
+export type ComboboxItemAction = ListItemAction;
 
 export type ComboboxOption = ComboboxSingleOption | ComboboxGroupedOption;
 
@@ -452,7 +457,7 @@ function ComboboxDrawer({
     return { mapped, totalOptions };
   }, [options, openedCategoryGroup]);
 
-  function renderOption(option: SelectboxOption, index: number) {
+  function renderOption(option: ComboboxSingleOption, index: number) {
     const optionValue = String(option.value);
     const isSelected = finalSelectedOptions.includes(optionValue);
 
@@ -463,6 +468,7 @@ function ComboboxDrawer({
       <List.Item
         id={String(option.value)}
         title={option.render ? option.render : option.text}
+        actions={option?.actions}
         styles={{
           rowStyle: listItemRowStyle({
             shouldHighlight,
@@ -748,6 +754,7 @@ const listItemRowStyle = ({
   transition: background-color 0ms;
   background-color: ${theme.backgroundColor};
   color: ${theme.textColor};
+  min-height: 36px;
 
   ${interactionMode !== "mouse" &&
   css`

--- a/components/context-menu.tsx
+++ b/components/context-menu.tsx
@@ -97,6 +97,9 @@ export default function ContextMenu({
       showSubMenuOn="self"
       onOpen={onOpen}
       open={open}
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
       subMenu={({ list }) => list(actions)}
       icon={{
         image: RiMoreFill,

--- a/components/list.tsx
+++ b/components/list.tsx
@@ -916,7 +916,6 @@ export interface ListItemProps {
   groupId?: string;
   selectable?: boolean;
   onSelected?: (selected: ChangeEvent<HTMLInputElement>) => void;
-  onClick?: () => void;
   rightSideContent?: ((prop: string) => ReactNode) | ReactNode;
   actions?: (id?: string) => ListItemAction[];
   children?: ReactNode;
@@ -931,6 +930,7 @@ export interface ListItemProps {
   hoverTextColor?: string;
   hoverBackgroundColor?: string;
   selected?: boolean;
+  onClick?: (e: MouseEvent<HTMLDivElement>) => void;
   onMouseEnter?: (e: MouseEvent<HTMLDivElement>) => void;
   onMouseDown?: (e: MouseEvent<HTMLDivElement>) => void;
   onMouseLeave?: (e: MouseEvent<HTMLDivElement>) => void;
@@ -1048,9 +1048,10 @@ const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
           }
           $textColor={listTheme.textColor}
           draggable={draggable}
-          onClick={() => {
+          onClick={(e) => {
+            e.preventDefault();
             if (onClick) {
-              onClick();
+              onClick(e);
             }
             if (openable) {
               setIsOpen(idFullname, "item");

--- a/components/list.tsx
+++ b/components/list.tsx
@@ -1211,10 +1211,6 @@ const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
                     ?.filter((action) => !action?.hidden)
                     .map((action) => ({
                       ...action,
-                      icon: {
-                        ...action?.icon,
-                        image: action?.icon?.image ?? RiArrowRightSLine,
-                      },
                       onClick: (e?: React.MouseEvent) => {
                         action?.onClick?.(e);
                         if (listActions?.length > 1) {

--- a/components/tip-menu.tsx
+++ b/components/tip-menu.tsx
@@ -122,7 +122,7 @@ function TipMenu({
 }
 
 export interface TipMenuItemProps {
-  caption: string;
+  caption?: string;
   icon?: FigureProps;
   onClick?: (e?: React.MouseEvent) => void;
   variant?: TipMenuVariant;

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -1,6 +1,7 @@
 import {
   Combobox,
   ComboboxAction,
+  ComboboxItemAction,
   ComboboxOption,
   ComboboxProps,
   ComboboxSingleOption,
@@ -8,8 +9,10 @@ import {
 import { Button } from "./../../components/button";
 import {
   RiAddLine,
+  RiDeleteBack2Line,
   RiHome2Line,
   RiLogoutBoxLine,
+  RiRunLine,
   RiSettings2Line,
   RiUser2Line,
 } from "@remixicon/react";
@@ -23,6 +26,33 @@ const FRUIT_OPTIONS: ComboboxSingleOption[] = [
   { text: "Pineapple", value: "5" },
   { text: "Strawberry", value: "6" },
   { text: "Watermelon", value: "7" },
+];
+
+const OPTION_ACTIONS = (id: string | number): ComboboxItemAction[] => [
+  {
+    caption: "Run",
+    onClick: () => {
+      console.log(`run this ${id}`);
+    },
+    icon: { image: RiRunLine },
+  },
+  {
+    caption: "Delete",
+    onClick: () => {
+      console.log(`delete this ${id}`);
+    },
+    icon: { image: RiDeleteBack2Line },
+  },
+];
+
+const FRUIT_OPTIONS_WITH_ACTIONS: ComboboxSingleOption[] = [
+  { text: "Apple", value: "1", actions: OPTION_ACTIONS },
+  { text: "Banana", value: "2", actions: OPTION_ACTIONS },
+  { text: "Orange", value: "3", actions: OPTION_ACTIONS },
+  { text: "Grape", value: "4", actions: OPTION_ACTIONS },
+  { text: "Pineapple", value: "5", actions: OPTION_ACTIONS },
+  { text: "Strawberry", value: "6", actions: OPTION_ACTIONS },
+  { text: "Watermelon", value: "7", actions: OPTION_ACTIONS },
 ];
 
 const MIX_FRUIT_OPTIONS: ComboboxOption[] = [
@@ -101,6 +131,46 @@ describe("Combobox", () => {
       />
     );
   }
+
+  context("option with actions", () => {
+    context("with single option", () => {
+      beforeEach(() => {
+        cy.window().then((win) => {
+          cy.spy(win.console, "log").as("consoleLog");
+        });
+
+        cy.mount(<ProductCombobox options={FRUIT_OPTIONS_WITH_ACTIONS} />);
+        cy.findByLabelText("action-button").should("not.exist");
+
+        cy.findByPlaceholderText("Select a fruit...").click();
+        cy.findByText("Apple").trigger("mouseover");
+      });
+
+      it("renders the action in the combobox option", () => {
+        cy.findAllByLabelText("action-button").eq(0).should("exist");
+      });
+
+      context("with clicking the ellipsis", () => {
+        it("shows the tip menu option", () => {
+          cy.findAllByLabelText("action-button").eq(0).should("exist").click();
+          cy.findByText("Run").should("exist");
+          cy.findByText("Delete").should("exist");
+        });
+
+        context("when clicking the one of tip menu option", () => {
+          it("renders the console log", () => {
+            cy.findAllByLabelText("action-button")
+              .eq(0)
+              .should("exist")
+              .click();
+            cy.findByText("Run").should("exist").click();
+
+            cy.get("@consoleLog").should("have.been.calledWith", "run this 1");
+          });
+        });
+      });
+    });
+  });
 
   context("style", () => {
     it("should render the height with 34px", () => {


### PR DESCRIPTION
Description:
This pull request introduces an `actions` in the `Combobox` option to be able using `action`, similar like in the `TreeList` or `List`. It also updates the story `with actions` with 3 actions:
1. one without icon (caption: Run) 
2. one with icon (caption: Delete), 
3. one just icon (let's say using icon of copy).

Source:
[[Feature] SYST-634: Allow defining action to a combobox option](https://linear.app/systatum/issue/SYST-634/allow-defining-action-to-a-combobox-option)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself