### PR TITLE
[Bug] SYST-647: Fix bug input file is opening dialog twice

### DIFF
--- a/components/file-input-box.tsx
+++ b/components/file-input-box.tsx
@@ -45,13 +45,8 @@ function BaseFileInputBox({
   const { currentTheme } = useTheme();
   const fileInputBoxTheme = currentTheme.fileInputBox;
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
-
-  const handleBrowseClick = () => {
-    fileInputRef.current?.click();
-  };
 
   const handleDeleteFile = (index: number) => {
     const updatedFiles = selectedFiles.filter((_, i) => i !== index);
@@ -100,10 +95,6 @@ function BaseFileInputBox({
       $style={styles?.self}
       $isDragging={!disabled && isDragging}
       $hasFile={selectedFiles.length > 0}
-      onClick={() => {
-        if (disabled) return;
-        handleBrowseClick();
-      }}
       onDrop={(e) => {
         if (disabled) return;
         handleDrop(e);
@@ -155,7 +146,6 @@ function BaseFileInputBox({
       )}
       <input
         {...props}
-        ref={fileInputRef}
         type="file"
         accept={accept}
         disabled={disabled}


### PR DESCRIPTION
Description:
This pull request fixes an issue where the file explorer would open multiple times when users clicked the input element. It also ensuring it now opens only once.

Source:
[[Bug] SYST-647: Fix bug input file is opening dialog twice](https://linear.app/systatum/issue/SYST-647/fix-bug-input-file-is-opening-dialog-twice)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself