### PR TITLE
[Improvement] SYST-649: Rename `id` on onClick for all dialog to be `buttonId`

### DIFF
--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -45,7 +45,7 @@ export interface DialogProps {
   onVisibilityChange?: (isOpen?: boolean) => void;
   closable?: boolean;
   styles?: DialogStyles;
-  onClick?: (args: { id: string; closeDialog: () => void }) => void;
+  onClick?: (args: { buttonId: string; closeDialog: () => void }) => void;
   buttons?: DialogButton[];
   title?: ReactNode;
   subtitle?: ReactNode;
@@ -219,22 +219,22 @@ function Dialog({
 
         {buttons && (
           <Footer $style={styles?.buttonWrapperStyle}>
-            {buttons.map((props, index) => (
+            {buttons.map((button, index) => (
               <Button
                 key={index}
-                isLoading={props.isLoading}
-                disabled={props.disabled}
-                variant={props.variant}
-                onClick={() => onClick?.({ id: props.id, closeDialog })}
+                isLoading={button.isLoading}
+                disabled={button.disabled}
+                variant={button.variant}
+                onClick={() => onClick?.({ buttonId: button.id, closeDialog })}
                 styles={{
-                  ...props?.styles,
+                  ...button?.styles,
                   self: css`
                     min-width: 100px;
-                    ${props?.styles?.self}
+                    ${button?.styles?.self}
                   `,
                 }}
               >
-                {props.caption}
+                {button.caption}
               </Button>
             ))}
           </Footer>
@@ -415,8 +415,8 @@ function DialogProvider({
       onVisibilityChange={(open?: boolean) => {
         if (!open) closeDialog();
       }}
-      onClick={({ id }) => {
-        config.onClick({ id, closeDialog });
+      onClick={({ buttonId }) => {
+        config.onClick({ buttonId, closeDialog });
       }}
       onClosed={() => {
         config.onClosed?.();

--- a/test/component/dialog.cy.tsx
+++ b/test/component/dialog.cy.tsx
@@ -15,7 +15,7 @@ describe("Dialog", () => {
   }
 
   context("with Dialog.show()", () => {
-    it("renders the modal dialog", () => {
+    beforeEach(() => {
       cy.mount(
         <Button
           onClick={() =>
@@ -27,6 +27,10 @@ describe("Dialog", () => {
                 { id: "confirm", caption: "Confirm", variant: "primary" },
                 { id: "cancel", caption: "Cancel", variant: "default" },
               ],
+              onClick: ({ buttonId, closeDialog }) => {
+                console.log(`this is button ${buttonId}`);
+                closeDialog();
+              },
             })
           }
         >
@@ -40,6 +44,25 @@ describe("Dialog", () => {
       cy.findByLabelText("dialog-wrapper").should("exist");
       cy.findByText("Default Modal").should("exist");
       cy.findByText("This is a subtitle").should("exist");
+    });
+
+    it("renders the modal dialog", () => {
+      // will covered by beforeEach
+    });
+  });
+
+  context("when clicking button", () => {
+    it("should display console per id", () => {
+      cy.window().then((win) => {
+        cy.spy(win.console, "log").as("consoleLog");
+      });
+
+      cy.findByText("Confirm").should("exist").click();
+      cy.wait(300);
+      cy.get("@consoleLog").should(
+        "have.been.calledWith",
+        "this is button confirm"
+      );
     });
   });
 

--- a/test/component/dialog.cy.tsx
+++ b/test/component/dialog.cy.tsx
@@ -40,14 +40,12 @@ describe("Dialog", () => {
 
       cy.findByLabelText("dialog-wrapper").should("not.exist");
       cy.findByRole("button").click();
-
-      cy.findByLabelText("dialog-wrapper").should("exist");
-      cy.findByText("Default Modal").should("exist");
-      cy.findByText("This is a subtitle").should("exist");
     });
 
     it("renders the modal dialog", () => {
-      // will covered by beforeEach
+      cy.findByLabelText("dialog-wrapper").should("exist");
+      cy.findByText("Default Modal").should("exist");
+      cy.findByText("This is a subtitle").should("exist");
     });
   });
 
@@ -56,6 +54,10 @@ describe("Dialog", () => {
       cy.window().then((win) => {
         cy.spy(win.console, "log").as("consoleLog");
       });
+
+      cy.findByLabelText("dialog-wrapper").should("exist");
+      cy.findByText("Default Modal").should("exist");
+      cy.findByText("This is a subtitle").should("exist");
 
       cy.findByText("Confirm").should("exist").click();
       cy.wait(300);


### PR DESCRIPTION
Description:
This pull request improves the `Button.onClick` handler inside the `Dialog` by renaming the `id` parameter to `buttonId`, making the argument name clearer and more explicit.

Source:
[[Improvement] SYST-649: Rename `id` on onClick for all dialog to be `buttonId`](https://linear.app/systatum/issue/SYST-649/rename-id-on-onclick-for-all-dialog-to-be-buttonid)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself