### PR TITLE
[Improvement] SYST-658: Make "Welcome" always displayed first

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,4 @@
 import type { StorybookConfig } from "@storybook/react-vite";
-import path from "path";
 
 const config: StorybookConfig = {
   staticDirs: ["../public"],

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,6 +4,11 @@ import { ThemeProvider } from "./../theme/provider";
 
 const preview: Preview = {
   parameters: {
+    options: {
+      storySort: {
+        order: ["Welcome", "*"],
+      },
+    },
     backgrounds: { disable: true },
     controls: {
       matchers: {


### PR DESCRIPTION
Description:
This pull request fixes an issue where `Welcome.mdx` was always displayed first. Now, when opening the content, the correct page is shown.

Source:
[[Improvement] SYST-658: Make "Welcome" always displayed first](https://linear.app/systatum/issue/SYST-658/make-welcome-always-displayed-first)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself