### PR TITLE
[Bug] SYST-648: Fix theme error: cannot import from `@systatum/coneto/theme`

### DIFF
--- a/components/Dark mode.mdx
+++ b/components/Dark mode.mdx
@@ -35,6 +35,43 @@ mode. No additional configuration is required.
 
 If no theme is provided, the default mode is `"light"`.
 
+## Using currentTheme (fully theme-driven styling)
+
+You can use `currentTheme` from `useTheme()` to automatically follow the design system tokens defined in AppTheme.
+
+This is useful when:
+
+- You want consistent UI across components
+- You want to follow your theme system (body, button, textbox, etc.)
+
+```tsx
+import { useTheme } from "@systatum/coneto/theme";
+
+function Content() {
+  const { currentTheme } = useTheme();
+
+  // base layout colors from body theme
+  const body = currentTheme.body;
+
+  // focus border color from fieldLane theme
+  const borderColor = currentTheme.fieldLane.focusedBorderColor;
+
+  return (
+    <div
+      style={{
+        backgroundColor: body.backgroundColor,
+        color: body.textColor,
+        padding: 16,
+        borderRadius: 8,
+        border: `1px solid ${borderColor}`,
+      }}
+    >
+      {"Your Content"}
+    </div>
+  );
+}
+```
+
 ## Automatic component adaptation
 
 Components just work with the theme out of the box. Take a `Button`, for example. In

--- a/components/Dark mode.mdx
+++ b/components/Dark mode.mdx
@@ -42,7 +42,7 @@ You can use `currentTheme` from `useTheme()` to automatically follow the design 
 This is useful when:
 
 - You want consistent UI across components
-- You want to follow your theme system (body, button, textbox, etc.)
+- You want to follow our theme system (body, button, textbox, etc.)
 
 ```tsx
 import { useTheme } from "@systatum/coneto/theme";
@@ -66,7 +66,43 @@ function Content() {
         border: `1px solid ${borderColor}`,
       }}
     >
-      {"Your Content"}
+      Your Content
+    </div>
+  );
+}
+```
+
+## Using `mode` from `useTheme()` (manual theme switch styling)
+
+The mode value comes from the `<Theme />` or `<ThemeProvider />` and reflects the current theme state (`light` or `dark`).
+
+By default, the theme is set to `light` unless explicitly configured otherwise in the provider.
+
+This is useful when:
+
+- You want simple `light`/`dark` conditional styling
+- You don’t depend on full theme tokens
+- You need quick custom UI adjustments
+
+```tsx
+import { useTheme } from "@systatum/coneto/theme";
+
+function Content() {
+  const { mode } = useTheme();
+
+  const isDark = mode === "dark";
+
+  return (
+    <div
+      style={{
+        backgroundColor: isDark ? "#111827" : "#ffffff",
+        color: isDark ? "#f9fafb" : "#111827",
+        padding: 16,
+        borderRadius: 8,
+        border: `1px solid ${isDark ? "#374151" : "#e5e7eb"}`,
+      }}
+    >
+      Your Content
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -117,6 +117,10 @@
       "import": "./dist/components/grid.js",
       "types": "./dist/components/grid.d.ts"
     },
+    "./helper": {
+      "import": "./dist/components/helper.js",
+      "types": "./dist/components/helper.d.ts"
+    },
     "./imagebox": {
       "import": "./dist/components/imagebox.js",
       "types": "./dist/components/imagebox.d.ts"
@@ -209,6 +213,10 @@
       "import": "./dist/components/signbox.js",
       "types": "./dist/components/signbox.d.ts"
     },
+    "./split-pane": {
+      "import": "./dist/components/split-pane.js",
+      "types": "./dist/components/split-pane.d.ts"
+    },
     "./stateful-form": {
       "import": "./dist/components/stateful-form.js",
       "types": "./dist/components/stateful-form.d.ts"
@@ -220,10 +228,6 @@
     "./stepline": {
       "import": "./dist/components/stepline.js",
       "types": "./dist/components/stepline.d.ts"
-    },
-    "./split-pane": {
-      "import": "./dist/components/split-pane.js",
-      "types": "./dist/components/split-pane.d.ts"
     },
     "./table": {
       "import": "./dist/components/table.js",
@@ -272,6 +276,14 @@
     "./constants/*": {
       "import": "./dist/constants/*.js",
       "types": "./dist/constants/*.d.ts"
+    },
+    "./theme": {
+      "import": "./dist/theme/index.js",
+      "types": "./dist/theme/index.d.ts"
+    },
+    "./theme/*": {
+      "import": "./dist/theme/*.js",
+      "types": "./dist/theme/*.d.ts"
     },
     "./code-color": {
       "import": "./dist/lib/code-color.js",

--- a/scripts/generate-export.cjs
+++ b/scripts/generate-export.cjs
@@ -40,6 +40,10 @@ const additionalExports = {
     import: "./dist/constants/*.js",
     types: "./dist/constants/*.d.ts",
   },
+  "./theme": {
+    import: "./dist/theme/index.js",
+    types: "./dist/theme/index.d.ts",
+  },
   "./theme/*": {
     import: "./dist/theme/*.js",
     types: "./dist/theme/*.d.ts",

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -792,3 +792,4 @@ export interface AppTheme {
 }
 
 export * from "./provider";
+export * from "./mode";


### PR DESCRIPTION
Description:
This pull request fixes an issue `import` behavior, allowing modules to be resolved not only per folder, but also through the `theme` entry point via `index.ts`. As a result, users now can import using:

`import { Theme } from "@systatum/coneto/theme"`

Source:
[[Bug] SYST-648: Fix theme error: cannot import from `@systatum/coneto/theme`](https://linear.app/systatum/issue/SYST-648/fix-theme-error-cannot-import-from-systatumconetotheme)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself