### PR TITLE
[Improvement] SYST-601: Allow nested menu/submenu in TipMenu

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -443,12 +443,12 @@ function ButtonTipMenuContainer({
 
   return (
     <TipMenuContainer
+      aria-label="button-tip-menu-container"
       {...props}
       $theme={buttonTipMenuContainer}
       onClick={(e) => {
         if (props.onClick) props.onClick?.(e);
       }}
-      aria-label="button-tip-menu-container"
       $style={styles?.self}
     >
       {children}

--- a/components/tip-menu.stories.tsx
+++ b/components/tip-menu.stories.tsx
@@ -413,6 +413,7 @@ export const NestedSubmenu: Story = {
         caption: "Edit Draft",
         icon: { image: RiEditLine },
         variant: "default",
+        disabled: true,
         subMenuList: [
           {
             caption: "Open in Editor",

--- a/components/tip-menu.stories.tsx
+++ b/components/tip-menu.stories.tsx
@@ -253,7 +253,7 @@ export const Default: Story = {
 
 export const NestedSubmenu: Story = {
   render: () => {
-    const TIP_MENU_LIST: TipMenuItemProps[] = [
+    const NESTED_TIP_MENU_ITEMS: TipMenuItemProps[] = [
       {
         caption: "Report Message",
         icon: { image: RiSpam2Line },
@@ -435,6 +435,6 @@ export const NestedSubmenu: Story = {
       },
     ];
 
-    return <TipMenu subMenuList={TIP_MENU_LIST} />;
+    return <TipMenu subMenuList={NESTED_TIP_MENU_ITEMS} />;
   },
 };

--- a/components/tip-menu.stories.tsx
+++ b/components/tip-menu.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { TipMenu } from "./tip-menu";
+import { TipMenu, TipMenuItemProps } from "./tip-menu";
 import { useState } from "react";
 import {
   RiSpam2Line,
@@ -12,6 +12,20 @@ import {
   RiShareLine,
   RiEditLine,
   RiDeleteBinLine,
+  RiSaveLine,
+  RiEyeLine,
+  RiDriveLine,
+  RiAttachmentLine,
+  RiShareForwardLine,
+  RiFlagLine,
+  RiStarLine,
+  RiMailUnreadLine,
+  RiFolderLine,
+  RiArchiveLine,
+  RiMailCloseLine,
+  RiShieldCrossLine,
+  RiAlertLine,
+  RiMailForbidLine,
 } from "@remixicon/react";
 import { ModalDialog, ModalDialogButton } from "./modal-dialog";
 
@@ -234,5 +248,192 @@ export const Default: Story = {
         </ModalDialog>
       </>
     );
+  },
+};
+
+export const NestedSubmenu: Story = {
+  render: () => {
+    const TIP_MENU_LIST: TipMenuItemProps[] = [
+      {
+        caption: "Report Message",
+        icon: { image: RiSpam2Line },
+        variant: "primary",
+        subMenuList: [
+          {
+            caption: "Report Phishing Attempt",
+            icon: { image: RiSpam2Line },
+            variant: "primary",
+            onClick: () => console.log("Phishing reported"),
+          },
+          {
+            caption: "Report as Junk",
+            icon: { image: RiForbid2Line },
+            onClick: () => console.log("Junk reported"),
+          },
+          {
+            caption: "Report Suspicious Content",
+            icon: { image: RiMailForbidLine },
+            variant: "default",
+            onClick: () => console.log("Spam reported"),
+          },
+          {
+            caption: "Report Online Scam",
+            icon: { image: RiAlertLine },
+            onClick: () => console.log("Scam reported"),
+          },
+        ],
+      },
+      {
+        caption: "Block Contact",
+        icon: { image: RiShieldLine },
+        subMenuList: [
+          {
+            caption: "Block This Sender",
+            icon: { image: RiShieldLine },
+            variant: "danger",
+            onClick: () => console.log("Sender blocked"),
+          },
+          {
+            caption: "Block Entire Domain",
+            icon: { image: RiShieldCrossLine },
+            onClick: () => console.log("Domain blocked"),
+          },
+          {
+            caption: "Unsubscribe from Mailing List",
+            icon: { image: RiMailCloseLine },
+            variant: "default",
+            onClick: () => console.log("Unsubscribed"),
+          },
+        ],
+      },
+      {
+        caption: "Move Message",
+        icon: { image: RiInboxArchiveLine },
+        variant: "success",
+        subMenuList: [
+          {
+            caption: "Move to Spam Folder",
+            icon: { image: RiInboxArchiveLine },
+            onClick: () => console.log("Moved to spam"),
+          },
+          {
+            caption: "Move to Trash",
+            icon: { image: RiDeleteBinLine },
+            variant: "danger",
+            onClick: () => console.log("Moved to trash"),
+          },
+          {
+            caption: "Move to Specific Folder",
+            icon: { image: RiFolderLine },
+            onClick: () => console.log("Moved to folder"),
+          },
+          {
+            caption: "Archive This Message",
+            icon: { image: RiArchiveLine },
+            variant: "primary",
+            onClick: () => console.log("Archived"),
+          },
+        ],
+      },
+      {
+        caption: "Mark Status",
+        icon: { image: RiCheckLine },
+        subMenuList: [
+          {
+            caption: "Mark as Read",
+            icon: { image: RiCheckLine },
+            variant: "primary",
+            onClick: () => console.log("Marked as read"),
+          },
+          {
+            caption: "Mark as Unread",
+            icon: { image: RiMailUnreadLine },
+            onClick: () => console.log("Marked as unread"),
+          },
+          {
+            caption: "Mark as Important",
+            icon: { image: RiStarLine },
+            variant: "default",
+            onClick: () => console.log("Marked as important"),
+          },
+          {
+            caption: "Flag for Follow Up",
+            icon: { image: RiFlagLine },
+            onClick: () => console.log("Flagged"),
+          },
+        ],
+      },
+      {
+        caption: "Share Message",
+        icon: { image: RiShareLine },
+        variant: "danger",
+        subMenuList: [
+          {
+            caption: "Forward to Someone",
+            icon: { image: RiShareForwardLine },
+            onClick: () => console.log("Forwarded"),
+          },
+          {
+            caption: "Copy Shareable Link",
+            icon: { image: RiLink },
+            variant: "default",
+            onClick: () => console.log("Link copied"),
+          },
+          {
+            caption: "Share via Other Apps",
+            icon: { image: RiShareLine },
+            onClick: () => console.log("Shared"),
+          },
+        ],
+      },
+      {
+        caption: "Manage Attachments",
+        icon: { image: RiAttachmentLine },
+        subMenuList: [
+          {
+            caption: "Download All Attachments",
+            icon: { image: RiDownloadLine },
+            variant: "success",
+            onClick: () => console.log("Downloading all"),
+          },
+          {
+            caption: "Save to Google Drive",
+            icon: { image: RiDriveLine },
+            onClick: () => console.log("Saved to drive"),
+          },
+          {
+            caption: "Preview Attachment Files",
+            icon: { image: RiEyeLine },
+            variant: "default",
+            onClick: () => console.log("Previewing"),
+          },
+        ],
+      },
+      {
+        caption: "Edit Draft",
+        icon: { image: RiEditLine },
+        variant: "default",
+        subMenuList: [
+          {
+            caption: "Open in Editor",
+            icon: { image: RiEditLine },
+            onClick: () => console.log("Edit mode"),
+          },
+          {
+            caption: "Save as Draft",
+            icon: { image: RiSaveLine },
+            variant: "primary",
+            onClick: () => console.log("Saved as draft"),
+          },
+          {
+            caption: "Discard This Draft",
+            icon: { image: RiDeleteBinLine },
+            onClick: () => console.log("Discarded"),
+          },
+        ],
+      },
+    ];
+
+    return <TipMenu subMenuList={TIP_MENU_LIST} />;
   },
 };

--- a/components/tip-menu.stories.tsx
+++ b/components/tip-menu.stories.tsx
@@ -13,19 +13,15 @@ import {
   RiEditLine,
   RiDeleteBinLine,
   RiSaveLine,
-  RiEyeLine,
-  RiDriveLine,
-  RiAttachmentLine,
-  RiShareForwardLine,
   RiFlagLine,
   RiStarLine,
   RiMailUnreadLine,
   RiFolderLine,
   RiArchiveLine,
-  RiMailCloseLine,
-  RiShieldCrossLine,
-  RiAlertLine,
-  RiMailForbidLine,
+  RiSendPlaneLine,
+  RiComputerLine,
+  RiCloudLine,
+  RiSmartphoneLine,
 } from "@remixicon/react";
 import { ModalDialog, ModalDialogButton } from "./modal-dialog";
 
@@ -190,7 +186,6 @@ export const Default: Story = {
               caption: "Download Attachment",
               icon: {
                 image: RiDownloadLine,
-                color: "teal",
               },
               variant: "success",
 
@@ -217,13 +212,13 @@ export const Default: Story = {
               caption: "Edit",
               icon: {
                 image: RiEditLine,
-                color: "yellow",
+                color: "orange",
               },
               onClick: () => console.log("Edit mode"),
             },
             {
               caption: "Delete",
-              icon: { image: RiDeleteBinLine, color: "red" },
+              icon: { image: RiDeleteBinLine },
               variant: "danger",
               onClick: () => setIsOpen(!isOpen),
             },
@@ -257,59 +252,10 @@ export const NestedSubmenu: Story = {
       {
         caption: "Report Message",
         icon: { image: RiSpam2Line },
-        variant: "primary",
-        subMenuList: [
-          {
-            caption: "Report Phishing Attempt",
-            icon: { image: RiSpam2Line },
-            variant: "primary",
-            onClick: () => console.log("Phishing reported"),
-          },
-          {
-            caption: "Report as Junk",
-            icon: { image: RiForbid2Line },
-            onClick: () => console.log("Junk reported"),
-          },
-          {
-            caption: "Report Suspicious Content",
-            icon: { image: RiMailForbidLine },
-            variant: "default",
-            onClick: () => console.log("Spam reported"),
-          },
-          {
-            caption: "Report Online Scam",
-            icon: { image: RiAlertLine },
-            onClick: () => console.log("Scam reported"),
-          },
-        ],
-      },
-      {
-        caption: "Block Contact",
-        icon: { image: RiShieldLine },
-        subMenuList: [
-          {
-            caption: "Block This Sender",
-            icon: { image: RiShieldLine },
-            variant: "danger",
-            onClick: () => console.log("Sender blocked"),
-          },
-          {
-            caption: "Block Entire Domain",
-            icon: { image: RiShieldCrossLine },
-            onClick: () => console.log("Domain blocked"),
-          },
-          {
-            caption: "Unsubscribe from Mailing List",
-            icon: { image: RiMailCloseLine },
-            variant: "default",
-            onClick: () => console.log("Unsubscribed"),
-          },
-        ],
       },
       {
         caption: "Move Message",
         icon: { image: RiInboxArchiveLine },
-        variant: "success",
         subMenuList: [
           {
             caption: "Move to Spam Folder",
@@ -319,7 +265,6 @@ export const NestedSubmenu: Story = {
           {
             caption: "Move to Trash",
             icon: { image: RiDeleteBinLine },
-            variant: "danger",
             onClick: () => console.log("Moved to trash"),
           },
           {
@@ -330,7 +275,6 @@ export const NestedSubmenu: Story = {
           {
             caption: "Archive This Message",
             icon: { image: RiArchiveLine },
-            variant: "primary",
             onClick: () => console.log("Archived"),
           },
         ],
@@ -342,7 +286,6 @@ export const NestedSubmenu: Story = {
           {
             caption: "Mark as Read",
             icon: { image: RiCheckLine },
-            variant: "primary",
             onClick: () => console.log("Marked as read"),
           },
           {
@@ -353,7 +296,6 @@ export const NestedSubmenu: Story = {
           {
             caption: "Mark as Important",
             icon: { image: RiStarLine },
-            variant: "default",
             onClick: () => console.log("Marked as important"),
           },
           {
@@ -364,55 +306,8 @@ export const NestedSubmenu: Story = {
         ],
       },
       {
-        caption: "Share Message",
-        icon: { image: RiShareLine },
-        variant: "danger",
-        subMenuList: [
-          {
-            caption: "Forward to Someone",
-            icon: { image: RiShareForwardLine },
-            onClick: () => console.log("Forwarded"),
-          },
-          {
-            caption: "Copy Shareable Link",
-            icon: { image: RiLink },
-            variant: "default",
-            onClick: () => console.log("Link copied"),
-          },
-          {
-            caption: "Share via Other Apps",
-            icon: { image: RiShareLine },
-            onClick: () => console.log("Shared"),
-          },
-        ],
-      },
-      {
-        caption: "Manage Attachments",
-        icon: { image: RiAttachmentLine },
-        subMenuList: [
-          {
-            caption: "Download All Attachments",
-            icon: { image: RiDownloadLine },
-            variant: "success",
-            onClick: () => console.log("Downloading all"),
-          },
-          {
-            caption: "Save to Google Drive",
-            icon: { image: RiDriveLine },
-            onClick: () => console.log("Saved to drive"),
-          },
-          {
-            caption: "Preview Attachment Files",
-            icon: { image: RiEyeLine },
-            variant: "default",
-            onClick: () => console.log("Previewing"),
-          },
-        ],
-      },
-      {
         caption: "Edit Draft",
         icon: { image: RiEditLine },
-        variant: "default",
         disabled: true,
         subMenuList: [
           {
@@ -423,13 +318,59 @@ export const NestedSubmenu: Story = {
           {
             caption: "Save as Draft",
             icon: { image: RiSaveLine },
-            variant: "primary",
             onClick: () => console.log("Saved as draft"),
           },
           {
             caption: "Discard This Draft",
             icon: { image: RiDeleteBinLine },
             onClick: () => console.log("Discarded"),
+          },
+        ],
+      },
+      {
+        caption: "Send to",
+        icon: { image: RiSendPlaneLine },
+        subMenuList: [
+          {
+            caption: "My computer",
+            icon: { image: RiComputerLine },
+            subMenuList: [
+              {
+                caption: "C:/My Documents",
+                icon: { image: RiFolderLine },
+                onClick: () => console.log("Open My Documents"),
+              },
+              {
+                caption: "C:/My Pictures",
+                icon: { image: RiFolderLine },
+                onClick: () => console.log("Open My Pictures"),
+              },
+            ],
+          },
+          {
+            caption: "Cloud storage",
+            icon: { image: RiCloudLine },
+            onClick: () => console.log("Open Cloud Storage"),
+          },
+          {
+            caption: "Smart Phone",
+            icon: { image: RiSmartphoneLine },
+            subMenuList: [
+              {
+                caption: "Blackberry Bold",
+                icon: { image: RiSmartphoneLine },
+                onClick: () => console.log("Blackberry Bold selected"),
+              },
+              {
+                caption: "Nokia N95",
+                onClick: () => console.log("Nokia N95 selected"),
+              },
+              {
+                caption: "Palm Pre 3",
+                icon: { image: RiSmartphoneLine },
+                onClick: () => console.log("Palm Pre 3 selected"),
+              },
+            ],
           },
         ],
       },

--- a/components/tip-menu.stories.tsx
+++ b/components/tip-menu.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { TipMenu, TipMenuItemProps } from "./tip-menu";
+import { TipMenu, TipMenuSubMenuList } from "./tip-menu";
 import { useState } from "react";
 import {
   RiSpam2Line,
@@ -253,7 +253,7 @@ export const Default: Story = {
 
 export const NestedSubmenu: Story = {
   render: () => {
-    const NESTED_TIP_MENU_ITEMS: TipMenuItemProps[] = [
+    const NESTED_TIP_MENU_ITEMS: TipMenuSubMenuList[] = [
       {
         caption: "Report Message",
         icon: { image: RiSpam2Line },

--- a/components/tip-menu.tsx
+++ b/components/tip-menu.tsx
@@ -111,13 +111,17 @@ function TipMenu({
           styles={menu.styles}
           subMenuList={menu.subMenuList}
           hidden={menu.hidden}
+          disabled={menu.disabled}
           onClick={(e) => {
             e.stopPropagation();
 
             if (menu.onClick) {
               menu.onClick();
             }
-            setIsOpen?.();
+
+            if (!menu?.disabled) {
+              setIsOpen?.();
+            }
           }}
         />
       ))}
@@ -135,6 +139,7 @@ export interface TipMenuItemProps {
   hidden?: boolean;
   subMenuList?: TipMenuItemProps[];
   styles?: TipMenuItemStyles;
+  disabled?: boolean;
 }
 export interface TipMenuItemStyles {
   containerStyle?: CSSProp;
@@ -150,6 +155,7 @@ function TipMenuItem({
   hidden,
   subMenuList,
   styles,
+  disabled,
 }: TipMenuItemProps) {
   const { currentTheme } = useTheme();
   const tipMenuTheme = currentTheme.tipmenu;
@@ -164,8 +170,12 @@ function TipMenuItem({
       $variant={variant}
       $size={size}
       aria-label="tip-menu-item"
-      onMouseDown={onClick}
+      onMouseDown={(e) => {
+        if (disabled) return;
+        onClick?.(e);
+      }}
       $theme={tipMenuTheme}
+      $disabled={disabled}
       $style={styles?.containerStyle}
     >
       <TipMenuItemContent $size={size} $style={styles?.self}>
@@ -192,6 +202,10 @@ function TipMenuItem({
           `,
           drawerStyle: (placement) => css`
             padding: 0px;
+            ${disabled &&
+            css`
+              display: none;
+            `}
             ${placement?.startsWith("right")
               ? css`
                   right: 9px;
@@ -226,6 +240,7 @@ const TipMenuItemWrapper = styled.div<{
   $theme: Record<TipMenuVariant, TipMenuThemeConfig>;
   $size?: TipMenuSize;
   $style?: CSSProp;
+  $disabled?: boolean;
 }>`
   display: flex;
   align-items: center;
@@ -248,23 +263,32 @@ const TipMenuItemWrapper = styled.div<{
           padding: 8px;
         `};
 
-  &:hover {
-    background-color: ${({ $theme, $variant }) =>
-      $theme[$variant]?.hoverBackgroundColor};
-  }
+  ${({ $disabled, $theme, $variant }) =>
+    !$disabled &&
+    css`
+      &:hover {
+        background-color: ${$theme[$variant]?.hoverBackgroundColor};
+      }
 
-  &:active {
-    background-color: ${({ $theme, $variant }) =>
-      $theme[$variant]?.activeBackgroundColor};
+      &:active {
+        background-color: ${$theme[$variant]?.activeBackgroundColor};
 
-    box-shadow: inset 0 0.5px 4px rgba(0, 0, 0, 0.2);
-  }
+        box-shadow: inset 0 0.5px 4px rgba(0, 0, 0, 0.2);
+      }
 
-  &:focus-visible {
-    outline: none;
-    box-shadow: inset 0 0 0 2px
-      ${({ $theme, $variant }) => $theme[$variant]?.focusBackgroundColor};
-  }
+      &:focus-visible {
+        outline: none;
+        box-shadow: inset 0 0 0 2px ${$theme[$variant]?.focusBackgroundColor};
+      }
+    `}
+
+  ${({ $disabled, $theme, $variant }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+      filter: grayscale(80%) brightness(1.1) contrast(1);
+      color: ${$theme?.[$variant]?.disabledTextColor};
+    `}
 
   ${({ $style }) => $style}
 `;
@@ -275,8 +299,6 @@ const TipMenuItemContent = styled.div<{
 }>`
   display: flex;
   align-items: center;
-  cursor: pointer;
-  border-radius: 4px;
   width: 100%;
 
   ${({ $size }) =>

--- a/components/tip-menu.tsx
+++ b/components/tip-menu.tsx
@@ -1,11 +1,13 @@
 import styled, { css, CSSProp } from "styled-components";
 import { COLOR_STYLE_MAP } from "../constants/color-map";
-import React, { ReactNode, useMemo, useState } from "react";
+import React, { ReactNode, useMemo, useRef, useState } from "react";
 import { Button } from "./button";
 import { Searchbox } from "./searchbox";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "../theme/provider";
 import { TipMenuThemeConfig } from "./../theme";
+import { Tooltip, TooltipRef } from "./tooltip";
+import { RiArrowRightSFill } from "@remixicon/react";
 
 export const TipMenuVariant = {
   Default: "default",
@@ -64,7 +66,9 @@ function TipMenu({
   return (
     <Button.TipMenuContainer
       aria-label="tip-menu"
-      styles={{ self: styles?.self }}
+      styles={{
+        self: styles?.self,
+      }}
     >
       {withFilter && (
         <Searchbox
@@ -104,7 +108,8 @@ function TipMenu({
           caption={menu.caption}
           icon={menu.icon}
           size={menu.size ?? size}
-          className={menu.className}
+          styles={menu.styles}
+          subMenuList={menu.subMenuList}
           hidden={menu.hidden}
           onClick={(e) => {
             e.stopPropagation();
@@ -127,8 +132,13 @@ export interface TipMenuItemProps {
   onClick?: (e?: React.MouseEvent) => void;
   variant?: TipMenuVariant;
   size?: TipMenuSize;
-  className?: string;
   hidden?: boolean;
+  subMenuList?: TipMenuItemProps[];
+  styles?: TipMenuItemStyles;
+}
+export interface TipMenuItemStyles {
+  containerStyle?: CSSProp;
+  self?: CSSProp;
 }
 
 function TipMenuItem({
@@ -137,35 +147,85 @@ function TipMenuItem({
   onClick,
   variant,
   size,
-  className,
   hidden,
+  subMenuList,
+  styles,
 }: TipMenuItemProps) {
   const { currentTheme } = useTheme();
   const tipMenuTheme = currentTheme.tipmenu;
+  const tooltipRef = useRef<TooltipRef>(null);
 
   if (hidden) {
     return;
   }
 
-  return (
-    <StyledTipMenuItem
+  const tipMenuElement = (
+    <TipMenuItemWrapper
       $variant={variant}
       $size={size}
       aria-label="tip-menu-item"
       onMouseDown={onClick}
       $theme={tipMenuTheme}
-      className={className}
+      $style={styles?.containerStyle}
     >
-      {icon && <Figure {...icon} aria-label="tip-menu-icon" />}
-      <StyledCaption>{caption}</StyledCaption>
-    </StyledTipMenuItem>
+      <TipMenuItemContent $size={size} $style={styles?.self}>
+        {icon && <Figure {...icon} aria-label="tip-menu-icon" />}
+        <StyledCaption>{caption}</StyledCaption>
+      </TipMenuItemContent>
+
+      {subMenuList && <Figure image={RiArrowRightSFill} />}
+    </TipMenuItemWrapper>
   );
+
+  if (subMenuList && subMenuList?.length > 0) {
+    return (
+      <Tooltip
+        ref={tooltipRef}
+        dialogPlacement="right-center"
+        safeAreaAriaLabels={["tip-menu"]}
+        styles={{
+          containerStyle: css`
+            width: 100%;
+          `,
+          triggerStyle: css`
+            width: 100%;
+          `,
+          drawerStyle: (placement) => css`
+            padding: 0px;
+            ${placement?.startsWith("right")
+              ? css`
+                  right: 9px;
+                `
+              : css`
+                  left: 9px;
+                `}
+          `,
+          arrowStyle: css`
+            display: none;
+          `,
+        }}
+        dialog={
+          <TipMenu
+            subMenuList={subMenuList}
+            variant={variant}
+            size={size}
+            setIsOpen={() => tooltipRef.current?.close()}
+          />
+        }
+      >
+        {tipMenuElement}
+      </Tooltip>
+    );
+  }
+
+  return tipMenuElement;
 }
 
-const StyledTipMenuItem = styled.div<{
+const TipMenuItemWrapper = styled.div<{
   $variant?: TipMenuVariant;
   $theme: Record<TipMenuVariant, TipMenuThemeConfig>;
   $size?: TipMenuSize;
+  $style?: CSSProp;
 }>`
   display: flex;
   align-items: center;
@@ -205,6 +265,30 @@ const StyledTipMenuItem = styled.div<{
     box-shadow: inset 0 0 0 2px
       ${({ $theme, $variant }) => $theme[$variant]?.focusBackgroundColor};
   }
+
+  ${({ $style }) => $style}
+`;
+
+const TipMenuItemContent = styled.div<{
+  $size?: TipMenuSize;
+  $style?: CSSProp;
+}>`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  border-radius: 4px;
+  width: 100%;
+
+  ${({ $size }) =>
+    $size === "sm"
+      ? css`
+          gap: 8px;
+        `
+      : css`
+          gap: 12px;
+        `};
+
+  ${({ $style }) => $style}
 `;
 
 const StyledCaption = styled.span`

--- a/components/tip-menu.tsx
+++ b/components/tip-menu.tsx
@@ -1,5 +1,4 @@
 import styled, { css, CSSProp } from "styled-components";
-import { COLOR_STYLE_MAP } from "../constants/color-map";
 import React, { ReactNode, useMemo, useRef, useState } from "react";
 import { Button } from "./button";
 import { Searchbox } from "./searchbox";
@@ -183,7 +182,9 @@ function TipMenuItem({
         <StyledCaption>{caption}</StyledCaption>
       </TipMenuItemContent>
 
-      {subMenuList && <Figure image={RiArrowRightSFill} />}
+      {subMenuList && (
+        <Figure aria-label="tip-menu-item-arrow" image={RiArrowRightSFill} />
+      )}
     </TipMenuItemWrapper>
   );
 

--- a/components/tip-menu.tsx
+++ b/components/tip-menu.tsx
@@ -286,6 +286,7 @@ const TipMenuItemWrapper = styled.div<{
     $disabled &&
     css`
       cursor: not-allowed;
+      opacity: 0.6;
       filter: grayscale(80%) brightness(1.1) contrast(1);
       color: ${$theme?.[$variant]?.disabledTextColor};
     `}

--- a/components/tip-menu.tsx
+++ b/components/tip-menu.tsx
@@ -113,6 +113,7 @@ function TipMenu({
           subMenuList={menu.subMenuList}
           hidden={menu.hidden}
           disabled={menu.disabled}
+          setIsOpen={setIsOpen}
           onClick={(e) => {
             e.stopPropagation();
 
@@ -157,7 +158,10 @@ function TipMenuItem({
   subMenuList,
   styles,
   disabled,
-}: TipMenuItemProps) {
+  setIsOpen,
+}: TipMenuItemProps & {
+  setIsOpen?: () => void;
+}) {
   const { currentTheme } = useTheme();
   const tipMenuTheme = currentTheme.tipmenu;
   const tooltipRef = useRef<TooltipRef>(null);
@@ -226,7 +230,10 @@ function TipMenuItem({
             subMenuList={subMenuList}
             variant={variant}
             size={size}
-            setIsOpen={() => tooltipRef.current?.close()}
+            setIsOpen={() => {
+              tooltipRef.current?.close();
+              setIsOpen?.();
+            }}
           />
         }
       >

--- a/components/tip-menu.tsx
+++ b/components/tip-menu.tsx
@@ -25,9 +25,11 @@ export const TipMenuSize = {
 
 export type TipMenuSize = (typeof TipMenuSize)[keyof typeof TipMenuSize];
 
+export type TipMenuSubMenuList = TipMenuItemProps;
+
 export interface TipMenuProps {
   children?: ReactNode;
-  subMenuList?: TipMenuItemProps[];
+  subMenuList?: TipMenuSubMenuList[];
   setIsOpen?: () => void;
   variant?: TipMenuVariant;
   size?: TipMenuSize;

--- a/test/component/tip-menu.cy.tsx
+++ b/test/component/tip-menu.cy.tsx
@@ -1,9 +1,29 @@
 import { TipMenu, TipMenuItemProps } from "../../components/tip-menu";
 import {
+  RiSpam2Line,
   RiForbid2Line,
   RiShieldLine,
   RiCheckLine,
+  RiInboxArchiveLine,
   RiDownloadLine,
+  RiLink,
+  RiShareLine,
+  RiEditLine,
+  RiDeleteBinLine,
+  RiSaveLine,
+  RiEyeLine,
+  RiDriveLine,
+  RiAttachmentLine,
+  RiShareForwardLine,
+  RiFlagLine,
+  RiStarLine,
+  RiMailUnreadLine,
+  RiFolderLine,
+  RiArchiveLine,
+  RiMailCloseLine,
+  RiShieldCrossLine,
+  RiAlertLine,
+  RiMailForbidLine,
 } from "@remixicon/react";
 
 describe("TipMenu", () => {
@@ -52,6 +72,233 @@ describe("TipMenu", () => {
       onClick: () => console.log("Mark as read clicked"),
     },
   ];
+
+  const NESTED_TIP_MENU_ITEMS: TipMenuItemProps[] = [
+    {
+      caption: "Report Message",
+      icon: { image: RiSpam2Line },
+      variant: "primary",
+      subMenuList: [
+        {
+          caption: "Report Phishing Attempt",
+          icon: { image: RiSpam2Line },
+          variant: "primary",
+          onClick: () => console.log("Phishing reported"),
+        },
+        {
+          caption: "Report as Junk",
+          icon: { image: RiForbid2Line },
+          onClick: () => console.log("Junk reported"),
+        },
+        {
+          caption: "Report Suspicious Content",
+          icon: { image: RiMailForbidLine },
+          variant: "default",
+          onClick: () => console.log("Spam reported"),
+        },
+        {
+          caption: "Report Online Scam",
+          icon: { image: RiAlertLine },
+          onClick: () => console.log("Scam reported"),
+        },
+      ],
+    },
+    {
+      caption: "Block Contact",
+      icon: { image: RiShieldLine },
+    },
+    {
+      caption: "Move Message",
+      icon: { image: RiInboxArchiveLine },
+      variant: "success",
+      subMenuList: [
+        {
+          caption: "Move to Spam Folder",
+          icon: { image: RiInboxArchiveLine },
+          onClick: () => console.log("Moved to spam"),
+        },
+        {
+          caption: "Move to Trash",
+          icon: { image: RiDeleteBinLine },
+          variant: "danger",
+          onClick: () => console.log("Moved to trash"),
+        },
+        {
+          caption: "Move to Specific Folder",
+          icon: { image: RiFolderLine },
+          onClick: () => console.log("Moved to folder"),
+        },
+        {
+          caption: "Archive This Message",
+          icon: { image: RiArchiveLine },
+          variant: "primary",
+          onClick: () => console.log("Archived"),
+        },
+      ],
+    },
+    {
+      caption: "Mark Status",
+      icon: { image: RiCheckLine },
+      subMenuList: [
+        {
+          caption: "Mark as Read",
+          icon: { image: RiCheckLine },
+          variant: "primary",
+          onClick: () => console.log("Marked as read"),
+        },
+        {
+          caption: "Mark as Unread",
+          icon: { image: RiMailUnreadLine },
+          onClick: () => console.log("Marked as unread"),
+        },
+        {
+          caption: "Mark as Important",
+          icon: { image: RiStarLine },
+          variant: "default",
+          onClick: () => console.log("Marked as important"),
+        },
+        {
+          caption: "Flag for Follow Up",
+          icon: { image: RiFlagLine },
+          onClick: () => console.log("Flagged"),
+        },
+      ],
+    },
+    {
+      caption: "Share Message",
+      icon: { image: RiShareLine },
+      variant: "danger",
+      subMenuList: [
+        {
+          caption: "Forward to Someone",
+          icon: { image: RiShareForwardLine },
+          onClick: () => console.log("Forwarded"),
+        },
+        {
+          caption: "Copy Shareable Link",
+          icon: { image: RiLink },
+          variant: "default",
+          onClick: () => console.log("Link copied"),
+        },
+        {
+          caption: "Share via Other Apps",
+          icon: { image: RiShareLine },
+          onClick: () => console.log("Shared"),
+        },
+      ],
+    },
+    {
+      caption: "Manage Attachments",
+      icon: { image: RiAttachmentLine },
+      subMenuList: [
+        {
+          caption: "Download All Attachments",
+          icon: { image: RiDownloadLine },
+          variant: "success",
+          onClick: () => console.log("Downloading all"),
+        },
+        {
+          caption: "Save to Google Drive",
+          icon: { image: RiDriveLine },
+          onClick: () => console.log("Saved to drive"),
+        },
+        {
+          caption: "Preview Attachment Files",
+          icon: { image: RiEyeLine },
+          variant: "default",
+          onClick: () => console.log("Previewing"),
+        },
+      ],
+    },
+    {
+      caption: "Edit Draft",
+      icon: { image: RiEditLine },
+      variant: "default",
+      disabled: true,
+      subMenuList: [
+        {
+          caption: "Open in Editor",
+          icon: { image: RiEditLine },
+          onClick: () => console.log("Edit mode"),
+        },
+        {
+          caption: "Save as Draft",
+          icon: { image: RiSaveLine },
+          variant: "primary",
+          onClick: () => console.log("Saved as draft"),
+        },
+        {
+          caption: "Discard This Draft",
+          icon: { image: RiDeleteBinLine },
+          onClick: () => console.log("Discarded"),
+        },
+      ],
+    },
+  ];
+
+  context("nested", () => {
+    it("should be render with arrow right", () => {
+      cy.mount(<TipMenu subMenuList={NESTED_TIP_MENU_ITEMS} />);
+      cy.findAllByLabelText("tip-menu-item")
+        .eq(0)
+        .then(($element) => {
+          cy.wrap($element)
+            .findByLabelText("tip-menu-item-arrow")
+            .should("exist");
+        });
+      cy.findAllByLabelText("tip-menu-item")
+        .eq(1)
+        .then(($element) => {
+          cy.wrap($element)
+            .findByLabelText("tip-menu-item-arrow")
+            .should("not.exist");
+        });
+    });
+
+    context("when hovering", () => {
+      it("should shows the items", () => {
+        cy.mount(<TipMenu subMenuList={NESTED_TIP_MENU_ITEMS} />);
+        NESTED_TIP_MENU_ITEMS[0]?.subMenuList?.map((menu) => {
+          cy.findByText(menu.caption).should("not.exist");
+        });
+
+        cy.findAllByLabelText("tip-menu-item").eq(0).realHover().wait(300);
+        NESTED_TIP_MENU_ITEMS[0]?.subMenuList?.map((menu) => {
+          cy.findByText(menu.caption).should("exist");
+        });
+      });
+    });
+    context("when disabled", () => {
+      context("when hovering", () => {
+        it("should not shows the items", () => {
+          cy.mount(<TipMenu subMenuList={NESTED_TIP_MENU_ITEMS} />);
+          NESTED_TIP_MENU_ITEMS[6]?.subMenuList?.map((menu) => {
+            cy.findByText(menu.caption).should("not.exist");
+          });
+
+          cy.findAllByLabelText("tip-menu-item").eq(6).realHover().wait(300);
+
+          NESTED_TIP_MENU_ITEMS[6]?.subMenuList?.map((menu) => {
+            cy.findByText(menu.caption).should("not.exist");
+          });
+        });
+      });
+    });
+  });
+
+  context("disabled", () => {
+    it("renders with grayscale and opacity 0.6", () => {
+      cy.mount(<TipMenu subMenuList={NESTED_TIP_MENU_ITEMS} />);
+      cy.findAllByLabelText("tip-menu-item")
+        .eq(6)
+        .should("have.css", "opacity", "0.6")
+        .and(
+          "have.css",
+          "filter",
+          "grayscale(0.8) brightness(1.1) contrast(1)"
+        );
+    });
+  });
 
   context("when given hidden action", () => {
     it("should render without hidden action", () => {
@@ -115,7 +362,7 @@ describe("TipMenu", () => {
         cy.findAllByLabelText("tip-menu-item")
           .eq(index)
           .realHover()
-          .wait(200)
+          .wait(400)
           .should("have.css", "background-color", theme.background)
           .and("have.css", "color", theme.color);
       });

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -699,6 +699,7 @@ export interface TipMenuThemeConfig
   hoverBackgroundColor?: string;
   activeBackgroundColor?: string;
   focusBackgroundColor?: string;
+  disabledTextColor?: string;
 }
 
 // treelist.tsx

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1538,7 +1538,7 @@ export function createTimelineTheme(
 // tipmenu.tsx
 export function createTipMenuTheme(
   buttonTheme?: Record<Partial<ButtonVariants["variant"]>, ButtonThemeConfig>,
-  customTheme: Partial<TipMenuThemeConfig> = {}
+  customTheme: Partial<Record<TipMenuVariant, Partial<TipMenuThemeConfig>>> = {}
 ): Record<TipMenuVariant, TipMenuThemeConfig> {
   const defaultTheme: Record<TipMenuVariant, TipMenuThemeConfig> = {
     default: {
@@ -1547,6 +1547,7 @@ export function createTipMenuTheme(
       textColor: buttonTheme?.ghost?.textColor,
       activeBackgroundColor: buttonTheme?.ghost?.activeBackgroundColor,
       hoverBackgroundColor: buttonTheme?.ghost?.hoverBackgroundColor,
+      ...customTheme?.default,
     },
     danger: {
       focusBackgroundColor: buttonTheme?.danger?.focusBackgroundColor,
@@ -1554,6 +1555,7 @@ export function createTipMenuTheme(
       textColor: buttonTheme?.danger?.textColor,
       activeBackgroundColor: buttonTheme?.danger?.activeBackgroundColor,
       hoverBackgroundColor: buttonTheme?.danger?.hoverBackgroundColor,
+      ...customTheme?.danger,
     },
     success: {
       focusBackgroundColor: buttonTheme?.success?.focusBackgroundColor,
@@ -1561,6 +1563,7 @@ export function createTipMenuTheme(
       textColor: buttonTheme?.success?.textColor,
       activeBackgroundColor: buttonTheme?.success?.activeBackgroundColor,
       hoverBackgroundColor: buttonTheme?.success?.hoverBackgroundColor,
+      ...customTheme?.success,
     },
     primary: {
       focusBackgroundColor: buttonTheme?.primary?.focusBackgroundColor,
@@ -1568,12 +1571,12 @@ export function createTipMenuTheme(
       textColor: buttonTheme?.primary?.textColor,
       activeBackgroundColor: buttonTheme?.primary?.activeBackgroundColor,
       hoverBackgroundColor: buttonTheme?.primary?.hoverBackgroundColor,
+      ...customTheme?.primary,
     },
   };
 
   return {
     ...defaultTheme,
-    ...customTheme,
   };
 }
 

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -696,7 +696,12 @@ const darkTextbox = createTextboxTheme(darkBody, darkFieldLane, {
 
 const darkTimebox = createTimeboxTheme(darkBody, darkFieldLane);
 
-const darkTipMenu = createTipMenuTheme(darkButton);
+const darkTipMenu = createTipMenuTheme(darkButton, {
+  default: { disabledTextColor: "rgba(180, 180, 180, 0.45)" },
+  primary: { disabledTextColor: "rgba(180, 180, 180, 0.45)" },
+  danger: { disabledTextColor: "rgba(180, 180, 180, 0.45)" },
+  success: { disabledTextColor: "rgba(180, 180, 180, 0.45)" },
+});
 
 const darkThumbField = createThumbFieldTheme(darkBody, {
   thumbsUpColor: "rgb(134, 111, 238)",

--- a/theme/mode/light.ts
+++ b/theme/mode/light.ts
@@ -196,7 +196,12 @@ const lightTimebox = createTimeboxTheme(lightBody, lightFieldLane);
 
 const lightTimeline = createTimelineTheme(lightBody);
 
-const lightTipMenu = createTipMenuTheme(lightButton);
+const lightTipMenu = createTipMenuTheme(lightButton, {
+  default: { disabledTextColor: "rgba(107, 107, 107, 0.75)" },
+  primary: { disabledTextColor: "rgba(107, 107, 107, 0.75)" },
+  danger: { disabledTextColor: "rgba(107, 107, 107, 0.75)" },
+  success: { disabledTextColor: "rgba(107, 107, 107, 0.75)" },
+});
 
 const lightToggle = createToggleTheme(lightBody);
 


### PR DESCRIPTION
Description:
This pull request introduces a `nested` feature in the `TipMenu`, allowing more flexible menu structures within the component.

It also adds a disabled prop, applying styles such as `grayscale(80%) brightness(1.1) contrast(1)` along with adjusted `text-color`. When a `disabled` item is `hovered`, the appearance remains consistent and no menu will be displayed, including in `nested` mode.

Additionally, this PR improves the type definition for `subMenuList` by renaming it from `TipMenuItem[]` to `TipMenuSubMenuList` for better clarity and maintainability.

TipMenu interface improvement:
```tsx
export interface TipMenuProps {
  children?: ReactNode;
  subMenuList?: TipMenuSubMenuList[];
  setIsOpen?: () => void;
  variant?: TipMenuVariant;
  size?: TipMenuSize;
  withFilter?: boolean;
  styles?: TipMenuStyles;
}
```

TipMenuItems nested interface improvement:
```tsx
export interface TipMenuItemProps {
  caption?: string;
  icon?: FigureProps;
  onClick?: (e?: React.MouseEvent) => void;
  variant?: TipMenuVariant;
  size?: TipMenuSize;
  hidden?: boolean;
  subMenuList?: TipMenuItemProps[];
  styles?: TipMenuItemStyles;
  disabled?: boolean;
}
```

Result:
<img width="888" height="744" alt="image" src="https://github.com/user-attachments/assets/13be96e3-8441-4a9b-9ba7-cec430b47f70" />

Source:
[[Improvement] SYST-601: Allow nested menu/submenu in TipMenu](https://linear.app/systatum/issue/SYST-601/allow-nested-menusubmenu-in-tipmenu)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself