### PR TITLE
[Bug] SYST-651: Fix issue `FieldLane` can't opened after setup `onClick` in `Combobox`

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -239,13 +239,12 @@ function Button({
     >
       <BaseButton
         $theme={buttonTheme}
-        onMouseDown={(e) => {
+        onClick={(e) => {
           if (onClick && showSubMenuOn === "caret") {
             onClick(e);
           }
-          if (onClick && subMenu && showSubMenuOn === "self") {
+          if (subMenu && showSubMenuOn === "self") {
             e.stopPropagation();
-            e.preventDefault();
             setIsOpen(!isOpen);
           } else {
             setIsOpen(false);

--- a/components/context-menu.tsx
+++ b/components/context-menu.tsx
@@ -81,6 +81,10 @@ export default function ContextMenu({
             action.onClick(e);
           }
         }}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+        }}
         onOpen={onOpen}
         title={action.caption}
         className={action.className}
@@ -99,6 +103,10 @@ export default function ContextMenu({
       open={open}
       onClick={(e) => {
         e.stopPropagation();
+      }}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
       }}
       subMenu={({ list }) => list(actions)}
       icon={{


### PR DESCRIPTION
Description:
This pull request fixes the `button.onClick` behavior after updating the `Combobox` where using an action inside an option caused 

However, previous change also introduced a regression in other components. For example, in `FieldLane`, the drawer no longer opens after clicking.

<img width="558" height="230" alt="image" src="https://github.com/user-attachments/assets/426053a2-4463-4a73-9215-6943d811efa5" />

Source:
[[Bug] SYST-651: Fix issue `FieldLane` can't opened after setup `onClick` in `Combobox`](https://linear.app/systatum/issue/SYST-651/fix-issue-fieldlane-cant-opened-after-setup-onclick-in-combobox)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself