### PR TITLE
[Improvement] SYST-604: Add `actions` to separator

### DIFF
--- a/components/separator.stories.tsx
+++ b/components/separator.stories.tsx
@@ -24,6 +24,49 @@ Separator is a visual divider component that separates content into sections wit
 - ↔️ **Text float**: Title can float left or right.
 - 🧱 **Custom depth**: Adjust distance of the title from the container edge.
 - 🎨 **Customizable styles**: Supports container, line, and title styling via CSS props.
+
+### ⚡ Actions
+
+The \`actions\` prop allows you to attach interactive elements (such as icon buttons) to the separator.
+
+These actions are typically displayed on the opposite side of the title and can be used for quick operations like edit, copy, or open menus.
+
+---
+
+#### 🧱 Action Structure
+Each item in \`actions\` follows this shape:
+
+- \`icon\` (**required**) → Icon configuration (FigureProps)
+- \`caption\` → Tooltip text
+- \`onClick\` → Click handler
+- \`alwaysShow\` → Control visibility behavior (default: true)
+- \`hidden\` → Hide action completely
+- \`styles\` → Custom styles for button, tooltip, and positioning
+
+---
+
+#### 📌 Example
+\`\`\`tsx
+const actions = [
+  {
+    icon: { image: RiEditLine },
+    caption: "Edit",
+    onClick: () => console.log("Edit clicked"),
+  },
+  {
+    icon: { image: RiDeleteBinLine },
+    caption: "Delete",
+    alwaysShow: false,
+  },
+];
+\`\`\`
+
+---
+
+#### 🎯 Behavior Notes
+- Actions are automatically positioned with spacing.
+- Position adjusts based on \`textFloat\` (left or right).
+- Hovering the separator reveals actions when \`alwaysShow\` is false.
         `,
       },
     },
@@ -46,6 +89,19 @@ Separator is a visual divider component that separates content into sections wit
       control: false,
       description:
         "Custom styles object for container, line, and title. Not editable via controls.",
+    },
+    actions: {
+      control: false,
+      description: `
+List of action items displayed on the separator.
+
+Each action can include an icon, tooltip (caption), click handler, visibility control, and custom styles.
+
+- Supports hover-based visibility using \`alwaysShow\`
+- Automatically positioned based on \`textFloat\`
+- Can be hidden using \`hidden\`
+- Fully customizable via \`styles\` inside each action
+  `,
     },
   },
 };

--- a/components/separator.stories.tsx
+++ b/components/separator.stories.tsx
@@ -1,5 +1,10 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Separator } from "./separator";
+import { Separator, SeparatorAction } from "./separator";
+import {
+  RiFileList3Line,
+  RiGitBranchLine,
+  RiUserAddLine,
+} from "@remixicon/react";
 
 const meta: Meta<typeof Separator> = {
   title: "Stage/Separator",
@@ -73,5 +78,20 @@ export const RightSide: Story = {
   },
   render: (args) => {
     return <Separator {...args} />;
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    title: "Antrikan App Redesign",
+  },
+  render: (args) => {
+    const ACTIONS: SeparatorAction[] = [
+      { icon: { image: RiUserAddLine }, caption: "Invite" },
+      { icon: { image: RiGitBranchLine }, caption: "Branch" },
+      { icon: { image: RiFileList3Line }, caption: "Specs" },
+    ];
+
+    return <Separator {...args} actions={ACTIONS} />;
   },
 };

--- a/components/separator.stories.tsx
+++ b/components/separator.stories.tsx
@@ -145,7 +145,7 @@ export const WithActions: Story = {
     const ACTIONS: SeparatorAction[] = [
       { icon: { image: RiUserAddLine }, caption: "Invite" },
       { icon: { image: RiGitBranchLine }, caption: "Branch" },
-      { icon: { image: RiFileList3Line }, caption: "Specs" },
+      { icon: { image: RiFileList3Line }, caption: "Specs", alwaysShow: false },
     ];
 
     return <Separator {...args} actions={ACTIONS} />;

--- a/components/separator.stories.tsx
+++ b/components/separator.stories.tsx
@@ -31,9 +31,6 @@ The \`actions\` prop allows you to attach interactive elements (such as icon but
 
 These actions are typically displayed on the opposite side of the title and can be used for quick operations like edit, copy, or open menus.
 
----
-
-#### 🧱 Action Structure
 Each item in \`actions\` follows this shape:
 
 - \`icon\` (**required**) → Icon configuration (FigureProps)

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -1,5 +1,8 @@
-import styled, { CSSProp } from "styled-components";
+import styled, { css, CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
+import { FigureProps } from "./figure";
+import { Button } from "./button";
+import { Tooltip } from "./tooltip";
 
 export const SeparatorTextFloat = {
   Left: "left",
@@ -14,6 +17,7 @@ export interface SeparatorProps {
   textFloat?: SeparatorTextFloat;
   depth?: string;
   styles?: SeparatorStyles;
+  actions?: SeparatorAction[];
 }
 
 export interface SeparatorStyles {
@@ -27,6 +31,7 @@ function Separator({
   styles,
   textFloat = "left",
   depth = "20px",
+  actions,
 }: SeparatorProps) {
   const { currentTheme } = useTheme();
   const separatorTheme = currentTheme.separator;
@@ -36,7 +41,11 @@ function Separator({
       $style={styles?.containerStyle}
       $color={separatorTheme.containerColor}
     >
-      <Line $style={styles?.lineStyle} $color={separatorTheme.lineColor} $lineShadow={separatorTheme.lineShadow} />
+      <Line
+        $style={styles?.lineStyle}
+        $color={separatorTheme.lineColor}
+        $lineShadow={separatorTheme.lineShadow}
+      />
       <Title
         $style={styles?.titleStyle}
         $textFloat={textFloat}
@@ -46,6 +55,10 @@ function Separator({
       >
         {title}
       </Title>
+
+      {actions?.map((action, index) => (
+        <SeparatorAction key={index} {...action} />
+      ))}
     </SeparatorContainer>
   );
 }
@@ -58,7 +71,11 @@ const SeparatorContainer = styled.div<{ $style?: CSSProp; $color?: string }>`
   ${({ $style }) => $style}
 `;
 
-const Line = styled.span<{ $style?: CSSProp; $color?: string, $lineShadow?: string }>`
+const Line = styled.span<{
+  $style?: CSSProp;
+  $color?: string;
+  $lineShadow?: string;
+}>`
   position: absolute;
   width: 100%;
   height: 2px;
@@ -89,5 +106,79 @@ const Title = styled.span<{
 
   ${({ $style }) => $style}
 `;
+
+export interface SeparatorAction {
+  caption?: string;
+  icon: FigureProps;
+  alwaysShow?: boolean;
+  onClick?: () => void;
+  hidden?: boolean;
+  styles?: SeparatorStyles;
+}
+
+export interface SeparatorStyles {
+  self?: CSSProp;
+}
+
+function SeparatorAction({
+  icon,
+  alwaysShow,
+  caption,
+  hidden,
+  onClick,
+  styles,
+}: SeparatorAction) {
+  const { currentTheme } = useTheme();
+  const separatorTheme = currentTheme?.separator;
+
+  if (hidden) {
+    return;
+  }
+  return (
+    <Tooltip
+      dialog={caption}
+      styles={{
+        containerStyle: css`
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+          right: 20px;
+          ${!alwaysShow &&
+          css`
+            opacity: 0;
+            pointer-events: none;
+          `}
+
+          ${SeparatorContainer}:hover & {
+            opacity: 1;
+            pointer-events: auto;
+          }
+        `,
+      }}
+    >
+      <Button
+        variant="outline-default"
+        icon={icon}
+        onClick={() => onClick?.()}
+        styles={{
+          containerStyle: css`
+            border-radius: 9999px;
+          `,
+          self: css`
+            border-radius: 9999px;
+            height: 24px;
+            width: 24px;
+            padding: 2px;
+            background-color: ${separatorTheme?.backgroundTitleColor};
+            &:hover {
+              color: inherit;
+            }
+            ${styles?.self}
+          `,
+        }}
+      />
+    </Tooltip>
+  );
+}
 
 export { Separator };

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -56,9 +56,42 @@ function Separator({
         {title}
       </Title>
 
-      {actions?.map((action, index) => (
-        <SeparatorAction key={index} {...action} />
-      ))}
+      {actions?.map((action, index) => {
+        const base = 20;
+        const gap = 30;
+        const offset = base + index * gap;
+
+        return (
+          <SeparatorAction
+            key={index}
+            {...action}
+            alwaysShow={action?.alwaysShow ?? true}
+            styles={{
+              ...action?.styles,
+              arrowStyle: css`
+                ${textFloat === "right"
+                  ? css`
+                      right: 9px;
+                    `
+                  : css`
+                      left: 9px;
+                    `}
+
+                ${action?.styles?.arrowStyle}
+              `,
+              containerStyle: css`
+                ${textFloat === "right"
+                  ? css`
+                      left: ${offset}px;
+                    `
+                  : css`
+                      right: ${offset}px;
+                    `}
+              `,
+            }}
+          />
+        );
+      })}
     </SeparatorContainer>
   );
 }
@@ -113,11 +146,14 @@ export interface SeparatorAction {
   alwaysShow?: boolean;
   onClick?: () => void;
   hidden?: boolean;
-  styles?: SeparatorStyles;
+  styles?: SeparatorActionStyles;
 }
 
-export interface SeparatorStyles {
+export interface SeparatorActionStyles {
   self?: CSSProp;
+  containerStyle?: CSSProp;
+  drawerStyle?: CSSProp;
+  arrowStyle?: CSSProp;
 }
 
 function SeparatorAction({
@@ -138,11 +174,17 @@ function SeparatorAction({
     <Tooltip
       dialog={caption}
       styles={{
+        arrowStyle: styles?.arrowStyle,
         containerStyle: css`
           position: absolute;
           top: 50%;
           transform: translateY(-50%);
           right: 20px;
+
+          transition:
+            opacity 0.2s ease,
+            transform 0.2s ease;
+
           ${!alwaysShow &&
           css`
             opacity: 0;
@@ -153,7 +195,10 @@ function SeparatorAction({
             opacity: 1;
             pointer-events: auto;
           }
+
+          ${styles?.containerStyle}
         `,
+        drawerStyle: styles?.drawerStyle,
       }}
     >
       <Button

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -102,7 +102,10 @@ const SeparatorContainer = styled.div<{ $style?: CSSProp; $color?: string }>`
   position: relative;
   width: 100%;
   display: flex;
+  height: 24px;
+  align-items: center;
   color: ${({ $color }) => $color};
+
   ${({ $style }) => $style}
 `;
 

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -38,10 +38,12 @@ function Separator({
 
   return (
     <SeparatorContainer
+      aria-label="separator-container"
       $style={styles?.containerStyle}
       $color={separatorTheme.containerColor}
     >
       <Line
+        aria-label="separator-line"
         $style={styles?.lineStyle}
         $color={separatorTheme.lineColor}
         $lineShadow={separatorTheme.lineShadow}
@@ -204,6 +206,7 @@ function SeparatorAction({
       <Button
         variant="outline-default"
         icon={icon}
+        aria-label="separator-action"
         onClick={() => onClick?.()}
         styles={{
           containerStyle: css`

--- a/test/component/separator.cy.tsx
+++ b/test/component/separator.cy.tsx
@@ -38,7 +38,7 @@ describe("Separator", () => {
     });
 
     context("with alwaysShows", () => {
-      context("when given true", () => {
+      context("with true", () => {
         it("should shows the actions", () => {
           cy.findAllByLabelText("separator-action")
             .should("exist")
@@ -46,7 +46,7 @@ describe("Separator", () => {
         });
       });
 
-      context("when given false", () => {
+      context("with false", () => {
         beforeEach(() => {
           cy.mount(
             <ProductSeparator

--- a/test/component/separator.cy.tsx
+++ b/test/component/separator.cy.tsx
@@ -61,6 +61,7 @@ describe("Separator", () => {
             />
           );
         });
+
         it("should not shows the actions", () => {
           cy.findAllByLabelText("separator-action")
             .should("not.be.visible")

--- a/test/component/separator.cy.tsx
+++ b/test/component/separator.cy.tsx
@@ -1,0 +1,119 @@
+import {
+  RiFileList3Line,
+  RiGitBranchLine,
+  RiUserAddLine,
+} from "@remixicon/react";
+import {
+  Separator,
+  SeparatorAction,
+  SeparatorProps,
+} from "./../../components/separator";
+
+describe("Separator", () => {
+  const ACTIONS: SeparatorAction[] = [
+    {
+      icon: { image: RiUserAddLine },
+      caption: "Invite",
+      onClick: () => console.log("this is invite"),
+    },
+    {
+      icon: { image: RiGitBranchLine },
+      caption: "Branch",
+      onClick: () => console.log("this is branch"),
+    },
+    {
+      icon: { image: RiFileList3Line },
+      caption: "Specs",
+      onClick: () => console.log("this is specs"),
+    },
+  ];
+  function ProductSeparator(props: SeparatorProps) {
+    return (
+      <Separator actions={ACTIONS} title="Antrikan App Redesign" {...props} />
+    );
+  }
+  context("actions", () => {
+    beforeEach(() => {
+      cy.mount(<ProductSeparator />);
+    });
+
+    context("with alwaysShows", () => {
+      context("when given true", () => {
+        it("should shows the actions", () => {
+          cy.findAllByLabelText("separator-action")
+            .should("exist")
+            .and("have.length", 3);
+        });
+      });
+
+      context("when given false", () => {
+        beforeEach(() => {
+          cy.mount(
+            <ProductSeparator
+              actions={[
+                {
+                  icon: { image: RiUserAddLine },
+                  caption: "Invite",
+                  onClick: () => console.log("this is invite"),
+                  alwaysShow: false,
+                },
+              ]}
+            />
+          );
+        });
+        it("should not shows the actions", () => {
+          cy.findAllByLabelText("separator-action")
+            .should("not.be.visible")
+            .and("have.length", 1);
+        });
+
+        context("when hovering the separator", () => {
+          it("should shows the actions", () => {
+            cy.findAllByLabelText("separator-action")
+              .should("not.be.visible")
+              .and("have.length", 1);
+
+            cy.findByLabelText("separator-container").realHover().wait(100);
+            cy.findAllByLabelText("separator-action")
+              .should("be.visible")
+              .and("have.length", 1);
+          });
+        });
+      });
+    });
+
+    context("when given", () => {
+      it("should shows the actions", () => {
+        cy.findAllByLabelText("separator-action")
+          .should("exist")
+          .and("have.length", 3);
+      });
+    });
+
+    context("when clicking", () => {
+      it("should shows the console log", () => {
+        cy.window().then((win) => {
+          cy.spy(win.console, "log").as("consoleLog");
+        });
+
+        cy.mount(<ProductSeparator />);
+
+        cy.findAllByLabelText("separator-action").should("exist").eq(0).click();
+
+        cy.get("@consoleLog").should("have.been.calledWith", "this is invite");
+      });
+    });
+
+    context("when hovering", () => {
+      it("should shows the caption", () => {
+        cy.findByText(ACTIONS[0].caption).should("not.exist");
+        cy.findAllByLabelText("separator-action")
+          .should("exist")
+          .eq(0)
+          .realHover()
+          .wait(100);
+        cy.findByText("Invite").should("exist");
+      });
+    });
+  });
+});


### PR DESCRIPTION
Description:
This pull request introduces an `actions` prop to the `Separator`, which can be positioned on the left or right depending on the `textFloat` prop. The `actions` prop defining items with `caption`, `icon`, `onClick`, `hidden`, `styles`, and `alwaysShow`. 

The `alwaysShow` property controls visibility behavior: when set to `true` (by default is false), the action is always visible; when `false`, it oly appears on hover over the separator.

Interface:
```tsx
export interface SeparatorAction {
  caption?: string;
  icon: FigureProps;
  alwaysShow?: boolean;
  onClick?: () => void;
  hidden?: boolean;
  styles?: SeparatorActionStyles;
}
```

Source:
[[Improvement] SYST-604: Add `actions` to separator](https://linear.app/systatum/issue/SYST-604/add-actions-to-separator)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[] I have created/updated any relevant test code
[x] I have tested it myself