### PR TITLE
[Bug] SYST-559: Investigate (and fix if a bug) why border for some input in Firefox is rendered too bold on certain side

### DIFF
--- a/components/pinbox.tsx
+++ b/components/pinbox.tsx
@@ -431,8 +431,13 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
                 $isStatic={isStatic}
                 $fontSize={fontSize}
                 $isAnimate={isAnimate}
+                autoComplete="off"
               />
-              <PinboxIndicator $theme={pinboxTheme} $error={showError} />
+              <PinboxIndicator
+                aria-label="pinbox-indicator"
+                $theme={pinboxTheme}
+                $error={showError}
+              />
             </PinboxInputContent>
           );
         })}

--- a/components/pinbox.tsx
+++ b/components/pinbox.tsx
@@ -573,12 +573,11 @@ const PinboxIndicator = styled.div<{
   transform: translateX(-50%);
   position: absolute;
   display: none;
+  border-bottom-width: 0.5px;
 
   border-color: ${({ $theme, $error }) =>
     $error ? $theme.errorBorderColor : $theme.focusedBorderColor};
-  box-shadow: 0 0 0 0.5px
-    ${({ $theme, $error }) =>
-      $error ? $theme.errorBorderColor : $theme.focusedBorderColor};
+
   color: ${({ $theme, $error }) =>
     $error ? $theme.errorTextColor : $theme.textColor};
   z-index: 9999;

--- a/test/component/pinbox.cy.tsx
+++ b/test/component/pinbox.cy.tsx
@@ -17,6 +17,89 @@ describe("Pinbox", () => {
     );
   }
 
+  context("indicators", () => {
+    beforeEach(() => {
+      cy.mount(<ProductPinbox parts={PARTS_INPUT} />);
+    });
+
+    it("not shows the indicator", () => {
+      cy.findAllByLabelText("pinbox-indicator").should("not.be.visible");
+    });
+
+    context("when clicking", () => {
+      it("shows the indicator", () => {
+        cy.findAllByLabelText("pinbox-indicator").should("not.be.visible");
+
+        cy.get("input").eq(1).realClick();
+
+        cy.findAllByLabelText("pinbox-indicator")
+          .eq(1)
+          .should("be.visible")
+          .and("have.css", "border-bottom", "0.5px solid rgb(97, 169, 249)");
+      });
+    });
+
+    context("when pasting alphabet", () => {
+      it("shows those alphabet", () => {
+        cy.get("input")
+          .eq(1)
+          .trigger("paste", {
+            clipboardData: {
+              getData: () => "abcd",
+            },
+          });
+
+        cy.get("input").eq(1).should("have.value", "A");
+        cy.get("input").eq(2).should("have.value", "B");
+        cy.get("input").eq(3).should("have.value", "C");
+        cy.get("input").eq(5).should("have.value", "D");
+      });
+
+      it("shows static still not replace", () => {
+        cy.get("input")
+          .eq(1)
+          .trigger("paste", {
+            clipboardData: {
+              getData: () => "abcd",
+            },
+          });
+
+        cy.get("input").eq(0).should("have.value", "S");
+        cy.get("input").eq(4).should("have.value", "-");
+      });
+    });
+
+    context("when pasting alphanumeric", () => {
+      it("shows those alphanumeric", () => {
+        cy.get("input")
+          .eq(1)
+          .trigger("paste", {
+            clipboardData: {
+              getData: () => "ab12",
+            },
+          });
+
+        cy.get("input").eq(1).should("have.value", "A");
+        cy.get("input").eq(2).should("have.value", "B");
+        cy.get("input").eq(3).should("have.value", "1");
+        cy.get("input").eq(5).should("have.value", "2");
+      });
+
+      it("shows static still not replace", () => {
+        cy.get("input")
+          .eq(1)
+          .trigger("paste", {
+            clipboardData: {
+              getData: () => "ab12",
+            },
+          });
+
+        cy.get("input").eq(0).should("have.value", "S");
+        cy.get("input").eq(4).should("have.value", "-");
+      });
+    });
+  });
+
   context("when pasting", () => {
     context("with alphanumeric parts", () => {
       beforeEach(() => {


### PR DESCRIPTION
Description:
This pull request fixes an issue in the `Pinbox` component where the indicator relied on `box-shadow`, causing inconsistent appearance, especially in the `Firefox`.

Source:
[[Bug] SYST-559: Investigate (and fix if a bug) why border for some input in Firefox is rendered too bold on certain side](https://linear.app/systatum/issue/SYST-559/investigate-and-fix-if-a-bug-why-border-for-some-input-in-firefox-is)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself