### PR TITLE
[Improvement] SYST-587: Remove `controlled` props

### DIFF
--- a/components/combobox.stories.tsx
+++ b/components/combobox.stories.tsx
@@ -146,10 +146,6 @@ Each field accepts a \`CSSProp\` (styled-components compatible) and can be used 
       control: "text",
       description: "Name/id used for accessibility and aria-label.",
     },
-    controlled: {
-      description: "Enable controlled mode (external state management)",
-      control: "boolean",
-    },
   },
 };
 

--- a/components/combobox.stories.tsx
+++ b/components/combobox.stories.tsx
@@ -33,7 +33,6 @@ Combobox makes use of the base Selectbox, featuring searchability, options-group
 - ⚡ Dynamic filtering based on user input
 - 🧩 Custom **actions** inside dropdown
 - 🚫 Handles **disabled** and **hidden** options
-- 📊 Supports **controlled and uncontrolled** modes
 
 ---
 
@@ -62,7 +61,6 @@ Combobox makes use of the base Selectbox, featuring searchability, options-group
 ### 📌 Usage Guidelines
 - Use **grouped options** for large datasets
 - Enable \`multiple\` for multi-select use cases
-- Use **controlled mode** to keep the value synchronized with the input and ensure it is consistently validated.
 - Use \`maxSelectableItems\` to limit selections
         `,
       },

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -46,7 +46,6 @@ interface BaseComboboxProps {
   options: ComboboxOption[];
   isLoading?: boolean;
   labels?: ComboboxLabelsProps;
-  controlled?: boolean;
 }
 
 export const ComboboxGroupInitialState = {
@@ -148,7 +147,6 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       required,
       isLoading,
       labels,
-      controlled = false,
     },
     ref
   ) => {
@@ -195,7 +193,6 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         showError={showError}
         errorMessage={errorMessage}
         labelGap={labelGap}
-        controlled={controlled}
         labelWidth={labelWidth}
         labelPosition={labelPosition}
         label={label}

--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -145,7 +145,7 @@ const PaginationItem = ({
       {totalPages > threshold ? (
         <>
           <Combobox
-            controlled
+            key={`${currentPageLocal}`}
             highlightOnMatch={highlightOnMatch}
             options={comboBoxPages.map((data) => formatOption(String(data)))}
             selectedOptions={currentPageLocal}

--- a/components/selectbox.stories.tsx
+++ b/components/selectbox.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Selectbox> = {
     docs: {
       description: {
         component: `
-The **Selectbox** is a flexible and customizable input component that supports searchable dropdowns, single and multiple selection, keyboard navigation, and both controlled and uncontrolled usage.
+The **Selectbox** is a flexible and customizable input component that supports searchable dropdowns, single and multiple selection, and keyboard navigation.
 
 It is designed to handle complex interaction patterns such as filtering, strict validation, async loading states, and fully custom dropdown rendering via render props.
 
@@ -24,7 +24,6 @@ It is designed to handle complex interaction patterns such as filtering, strict 
 - Searchable options with filtering
 - Single and multiple selection modes
 - Full keyboard navigation support
-- Controlled and uncontrolled behavior
 - Strict mode validation (enforces valid options)
 - Clearable input support
 - Loading state with customizable label
@@ -41,22 +40,6 @@ It is designed to handle complex interaction patterns such as filtering, strict 
     { text: "Banana", value: "banana" },
   ]}
   placeholder="Select a fruit"
-/>
-\`\`\`
-
----
-
-### 🔁 Controlled Mode
-Use controlled mode when you need to **synchronize and manage the value from the parent state**.
-
-\`\`\`tsx
-const [value, setValue] = useState("apple");
-
-<Selectbox
-  options={options}
-  selectedOptions={value}
-  onChange={setValue}
-  controlled
 />
 \`\`\`
 
@@ -182,11 +165,6 @@ When \`strict\` is enabled:
     name: {
       control: "text",
       description: "Name or identifier used for accessibility (aria-label).",
-    },
-    controlled: {
-      control: "boolean",
-      description:
-        "Enables controlled mode, allowing the parent component to manage and synchronize the selected value.",
     },
   },
 };

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -59,7 +59,6 @@ interface BaseSelectboxProps
   showError?: boolean;
   maxSelectableItems?: number | undefined;
   isLoading?: boolean;
-  controlled?: boolean;
   children?: (
     props: DrawerProps &
       InteractionModeProps & {
@@ -141,7 +140,6 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
       isLoading,
       labels,
       disabled,
-      controlled,
       ...props
     },
     ref
@@ -153,25 +151,6 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
       () => (Array.isArray(options) ? options : []),
       [options]
     );
-
-    useEffect(() => {
-      if (!controlled) return;
-
-      const matched = finalOptions.find(
-        (opt) => String(opt.value) === finalSelectedOptions?.[0]
-      );
-
-      if (matched) {
-        setSelectedOptionsLocal(matched);
-      } else if (finalSelectedOptions?.[0]) {
-        setSelectedOptionsLocal({
-          text: finalSelectedOptions[0],
-          value: finalSelectedOptions[0],
-        });
-      } else {
-        setSelectedOptionsLocal({ text: "", value: "0" });
-      }
-    }, [selectedOptions, controlled, finalOptions]);
 
     const finalSelectedOptions = useMemo(() => {
       if (Array.isArray(selectedOptions)) {
@@ -819,7 +798,9 @@ const ClearIcon = styled(RiCloseLine)<{
   border-radius: 2px;
   padding: 2px;
 
-  &&:hover {
+  transition: all 0.3s ease-in-out;
+
+  &:hover {
     background-color: ${({ $theme }) =>
       $theme.clearIconHoverBackground || "#e5e7eb"};
   }

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -259,6 +259,7 @@ export interface FieldLaneThemeConfig
 
   actionColor?: string;
   actionHoverColor?: string;
+  actionHoverBackgroundColor?: string;
 
   errorColor?: string;
   errorBackground?: string;

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -677,6 +677,7 @@ export function createFieldLaneTheme(
 
     actionColor: "#6b7280",
     actionHoverColor: "#374151",
+    actionHoverBackgroundColor: "#e5e7eb",
 
     placeholderColor: "rgb(107, 114, 128)",
     focusedBorderColor: "#61A9F9",
@@ -1251,7 +1252,7 @@ export function createSelectboxTheme(
 
     clearIconColor: fieldLane.actionColor || "#9ca3af",
     clearIconBackground: "transparent",
-    clearIconHoverBackground: fieldLane.actionHoverColor || "#e5e7eb",
+    clearIconHoverBackground: fieldLane.actionHoverBackgroundColor || "#e5e7eb",
 
     dividerColor: fieldLane.dividerColor || "#9ca3af",
     disabledOpacity: fieldLane.disabledOpacity,

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -88,6 +88,7 @@ const darkFieldLane = createFieldLaneTheme(darkBody, {
 
   actionColor: "#cbd5e1",
   actionHoverColor: "#616161",
+  actionHoverBackgroundColor: "#4b4b4b",
 
   placeholderColor: "#9ca3af",
   focusedBorderColor: "rgb(105, 85, 193)",


### PR DESCRIPTION
Description:
This pull request removes the `controlled` in the `Combobox` component, which relied on the `Pagination`, since the current page need synchronize on the `combobox` when have behavior through the `navigation` buttons. Because of this, the selected value must always stay synchronized with the current page state.

One approach to address this is by using the `key` prop to made the `Combobox` always check after the page change.

```tsx
<Combobox key={`${currentPage}`} />
```

This ensures the combobox always reflects the latest value by remounting the component.

Source:
[[Improvement] SYST-587: Remove `controlled` props](https://linear.app/systatum/issue/SYST-587/remove-controlled-props)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself