### PR TITLE
[Improvement] SYST-659: Add default class for each component and allow defining id

### DIFF
--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -4,6 +4,7 @@ import { strToColor } from "./../lib/code-color";
 import { ChangeEvent, HTMLAttributes, useRef } from "react";
 import styled, { CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface AvatarProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "title" | "style" | "onChange"> {
@@ -80,6 +81,8 @@ function Avatar({
     }
   };
 
+  const avatarClassName = applyConetoClassName("avatar", className);
+
   return (
     <AvatarContainer
       {...props}
@@ -93,7 +96,7 @@ function Avatar({
       $fontSize={fontSize}
       $frameSize={frameSize}
       id={id}
-      className={`coneto-avatar${className ? ` ${className}` : ""}`}
+      className={avatarClassName}
       $borderColor={avatarTheme.borderColor}
       $textColor={avatarTheme.textColor}
       $style={styles?.self}

--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -50,6 +50,8 @@ function Avatar({
   styles,
   onChange,
   onClick,
+  className,
+  id,
   ...props
 }: AvatarProps) {
   const { currentTheme } = useTheme();
@@ -90,6 +92,8 @@ function Avatar({
       $backgroundColor={!isImageValid ? backgroundColor : undefined}
       $fontSize={fontSize}
       $frameSize={frameSize}
+      id={id}
+      className={`coneto-avatar${className ? ` ${className}` : ""}`}
       $borderColor={avatarTheme.borderColor}
       $textColor={avatarTheme.textColor}
       $style={styles?.self}

--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -4,7 +4,7 @@ import { strToColor } from "./../lib/code-color";
 import { ChangeEvent, HTMLAttributes, useRef } from "react";
 import styled, { CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface AvatarProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "title" | "style" | "onChange"> {
@@ -81,8 +81,6 @@ function Avatar({
     }
   };
 
-  const avatarClassName = applyConetoClassName("avatar", className);
-
   return (
     <AvatarContainer
       {...props}
@@ -96,7 +94,7 @@ function Avatar({
       $fontSize={fontSize}
       $frameSize={frameSize}
       id={id}
-      className={avatarClassName}
+      className={applyClassName("avatar", className)}
       $borderColor={avatarTheme.borderColor}
       $textColor={avatarTheme.textColor}
       $style={styles?.self}

--- a/components/badge.tsx
+++ b/components/badge.tsx
@@ -111,6 +111,7 @@ function Badge({
   id = "badge",
   actions,
   metadata,
+  className,
   ...props
 }: BadgeProps) {
   const { currentTheme } = useTheme();
@@ -195,6 +196,7 @@ function Badge({
     <BadgeWrapper
       {...props}
       id={String(id)}
+      className={`coneto-badge${className ? ` ${className}` : ""}`}
       onClick={onClick}
       aria-label="badge"
       $theme={badgeTheme}

--- a/components/badge.tsx
+++ b/components/badge.tsx
@@ -5,6 +5,7 @@ import { FigureProps } from "./figure";
 import { Button, ButtonStyles } from "./button";
 import { useTheme } from "./../theme/provider";
 import { BadgeThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const BadgeVariant = {
   Neutral: "neutral",
@@ -192,11 +193,13 @@ function Badge({
 
   const hasActions = actionsWithStyles && actionsWithStyles.length > 0;
 
+  const badgeClassName = applyConetoClassName("badge", className);
+
   return (
     <BadgeWrapper
       {...props}
       id={String(id)}
-      className={`coneto-badge${className ? ` ${className}` : ""}`}
+      className={badgeClassName}
       onClick={onClick}
       aria-label="badge"
       $theme={badgeTheme}

--- a/components/badge.tsx
+++ b/components/badge.tsx
@@ -5,7 +5,7 @@ import { FigureProps } from "./figure";
 import { Button, ButtonStyles } from "./button";
 import { useTheme } from "./../theme/provider";
 import { BadgeThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const BadgeVariant = {
   Neutral: "neutral",
@@ -193,13 +193,11 @@ function Badge({
 
   const hasActions = actionsWithStyles && actionsWithStyles.length > 0;
 
-  const badgeClassName = applyConetoClassName("badge", className);
-
   return (
     <BadgeWrapper
       {...props}
       id={String(id)}
-      className={badgeClassName}
+      className={applyClassName("badge", className)}
       onClick={onClick}
       aria-label="badge"
       $theme={badgeTheme}

--- a/components/boxbar.tsx
+++ b/components/boxbar.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import styled, { CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
 import { BoxbarThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface BoxbarProps {
   children: ReactNode;
@@ -69,11 +70,13 @@ function Boxbar({ styles, children, className, id }: BoxbarProps) {
 
   const shouldShowToggle = contentHeight > collapsedHeight;
 
+  const boxbarClassName = applyConetoClassName("boxbar", className);
+
   return (
     <BaseBoxbar
       ref={contentRef}
       id={id}
-      className={`coneto-boxbar${className ? ` ${className}` : ""}`}
+      className={boxbarClassName}
       initial={{ height: collapsedHeight }}
       animate={{ height: isOpen ? contentHeight : collapsedHeight }}
       transition={{ duration: 0.2, ease: "easeInOut" }}

--- a/components/boxbar.tsx
+++ b/components/boxbar.tsx
@@ -8,13 +8,15 @@ import { BoxbarThemeConfig } from "./../theme";
 export interface BoxbarProps {
   children: ReactNode;
   styles?: BoxbarStyles;
+  className?: string;
+  id?: string;
 }
 
 export interface BoxbarStyles {
   self: CSSProp;
 }
 
-function Boxbar({ styles, children }: BoxbarProps) {
+function Boxbar({ styles, children, className, id }: BoxbarProps) {
   const { currentTheme } = useTheme();
   const boxbarTheme = currentTheme.boxbar;
 
@@ -70,6 +72,8 @@ function Boxbar({ styles, children }: BoxbarProps) {
   return (
     <BaseBoxbar
       ref={contentRef}
+      id={id}
+      className={`coneto-boxbar${className ? ` ${className}` : ""}`}
       initial={{ height: collapsedHeight }}
       animate={{ height: isOpen ? contentHeight : collapsedHeight }}
       transition={{ duration: 0.2, ease: "easeInOut" }}

--- a/components/boxbar.tsx
+++ b/components/boxbar.tsx
@@ -4,7 +4,7 @@ import { motion } from "framer-motion";
 import styled, { CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
 import { BoxbarThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface BoxbarProps {
   children: ReactNode;
@@ -70,13 +70,11 @@ function Boxbar({ styles, children, className, id }: BoxbarProps) {
 
   const shouldShowToggle = contentHeight > collapsedHeight;
 
-  const boxbarClassName = applyConetoClassName("boxbar", className);
-
   return (
     <BaseBoxbar
       ref={contentRef}
       id={id}
-      className={boxbarClassName}
+      className={applyClassName("boxbar", className)}
       initial={{ height: collapsedHeight }}
       animate={{ height: isOpen ? contentHeight : collapsedHeight }}
       transition={{ duration: 0.2, ease: "easeInOut" }}

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -135,6 +135,7 @@ function Button({
   icon,
   hoverBackgroundColor,
   labelMode = "ellipsis",
+  className,
   ...props
 }: ButtonProps) {
   const { currentTheme } = useTheme();
@@ -236,6 +237,7 @@ function Button({
       $isOpen={isOpen}
       $theme={buttonTheme}
       $variant={variant}
+      className={`coneto-button${className ? ` ${className}` : ""}`}
     >
       <BaseButton
         $theme={buttonTheme}

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -21,6 +21,7 @@ import {
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { AppTheme, TipMenuContainerThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const ButtonVariant = {
   Link: "link",
@@ -224,6 +225,8 @@ function Button({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [safeAreaAriaLabelsLocal]);
 
+  const buttonClassName = applyConetoClassName("button", className);
+
   return (
     <ButtonWrapper
       $disabled={disabled}
@@ -237,7 +240,7 @@ function Button({
       $isOpen={isOpen}
       $theme={buttonTheme}
       $variant={variant}
-      className={`coneto-button${className ? ` ${className}` : ""}`}
+      className={buttonClassName}
     >
       <BaseButton
         $theme={buttonTheme}

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -21,7 +21,7 @@ import {
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { AppTheme, TipMenuContainerThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const ButtonVariant = {
   Link: "link",
@@ -225,8 +225,6 @@ function Button({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [safeAreaAriaLabelsLocal]);
 
-  const buttonClassName = applyConetoClassName("button", className);
-
   return (
     <ButtonWrapper
       $disabled={disabled}
@@ -240,7 +238,7 @@ function Button({
       $isOpen={isOpen}
       $theme={buttonTheme}
       $variant={variant}
-      className={buttonClassName}
+      className={applyClassName("button", className)}
     >
       <BaseButton
         $theme={buttonTheme}

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -992,6 +992,7 @@ function Calendar({
   name,
   id,
   labelPosition,
+  className,
   ...rest
 }: CalendarProps) {
   const inputId = StatefulForm.sanitizeId({
@@ -1015,6 +1016,7 @@ function Calendar({
       errorMessage={errorMessage}
       labelPosition={labelPosition}
       label={label}
+      className={`coneto-calendar${className ? ` ${className}` : ""}`}
       actions={actions}
       helper={helper}
       disabled={disabled}

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -19,6 +19,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { CalendarThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface BaseCalendarProps extends Partial<DrawerProps> {
   options?: CalendarOption[];
@@ -1009,6 +1010,8 @@ function Calendar({
     ...baseCalendartyles
   } = styles ?? {};
 
+  const calendarClassName = applyConetoClassName("calendar", className);
+
   return (
     <FieldLane
       id={inputId}
@@ -1016,7 +1019,7 @@ function Calendar({
       errorMessage={errorMessage}
       labelPosition={labelPosition}
       label={label}
-      className={`coneto-calendar${className ? ` ${className}` : ""}`}
+      className={calendarClassName}
       actions={actions}
       helper={helper}
       disabled={disabled}

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -19,7 +19,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { CalendarThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface BaseCalendarProps extends Partial<DrawerProps> {
   options?: CalendarOption[];
@@ -1010,8 +1010,6 @@ function Calendar({
     ...baseCalendartyles
   } = styles ?? {};
 
-  const calendarClassName = applyConetoClassName("calendar", className);
-
   return (
     <FieldLane
       id={inputId}
@@ -1019,7 +1017,7 @@ function Calendar({
       errorMessage={errorMessage}
       labelPosition={labelPosition}
       label={label}
-      className={calendarClassName}
+      className={applyClassName("calendar", className)}
       actions={actions}
       helper={helper}
       disabled={disabled}

--- a/components/capsule-tab.tsx
+++ b/components/capsule-tab.tsx
@@ -3,6 +3,7 @@ import { Capsule } from "./capsule";
 import styled, { css, CSSProp } from "styled-components";
 import { CapsuleTabThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface CapsuleTabProps {
   tabs: CapsuleTabTab[];
@@ -57,14 +58,17 @@ function CapsuleTab({
     },
     [isControlled, onTabChange]
   );
+
   const activeContent = tabs.filter((tab) => tab.id === selected);
+
+  const capsuleTabClassName = applyConetoClassName("capsule-tab", className);
 
   return (
     <CapsuleTabWrapper
       $theme={capsuleTabTheme}
       aria-label="capsule-tab-wrapper"
       $style={styles?.self}
-      className={`coneto-capsule-tab${className ? ` ${className}` : ""}`}
+      className={capsuleTabClassName}
       id={id}
     >
       <Capsule

--- a/components/capsule-tab.tsx
+++ b/components/capsule-tab.tsx
@@ -3,7 +3,7 @@ import { Capsule } from "./capsule";
 import styled, { css, CSSProp } from "styled-components";
 import { CapsuleTabThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface CapsuleTabProps {
   tabs: CapsuleTabTab[];
@@ -61,14 +61,12 @@ function CapsuleTab({
 
   const activeContent = tabs.filter((tab) => tab.id === selected);
 
-  const capsuleTabClassName = applyConetoClassName("capsule-tab", className);
-
   return (
     <CapsuleTabWrapper
       $theme={capsuleTabTheme}
       aria-label="capsule-tab-wrapper"
       $style={styles?.self}
-      className={capsuleTabClassName}
+      className={applyClassName("capsule-tab", className)}
       id={id}
     >
       <Capsule

--- a/components/capsule-tab.tsx
+++ b/components/capsule-tab.tsx
@@ -11,6 +11,8 @@ export interface CapsuleTabProps {
   styles?: CapsuleTabStyles;
   onTabChange?: (id: string) => void;
   children?: ReactNode;
+  id?: string;
+  className?: string;
 }
 
 export interface CapsuleTabStyles {
@@ -24,6 +26,7 @@ export interface CapsuleTabTab {
   id: string;
   title: string;
   content: ReactNode;
+  className?: string;
 }
 
 function CapsuleTab({
@@ -33,6 +36,8 @@ function CapsuleTab({
   activeBackgroundColor,
   onTabChange,
   children,
+  className,
+  id,
 }: CapsuleTabProps) {
   const { currentTheme } = useTheme();
   const capsuleTabTheme = currentTheme.capsuleTab;
@@ -59,6 +64,8 @@ function CapsuleTab({
       $theme={capsuleTabTheme}
       aria-label="capsule-tab-wrapper"
       $style={styles?.self}
+      className={`coneto-capsule-tab${className ? ` ${className}` : ""}`}
+      id={id}
     >
       <Capsule
         styles={{

--- a/components/capsule.tsx
+++ b/components/capsule.tsx
@@ -6,6 +6,7 @@ import { Figure, FigureProps } from "./figure";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { CapsuleThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface CapsuleTab {
   id: string;
@@ -210,6 +211,11 @@ function BaseCapsule({
       {tabs.map((tab, index) => {
         const isActive = activeTab === tab.id;
 
+        const capsulePillClassName = applyConetoClassName(
+          "capsule-tab",
+          tab?.className
+        );
+
         return (
           <Tab
             $theme={capsuleTheme}
@@ -218,7 +224,7 @@ function BaseCapsule({
             $disabled={disabled}
             role="tab"
             key={index}
-            className={`coneto-capsule-pill${tab?.className ? ` ${tab?.className}` : ""}`}
+            className={capsulePillClassName}
             id={tab?.id}
             ref={setTabRef(index)}
             $activeTabStyle={styles?.tabStyle}
@@ -272,10 +278,12 @@ function Capsule({
     id,
   });
 
+  const capsuleClassName = applyConetoClassName("capsule", className);
+
   return (
     <FieldLane
       id={inputId}
-      className={`coneto-capsule${className ? ` ${className}` : ""}`}
+      className={capsuleClassName}
       showError={showError}
       errorMessage={errorMessage}
       labelPosition={labelPosition}

--- a/components/capsule.tsx
+++ b/components/capsule.tsx
@@ -12,6 +12,7 @@ export interface CapsuleTab {
   title?: string;
   content?: ReactNode;
   icon?: FigureProps;
+  className?: string;
 }
 
 interface BaseCapsuleProps {
@@ -217,6 +218,8 @@ function BaseCapsule({
             $disabled={disabled}
             role="tab"
             key={index}
+            className={`coneto-capsule-pill${tab?.className ? ` ${tab?.className}` : ""}`}
+            id={tab?.id}
             ref={setTabRef(index)}
             $activeTabStyle={styles?.tabStyle}
             onMouseEnter={() => !disabled && setHovered(tab.id)}
@@ -260,6 +263,7 @@ function Capsule({
   labelPosition,
   labelGap,
   labelWidth,
+  className,
   ...rest
 }: CapsuleProps) {
   const inputId = StatefulForm.sanitizeId({
@@ -271,6 +275,7 @@ function Capsule({
   return (
     <FieldLane
       id={inputId}
+      className={`coneto-capsule${className ? ` ${className}` : ""}`}
       showError={showError}
       errorMessage={errorMessage}
       labelPosition={labelPosition}

--- a/components/capsule.tsx
+++ b/components/capsule.tsx
@@ -6,7 +6,7 @@ import { Figure, FigureProps } from "./figure";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { CapsuleThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface CapsuleTab {
   id: string;
@@ -211,11 +211,6 @@ function BaseCapsule({
       {tabs.map((tab, index) => {
         const isActive = activeTab === tab.id;
 
-        const capsulePillClassName = applyConetoClassName(
-          "capsule-pill",
-          tab?.className
-        );
-
         return (
           <Tab
             $theme={capsuleTheme}
@@ -224,7 +219,7 @@ function BaseCapsule({
             $disabled={disabled}
             role="tab"
             key={index}
-            className={capsulePillClassName}
+            className={applyClassName("capsule-pill", tab?.className)}
             id={tab?.id}
             ref={setTabRef(index)}
             $activeTabStyle={styles?.tabStyle}
@@ -278,12 +273,10 @@ function Capsule({
     id,
   });
 
-  const capsuleClassName = applyConetoClassName("capsule", className);
-
   return (
     <FieldLane
       id={inputId}
-      className={capsuleClassName}
+      className={applyClassName("capsule", className)}
       showError={showError}
       errorMessage={errorMessage}
       labelPosition={labelPosition}

--- a/components/capsule.tsx
+++ b/components/capsule.tsx
@@ -212,7 +212,7 @@ function BaseCapsule({
         const isActive = activeTab === tab.id;
 
         const capsulePillClassName = applyConetoClassName(
-          "capsule-tab",
+          "capsule-pill",
           tab?.className
         );
 

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -11,7 +11,7 @@ import { Toggle } from "./toggle";
 import { AnimatePresence, motion } from "framer-motion";
 import { useTheme } from "./../theme/provider";
 import { CardThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const CardShadow = {
   None: "none",
@@ -108,8 +108,6 @@ function Card({
 
   const hasActions = filteredHeaderActions.length > 0;
 
-  const cardClassName = applyConetoClassName("card", className);
-
   return (
     <CardContainer
       {...props}
@@ -117,7 +115,7 @@ function Card({
       $radius={radius}
       $padding={padding}
       id={id}
-      className={cardClassName}
+      className={applyClassName("card", className)}
       $containerStyle={styles?.containerStyle}
       $theme={cardTheme}
     >

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -94,6 +94,8 @@ function Card({
   toggleable,
   onToggleChange,
   open = true,
+  id,
+  className,
   ...props
 }: CardProps) {
   const { currentTheme } = useTheme();
@@ -111,6 +113,8 @@ function Card({
       $shadow={shadow}
       $radius={radius}
       $padding={padding}
+      id={id}
+      className={`coneto-card${className ? ` ${className}` : ""}`}
       $containerStyle={styles?.containerStyle}
       $theme={cardTheme}
     >

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -11,6 +11,7 @@ import { Toggle } from "./toggle";
 import { AnimatePresence, motion } from "framer-motion";
 import { useTheme } from "./../theme/provider";
 import { CardThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const CardShadow = {
   None: "none",
@@ -107,6 +108,8 @@ function Card({
 
   const hasActions = filteredHeaderActions.length > 0;
 
+  const cardClassName = applyConetoClassName("card", className);
+
   return (
     <CardContainer
       {...props}
@@ -114,7 +117,7 @@ function Card({
       $radius={radius}
       $padding={padding}
       id={id}
-      className={`coneto-card${className ? ` ${className}` : ""}`}
+      className={cardClassName}
       $containerStyle={styles?.containerStyle}
       $theme={cardTheme}
     >

--- a/components/checkbox.tsx
+++ b/components/checkbox.tsx
@@ -9,6 +9,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { CheckboxThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 type WithoutStyle<T> = Omit<T, "style">;
 
@@ -193,6 +194,8 @@ function Checkbox({
     ...CheckboxStyles
   } = styles ?? {};
 
+  const checkboxClassName = applyConetoClassName("checkbox", className);
+
   return (
     <FieldLane
       id={inputId}
@@ -206,7 +209,7 @@ function Checkbox({
       disabled={disabled}
       label={title}
       required={rest.required}
-      className={`coneto-checkbox${className ? ` ${className}` : ""}`}
+      className={checkboxClassName}
       errorIconPosition="none"
       styles={{
         bodyStyle: css`

--- a/components/checkbox.tsx
+++ b/components/checkbox.tsx
@@ -52,7 +52,6 @@ function BaseCheckbox({
   indeterminate = false,
   styles,
   id,
-  className,
   ...props
 }: BaseCheckboxProps) {
   const { currentTheme } = useTheme();
@@ -72,7 +71,6 @@ function BaseCheckbox({
     <InputWrapper
       aria-label="input-wrapper-checkbox"
       htmlFor={props.disabled ? null : id}
-      className={`coneto-checkbox${className ? ` ${className}` : ""}`}
       $hasDescription={!!description}
       $highlight={!!highlightOnChecked}
       $checked={isChecked}
@@ -178,6 +176,7 @@ function Checkbox({
   labelGap,
   labelWidth,
   labelPosition,
+  className,
   ...rest
 }: CheckboxProps) {
   const inputId = StatefulForm.sanitizeId({
@@ -207,6 +206,7 @@ function Checkbox({
       disabled={disabled}
       label={title}
       required={rest.required}
+      className={`coneto-checkbox${className ? ` ${className}` : ""}`}
       errorIconPosition="none"
       styles={{
         bodyStyle: css`

--- a/components/checkbox.tsx
+++ b/components/checkbox.tsx
@@ -9,7 +9,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { CheckboxThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 type WithoutStyle<T> = Omit<T, "style">;
 
@@ -194,8 +194,6 @@ function Checkbox({
     ...CheckboxStyles
   } = styles ?? {};
 
-  const checkboxClassName = applyConetoClassName("checkbox", className);
-
   return (
     <FieldLane
       id={inputId}
@@ -209,7 +207,7 @@ function Checkbox({
       disabled={disabled}
       label={title}
       required={rest.required}
-      className={checkboxClassName}
+      className={applyClassName("checkbox", className)}
       errorIconPosition="none"
       styles={{
         bodyStyle: css`

--- a/components/checkbox.tsx
+++ b/components/checkbox.tsx
@@ -52,6 +52,7 @@ function BaseCheckbox({
   indeterminate = false,
   styles,
   id,
+  className,
   ...props
 }: BaseCheckboxProps) {
   const { currentTheme } = useTheme();
@@ -71,6 +72,7 @@ function BaseCheckbox({
     <InputWrapper
       aria-label="input-wrapper-checkbox"
       htmlFor={props.disabled ? null : id}
+      className={`coneto-checkbox${className ? ` ${className}` : ""}`}
       $hasDescription={!!description}
       $highlight={!!highlightOnChecked}
       $checked={isChecked}

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -30,7 +30,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { ChipsThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export type ChipAction = BadgeAction;
 
@@ -529,8 +529,6 @@ function Chips({
     ...baseChipStyles
   } = styles ?? {};
 
-  const chipsClassName = applyConetoClassName("chips", className);
-
   return (
     <FieldLane
       id={inputId}
@@ -543,7 +541,7 @@ function Chips({
       labelGap={labelGap}
       labelWidth={labelWidth}
       labelPosition={labelPosition}
-      className={chipsClassName}
+      className={applyClassName("chips", className)}
       required={rest.required}
       styles={{
         bodyStyle: css`

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -55,7 +55,6 @@ interface BaseChipsProps {
   name?: string;
   id?: string;
   disabled?: boolean;
-  className?: string;
 }
 
 export interface BaseChipsStyles {
@@ -134,7 +133,6 @@ function BaseChips(props: BaseChipsProps) {
         id={props?.id}
         aria-label="chip-input"
         $disabled={props?.disabled}
-        className={`coneto-chips${props?.className ? ` ${props?.className}` : ""}`}
         $containerStyle={props?.styles?.chipsContainerStyle}
       >
         {CLICKED_OPTIONS.map((badge) =>
@@ -513,6 +511,7 @@ function Chips({
   labelGap,
   labelWidth,
   labelPosition,
+  className,
   ...rest
 }: ChipsProps) {
   const inputId = StatefulForm.sanitizeId({
@@ -541,6 +540,7 @@ function Chips({
       labelGap={labelGap}
       labelWidth={labelWidth}
       labelPosition={labelPosition}
+      className={`coneto-chips${className ? ` ${className}` : ""}`}
       required={rest.required}
       styles={{
         bodyStyle: css`

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -30,6 +30,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { ChipsThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export type ChipAction = BadgeAction;
 
@@ -528,6 +529,8 @@ function Chips({
     ...baseChipStyles
   } = styles ?? {};
 
+  const chipsClassName = applyConetoClassName("chips", className);
+
   return (
     <FieldLane
       id={inputId}
@@ -540,7 +543,7 @@ function Chips({
       labelGap={labelGap}
       labelWidth={labelWidth}
       labelPosition={labelPosition}
-      className={`coneto-chips${className ? ` ${className}` : ""}`}
+      className={chipsClassName}
       required={rest.required}
       styles={{
         bodyStyle: css`

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -55,6 +55,7 @@ interface BaseChipsProps {
   name?: string;
   id?: string;
   disabled?: boolean;
+  className?: string;
 }
 
 export interface BaseChipsStyles {
@@ -130,8 +131,10 @@ function BaseChips(props: BaseChipsProps) {
   return (
     <>
       <InputGroup
+        id={props?.id}
         aria-label="chip-input"
         $disabled={props?.disabled}
+        className={`coneto-chips${props?.className ? ` ${props?.className}` : ""}`}
         $containerStyle={props?.styles?.chipsContainerStyle}
       >
         {CLICKED_OPTIONS.map((badge) =>

--- a/components/choice-group.tsx
+++ b/components/choice-group.tsx
@@ -10,6 +10,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { Radio, RadioProps } from "./radio";
 import { Checkbox, CheckboxProps } from "./checkbox";
 import { useTheme } from "./../theme/provider";
+import { applyClassName } from "./../constants/classname";
 
 export interface ChoiceGroupProps {
   children: ReactNode;
@@ -23,7 +24,7 @@ export interface ChoiceGroupStyles {
   dividerStyle?: CSSProp;
 }
 
-function ChoiceGroup({ children, styles }: ChoiceGroupProps) {
+function ChoiceGroup({ children, styles, className, id }: ChoiceGroupProps) {
   const { currentTheme } = useTheme();
   const choiceGroupTheme = currentTheme.choiceGroup;
 
@@ -36,6 +37,8 @@ function ChoiceGroup({ children, styles }: ChoiceGroupProps) {
 
   return (
     <ChoiceGroupWrapper
+      id={id}
+      className={applyClassName("choice-group", className)}
       $isRowDirection={isRadioButton}
       $style={styles?.containerStyle}
       $borderColor={choiceGroupTheme.borderColor}

--- a/components/choice-group.tsx
+++ b/components/choice-group.tsx
@@ -14,6 +14,8 @@ import { useTheme } from "./../theme/provider";
 export interface ChoiceGroupProps {
   children: ReactNode;
   styles?: ChoiceGroupStyles;
+  id?: string;
+  className?: string;
 }
 
 export interface ChoiceGroupStyles {

--- a/components/code-editor.tsx
+++ b/components/code-editor.tsx
@@ -100,7 +100,7 @@ export interface CodeEditorAction extends Omit<RichEditorAction, "onClick"> {
 }
 
 export interface CodeEditorProps {
-  id: string;
+  id?: string;
   value?: string;
   language?: CodeEditorLanguage;
   onChange?: (code: string, lang: string) => void;
@@ -113,6 +113,7 @@ export interface CodeEditorProps {
   toolbarPosition?: RichEditorToolbarPosition;
   removeOnEmpty?: boolean;
   autoFocus?: boolean;
+  className?: string;
 }
 
 interface CodeEditorStyles {
@@ -136,6 +137,7 @@ function CodeEditor({
   toolbarPosition = "top",
   removeOnEmpty,
   autoFocus,
+  className,
 }: CodeEditorProps) {
   const { currentTheme, mode } = useTheme();
   const richEditorTheme = currentTheme?.richEditor;
@@ -346,6 +348,7 @@ function CodeEditor({
 
   return (
     <RichEditor.Base
+      className={`coneto-code-editor${className ? ` ${className}` : ""}`}
       actions={filteredActions}
       toolbarPosition={toolbarPosition}
       theme={richEditorTheme}
@@ -425,6 +428,7 @@ function CodeEditor({
         </Placeholder>
       )}
       <Editor
+        id={id}
         aria-label="rich-editor-code"
         $readOnly={readOnly}
         onKeyDown={(e) => {

--- a/components/code-editor.tsx
+++ b/components/code-editor.tsx
@@ -51,6 +51,7 @@ import TsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker"
 import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 import CssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
 import HtmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+import { applyConetoClassName } from "./../constants/classname";
 
 /**
  * Registers the Monaco web worker factory on `window.MonacoEnvironment`.
@@ -346,9 +347,11 @@ function CodeEditor({
       }),
   }));
 
+  const codeEditorClassName = applyConetoClassName("code-editor", className);
+
   return (
     <RichEditor.Base
-      className={`coneto-code-editor${className ? ` ${className}` : ""}`}
+      className={codeEditorClassName}
       actions={filteredActions}
       toolbarPosition={toolbarPosition}
       theme={richEditorTheme}

--- a/components/code-editor.tsx
+++ b/components/code-editor.tsx
@@ -51,7 +51,7 @@ import TsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker"
 import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 import CssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
 import HtmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 /**
  * Registers the Monaco web worker factory on `window.MonacoEnvironment`.
@@ -347,11 +347,9 @@ function CodeEditor({
       }),
   }));
 
-  const codeEditorClassName = applyConetoClassName("code-editor", className);
-
   return (
     <RichEditor.Base
-      className={codeEditorClassName}
+      className={applyClassName("code-editor", className)}
       actions={filteredActions}
       toolbarPosition={toolbarPosition}
       theme={richEditorTheme}

--- a/components/colorbox.tsx
+++ b/components/colorbox.tsx
@@ -16,6 +16,7 @@ import {
 import { StatefulForm } from "./stateful-form";
 import { ColorboxThemeConfig } from "theme";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 interface BaseColorboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "style"> {
@@ -185,6 +186,8 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
       id: props.id,
     });
 
+    const colorboxClassName = applyConetoClassName("colorbox", className);
+
     return (
       <FieldLane
         id={inputId}
@@ -200,7 +203,7 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
         helper={helper}
         disabled={disabled}
         required={rest.required}
-        className={`coneto-colorbox${className ? ` ${className}` : ""}`}
+        className={colorboxClassName}
         styles={{
           containerStyle: styles?.containerStyle,
           labelStyle: styles?.labelStyle,

--- a/components/colorbox.tsx
+++ b/components/colorbox.tsx
@@ -16,7 +16,7 @@ import {
 import { StatefulForm } from "./stateful-form";
 import { ColorboxThemeConfig } from "theme";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseColorboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "style"> {
@@ -186,8 +186,6 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
       id: props.id,
     });
 
-    const colorboxClassName = applyConetoClassName("colorbox", className);
-
     return (
       <FieldLane
         id={inputId}
@@ -203,7 +201,7 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
         helper={helper}
         disabled={disabled}
         required={rest.required}
-        className={colorboxClassName}
+        className={applyClassName("colorbox", className)}
         styles={{
           containerStyle: styles?.containerStyle,
           labelStyle: styles?.labelStyle,

--- a/components/colorbox.tsx
+++ b/components/colorbox.tsx
@@ -175,6 +175,7 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
       labelGap,
       labelWidth,
       labelPosition,
+      className,
       ...rest
     } = props;
 
@@ -199,6 +200,7 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
         helper={helper}
         disabled={disabled}
         required={rest.required}
+        className={`coneto-colorbox${className ? ` ${className}` : ""}`}
         styles={{
           containerStyle: styles?.containerStyle,
           labelStyle: styles?.labelStyle,

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -25,6 +25,7 @@ import { Figure, FigureProps } from "./figure";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { ComboboxThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 interface BaseComboboxProps {
   selectedOptions?: SelectboxSelectedOptions;
@@ -185,10 +186,12 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         ?.filter((option) => !option.hidden);
     }, [options, openedCategoryGroup]);
 
+    const comboboxClassName = applyConetoClassName("colorbox", className);
+
     return (
       <Selectbox
         ref={ref}
-        className={`coneto-combobox${className ? ` ${className}` : ""};`}
+        className={comboboxClassName}
         isLoading={isLoading}
         helper={helper}
         errorIconPosition={errorIconPosition}

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -148,6 +148,7 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       required,
       isLoading,
       labels,
+      className,
     },
     ref
   ) => {
@@ -187,6 +188,7 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
     return (
       <Selectbox
         ref={ref}
+        className={`coneto-combobox${className ? ` ${className}` : ""};`}
         isLoading={isLoading}
         helper={helper}
         errorIconPosition={errorIconPosition}

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -25,7 +25,7 @@ import { Figure, FigureProps } from "./figure";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { ComboboxThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseComboboxProps {
   selectedOptions?: SelectboxSelectedOptions;
@@ -186,12 +186,10 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         ?.filter((option) => !option.hidden);
     }, [options, openedCategoryGroup]);
 
-    const comboboxClassName = applyConetoClassName("colorbox", className);
-
     return (
       <Selectbox
         ref={ref}
-        className={comboboxClassName}
+        className={applyClassName("combobox", className)}
         isLoading={isLoading}
         helper={helper}
         errorIconPosition={errorIconPosition}

--- a/components/crumb.tsx
+++ b/components/crumb.tsx
@@ -12,7 +12,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { CrumbThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface CrumbProps {
   children?: ReactNode;
@@ -93,10 +93,12 @@ function Crumb({
     );
   }
 
-  const crumbClassName = applyConetoClassName("crumb", className);
-
   return (
-    <CrumbNav aria-label="crumb" id={id} className={crumbClassName}>
+    <CrumbNav
+      aria-label="crumb"
+      id={id}
+      className={applyClassName("crumb", className)}
+    >
       <AnimatePresence initial={false} mode="popLayout">
         {shownItems.map((data, index) => {
           const isEllipsis = data === "ellipsis";
@@ -223,13 +225,11 @@ function CrumbItem({
   const { currentTheme } = useTheme();
   const crumbTheme = currentTheme.crumb;
 
-  const crumbItemClassName = applyConetoClassName("crumb-item", className);
-
   return path ? (
     <CrumbItemLink
       $theme={crumbTheme}
       id={id}
-      className={crumbItemClassName}
+      className={applyClassName("crumb-item", className)}
       aria-label="crumb-item-link"
       $fontSize={fontSize}
       $hoverColor={hoverColor}
@@ -245,7 +245,7 @@ function CrumbItem({
     <CrumbItemSpan
       $theme={crumbTheme}
       id={id}
-      className={crumbItemClassName}
+      className={applyClassName("crumb-item", className)}
       aria-label="crumb-item-span"
       $fontSize={fontSize}
       $hoverColor={hoverColor}

--- a/components/crumb.tsx
+++ b/components/crumb.tsx
@@ -23,6 +23,8 @@ export interface CrumbProps {
   lastTextColor?: string;
   arrowColor?: string;
   styles?: CrumbStyles;
+  id?: string;
+  className?: string;
 }
 
 export interface CrumbStyles {
@@ -39,6 +41,8 @@ function Crumb({
   textColor,
   lastTextColor,
   arrowColor,
+  className,
+  id,
 }: CrumbProps) {
   const { currentTheme } = useTheme();
   const crumbTheme = currentTheme.crumb;
@@ -89,7 +93,11 @@ function Crumb({
   }
 
   return (
-    <CrumbNav aria-label="crumb">
+    <CrumbNav
+      aria-label="crumb"
+      id={id}
+      className={`coneto-crumb${className ? ` ${className}` : ""}`}
+    >
       <AnimatePresence initial={false} mode="popLayout">
         {shownItems.map((data, index) => {
           const isEllipsis = data === "ellipsis";
@@ -192,6 +200,8 @@ export interface CrumbItemProps {
   textColor?: string;
   hoverColor?: string;
   lastTextColor?: string;
+  className?: string;
+  id?: string;
 }
 
 export interface CrumbItemStyles {
@@ -208,6 +218,8 @@ function CrumbItem({
   hoverColor,
   textColor,
   lastTextColor,
+  className,
+  id,
 }: CrumbItemProps) {
   const { currentTheme } = useTheme();
   const crumbTheme = currentTheme.crumb;
@@ -215,6 +227,8 @@ function CrumbItem({
   return path ? (
     <CrumbItemLink
       $theme={crumbTheme}
+      id={id}
+      className={`coneto-crumb-item${className ? ` ${className}` : ""}`}
       aria-label="crumb-item-link"
       $fontSize={fontSize}
       $hoverColor={hoverColor}
@@ -229,6 +243,8 @@ function CrumbItem({
   ) : (
     <CrumbItemSpan
       $theme={crumbTheme}
+      id={id}
+      className={`coneto-crumb-item${className ? ` ${className}` : ""}`}
       aria-label="crumb-item-span"
       $fontSize={fontSize}
       $hoverColor={hoverColor}

--- a/components/crumb.tsx
+++ b/components/crumb.tsx
@@ -12,6 +12,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { CrumbThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface CrumbProps {
   children?: ReactNode;
@@ -92,12 +93,10 @@ function Crumb({
     );
   }
 
+  const crumbClassName = applyConetoClassName("crumb", className);
+
   return (
-    <CrumbNav
-      aria-label="crumb"
-      id={id}
-      className={`coneto-crumb${className ? ` ${className}` : ""}`}
-    >
+    <CrumbNav aria-label="crumb" id={id} className={crumbClassName}>
       <AnimatePresence initial={false} mode="popLayout">
         {shownItems.map((data, index) => {
           const isEllipsis = data === "ellipsis";
@@ -224,11 +223,13 @@ function CrumbItem({
   const { currentTheme } = useTheme();
   const crumbTheme = currentTheme.crumb;
 
+  const crumbItemClassName = applyConetoClassName("crumb-item", className);
+
   return path ? (
     <CrumbItemLink
       $theme={crumbTheme}
       id={id}
-      className={`coneto-crumb-item${className ? ` ${className}` : ""}`}
+      className={crumbItemClassName}
       aria-label="crumb-item-link"
       $fontSize={fontSize}
       $hoverColor={hoverColor}
@@ -244,7 +245,7 @@ function CrumbItem({
     <CrumbItemSpan
       $theme={crumbTheme}
       id={id}
-      className={`coneto-crumb-item${className ? ` ${className}` : ""}`}
+      className={crumbItemClassName}
       aria-label="crumb-item-span"
       $fontSize={fontSize}
       $hoverColor={hoverColor}

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -75,6 +75,7 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
     labelPosition,
     isLoading,
     labels,
+    className,
     ...rest
   } = props;
 
@@ -91,6 +92,7 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
       labels={labels}
       labelGap={labelGap}
       labelWidth={labelWidth}
+      className={`coneto-datebox${className ? ` ${className}` : ""}`}
       labelPosition={labelPosition}
       id={inputId}
       showError={showError}

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -16,7 +16,7 @@ import { forwardRef, ReactNode } from "react";
 import { FieldLaneDropdownOption, FieldLaneProps } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 type BaseDateboxProps = BaseCalendarProps & {
   name?: string;
@@ -86,8 +86,6 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
     id,
   });
 
-  const dateboxClassName = applyConetoClassName("datebox", className);
-
   return (
     <Selectbox
       {...rest}
@@ -95,7 +93,7 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
       labels={labels}
       labelGap={labelGap}
       labelWidth={labelWidth}
-      className={dateboxClassName}
+      className={applyClassName("datebox", className)}
       labelPosition={labelPosition}
       id={inputId}
       showError={showError}

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -16,6 +16,7 @@ import { forwardRef, ReactNode } from "react";
 import { FieldLaneDropdownOption, FieldLaneProps } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 type BaseDateboxProps = BaseCalendarProps & {
   name?: string;
@@ -85,6 +86,8 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
     id,
   });
 
+  const dateboxClassName = applyConetoClassName("datebox", className);
+
   return (
     <Selectbox
       {...rest}
@@ -92,7 +95,7 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
       labels={labels}
       labelGap={labelGap}
       labelWidth={labelWidth}
-      className={`coneto-datebox${className ? ` ${className}` : ""}`}
+      className={dateboxClassName}
       labelPosition={labelPosition}
       id={inputId}
       showError={showError}

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -23,7 +23,7 @@ import {
   useTheme,
 } from "./../theme/provider";
 import { DialogThemeConfig } from "./../theme";
-import { applyClassName } from "@/constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 const zoomIn = keyframes`from {transform: translate(-50%, -50%) scale(0.95); opacity: 0;} to {transform: translate(-50%, -50%) scale(1); opacity: 1;}`;
 const zoomOut = keyframes`from {transform: translate(-50%, -50%) scale(1); opacity: 1;} to {transform: translate(-50%, -50%) scale(0.95); opacity: 0;}`;

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -23,6 +23,7 @@ import {
   useTheme,
 } from "./../theme/provider";
 import { DialogThemeConfig } from "./../theme";
+import { applyClassName } from "@/constants/classname";
 
 const zoomIn = keyframes`from {transform: translate(-50%, -50%) scale(0.95); opacity: 0;} to {transform: translate(-50%, -50%) scale(1); opacity: 1;}`;
 const zoomOut = keyframes`from {transform: translate(-50%, -50%) scale(1); opacity: 1;} to {transform: translate(-50%, -50%) scale(0.95); opacity: 0;}`;
@@ -94,12 +95,6 @@ function Dialog({
   const { currentTheme, mode } = useTheme();
   const dialogTheme = currentTheme.dialog;
 
-  const hasModalDialog = className?.includes("coneto-modal-dialog");
-
-  const filteredDialogClassName = hasModalDialog
-    ? className
-    : ["coneto-dialog", className].filter(Boolean).join(" ");
-
   const [isVisible, setIsVisible] = useState(false);
   const { mounted, target } = usePortal();
 
@@ -133,6 +128,8 @@ function Dialog({
     }
   }, [isOpen]);
 
+  const hasModalDialog = className?.includes("coneto-modal-dialog");
+
   if (!mounted || !target || !isVisible) return null;
 
   return ReactDOM.createPortal(
@@ -154,7 +151,9 @@ function Dialog({
       />
       <Wrapper
         id={id}
-        className={filteredDialogClassName}
+        className={
+          hasModalDialog ? className : applyClassName("dialog", className)
+        }
         $theme={dialogTheme}
         aria-label="dialog-wrapper"
         $isOpen={isOpen}

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -51,6 +51,8 @@ export interface DialogProps {
   subtitle?: ReactNode;
   icon?: FigureProps;
   onClosed?: () => void;
+  className?: string;
+  id?: string;
 }
 
 export interface DialogStyles {
@@ -71,6 +73,7 @@ export interface DialogButton extends Pick<ButtonVariants, "variant"> {
   isLoading?: boolean;
   disabled?: boolean;
   styles?: ButtonStyles;
+  className?: string;
 }
 
 function Dialog({
@@ -85,9 +88,17 @@ function Dialog({
   onClick,
   icon,
   onClosed,
+  className,
+  id,
 }: DialogProps) {
   const { currentTheme, mode } = useTheme();
   const dialogTheme = currentTheme.dialog;
+
+  const hasModalDialog = className?.includes("coneto-modal-dialog");
+
+  const filteredDialogClassName = hasModalDialog
+    ? className
+    : ["coneto-dialog", className].filter(Boolean).join(" ");
 
   const [isVisible, setIsVisible] = useState(false);
   const { mounted, target } = usePortal();
@@ -142,6 +153,8 @@ function Dialog({
         }}
       />
       <Wrapper
+        id={id}
+        className={filteredDialogClassName}
         $theme={dialogTheme}
         aria-label="dialog-wrapper"
         $isOpen={isOpen}
@@ -225,6 +238,8 @@ function Dialog({
                 isLoading={button.isLoading}
                 disabled={button.disabled}
                 variant={button.variant}
+                id={button.id}
+                className={button.className}
                 onClick={() => onClick?.({ buttonId: button.id, closeDialog })}
                 styles={{
                   ...button?.styles,

--- a/components/document-viewer.tsx
+++ b/components/document-viewer.tsx
@@ -40,6 +40,8 @@ export interface DocumentViewerProps {
   selectable?: boolean;
   labels?: DocumentViewerLabels;
   title?: string;
+  className?: string;
+  id?: string;
 }
 
 export interface DocumentViewerLabels {
@@ -109,6 +111,8 @@ const DocumentViewer = forwardRef<DocumentViewerRef, DocumentViewerProps>(
       libPdfJsWorkerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/5.4.54/pdf.worker.min.mjs",
       selectable,
       title,
+      className,
+      id,
     },
     ref
   ) => {
@@ -633,6 +637,8 @@ const DocumentViewer = forwardRef<DocumentViewerRef, DocumentViewerProps>(
 
     return (
       <PDFViewerContainer
+        id={id}
+        className={`coneto-document-viewer${className ? ` ${className}` : ""}`}
         $backgroundColor={documentViewerTheme.backgroundColor}
       >
         <ToolbarWrapper

--- a/components/document-viewer.tsx
+++ b/components/document-viewer.tsx
@@ -13,7 +13,7 @@ import styled, { css, type CSSProp } from "styled-components";
 import { Combobox } from "./combobox";
 import type { PDFDocumentProxy } from "pdfjs-dist";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 type ResolvedSource =
   | { type: "pdf"; src: string }
@@ -636,15 +636,10 @@ const DocumentViewer = forwardRef<DocumentViewerRef, DocumentViewerProps>(
       setStart(null);
     };
 
-    const documentClassName = applyConetoClassName(
-      "document-viewer",
-      className
-    );
-
     return (
       <PDFViewerContainer
         id={id}
-        className={documentClassName}
+        className={applyClassName("document-viewer", className)}
         $backgroundColor={documentViewerTheme.backgroundColor}
       >
         <ToolbarWrapper

--- a/components/document-viewer.tsx
+++ b/components/document-viewer.tsx
@@ -13,6 +13,7 @@ import styled, { css, type CSSProp } from "styled-components";
 import { Combobox } from "./combobox";
 import type { PDFDocumentProxy } from "pdfjs-dist";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 type ResolvedSource =
   | { type: "pdf"; src: string }
@@ -635,10 +636,15 @@ const DocumentViewer = forwardRef<DocumentViewerRef, DocumentViewerProps>(
       setStart(null);
     };
 
+    const documentClassName = applyConetoClassName(
+      "document-viewer",
+      className
+    );
+
     return (
       <PDFViewerContainer
         id={id}
-        className={`coneto-document-viewer${className ? ` ${className}` : ""}`}
+        className={documentClassName}
         $backgroundColor={documentViewerTheme.backgroundColor}
       >
         <ToolbarWrapper

--- a/components/dormant-text.tsx
+++ b/components/dormant-text.tsx
@@ -16,7 +16,7 @@ import styled, { CSSProp } from "styled-components";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { DormantTextThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const DormantTextAcceptChangeOn = {
   Enter: "enter",
@@ -148,12 +148,10 @@ function DormantText({
     });
   });
 
-  const dormantClassName = applyConetoClassName("dormant-text", className);
-
   return dormantedLocal ? (
     <DormantLabel
       id={id}
-      className={dormantClassName}
+      className={applyClassName("dormant-text", className)}
       $theme={dormantTextTheme}
       aria-label="dormant-wrapper"
       ref={measureLabelSize}

--- a/components/dormant-text.tsx
+++ b/components/dormant-text.tsx
@@ -38,6 +38,8 @@ export interface DormantTextProps {
   onCancelRequested?: () => void;
   dormantedMaxWidth?: string;
   styles?: DormantTextStyles;
+  className?: string;
+  id?: string;
 }
 
 export interface DormantTextIconsProps {
@@ -68,6 +70,8 @@ function DormantText({
   onActive,
   onCancelRequested,
   dormantedMaxWidth,
+  className,
+  id,
 }: DormantTextProps) {
   const { currentTheme } = useTheme();
   const dormantTextTheme = currentTheme.dormantText;
@@ -145,6 +149,8 @@ function DormantText({
 
   return dormantedLocal ? (
     <DormantLabel
+      id={id}
+      className={`coneto-dormant-text${className ? ` ${className}` : ""}`}
       $theme={dormantTextTheme}
       aria-label="dormant-wrapper"
       ref={measureLabelSize}

--- a/components/dormant-text.tsx
+++ b/components/dormant-text.tsx
@@ -16,6 +16,7 @@ import styled, { CSSProp } from "styled-components";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { DormantTextThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const DormantTextAcceptChangeOn = {
   Enter: "enter",
@@ -147,10 +148,12 @@ function DormantText({
     });
   });
 
+  const dormantClassName = applyConetoClassName("dormant-text", className);
+
   return dormantedLocal ? (
     <DormantLabel
       id={id}
-      className={`coneto-dormant-text${className ? ` ${className}` : ""}`}
+      className={dormantClassName}
       $theme={dormantTextTheme}
       aria-label="dormant-wrapper"
       ref={measureLabelSize}

--- a/components/drawer-tab.tsx
+++ b/components/drawer-tab.tsx
@@ -5,6 +5,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { DrawerTabThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const DrawerTabPosition = {
   Left: "left",
@@ -69,11 +70,13 @@ function DrawerTab({
     return null;
   }
 
+  const drawerTabClassName = applyConetoClassName("drawer-tab", className);
+
   return (
     <DrawerTabContainer
       initial={{ x: isLeft ? "-100%" : "+100%" }}
       id={id}
-      className={`coneto-drawer-tab${className ? ` ${className}` : ""}`}
+      className={drawerTabClassName}
       animate={controls}
       $position={position}
       $style={styles?.drawerTabStyle}

--- a/components/drawer-tab.tsx
+++ b/components/drawer-tab.tsx
@@ -5,7 +5,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { DrawerTabThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const DrawerTabPosition = {
   Left: "left",
@@ -70,13 +70,11 @@ function DrawerTab({
     return null;
   }
 
-  const drawerTabClassName = applyConetoClassName("drawer-tab", className);
-
   return (
     <DrawerTabContainer
       initial={{ x: isLeft ? "-100%" : "+100%" }}
       id={id}
-      className={drawerTabClassName}
+      className={applyClassName("drawer-tab", className)}
       animate={controls}
       $position={position}
       $style={styles?.drawerTabStyle}

--- a/components/drawer-tab.tsx
+++ b/components/drawer-tab.tsx
@@ -18,6 +18,8 @@ export interface DrawerTabProps {
   tabs: DrawerTabTab[];
   position?: DrawerTabPosition;
   styles?: DrawerTabStyles;
+  className?: string;
+  id?: string;
 }
 export interface DrawerTabStyles {
   tabStyle?: CSSProp;
@@ -31,7 +33,13 @@ export interface DrawerTabTab {
   content: ReactNode;
 }
 
-function DrawerTab({ tabs, styles, position = "right" }: DrawerTabProps) {
+function DrawerTab({
+  tabs,
+  styles,
+  position = "right",
+  className,
+  id,
+}: DrawerTabProps) {
   const { currentTheme } = useTheme();
   const drawerTabTheme = currentTheme.drawerTab;
 
@@ -64,6 +72,8 @@ function DrawerTab({ tabs, styles, position = "right" }: DrawerTabProps) {
   return (
     <DrawerTabContainer
       initial={{ x: isLeft ? "-100%" : "+100%" }}
+      id={id}
+      className={`coneto-drawer-tab${className ? ` ${className}` : ""}`}
       animate={controls}
       $position={position}
       $style={styles?.drawerTabStyle}

--- a/components/empty-slate.tsx
+++ b/components/empty-slate.tsx
@@ -1,3 +1,4 @@
+import { applyConetoClassName } from "./../constants/classname";
 import { ReactNode } from "react";
 import styled, { CSSProp } from "styled-components";
 
@@ -28,10 +29,12 @@ function EmptySlate({
   className,
   id,
 }: EmptySlateProps) {
+  const emptySlateClassName = applyConetoClassName("empty-slate", className);
+
   return (
     <Container
       id={id}
-      className={`coneto-empty-slate${className ? ` ${className}` : ""}`}
+      className={emptySlateClassName}
       $style={styles?.containerStyle}
     >
       {imageUrl && (

--- a/components/empty-slate.tsx
+++ b/components/empty-slate.tsx
@@ -1,4 +1,4 @@
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 import { ReactNode } from "react";
 import styled, { CSSProp } from "styled-components";
 
@@ -29,12 +29,10 @@ function EmptySlate({
   className,
   id,
 }: EmptySlateProps) {
-  const emptySlateClassName = applyConetoClassName("empty-slate", className);
-
   return (
     <Container
       id={id}
-      className={emptySlateClassName}
+      className={applyClassName("empty-slate", className)}
       $style={styles?.containerStyle}
     >
       {imageUrl && (

--- a/components/empty-slate.tsx
+++ b/components/empty-slate.tsx
@@ -7,6 +7,8 @@ export interface EmptySlateProps {
   subtitle?: string;
   actions?: ReactNode;
   styles?: EmptySlateStyles;
+  className?: string;
+  id?: string;
 }
 
 export interface EmptySlateStyles {
@@ -23,9 +25,15 @@ function EmptySlate({
   subtitle,
   actions,
   styles,
+  className,
+  id,
 }: EmptySlateProps) {
   return (
-    <Container $style={styles?.containerStyle}>
+    <Container
+      id={id}
+      className={`coneto-empty-slate${className ? ` ${className}` : ""}`}
+      $style={styles?.containerStyle}
+    >
       {imageUrl && (
         <ImageWrapper $style={styles?.imageStyle}>
           <StyledImage

--- a/components/error-slate.tsx
+++ b/components/error-slate.tsx
@@ -26,6 +26,8 @@ export interface ErrorSlateProps {
   children?: ReactNode;
   title?: string;
   styles?: ErrorSlateStyles;
+  className?: string;
+  id?: string;
 }
 
 export interface ErrorSlateStyles {
@@ -63,7 +65,14 @@ const transformStyles = {
   `,
 };
 
-function ErrorSlate({ code, children, title, styles }: ErrorSlateProps) {
+function ErrorSlate({
+  code,
+  children,
+  title,
+  styles,
+  className,
+  id,
+}: ErrorSlateProps) {
   const { currentTheme } = useTheme();
   const errorSlateTheme = currentTheme.errorSlate;
 
@@ -77,7 +86,10 @@ function ErrorSlate({ code, children, title, styles }: ErrorSlateProps) {
   ] as const;
 
   return (
-    <ErrorSlateWrapper>
+    <ErrorSlateWrapper
+      id={id}
+      className={`coneto-error-slate${className ? ` ${className}` : ""}`}
+    >
       <ErrorSlatePerspective>
         <Cube>
           {FACE_DATA.map(({ face, content }, i) => (

--- a/components/error-slate.tsx
+++ b/components/error-slate.tsx
@@ -2,7 +2,7 @@ import styled, { css, CSSProp, keyframes } from "styled-components";
 import { ReactNode } from "react";
 import { useTheme } from "./../theme/provider";
 import { ErrorSlateThemeConfig } from "theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface ErrorSlateProps {
   code?:
@@ -86,10 +86,11 @@ function ErrorSlate({
     { face: "bottom", content: code[2] },
   ] as const;
 
-  const errorSlateClassName = applyConetoClassName("error-slate", className);
-
   return (
-    <ErrorSlateWrapper id={id} className={errorSlateClassName}>
+    <ErrorSlateWrapper
+      id={id}
+      className={applyClassName("error-slate", className)}
+    >
       <ErrorSlatePerspective>
         <Cube>
           {FACE_DATA.map(({ face, content }, i) => (

--- a/components/error-slate.tsx
+++ b/components/error-slate.tsx
@@ -2,6 +2,7 @@ import styled, { css, CSSProp, keyframes } from "styled-components";
 import { ReactNode } from "react";
 import { useTheme } from "./../theme/provider";
 import { ErrorSlateThemeConfig } from "theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface ErrorSlateProps {
   code?:
@@ -85,11 +86,10 @@ function ErrorSlate({
     { face: "bottom", content: code[2] },
   ] as const;
 
+  const errorSlateClassName = applyConetoClassName("error-slate", className);
+
   return (
-    <ErrorSlateWrapper
-      id={id}
-      className={`coneto-error-slate${className ? ` ${className}` : ""}`}
-    >
+    <ErrorSlateWrapper id={id} className={errorSlateClassName}>
       <ErrorSlatePerspective>
         <Cube>
           {FACE_DATA.map(({ face, content }, i) => (

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -7,6 +7,7 @@ import { Tooltip } from "./tooltip";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { FieldLaneThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const FieldLaneErrorIconPosition = {
   Absolute: "absolute",
@@ -375,15 +376,13 @@ function FieldLane({
     className?.includes(cls)
   );
 
-  console.log(hasCustomConetoClass);
-
-  const filteredClassName = hasCustomConetoClass
+  const fieldLaneClassName = hasCustomConetoClass
     ? className
-    : ["coneto-field-lane", className].filter(Boolean).join(" ");
+    : applyConetoClassName("field-lane", className);
 
   return (
     <Container
-      className={filteredClassName}
+      className={fieldLaneClassName}
       $disabled={disabled}
       $style={css`
         ${styles?.containerStyle}

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from "./tooltip";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { FieldLaneThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const FieldLaneErrorIconPosition = {
   Absolute: "absolute",
@@ -376,13 +376,13 @@ function FieldLane({
     className?.includes(cls)
   );
 
-  const fieldLaneClassName = hasCustomConetoClass
-    ? className
-    : applyConetoClassName("field-lane", className);
-
   return (
     <Container
-      className={fieldLaneClassName}
+      className={
+        hasCustomConetoClass
+          ? className
+          : applyClassName("field-lane", className)
+      }
       $disabled={disabled}
       $style={css`
         ${styles?.containerStyle}

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -347,9 +347,43 @@ function FieldLane({
     </InputWrapper>
   );
 
+  const CONETO_CLASSES = [
+    "coneto-textarea",
+    "coneto-calendar",
+    "coneto-capsule",
+    "coneto-checkbox",
+    "coneto-chips",
+    "coneto-colorbox",
+    "coneto-combobox",
+    "coneto-datebox",
+    "coneto-file-input-box",
+    "coneto-imagebox",
+    "coneto-moneybox",
+    "coneto-phonebox",
+    "coneto-pinbox",
+    "coneto-rating",
+    "coneto-radio",
+    "coneto-signbox",
+    "coneto-selectbox",
+    "coneto-thumb-field",
+    "coneto-toggle",
+    "coneto-timebox",
+    "coneto-textbox",
+  ];
+
+  const hasCustomConetoClass = CONETO_CLASSES.some((cls) =>
+    className?.includes(cls)
+  );
+
+  console.log(hasCustomConetoClass);
+
+  const filteredClassName = hasCustomConetoClass
+    ? className
+    : ["coneto-field-lane", className].filter(Boolean).join(" ");
+
   return (
     <Container
-      className={className ? className : "coneto-field-lane"}
+      className={filteredClassName}
       $disabled={disabled}
       $style={css`
         ${styles?.containerStyle}

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -35,13 +35,14 @@ export interface FieldLaneProps {
   helper?: string;
   disabled?: boolean;
   children?: ReactNode;
-  id?: string;
   actions?: FieldLaneAction[];
   type?: string;
   labelPosition?: FieldLaneLabelPosition;
   labelWidth?: string;
   labelGap?: number;
   required?: boolean;
+  className?: string;
+  id?: string;
 }
 
 export interface FieldLaneStyles {
@@ -105,6 +106,7 @@ function FieldLane({
   labelGap,
   labelWidth,
   required,
+  className,
 }: FieldLaneProps) {
   const { currentTheme } = useTheme();
   const fieldLaneTheme = currentTheme.fieldLane;
@@ -347,6 +349,7 @@ function FieldLane({
 
   return (
     <Container
+      className={className ? className : "coneto-field-lane"}
       $disabled={disabled}
       $style={css`
         ${styles?.containerStyle}

--- a/components/figure.tsx
+++ b/components/figure.tsx
@@ -1,4 +1,4 @@
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 import { ComponentType, HTMLAttributes } from "react";
 import styled, { CSSProp } from "styled-components";
 
@@ -25,10 +25,12 @@ function Figure({
 }: FigureProps) {
   if (!Icon) return null;
 
-  const figureClassName = applyConetoClassName("figure", className);
-
   return (
-    <Wrapper {...rest} className={figureClassName} $style={styles?.self}>
+    <Wrapper
+      {...rest}
+      className={applyClassName("figure", className)}
+      $style={styles?.self}
+    >
       {typeof Icon === "string" ? (
         <img
           alt="figure-icon"

--- a/components/figure.tsx
+++ b/components/figure.tsx
@@ -1,3 +1,4 @@
+import { applyConetoClassName } from "./../constants/classname";
 import { ComponentType, HTMLAttributes } from "react";
 import styled, { CSSProp } from "styled-components";
 
@@ -24,12 +25,10 @@ function Figure({
 }: FigureProps) {
   if (!Icon) return null;
 
+  const figureClassName = applyConetoClassName("figure", className);
+
   return (
-    <Wrapper
-      {...rest}
-      className={`coneto-figure${className ? ` ${className}` : ""}`}
-      $style={styles?.self}
-    >
+    <Wrapper {...rest} className={figureClassName} $style={styles?.self}>
       {typeof Icon === "string" ? (
         <img
           alt="figure-icon"

--- a/components/figure.tsx
+++ b/components/figure.tsx
@@ -19,12 +19,17 @@ function Figure({
   color,
   styles,
   "aria-label": ariaLabel,
+  className,
   ...rest
 }: FigureProps) {
   if (!Icon) return null;
 
   return (
-    <Wrapper {...rest} $style={styles?.self}>
+    <Wrapper
+      {...rest}
+      className={`coneto-figure${className ? ` ${className}` : ""}`}
+      $style={styles?.self}
+    >
       {typeof Icon === "string" ? (
         <img
           alt="figure-icon"

--- a/components/file-drop-box.tsx
+++ b/components/file-drop-box.tsx
@@ -49,6 +49,7 @@ export interface FileDropBoxProps {
   labelWidth?: FieldLaneProps["labelWidth"];
   required?: boolean;
   disabled?: boolean;
+  className?: string;
 }
 
 export interface FileDropBoxStyles {
@@ -77,6 +78,7 @@ function FileDropBox({
   labelWidth,
   required,
   disabled,
+  className,
 }: FileDropBoxProps) {
   const { currentTheme } = useTheme();
   const fileDropBoxTheme = currentTheme.fileDropBox;
@@ -274,6 +276,7 @@ function FileDropBox({
 
   return (
     <InputWrapper
+      className={`coneto-file-drop-box${className ? ` ${className}` : ""}`}
       $disabled={disabled}
       $labelPosition={labelPosition}
       aria-label="file-drop-box-container"

--- a/components/file-drop-box.tsx
+++ b/components/file-drop-box.tsx
@@ -15,7 +15,7 @@ import { Figure } from "./figure";
 import { FieldLaneProps } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { FileDropBoxThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface OnFileDroppedFunctionArgs {
   files: File[];
@@ -275,11 +275,9 @@ function FileDropBox({
     </DropArea>
   );
 
-  const fileDropBoxClassName = applyConetoClassName("file-drop-box", className);
-
   return (
     <InputWrapper
-      className={fileDropBoxClassName}
+      className={applyClassName("file-drop-box", className)}
       $disabled={disabled}
       $labelPosition={labelPosition}
       aria-label="file-drop-box-container"

--- a/components/file-drop-box.tsx
+++ b/components/file-drop-box.tsx
@@ -15,6 +15,7 @@ import { Figure } from "./figure";
 import { FieldLaneProps } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { FileDropBoxThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface OnFileDroppedFunctionArgs {
   files: File[];
@@ -274,9 +275,11 @@ function FileDropBox({
     </DropArea>
   );
 
+  const fileDropBoxClassName = applyConetoClassName("file-drop-box", className);
+
   return (
     <InputWrapper
-      className={`coneto-file-drop-box${className ? ` ${className}` : ""}`}
+      className={fileDropBoxClassName}
       $disabled={disabled}
       $labelPosition={labelPosition}
       aria-label="file-drop-box-container"

--- a/components/file-input-box.tsx
+++ b/components/file-input-box.tsx
@@ -179,6 +179,7 @@ function FileInputBox({
   labelGap,
   labelWidth,
   labelPosition,
+  className,
   ...rest
 }: FileInputBoxProps) {
   const inputId = StatefulForm.sanitizeId({
@@ -198,6 +199,7 @@ function FileInputBox({
   return (
     <FieldLane
       id={inputId}
+      className={`coneto-file-input-box${className ? ` ${className}` : ""}`}
       showError={showError}
       labelGap={labelGap}
       labelWidth={labelWidth}

--- a/components/file-input-box.tsx
+++ b/components/file-input-box.tsx
@@ -12,7 +12,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { FileInputBoxThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseFileInputBoxProps extends InputHTMLAttributes<HTMLInputElement> {
   placeholder?: string;
@@ -197,15 +197,10 @@ function FileInputBox({
     ...baseFileInputBoxtyles
   } = styles ?? {};
 
-  const fileInputBoxClassName = applyConetoClassName(
-    "file-input-box",
-    className
-  );
-
   return (
     <FieldLane
       id={inputId}
-      className={fileInputBoxClassName}
+      className={applyClassName("file-input-box", className)}
       showError={showError}
       labelGap={labelGap}
       labelWidth={labelWidth}

--- a/components/file-input-box.tsx
+++ b/components/file-input-box.tsx
@@ -12,6 +12,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { FileInputBoxThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 interface BaseFileInputBoxProps extends InputHTMLAttributes<HTMLInputElement> {
   placeholder?: string;
@@ -196,10 +197,15 @@ function FileInputBox({
     ...baseFileInputBoxtyles
   } = styles ?? {};
 
+  const fileInputBoxClassName = applyConetoClassName(
+    "file-input-box",
+    className
+  );
+
   return (
     <FieldLane
       id={inputId}
-      className={`coneto-file-input-box${className ? ` ${className}` : ""}`}
+      className={fileInputBoxClassName}
       showError={showError}
       labelGap={labelGap}
       labelWidth={labelWidth}

--- a/components/frame.tsx
+++ b/components/frame.tsx
@@ -2,7 +2,7 @@ import React, { HTMLAttributes } from "react";
 import styled, { CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
 import { FrameThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface FrameProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "title" | "style"> {
@@ -27,14 +27,12 @@ function Frame({
   const { currentTheme } = useTheme();
   const frameTheme = currentTheme?.frame;
 
-  const frameClassName = applyConetoClassName("frame", className);
-
   return (
     <FrameContainer
       aria-label="frame"
       {...props}
       id={id}
-      className={frameClassName}
+      className={applyClassName("frame", className)}
       $style={styles?.containerStyle}
       $theme={frameTheme}
     >

--- a/components/frame.tsx
+++ b/components/frame.tsx
@@ -15,7 +15,14 @@ export interface FrameStyles {
   titleStyle?: CSSProp;
 }
 
-function Frame({ title, children, styles, ...props }: FrameProps) {
+function Frame({
+  title,
+  children,
+  styles,
+  className,
+  id,
+  ...props
+}: FrameProps) {
   const { currentTheme } = useTheme();
   const frameTheme = currentTheme?.frame;
 
@@ -23,6 +30,8 @@ function Frame({ title, children, styles, ...props }: FrameProps) {
     <FrameContainer
       aria-label="frame"
       {...props}
+      id={id}
+      className={`coneto-frame${className ? ` ${className}` : ""}`}
       $style={styles?.containerStyle}
       $theme={frameTheme}
     >

--- a/components/frame.tsx
+++ b/components/frame.tsx
@@ -2,6 +2,7 @@ import React, { HTMLAttributes } from "react";
 import styled, { CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
 import { FrameThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface FrameProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "title" | "style"> {
@@ -26,12 +27,14 @@ function Frame({
   const { currentTheme } = useTheme();
   const frameTheme = currentTheme?.frame;
 
+  const frameClassName = applyConetoClassName("frame", className);
+
   return (
     <FrameContainer
       aria-label="frame"
       {...props}
       id={id}
-      className={`coneto-frame${className ? ` ${className}` : ""}`}
+      className={frameClassName}
       $style={styles?.containerStyle}
       $theme={frameTheme}
     >

--- a/components/grid.tsx
+++ b/components/grid.tsx
@@ -34,6 +34,8 @@ function Grid({
   gap = 8,
   styles,
   preset = "1-to-4",
+  id,
+  className,
   ...props
 }: GridProps) {
   const style: CSSProperties = {
@@ -43,6 +45,8 @@ function Grid({
   return (
     <GridBase
       {...props}
+      id={id}
+      className={`coneto-grid${className ? ` ${className}` : ""}`}
       style={style}
       aria-label="grid"
       $style={css`

--- a/components/grid.tsx
+++ b/components/grid.tsx
@@ -2,7 +2,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { CSSProperties, HTMLAttributes, ReactNode, useState } from "react";
 import { Checkbox } from "./checkbox";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface GridProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "style"> {
@@ -43,13 +43,11 @@ function Grid({
     gap: typeof gap === "number" ? `${gap}px` : gap,
   };
 
-  const gridClassName = applyConetoClassName("grid", className);
-
   return (
     <GridBase
       {...props}
       id={id}
-      className={gridClassName}
+      className={applyClassName("grid", className)}
       style={style}
       aria-label="grid"
       $style={css`
@@ -69,6 +67,7 @@ function GridCard({
   onSelected,
   isSelected,
   selectable,
+  className,
   ...props
 }: GridCardProps) {
   const { currentTheme } = useTheme();
@@ -83,6 +82,7 @@ function GridCard({
       $style={styles?.self}
       $isSelected={isSelected}
       $selectable={selectable}
+      className={applyClassName("grid-card", className)}
       $backgroundColor={gridTheme.cardBackgroundColor}
       $hoverBackgroundColor={gridTheme.cardHoverBackgroundColor}
       $selectedBackgroundColor={gridTheme.cardSelectedBackgroundColor}

--- a/components/grid.tsx
+++ b/components/grid.tsx
@@ -2,6 +2,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { CSSProperties, HTMLAttributes, ReactNode, useState } from "react";
 import { Checkbox } from "./checkbox";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface GridProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "style"> {
@@ -42,11 +43,13 @@ function Grid({
     gap: typeof gap === "number" ? `${gap}px` : gap,
   };
 
+  const gridClassName = applyConetoClassName("grid", className);
+
   return (
     <GridBase
       {...props}
       id={id}
-      className={`coneto-grid${className ? ` ${className}` : ""}`}
+      className={gridClassName}
       style={style}
       aria-label="grid"
       $style={css`

--- a/components/helper.tsx
+++ b/components/helper.tsx
@@ -1,6 +1,7 @@
 import { css } from "styled-components";
 import { Tooltip } from "./tooltip";
 import { RiInformationLine } from "@remixicon/react";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface HelperProps {
   value: string;
@@ -10,10 +11,12 @@ export interface HelperProps {
 }
 
 function Helper({ value, showDelayPeriod = 400, className, id }: HelperProps) {
+  const helperClassName = applyConetoClassName("helper", className);
+
   return (
     <Tooltip
       id={id}
-      className={`coneto-helper${className ? ` ${className}` : ""}`}
+      className={helperClassName}
       styles={{
         containerStyle: css`
           width: fit-content;

--- a/components/helper.tsx
+++ b/components/helper.tsx
@@ -1,7 +1,7 @@
 import { css } from "styled-components";
 import { Tooltip } from "./tooltip";
 import { RiInformationLine } from "@remixicon/react";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface HelperProps {
   value: string;
@@ -11,12 +11,10 @@ export interface HelperProps {
 }
 
 function Helper({ value, showDelayPeriod = 400, className, id }: HelperProps) {
-  const helperClassName = applyConetoClassName("helper", className);
-
   return (
     <Tooltip
       id={id}
-      className={helperClassName}
+      className={applyClassName("helper", className)}
       styles={{
         containerStyle: css`
           width: fit-content;

--- a/components/helper.tsx
+++ b/components/helper.tsx
@@ -5,11 +5,15 @@ import { RiInformationLine } from "@remixicon/react";
 export interface HelperProps {
   value: string;
   showDelayPeriod?: number;
+  className?: string;
+  id?: string;
 }
 
-function Helper({ value, showDelayPeriod = 400 }: HelperProps) {
+function Helper({ value, showDelayPeriod = 400, className, id }: HelperProps) {
   return (
     <Tooltip
+      id={id}
+      className={`coneto-helper${className ? ` ${className}` : ""}`}
       styles={{
         containerStyle: css`
           width: fit-content;

--- a/components/imagebox.tsx
+++ b/components/imagebox.tsx
@@ -5,7 +5,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { ImageboxThemeConfig } from "theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const ImageboxSize = {
   ExtraSmall: "xs",
@@ -249,14 +249,12 @@ function Imagebox({
     ...ImageboxStyles
   } = styles ?? {};
 
-  const imageboxClassName = applyConetoClassName("imagebox", className);
-
   return (
     <FieldLane
       id={inputId}
       labelGap={labelGap}
       labelWidth={labelWidth}
-      className={imageboxClassName}
+      className={applyClassName("imagebox", className)}
       labelPosition={labelPosition}
       showError={showError}
       errorMessage={errorMessage}

--- a/components/imagebox.tsx
+++ b/components/imagebox.tsx
@@ -231,6 +231,7 @@ function Imagebox({
   labelGap,
   labelWidth,
   labelPosition,
+  className,
   ...rest
 }: ImageboxProps) {
   const inputId = StatefulForm.sanitizeId({
@@ -252,6 +253,7 @@ function Imagebox({
       id={inputId}
       labelGap={labelGap}
       labelWidth={labelWidth}
+      className={`coneto-imagebox${className ? ` ${className}` : ""}`}
       labelPosition={labelPosition}
       showError={showError}
       errorMessage={errorMessage}

--- a/components/imagebox.tsx
+++ b/components/imagebox.tsx
@@ -5,6 +5,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { ImageboxThemeConfig } from "theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const ImageboxSize = {
   ExtraSmall: "xs",
@@ -248,12 +249,14 @@ function Imagebox({
     ...ImageboxStyles
   } = styles ?? {};
 
+  const imageboxClassName = applyConetoClassName("imagebox", className);
+
   return (
     <FieldLane
       id={inputId}
       labelGap={labelGap}
       labelWidth={labelWidth}
-      className={`coneto-imagebox${className ? ` ${className}` : ""}`}
+      className={imageboxClassName}
       labelPosition={labelPosition}
       showError={showError}
       errorMessage={errorMessage}

--- a/components/keynote.tsx
+++ b/components/keynote.tsx
@@ -1,6 +1,7 @@
 import { Children, isValidElement, ReactNode } from "react";
 import styled, { CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 export type KeynoteKeys<T> = Extract<keyof T, string>;
 
@@ -18,6 +19,8 @@ export interface KeynotePointProps {
   label: string;
   children: ReactNode;
   styles?: KeynotePointStyles;
+  className?: string;
+  id?: string;
 }
 
 export interface KeynoteStyles extends KeynotePointStyles {
@@ -41,10 +44,12 @@ function Keynote<T extends object>({
 }: KeynoteProps<T>) {
   const shouldRenderFromData = data && keys;
 
+  const keynoteClassName = applyConetoClassName("keynote", className);
+
   return (
     <KeynoteWrapper
       id={id}
-      className={`coneto-keynote${className ? ` ${className}` : ""}`}
+      className={keynoteClassName}
       aria-label="keynote-wrapper"
       $style={styles?.self}
     >
@@ -100,12 +105,25 @@ function renderValue(value: unknown): ReactNode {
   return "-";
 }
 
-function KeynotePoint({ label, children, styles }: KeynotePointProps) {
+function KeynotePoint({
+  label,
+  children,
+  styles,
+  className,
+  id,
+}: KeynotePointProps) {
   const { currentTheme } = useTheme();
   const keynoteTheme = currentTheme.keynote;
 
+  const keynotePointClassName = applyConetoClassName(
+    "keynote-point",
+    className
+  );
+
   return (
     <KeynotePointWrapper
+      id={id}
+      className={keynotePointClassName}
       aria-label="keynote-point-wrapper"
       $style={styles?.rowStyle}
     >

--- a/components/keynote.tsx
+++ b/components/keynote.tsx
@@ -10,6 +10,8 @@ export interface KeynoteProps<T extends object> {
   keyLabels?: string[];
   children?: ReactNode;
   styles?: KeynoteStyles;
+  className?: string;
+  id?: string;
 }
 
 export interface KeynotePointProps {
@@ -34,11 +36,18 @@ function Keynote<T extends object>({
   keyLabels,
   children,
   styles,
+  className,
+  id,
 }: KeynoteProps<T>) {
   const shouldRenderFromData = data && keys;
 
   return (
-    <KeynoteWrapper aria-label="keynote-wrapper" $style={styles?.self}>
+    <KeynoteWrapper
+      id={id}
+      className={`coneto-keynote${className ? ` ${className}` : ""}`}
+      aria-label="keynote-wrapper"
+      $style={styles?.self}
+    >
       {shouldRenderFromData
         ? keys?.map((key, index) => {
             const keyLabel = keyLabels?.[index] ?? String(key);

--- a/components/keynote.tsx
+++ b/components/keynote.tsx
@@ -1,7 +1,7 @@
 import { Children, isValidElement, ReactNode } from "react";
 import styled, { CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export type KeynoteKeys<T> = Extract<keyof T, string>;
 
@@ -44,12 +44,10 @@ function Keynote<T extends object>({
 }: KeynoteProps<T>) {
   const shouldRenderFromData = data && keys;
 
-  const keynoteClassName = applyConetoClassName("keynote", className);
-
   return (
     <KeynoteWrapper
       id={id}
-      className={keynoteClassName}
+      className={applyClassName("keynote", className)}
       aria-label="keynote-wrapper"
       $style={styles?.self}
     >
@@ -115,15 +113,10 @@ function KeynotePoint({
   const { currentTheme } = useTheme();
   const keynoteTheme = currentTheme.keynote;
 
-  const keynotePointClassName = applyConetoClassName(
-    "keynote-point",
-    className
-  );
-
   return (
     <KeynotePointWrapper
       id={id}
-      className={keynotePointClassName}
+      className={applyClassName("keynote-point", className)}
       aria-label="keynote-point-wrapper"
       $style={styles?.rowStyle}
     >

--- a/components/launchpad.tsx
+++ b/components/launchpad.tsx
@@ -10,6 +10,7 @@ import { Separator } from "./separator";
 import { motion, useDragControls, useMotionValue } from "framer-motion";
 import { Grid, GridPresetKey } from "./grid";
 import styled, { CSSProp } from "styled-components";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface LaunchpadProps {
   children: ReactNode;
@@ -103,11 +104,13 @@ function Launchpad({
   const x = useMotionValue(0);
   const dragControls = useDragControls();
 
+  const launchpadClassName = applyConetoClassName("launchpad", className);
+
   return (
     <LaunchpadContainer
       ref={containerRef}
       id={id}
-      className={`coneto-launchpad${className ? ` ${className}` : ""}`}
+      className={launchpadClassName}
       onPointerDown={(e) => dragControls.start(e)}
       $containerStyle={containerStyle}
     >

--- a/components/launchpad.tsx
+++ b/components/launchpad.tsx
@@ -15,6 +15,8 @@ export interface LaunchpadProps {
   children: ReactNode;
   containerStyle?: CSSProp;
   maxSection?: number;
+  className?: string;
+  id?: string;
 }
 
 export interface LaunchpadSectionProps {
@@ -46,6 +48,8 @@ function Launchpad({
   children,
   containerStyle,
   maxSection = 3,
+  className,
+  id,
 }: LaunchpadProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
@@ -102,6 +106,8 @@ function Launchpad({
   return (
     <LaunchpadContainer
       ref={containerRef}
+      id={id}
+      className={`coneto-launchpad${className ? ` ${className}` : ""}`}
       onPointerDown={(e) => dragControls.start(e)}
       $containerStyle={containerStyle}
     >

--- a/components/launchpad.tsx
+++ b/components/launchpad.tsx
@@ -10,7 +10,7 @@ import { Separator } from "./separator";
 import { motion, useDragControls, useMotionValue } from "framer-motion";
 import { Grid, GridPresetKey } from "./grid";
 import styled, { CSSProp } from "styled-components";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface LaunchpadProps {
   children: ReactNode;
@@ -104,13 +104,11 @@ function Launchpad({
   const x = useMotionValue(0);
   const dragControls = useDragControls();
 
-  const launchpadClassName = applyConetoClassName("launchpad", className);
-
   return (
     <LaunchpadContainer
       ref={containerRef}
       id={id}
-      className={launchpadClassName}
+      className={applyClassName("launchpad", className)}
       onPointerDown={(e) => dragControls.start(e)}
       $containerStyle={containerStyle}
     >

--- a/components/list.tsx
+++ b/components/list.tsx
@@ -32,7 +32,7 @@ import { OverlayBlocker } from "./overlay-blocker";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { ListThemeConfig } from "theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const ListOpenerBehavior = {
   Any: "any",
@@ -244,8 +244,6 @@ function List({
   const isOpen = (id: string, level: "group" | "item" = "item") =>
     level === "group" ? openedGroupIds.has(id) : openedItemIds.has(id);
 
-  const listClassName = applyConetoClassName("list", className);
-
   return (
     <OpenedContext.Provider
       value={{
@@ -258,7 +256,7 @@ function List({
       <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
         <ListContainer
           id={id}
-          className={listClassName}
+          className={applyClassName("list", className)}
           $backgroundColor={listTheme.backgroundColor}
           aria-label="list-container"
           $containerStyle={styles?.containerStyle}
@@ -514,12 +512,10 @@ function ListGroup({
     setIsOpen(id, "group");
   };
 
-  const listGroupClassName = applyConetoClassName("list-group", className);
-
   return (
     <ListGroupContainer
       id={id}
-      className={listGroupClassName}
+      className={applyClassName("list-group", className)}
       $containerStyle={styles?.containerStyle}
     >
       <HeaderButton
@@ -1030,13 +1026,11 @@ const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
       return isOpen(idFullname, "item");
     }, [isOpen, idFullname]);
 
-    const listItemClassName = applyConetoClassName("list-item", className);
-
     return (
       <ListItemWrapper
         ref={ref}
         id={id}
-        className={listItemClassName}
+        className={applyClassName("list-item", className)}
         aria-label="list-item-wrapper"
         $openable={openable && isChildOpened}
         $style={styles?.containerStyle}

--- a/components/list.tsx
+++ b/components/list.tsx
@@ -64,6 +64,8 @@ export interface ListProps extends ListMaxItems {
   inputRef?: Ref<HTMLInputElement>;
   onSearchKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
   labels?: ListLabels;
+  className?: string;
+  id?: string;
 }
 
 export interface ListLabels {
@@ -154,6 +156,8 @@ function List({
   maxItems,
   labels,
   maxItemsWithIcon,
+  className,
+  id,
 }: ListProps) {
   const { currentTheme } = useTheme();
   const listTheme = currentTheme.list;
@@ -250,6 +254,8 @@ function List({
     >
       <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
         <ListContainer
+          id={id}
+          className={`coneto-list${className ? ` ${className}` : ""}`}
           $backgroundColor={listTheme.backgroundColor}
           aria-label="list-container"
           $containerStyle={styles?.containerStyle}
@@ -411,6 +417,7 @@ export interface ListGroupProps {
   selectable?: boolean;
   styles?: ListGroupStyles;
   onClick?: ({ toggle }: { toggle: () => void }) => void;
+  className?: string;
 }
 
 interface ListGroupStyles {
@@ -434,6 +441,7 @@ export interface ListGroupContent {
   initialState?: ListGroupInitialState;
   items: ListItemProps[];
   styles?: ListGroupStyles;
+  className?: string;
 }
 
 function ListGroup({
@@ -449,6 +457,7 @@ function ListGroup({
   emptySlate,
   styles,
   onClick,
+  className,
   ...props
 }: ListGroupProps) {
   const { currentTheme } = useTheme();
@@ -503,7 +512,11 @@ function ListGroup({
   };
 
   return (
-    <ListGroupContainer $containerStyle={styles?.containerStyle}>
+    <ListGroupContainer
+      id={id}
+      className={`coneto-list-group${className ? ` ${className}` : ""}`}
+      $containerStyle={styles?.containerStyle}
+    >
       <HeaderButton
         $isOpen={opened}
         onMouseDown={(e) => {
@@ -930,6 +943,7 @@ export interface ListItemProps {
   hoverTextColor?: string;
   hoverBackgroundColor?: string;
   selected?: boolean;
+  className?: string;
   onClick?: (e: MouseEvent<HTMLDivElement>) => void;
   onMouseEnter?: (e: MouseEvent<HTMLDivElement>) => void;
   onMouseDown?: (e: MouseEvent<HTMLDivElement>) => void;
@@ -975,6 +989,7 @@ const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
       hoverTextColor,
       hoverBackgroundColor,
       selected,
+      className,
       ...props
     },
     ref
@@ -1013,6 +1028,8 @@ const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
     return (
       <ListItemWrapper
         ref={ref}
+        id={id}
+        className={`coneto-list-item${className ? ` ${className}` : ""}`}
         aria-label="list-item-wrapper"
         $openable={openable && isChildOpened}
         $style={styles?.containerStyle}

--- a/components/list.tsx
+++ b/components/list.tsx
@@ -32,6 +32,7 @@ import { OverlayBlocker } from "./overlay-blocker";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { ListThemeConfig } from "theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const ListOpenerBehavior = {
   Any: "any",
@@ -243,6 +244,8 @@ function List({
   const isOpen = (id: string, level: "group" | "item" = "item") =>
     level === "group" ? openedGroupIds.has(id) : openedItemIds.has(id);
 
+  const listClassName = applyConetoClassName("list", className);
+
   return (
     <OpenedContext.Provider
       value={{
@@ -255,7 +258,7 @@ function List({
       <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
         <ListContainer
           id={id}
-          className={`coneto-list${className ? ` ${className}` : ""}`}
+          className={listClassName}
           $backgroundColor={listTheme.backgroundColor}
           aria-label="list-container"
           $containerStyle={styles?.containerStyle}
@@ -511,10 +514,12 @@ function ListGroup({
     setIsOpen(id, "group");
   };
 
+  const listGroupClassName = applyConetoClassName("list-group", className);
+
   return (
     <ListGroupContainer
       id={id}
-      className={`coneto-list-group${className ? ` ${className}` : ""}`}
+      className={listGroupClassName}
       $containerStyle={styles?.containerStyle}
     >
       <HeaderButton
@@ -1025,11 +1030,13 @@ const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
       return isOpen(idFullname, "item");
     }, [isOpen, idFullname]);
 
+    const listItemClassName = applyConetoClassName("list-item", className);
+
     return (
       <ListItemWrapper
         ref={ref}
         id={id}
-        className={`coneto-list-item${className ? ` ${className}` : ""}`}
+        className={listItemClassName}
         aria-label="list-item-wrapper"
         $openable={openable && isChildOpened}
         $style={styles?.containerStyle}

--- a/components/loading-skeleton.tsx
+++ b/components/loading-skeleton.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import styled, { css, CSSProp, keyframes } from "styled-components";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const FlashDirection = {
   LeftToRight: "left-to-right",
@@ -73,12 +74,17 @@ function LoadingSkeleton({
 
   const childArray = Children.toArray(children).filter(isValidElement);
 
+  const loadingSkeletonClassName = applyConetoClassName(
+    "loading-skeleton",
+    className
+  );
+
   return (
     <LoadingSkeletonWrapper
       aria-label="loading-skeleton-wrapper"
       {...props}
       id={id}
-      className={`coneto-loading-skeleton${className ? ` ${className}` : ""}`}
+      className={loadingSkeletonClassName}
       $style={styles?.self}
     >
       {childArray.map((child, index) => {

--- a/components/loading-skeleton.tsx
+++ b/components/loading-skeleton.tsx
@@ -60,6 +60,8 @@ function LoadingSkeleton({
   flashDirection = "left-to-right",
   baseColor,
   highlightColor,
+  className,
+  id,
   ...props
 }: LoadingSkeletonProps) {
   const { currentTheme } = useTheme();
@@ -75,6 +77,8 @@ function LoadingSkeleton({
     <LoadingSkeletonWrapper
       aria-label="loading-skeleton-wrapper"
       {...props}
+      id={id}
+      className={`coneto-loading-skeleton${className ? ` ${className}` : ""}`}
       $style={styles?.self}
     >
       {childArray.map((child, index) => {

--- a/components/loading-skeleton.tsx
+++ b/components/loading-skeleton.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import styled, { css, CSSProp, keyframes } from "styled-components";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const FlashDirection = {
   LeftToRight: "left-to-right",
@@ -74,17 +74,12 @@ function LoadingSkeleton({
 
   const childArray = Children.toArray(children).filter(isValidElement);
 
-  const loadingSkeletonClassName = applyConetoClassName(
-    "loading-skeleton",
-    className
-  );
-
   return (
     <LoadingSkeletonWrapper
       aria-label="loading-skeleton-wrapper"
       {...props}
       id={id}
-      className={loadingSkeletonClassName}
+      className={applyClassName("loading-skeleton", className)}
       $style={styles?.self}
     >
       {childArray.map((child, index) => {

--- a/components/loading-spinner.tsx
+++ b/components/loading-spinner.tsx
@@ -1,7 +1,7 @@
 import styled, { CSSProp, keyframes } from "styled-components";
 import { useTheme } from "./../theme/provider";
 import { LoadingSpinnerThemeConfig } from "theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface LoadingSpinnerProps {
   iconSize?: number;
@@ -30,15 +30,10 @@ function LoadingSpinner({
   const { currentTheme } = useTheme();
   const loadingSpinnerTheme = currentTheme.loadingSpinner;
 
-  const loadingSpinnerClassName = applyConetoClassName(
-    "loading-spinner",
-    className
-  );
-
   return (
     <SpinnerWrapper
       id={id}
-      className={loadingSpinnerClassName}
+      className={applyClassName("loading-spinner", className)}
       aria-label="loading-spinner"
       $style={styles?.containerStyle}
       $gap={gap}

--- a/components/loading-spinner.tsx
+++ b/components/loading-spinner.tsx
@@ -8,6 +8,8 @@ export interface LoadingSpinnerProps {
   label?: string;
   gap?: number;
   styles?: LoadingSpinnerStyles;
+  className?: string;
+  id?: string;
 }
 export interface LoadingSpinnerStyles {
   containerStyle?: CSSProp;
@@ -21,12 +23,16 @@ function LoadingSpinner({
   label,
   gap = 2,
   styles,
+  className,
+  id,
 }: LoadingSpinnerProps) {
   const { currentTheme } = useTheme();
   const loadingSpinnerTheme = currentTheme.loadingSpinner;
 
   return (
     <SpinnerWrapper
+      id={id}
+      className={`coneto-messagebox${className ? ` ${className}` : ""}`}
       aria-label="loading-spinner"
       $style={styles?.containerStyle}
       $gap={gap}

--- a/components/loading-spinner.tsx
+++ b/components/loading-spinner.tsx
@@ -1,6 +1,7 @@
 import styled, { CSSProp, keyframes } from "styled-components";
 import { useTheme } from "./../theme/provider";
 import { LoadingSpinnerThemeConfig } from "theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface LoadingSpinnerProps {
   iconSize?: number;
@@ -29,10 +30,15 @@ function LoadingSpinner({
   const { currentTheme } = useTheme();
   const loadingSpinnerTheme = currentTheme.loadingSpinner;
 
+  const loadingSpinnerClassName = applyConetoClassName(
+    "loading-spinner",
+    className
+  );
+
   return (
     <SpinnerWrapper
       id={id}
-      className={`coneto-messagebox${className ? ` ${className}` : ""}`}
+      className={loadingSpinnerClassName}
       aria-label="loading-spinner"
       $style={styles?.containerStyle}
       $gap={gap}

--- a/components/messagebox.tsx
+++ b/components/messagebox.tsx
@@ -25,6 +25,8 @@ export interface MessageboxProps {
   closable?: boolean;
   onCloseRequest?: () => void;
   styles?: MessageboxStyles;
+  className?: string;
+  id?: string;
 }
 
 export interface MessageboxStyles {
@@ -57,6 +59,8 @@ function Messagebox({
   onCloseRequest,
   closable = false,
   styles,
+  className,
+  id,
 }: MessageboxProps) {
   const { currentTheme } = useTheme();
   const messageboxTheme = currentTheme.messagebox;
@@ -64,6 +68,8 @@ function Messagebox({
 
   return (
     <Wrapper
+      id={id}
+      className={`coneto-messagebox${className ? ` ${className}` : ""}`}
       $theme={messageboxTheme}
       $variant={variant}
       $style={styles?.containerStyle}

--- a/components/messagebox.tsx
+++ b/components/messagebox.tsx
@@ -5,7 +5,7 @@ import { Button } from "./button";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { MessageboxThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const MessageboxVariant = {
   Primary: "primary",
@@ -67,12 +67,10 @@ function Messagebox({
   const messageboxTheme = currentTheme.messagebox;
   const variantStyle = messageboxTheme[variant];
 
-  const messageboxClassName = applyConetoClassName("messagebox", className);
-
   return (
     <Wrapper
       id={id}
-      className={messageboxClassName}
+      className={applyClassName("messagebox", className)}
       $theme={messageboxTheme}
       $variant={variant}
       $style={styles?.containerStyle}

--- a/components/messagebox.tsx
+++ b/components/messagebox.tsx
@@ -5,6 +5,7 @@ import { Button } from "./button";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { MessageboxThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const MessageboxVariant = {
   Primary: "primary",
@@ -66,10 +67,12 @@ function Messagebox({
   const messageboxTheme = currentTheme.messagebox;
   const variantStyle = messageboxTheme[variant];
 
+  const messageboxClassName = applyConetoClassName("messagebox", className);
+
   return (
     <Wrapper
       id={id}
-      className={`coneto-messagebox${className ? ` ${className}` : ""}`}
+      className={messageboxClassName}
       $theme={messageboxTheme}
       $variant={variant}
       $style={styles?.containerStyle}

--- a/components/modal-dialog.tsx
+++ b/components/modal-dialog.tsx
@@ -27,6 +27,8 @@ function ModalDialog({
   onClosed,
   closable = true,
   icon,
+  className,
+  id,
 }: ModalDialogProps) {
   const { currentTheme } = useTheme();
   const modalDialogTheme = currentTheme.modalDialog;
@@ -51,6 +53,8 @@ function ModalDialog({
   }));
   return (
     <Dialog
+      id={id}
+      className={`coneto-modal-dialog${className ? ` ${className}` : ""}`}
       closable={closable}
       isOpen={isOpen}
       buttons={customizeButtons}

--- a/components/modal-dialog.tsx
+++ b/components/modal-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 import { ModalDialogThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
 import {
@@ -34,8 +34,6 @@ function ModalDialog({
   const { currentTheme } = useTheme();
   const modalDialogTheme = currentTheme.modalDialog;
 
-  const modalDialogClassName = applyConetoClassName("modal-dialog", className);
-
   const customizeButtons = buttons?.map((button) => ({
     ...button,
     styles: {
@@ -57,7 +55,7 @@ function ModalDialog({
   return (
     <Dialog
       id={id}
-      className={modalDialogClassName}
+      className={applyClassName("modal-dialog", className)}
       closable={closable}
       isOpen={isOpen}
       buttons={customizeButtons}

--- a/components/modal-dialog.tsx
+++ b/components/modal-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { applyConetoClassName } from "./../constants/classname";
 import { ModalDialogThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
 import {
@@ -33,6 +34,8 @@ function ModalDialog({
   const { currentTheme } = useTheme();
   const modalDialogTheme = currentTheme.modalDialog;
 
+  const modalDialogClassName = applyConetoClassName("modal-dialog", className);
+
   const customizeButtons = buttons?.map((button) => ({
     ...button,
     styles: {
@@ -54,7 +57,7 @@ function ModalDialog({
   return (
     <Dialog
       id={id}
-      className={`coneto-modal-dialog${className ? ` ${className}` : ""}`}
+      className={modalDialogClassName}
       closable={closable}
       isOpen={isOpen}
       buttons={customizeButtons}

--- a/components/moneybox.tsx
+++ b/components/moneybox.tsx
@@ -280,6 +280,7 @@ const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
       labelGap,
       labelWidth,
       labelPosition,
+      className,
       ...rest
     } = props;
 
@@ -292,6 +293,7 @@ const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
     return (
       <FieldLane
         id={inputId}
+        className={`coneto-moneybox${className ? ` ${className}` : ""}`}
         labelGap={labelGap}
         labelWidth={labelWidth}
         labelPosition={labelPosition}

--- a/components/moneybox.tsx
+++ b/components/moneybox.tsx
@@ -19,7 +19,7 @@ import {
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { MoneyboxThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const MoneyboxSeparator = {
   Dot: "dot",
@@ -291,12 +291,10 @@ const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
       id: props.id,
     });
 
-    const moneyboxClassName = applyConetoClassName("moneybox", className);
-
     return (
       <FieldLane
         id={inputId}
-        className={moneyboxClassName}
+        className={applyClassName("moneybox", className)}
         labelGap={labelGap}
         labelWidth={labelWidth}
         labelPosition={labelPosition}

--- a/components/moneybox.tsx
+++ b/components/moneybox.tsx
@@ -19,6 +19,7 @@ import {
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { MoneyboxThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const MoneyboxSeparator = {
   Dot: "dot",
@@ -290,10 +291,12 @@ const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
       id: props.id,
     });
 
+    const moneyboxClassName = applyConetoClassName("moneybox", className);
+
     return (
       <FieldLane
         id={inputId}
-        className={`coneto-moneybox${className ? ` ${className}` : ""}`}
+        className={moneyboxClassName}
         labelGap={labelGap}
         labelWidth={labelWidth}
         labelPosition={labelPosition}

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -26,7 +26,8 @@ export interface NavTabProps {
   styles?: NavTabStyles;
   size?: NavTabSize;
   onChange?: (activeTab: string) => void;
-  active?: boolean;
+  className?: string;
+  id?: string;
 }
 
 export interface NavTabStyles {
@@ -58,6 +59,7 @@ export interface NavTabTab {
   actions?: NavTabTabAction[];
   subItems?: NavTabSubItem[];
   hidden?: boolean;
+  className?: string;
 }
 
 export interface NavTabSubItem {
@@ -68,6 +70,7 @@ export interface NavTabSubItem {
   content?: ReactNode;
   hidden?: boolean;
   styles?: NavTabSubItemStyles;
+  className?: string;
 }
 
 export interface NavTabSubItemStyles {
@@ -86,6 +89,8 @@ function NavTab({
   children,
   size = "md",
   onChange,
+  className,
+  id,
 }: NavTabProps) {
   const { currentTheme } = useTheme();
   const navTheme = currentTheme.navTab;
@@ -183,7 +188,11 @@ function NavTab({
   );
 
   return (
-    <NavTabContainer $style={styles?.containerStyle}>
+    <NavTabContainer
+      id={id}
+      className={`coneto-nav-tab${className ? ` ${className}` : ""}`}
+      $style={styles?.containerStyle}
+    >
       <NavTabBar $theme={navTheme} $style={styles?.barStyle}>
         <NavTabTabsSection
           aria-label="nav-tab-tabs-sections"
@@ -220,7 +229,9 @@ function NavTab({
                 ref={(el) => {
                   tooltipRefs.current[index] = el;
                 }}
-                key={tab.id}
+                id={tab.id}
+                className={`coneto-nav-tab-tab${tab?.className ? ` ${tab?.className}` : ""}`}
+                key={index}
                 styles={{
                   arrowStyle: css`
                     opacity: 0;
@@ -261,6 +272,8 @@ function NavTab({
                         ?.map((item, idx) => (
                           <NavTabTab
                             key={idx}
+                            id={item?.id}
+                            className={`coneto-nav-tab-sub-item${item?.className ? ` ${item?.className}` : ""}`}
                             $theme={navTheme}
                             $style={item?.styles?.self}
                             onClick={() => {
@@ -288,7 +301,7 @@ function NavTab({
               >
                 <NavTabTab
                   $theme={navTheme}
-                  key={tab.id}
+                  key={index}
                   $size={size}
                   aria-label="nav-tab-tab"
                   $style={styles?.tabStyle}

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -16,6 +16,7 @@ import { ActionButton, ActionButtonProps } from "./action-button";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "../theme/provider";
 import { NavTabThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface NavTabProps {
   tabs?: NavTabTab[];
@@ -187,10 +188,12 @@ function NavTab({
         .some((item) => item.id === selected)
   );
 
+  const navTabClassName = applyConetoClassName("nav-tab", className);
+
   return (
     <NavTabContainer
       id={id}
-      className={`coneto-nav-tab${className ? ` ${className}` : ""}`}
+      className={navTabClassName}
       $style={styles?.containerStyle}
     >
       <NavTabBar $theme={navTheme} $style={styles?.barStyle}>
@@ -224,13 +227,18 @@ function NavTab({
           />
 
           {visibleTabs.map((tab, index) => {
+            const navTabTabClassName = applyConetoClassName(
+              "nav-tab-tab",
+              tab?.className
+            );
+
             return (
               <Tooltip
                 ref={(el) => {
                   tooltipRefs.current[index] = el;
                 }}
                 id={tab.id}
-                className={`coneto-nav-tab-tab${tab?.className ? ` ${tab?.className}` : ""}`}
+                className={navTabTabClassName}
                 key={index}
                 styles={{
                   arrowStyle: css`
@@ -269,33 +277,41 @@ function NavTab({
                     {tab.subItems &&
                       tab.subItems
                         ?.filter((item) => !item?.hidden)
-                        ?.map((item, idx) => (
-                          <NavTabTab
-                            key={idx}
-                            id={item?.id}
-                            className={`coneto-nav-tab-sub-item${item?.className ? ` ${item?.className}` : ""}`}
-                            $theme={navTheme}
-                            $style={item?.styles?.self}
-                            onClick={() => {
-                              if (item.content) {
-                                setSelectedLocal(item.id);
-                              }
-                              if (onChange) {
-                                onChange(item.id);
-                              }
-                              tooltipRefs.current.forEach((ref) => {
-                                ref?.close();
-                              });
-                              if (item.onClick) {
-                                item.onClick();
-                              }
-                            }}
-                            $subMenu={true}
-                          >
-                            {item.icon && <Figure {...item.icon} />}
-                            {item.caption}
-                          </NavTabTab>
-                        ))}
+                        ?.map((item, idx) => {
+                          const navTabTabSubItemClassName =
+                            applyConetoClassName(
+                              "nav-tab-sub-item",
+                              item?.className
+                            );
+
+                          return (
+                            <NavTabTab
+                              key={idx}
+                              id={item?.id}
+                              className={navTabTabSubItemClassName}
+                              $theme={navTheme}
+                              $style={item?.styles?.self}
+                              onClick={() => {
+                                if (item.content) {
+                                  setSelectedLocal(item.id);
+                                }
+                                if (onChange) {
+                                  onChange(item.id);
+                                }
+                                tooltipRefs.current.forEach((ref) => {
+                                  ref?.close();
+                                });
+                                if (item.onClick) {
+                                  item.onClick();
+                                }
+                              }}
+                              $subMenu={true}
+                            >
+                              {item.icon && <Figure {...item.icon} />}
+                              {item.caption}
+                            </NavTabTab>
+                          );
+                        })}
                   </>
                 }
               >

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -16,7 +16,7 @@ import { ActionButton, ActionButtonProps } from "./action-button";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "../theme/provider";
 import { NavTabThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface NavTabProps {
   tabs?: NavTabTab[];
@@ -188,12 +188,10 @@ function NavTab({
         .some((item) => item.id === selected)
   );
 
-  const navTabClassName = applyConetoClassName("nav-tab", className);
-
   return (
     <NavTabContainer
       id={id}
-      className={navTabClassName}
+      className={applyClassName("nav-tab", className)}
       $style={styles?.containerStyle}
     >
       <NavTabBar $theme={navTheme} $style={styles?.barStyle}>
@@ -227,18 +225,13 @@ function NavTab({
           />
 
           {visibleTabs.map((tab, index) => {
-            const navTabTabClassName = applyConetoClassName(
-              "nav-tab-tab",
-              tab?.className
-            );
-
             return (
               <Tooltip
                 ref={(el) => {
                   tooltipRefs.current[index] = el;
                 }}
                 id={tab.id}
-                className={navTabTabClassName}
+                className={applyClassName("nav-tab-tab", tab?.className)}
                 key={index}
                 styles={{
                   arrowStyle: css`
@@ -278,17 +271,14 @@ function NavTab({
                       tab.subItems
                         ?.filter((item) => !item?.hidden)
                         ?.map((item, idx) => {
-                          const navTabTabSubItemClassName =
-                            applyConetoClassName(
-                              "nav-tab-sub-item",
-                              item?.className
-                            );
-
                           return (
                             <NavTabTab
                               key={idx}
                               id={item?.id}
-                              className={navTabTabSubItemClassName}
+                              className={applyClassName(
+                                "nav-tab-sub-item",
+                                item?.className
+                              )}
                               $theme={navTheme}
                               $style={item?.styles?.self}
                               onClick={() => {

--- a/components/overlay-blocker.tsx
+++ b/components/overlay-blocker.tsx
@@ -9,7 +9,7 @@ import {
 import styled, { CSSProp } from "styled-components";
 import { OverlayBlockerThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface OverlayBlockerRef {
   close: () => void;
@@ -97,15 +97,10 @@ export const OverlayBlocker = forwardRef<
 
     if (!visible) return null;
 
-    const overlayBlockerClassName = applyConetoClassName(
-      "overlay-blocker",
-      className
-    );
-
     return (
       <StyledOverlay
         id={id}
-        className={overlayBlockerClassName}
+        className={applyClassName("overlay-blocker", className)}
         aria-label="overlay-blocker"
         $zIndex={zIndex}
         $theme={overlayBlockerTheme}

--- a/components/overlay-blocker.tsx
+++ b/components/overlay-blocker.tsx
@@ -26,6 +26,8 @@ export interface OverlayBlockerProps {
   onClick?: OverlayBlockerClickHandler;
   styles?: OverlayBlockerStyles;
   children?: ReactNode;
+  className?: string;
+  id?: string;
 }
 
 export interface OverlayBlockerStyles {
@@ -37,7 +39,15 @@ export const OverlayBlocker = forwardRef<
   OverlayBlockerProps
 >(
   (
-    { show = false, zIndex = 9991999, onClick = "close", styles, children },
+    {
+      show = false,
+      zIndex = 9991999,
+      onClick = "close",
+      styles,
+      children,
+      className,
+      id,
+    },
     ref
   ) => {
     const { currentTheme } = useTheme();
@@ -88,6 +98,8 @@ export const OverlayBlocker = forwardRef<
 
     return (
       <StyledOverlay
+        id={id}
+        className={`coneto-overlay-blocker${className ? ` ${className}` : ""}`}
         aria-label="overlay-blocker"
         $zIndex={zIndex}
         $theme={overlayBlockerTheme}

--- a/components/overlay-blocker.tsx
+++ b/components/overlay-blocker.tsx
@@ -9,6 +9,7 @@ import {
 import styled, { CSSProp } from "styled-components";
 import { OverlayBlockerThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface OverlayBlockerRef {
   close: () => void;
@@ -96,10 +97,15 @@ export const OverlayBlocker = forwardRef<
 
     if (!visible) return null;
 
+    const overlayBlockerClassName = applyConetoClassName(
+      "overlay-blocker",
+      className
+    );
+
     return (
       <StyledOverlay
         id={id}
-        className={`coneto-overlay-blocker${className ? ` ${className}` : ""}`}
+        className={overlayBlockerClassName}
         aria-label="overlay-blocker"
         $zIndex={zIndex}
         $theme={overlayBlockerTheme}

--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -5,6 +5,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { clamp } from "./../lib/math";
 import { PaginationThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface PaginationProps {
   currentPage: number;
@@ -60,10 +61,12 @@ function Pagination({
     setCurrentPageLocal([String(safePage)]);
   }, []);
 
+  const paginationClassName = applyConetoClassName("pagination", className);
+
   return (
     <PaginationWrapper
       id={id}
-      className={`coneto-pagination${className ? ` ${className}` : ""}`}
+      className={paginationClassName}
       $style={styles?.containerStyle}
     >
       <PaginationButton

--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -5,7 +5,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { clamp } from "./../lib/math";
 import { PaginationThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface PaginationProps {
   currentPage: number;
@@ -61,12 +61,10 @@ function Pagination({
     setCurrentPageLocal([String(safePage)]);
   }, []);
 
-  const paginationClassName = applyConetoClassName("pagination", className);
-
   return (
     <PaginationWrapper
       id={id}
-      className={paginationClassName}
+      className={applyClassName("pagination", className)}
       $style={styles?.containerStyle}
     >
       <PaginationButton

--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -12,6 +12,8 @@ export interface PaginationProps {
   onPageChange: (page: number) => void;
   showNumbers?: boolean;
   styles?: PaginationStyles;
+  id?: string;
+  className?: string;
 }
 
 export interface PaginationStyles {
@@ -26,6 +28,8 @@ function Pagination({
   onPageChange,
   showNumbers = true,
   styles,
+  className,
+  id,
 }: PaginationProps) {
   const [currentPageLocal, setCurrentPageLocal] = useState<string[]>([]);
 
@@ -57,7 +61,11 @@ function Pagination({
   }, []);
 
   return (
-    <PaginationWrapper $style={styles?.containerStyle}>
+    <PaginationWrapper
+      id={id}
+      className={`coneto-pagination${className ? ` ${className}` : ""}`}
+      $style={styles?.containerStyle}
+    >
       <PaginationButton
         styles={{ self: styles?.buttonStyle }}
         onClick={handlePrevious}

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -49,6 +49,8 @@ export interface PaperDialogProps {
   styles?: PaperDialogStyles;
   onClosed?: () => void;
   icons?: PaperDialogIcons;
+  id?: string;
+  className?: string;
 }
 
 export interface PaperDialogIcons {
@@ -96,6 +98,8 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
       styles,
       onClosed,
       icons,
+      className,
+      id,
     },
     ref
   ) => {
@@ -140,7 +144,11 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
 
     return (
       dialogState !== "closed" && (
-        <DialogOverlay $dialogState={dialogState}>
+        <DialogOverlay
+          id={id}
+          className={`coneto-paper-dialog${className ? ` ${className}` : ""}`}
+          $dialogState={dialogState}
+        >
           {dialogState === "restored" && (
             <OverlayBlocker
               onClick={async ({ preventDefault, close }) => {

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -23,7 +23,7 @@ import { Figure, FigureProps } from "./figure";
 import { OverlayBlocker } from "./overlay-blocker";
 import { useTheme } from "./../theme/provider";
 import { PaperDialogThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const PaperDialogState = {
   Restored: "restored",
@@ -143,16 +143,11 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
       return () => document.removeEventListener("keydown", handleEscape);
     }, [handleEscape]);
 
-    const paperDialogClassName = applyConetoClassName(
-      "paper-dialog",
-      className
-    );
-
     return (
       dialogState !== "closed" && (
         <DialogOverlay
           id={id}
-          className={paperDialogClassName}
+          className={applyClassName("paper-dialog", className)}
           $dialogState={dialogState}
         >
           {dialogState === "restored" && (

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -23,6 +23,7 @@ import { Figure, FigureProps } from "./figure";
 import { OverlayBlocker } from "./overlay-blocker";
 import { useTheme } from "./../theme/provider";
 import { PaperDialogThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const PaperDialogState = {
   Restored: "restored",
@@ -142,11 +143,16 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
       return () => document.removeEventListener("keydown", handleEscape);
     }, [handleEscape]);
 
+    const paperDialogClassName = applyConetoClassName(
+      "paper-dialog",
+      className
+    );
+
     return (
       dialogState !== "closed" && (
         <DialogOverlay
           id={id}
-          className={`coneto-paper-dialog${className ? ` ${className}` : ""}`}
+          className={paperDialogClassName}
           $dialogState={dialogState}
         >
           {dialogState === "restored" && (

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -403,6 +403,7 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
       labelGap,
       labelWidth,
       labelPosition,
+      className,
       ...rest
     } = props;
 
@@ -426,6 +427,7 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
         type={type}
         helper={helper}
         disabled={disabled}
+        className={`coneto-phonebox${className ? ` ${className}` : ""}`}
         required={rest.required}
         styles={{
           bodyStyle: styles?.bodyStyle,

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -32,6 +32,7 @@ import { StatefulForm } from "./stateful-form";
 import { Searchbox } from "./searchbox";
 import { PhoneboxThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface PhoneboxCountryCode {
   id: string;
@@ -413,6 +414,8 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
       id: props.id,
     });
 
+    const phoneboxClassName = applyConetoClassName("phonebox", className);
+
     return (
       <FieldLane
         id={inputId}
@@ -427,7 +430,7 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
         type={type}
         helper={helper}
         disabled={disabled}
-        className={`coneto-phonebox${className ? ` ${className}` : ""}`}
+        className={phoneboxClassName}
         required={rest.required}
         styles={{
           bodyStyle: styles?.bodyStyle,

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -32,7 +32,7 @@ import { StatefulForm } from "./stateful-form";
 import { Searchbox } from "./searchbox";
 import { PhoneboxThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface PhoneboxCountryCode {
   id: string;
@@ -414,8 +414,6 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
       id: props.id,
     });
 
-    const phoneboxClassName = applyConetoClassName("phonebox", className);
-
     return (
       <FieldLane
         id={inputId}
@@ -430,7 +428,7 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
         type={type}
         helper={helper}
         disabled={disabled}
-        className={phoneboxClassName}
+        className={applyClassName("phonebox", className)}
         required={rest.required}
         styles={{
           bodyStyle: styles?.bodyStyle,

--- a/components/pinbox.tsx
+++ b/components/pinbox.tsx
@@ -11,7 +11,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { PinboxThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 interface BasePinboxProps {
   fontSize?: number;
@@ -496,8 +496,6 @@ const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
       ...pinboxStyles
     } = styles ?? {};
 
-    const pinboxClassName = applyConetoClassName("pinbox", className);
-
     return (
       <FieldLane
         id={inputId}
@@ -510,7 +508,7 @@ const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
         helper={helper}
         disabled={disabled}
         label={label}
-        className={pinboxClassName}
+        className={applyClassName("pinbox", className)}
         errorIconPosition="none"
         required={rest.required}
         styles={{

--- a/components/pinbox.tsx
+++ b/components/pinbox.tsx
@@ -11,6 +11,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { PinboxThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 interface BasePinboxProps {
   fontSize?: number;
@@ -495,6 +496,8 @@ const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
       ...pinboxStyles
     } = styles ?? {};
 
+    const pinboxClassName = applyConetoClassName("pinbox", className);
+
     return (
       <FieldLane
         id={inputId}
@@ -507,7 +510,7 @@ const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
         helper={helper}
         disabled={disabled}
         label={label}
-        className={`coneto-pinbox${className ? ` ${className}` : ""}`}
+        className={pinboxClassName}
         errorIconPosition="none"
         required={rest.required}
         styles={{

--- a/components/pinbox.tsx
+++ b/components/pinbox.tsx
@@ -476,6 +476,7 @@ const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
       labelGap,
       labelWidth,
       labelPosition,
+      className,
       ...rest
     },
     ref
@@ -506,6 +507,7 @@ const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
         helper={helper}
         disabled={disabled}
         label={label}
+        className={`coneto-pinbox${className ? ` ${className}` : ""}`}
         errorIconPosition="none"
         required={rest.required}
         styles={{

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -5,7 +5,7 @@ import { Figure, FigureProps } from "./figure";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { RadioThemeConfig } from "theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const RadioMode = {
   Radio: "radio",
@@ -173,8 +173,6 @@ function Radio({
     ...baseRadiotyles
   } = styles ?? {};
 
-  const radioClassName = applyConetoClassName("radio", className);
-
   return (
     <FieldLane
       id={inputId}
@@ -187,7 +185,7 @@ function Radio({
       actions={actions}
       helper={helper}
       disabled={disabled}
-      className={radioClassName}
+      className={applyClassName("radio", className)}
       required={rest.required}
       styles={{
         bodyStyle: css`

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -5,6 +5,7 @@ import { Figure, FigureProps } from "./figure";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { RadioThemeConfig } from "theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const RadioMode = {
   Radio: "radio",
@@ -172,6 +173,8 @@ function Radio({
     ...baseRadiotyles
   } = styles ?? {};
 
+  const radioClassName = applyConetoClassName("radio", className);
+
   return (
     <FieldLane
       id={inputId}
@@ -184,7 +187,7 @@ function Radio({
       actions={actions}
       helper={helper}
       disabled={disabled}
-      className={`coneto-radio${className ? ` ${className}` : ""}`}
+      className={radioClassName}
       required={rest.required}
       styles={{
         bodyStyle: css`

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -155,6 +155,7 @@ function Radio({
   labelGap,
   labelWidth,
   labelPosition,
+  className,
   ...rest
 }: RadioProps) {
   const inputId = StatefulForm.sanitizeId({
@@ -162,8 +163,6 @@ function Radio({
     prefix: `radio-${rest.value ?? "value"}`,
     name,
   });
-
-  const isChecked = !!rest.checked;
 
   const {
     bodyStyle,
@@ -185,6 +184,7 @@ function Radio({
       actions={actions}
       helper={helper}
       disabled={disabled}
+      className={`coneto-radio${className ? ` ${className}` : ""}`}
       required={rest.required}
       styles={{
         bodyStyle: css`

--- a/components/rating.tsx
+++ b/components/rating.tsx
@@ -190,6 +190,7 @@ function Rating({
   labelGap,
   labelWidth,
   labelPosition,
+  className,
   ...rest
 }: RatingProps) {
   const inputId = StatefulForm.sanitizeId({
@@ -219,6 +220,7 @@ function Rating({
       disabled={disabled}
       label={label}
       errorIconPosition="none"
+      className={`coneto-rating${className ? ` ${className}` : ""}`}
       required={rest.required}
       styles={{
         bodyStyle,

--- a/components/rating.tsx
+++ b/components/rating.tsx
@@ -4,6 +4,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { RatingThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const RatingSize = {
   Small: "sm",
@@ -207,6 +208,8 @@ function Rating({
     ...RatingStyles
   } = styles ?? {};
 
+  const ratingClassName = applyConetoClassName("rating", className);
+
   return (
     <FieldLane
       id={inputId}
@@ -220,7 +223,7 @@ function Rating({
       disabled={disabled}
       label={label}
       errorIconPosition="none"
-      className={`coneto-rating${className ? ` ${className}` : ""}`}
+      className={ratingClassName}
       required={rest.required}
       styles={{
         bodyStyle,

--- a/components/rating.tsx
+++ b/components/rating.tsx
@@ -4,7 +4,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { RatingThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const RatingSize = {
   Small: "sm",
@@ -208,8 +208,6 @@ function Rating({
     ...RatingStyles
   } = styles ?? {};
 
-  const ratingClassName = applyConetoClassName("rating", className);
-
   return (
     <FieldLane
       id={inputId}
@@ -223,7 +221,7 @@ function Rating({
       disabled={disabled}
       label={label}
       errorIconPosition="none"
-      className={ratingClassName}
+      className={applyClassName("rating", className)}
       required={rest.required}
       styles={{
         bodyStyle,

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -28,6 +28,7 @@ import { Figure, FigureProps } from "./figure";
 import { RichEditorThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
 import { CodeEditor, CodeEditorAction, CodeEditorOption } from "./code-editor";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface RichEditorProps {
   value?: string;
@@ -1592,13 +1593,15 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       );
     }
 
+    const richEditorClassName = applyConetoClassName("rich-editor", className);
+
     return (
       <BaseRichEditor
         actions={actions}
         value={value}
         mode={mode}
         id={id}
-        className={`coneto-rich-editor${className ? ` ${className}` : ""}`}
+        className={richEditorClassName}
         styles={{
           ...styles,
           toolbarStyle: css`
@@ -1753,7 +1756,7 @@ function BaseRichEditor({
   return (
     <Wrapper
       $theme={richEditorTheme}
-      className={`coneto-selectbox${className ? ` ${className}` : ""}`}
+      className={className}
       aria-label="rich-editor-wrapper"
       $containerStyle={styles?.containerStyle}
       $mode={mode}

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -28,7 +28,7 @@ import { Figure, FigureProps } from "./figure";
 import { RichEditorThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
 import { CodeEditor, CodeEditorAction, CodeEditorOption } from "./code-editor";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface RichEditorProps {
   value?: string;
@@ -1593,15 +1593,13 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       );
     }
 
-    const richEditorClassName = applyConetoClassName("rich-editor", className);
-
     return (
       <BaseRichEditor
         actions={actions}
         value={value}
         mode={mode}
         id={id}
-        className={richEditorClassName}
+        className={applyClassName("rich-editor", className)}
         styles={{
           ...styles,
           toolbarStyle: css`

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -40,12 +40,16 @@ export interface RichEditorProps {
   height?: number;
   actions?: RichEditorAction[];
   codeEditor?: RichEditorCode;
+  id?: string;
+  className?: string;
 }
 
 export interface RichEditorCode {
   language?: RichEditorCodeLanguage;
   actions?: RichEditorCodeAction[];
   languageOptions?: RichEditorCodeLanguage[];
+  id?: string;
+  className?: string;
 }
 
 export type RichEditorCodeAction = CodeEditorAction;
@@ -177,6 +181,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       height = 200,
       actions,
       codeEditor,
+      className,
+      id,
     },
     ref
   ) => {
@@ -184,6 +190,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       languageOptions: _languageOptions = Object.values(RichEditorCodeLanguage),
       language = _languageOptions[0],
       actions: codeEditorActions,
+      className: codeClassName,
+      id: codeId,
     } = codeEditor ?? {};
 
     const { currentTheme } = useTheme();
@@ -353,7 +361,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         return (
           node.nodeName === "INPUT" &&
           (node as HTMLInputElement).type === "checkbox" &&
-          (node as HTMLElement).classList.contains("custom-checkbox-wrapper")
+          (node as HTMLElement).classList.contains("coneto-checkbox-wrapper")
         );
       },
       replacement: (_content, node) => {
@@ -1557,7 +1565,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     if (mode === "code-editor") {
       return (
         <CodeEditor
-          id={codeEditorId}
+          id={codeId ? codeId : codeEditorId}
           styles={{
             self: css`
               padding: 0px;
@@ -1573,6 +1581,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
                   `};
             `,
           }}
+          className={codeClassName}
           toolbarPosition={toolbarPosition}
           actions={codeEditorActions}
           value={value}
@@ -1588,6 +1597,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         actions={actions}
         value={value}
         mode={mode}
+        id={id}
+        className={`coneto-rich-editor${className ? ` ${className}` : ""}`}
         styles={{
           ...styles,
           toolbarStyle: css`
@@ -1715,6 +1726,8 @@ interface BaseRichEditorProps {
   children?: ReactNode;
   mode?: RichEditorProps["mode"];
   value?: string;
+  id?: string;
+  className?: string;
 }
 
 interface BaseRichEditorStyles {
@@ -1735,10 +1748,12 @@ function BaseRichEditor({
   children,
   mode,
   value,
+  className,
 }: BaseRichEditorProps) {
   return (
     <Wrapper
       $theme={richEditorTheme}
+      className={`coneto-selectbox${className ? ` ${className}` : ""}`}
       aria-label="rich-editor-wrapper"
       $containerStyle={styles?.containerStyle}
       $mode={mode}
@@ -2115,7 +2130,7 @@ function createCheckboxWrapper(
   const input = document.createElement("input");
   input.type = "checkbox";
   input.checked = isChecked;
-  input.className = "custom-checkbox-wrapper";
+  input.className = "coneto-checkbox-wrapper";
   input.contentEditable = "false";
   input.style.cursor = isViewOnly ? "default" : "pointer";
   input.dataset.checked = String(isChecked);

--- a/components/searchbox.tsx
+++ b/components/searchbox.tsx
@@ -14,6 +14,7 @@ import { TipMenuItemProps } from "./tip-menu";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { SearchboxThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface SearchboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "style"> {
@@ -81,6 +82,8 @@ const Searchbox = forwardRef<Omit<HTMLInputElement, "style">, SearchboxProps>(
       id,
     });
 
+    const searchboxClassName = applyConetoClassName("searchbox", className);
+
     return (
       <SearchboxWrapper
         ref={anchorRef}
@@ -88,7 +91,7 @@ const Searchbox = forwardRef<Omit<HTMLInputElement, "style">, SearchboxProps>(
         $style={styles?.containerStyle}
         onFocus={() => setIsFocus(true)}
         onBlur={handleBlur}
-        className={`coneto-searchbox${className ? ` ${className}` : ""}`}
+        className={searchboxClassName}
       >
         <SearchIcon
           $theme={searchboxTheme}

--- a/components/searchbox.tsx
+++ b/components/searchbox.tsx
@@ -46,6 +46,7 @@ const Searchbox = forwardRef<Omit<HTMLInputElement, "style">, SearchboxProps>(
       resultMenu,
       showResultMenu,
       id,
+      className,
       ...props
     },
     ref
@@ -87,6 +88,7 @@ const Searchbox = forwardRef<Omit<HTMLInputElement, "style">, SearchboxProps>(
         $style={styles?.containerStyle}
         onFocus={() => setIsFocus(true)}
         onBlur={handleBlur}
+        className={`coneto-searchbox${className ? ` ${className}` : ""}`}
       >
         <SearchIcon
           $theme={searchboxTheme}

--- a/components/searchbox.tsx
+++ b/components/searchbox.tsx
@@ -14,7 +14,7 @@ import { TipMenuItemProps } from "./tip-menu";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { SearchboxThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface SearchboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "style"> {
@@ -82,8 +82,6 @@ const Searchbox = forwardRef<Omit<HTMLInputElement, "style">, SearchboxProps>(
       id,
     });
 
-    const searchboxClassName = applyConetoClassName("searchbox", className);
-
     return (
       <SearchboxWrapper
         ref={anchorRef}
@@ -91,7 +89,7 @@ const Searchbox = forwardRef<Omit<HTMLInputElement, "style">, SearchboxProps>(
         $style={styles?.containerStyle}
         onFocus={() => setIsFocus(true)}
         onBlur={handleBlur}
-        className={searchboxClassName}
+        className={applyClassName("searchbox", className)}
       >
         <SearchIcon
           $theme={searchboxTheme}

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -140,6 +140,7 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
       isLoading,
       labels,
       disabled,
+      className,
       ...props
     },
     ref
@@ -618,6 +619,7 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
       labelGap,
       labelWidth,
       labelPosition,
+      className,
       ...rest
     } = props;
     const inputId = StatefulForm.sanitizeId({
@@ -626,12 +628,21 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
       id,
     });
 
+    const hasCombo = className?.includes("coneto-combobox");
+    const hasDatebox = className?.includes("coneto-datebox");
+
+    const filteredClassName =
+      hasCombo || hasDatebox
+        ? className
+        : ["coneto-selectbox", className].filter(Boolean).join(" ");
+
     return (
       <FieldLane
         id={inputId}
         labelGap={labelGap}
         labelWidth={labelWidth}
         labelPosition={labelPosition}
+        className={filteredClassName}
         dropdowns={dropdowns}
         showError={showError}
         errorMessage={errorMessage}
@@ -650,6 +661,7 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
       >
         <BaseSelectbox
           {...rest}
+          className={className}
           id={inputId}
           actions={actions}
           showError={showError}

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -36,6 +36,7 @@ import { StatefulForm } from "./stateful-form";
 import { LoadingSpinner } from "./loading-spinner";
 import { useTheme } from "./../theme/provider";
 import { SelectboxThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 
 export type SelectboxSelectedOptions = number | string | number[] | string[];
 
@@ -631,18 +632,17 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
     const hasCombo = className?.includes("coneto-combobox");
     const hasDatebox = className?.includes("coneto-datebox");
 
-    const filteredClassName =
-      hasCombo || hasDatebox
-        ? className
-        : ["coneto-selectbox", className].filter(Boolean).join(" ");
-
     return (
       <FieldLane
         id={inputId}
         labelGap={labelGap}
         labelWidth={labelWidth}
         labelPosition={labelPosition}
-        className={filteredClassName}
+        className={
+          hasCombo || hasDatebox
+            ? className
+            : applyClassName("selectbox", className)
+        }
         dropdowns={dropdowns}
         showError={showError}
         errorMessage={errorMessage}
@@ -661,7 +661,6 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
       >
         <BaseSelectbox
           {...rest}
-          className={className}
           id={inputId}
           actions={actions}
           showError={showError}

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "./../theme/provider";
 import { FigureProps } from "./figure";
 import { Button } from "./button";
 import { Tooltip } from "./tooltip";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const SeparatorTextFloat = {
   Left: "left",
@@ -41,12 +41,10 @@ function Separator({
   const { currentTheme } = useTheme();
   const separatorTheme = currentTheme.separator;
 
-  const separatorClassName = applyConetoClassName("separator", className);
-
   return (
     <SeparatorContainer
       id={id}
-      className={separatorClassName}
+      className={applyClassName("separator", className)}
       aria-label="separator-container"
       $style={styles?.containerStyle}
       $color={separatorTheme.containerColor}
@@ -189,15 +187,10 @@ function SeparatorAction({
     return;
   }
 
-  const separatorActionClassName = applyConetoClassName(
-    "separator-action",
-    className
-  );
-
   return (
     <Tooltip
       id={id}
-      className={separatorActionClassName}
+      className={applyClassName("separator-action", className)}
       dialog={caption}
       styles={{
         arrowStyle: styles?.arrowStyle,

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -3,6 +3,7 @@ import { useTheme } from "./../theme/provider";
 import { FigureProps } from "./figure";
 import { Button } from "./button";
 import { Tooltip } from "./tooltip";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const SeparatorTextFloat = {
   Left: "left",
@@ -40,10 +41,12 @@ function Separator({
   const { currentTheme } = useTheme();
   const separatorTheme = currentTheme.separator;
 
+  const separatorClassName = applyConetoClassName("separator", className);
+
   return (
     <SeparatorContainer
       id={id}
-      className={`coneto-separator${className ? ` ${className}` : ""}`}
+      className={separatorClassName}
       aria-label="separator-container"
       $style={styles?.containerStyle}
       $color={separatorTheme.containerColor}
@@ -185,10 +188,16 @@ function SeparatorAction({
   if (hidden) {
     return;
   }
+
+  const separatorActionClassName = applyConetoClassName(
+    "separator-action",
+    className
+  );
+
   return (
     <Tooltip
       id={id}
-      className={`coneto-separator-action${className ? ` ${className}` : ""}`}
+      className={separatorActionClassName}
       dialog={caption}
       styles={{
         arrowStyle: styles?.arrowStyle,

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -18,6 +18,8 @@ export interface SeparatorProps {
   depth?: string;
   styles?: SeparatorStyles;
   actions?: SeparatorAction[];
+  className?: string;
+  id?: string;
 }
 
 export interface SeparatorStyles {
@@ -32,12 +34,16 @@ function Separator({
   textFloat = "left",
   depth = "20px",
   actions,
+  className,
+  id,
 }: SeparatorProps) {
   const { currentTheme } = useTheme();
   const separatorTheme = currentTheme.separator;
 
   return (
     <SeparatorContainer
+      id={id}
+      className={`coneto-separator${className ? ` ${className}` : ""}`}
       aria-label="separator-container"
       $style={styles?.containerStyle}
       $color={separatorTheme.containerColor}
@@ -152,6 +158,8 @@ export interface SeparatorAction {
   onClick?: () => void;
   hidden?: boolean;
   styles?: SeparatorActionStyles;
+  id?: string;
+  className?: string;
 }
 
 export interface SeparatorActionStyles {
@@ -168,6 +176,8 @@ function SeparatorAction({
   hidden,
   onClick,
   styles,
+  className,
+  id,
 }: SeparatorAction) {
   const { currentTheme } = useTheme();
   const separatorTheme = currentTheme?.separator;
@@ -177,6 +187,8 @@ function SeparatorAction({
   }
   return (
     <Tooltip
+      id={id}
+      className={`coneto-separator-action${className ? ` ${className}` : ""}`}
       dialog={caption}
       styles={{
         arrowStyle: styles?.arrowStyle,

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -20,6 +20,8 @@ export interface SidebarProps {
   children?: ReactNode;
   styles?: SidebarStyles;
   position?: SidebarPosition;
+  id?: string;
+  className?: string;
 }
 
 export interface SidebarStyles {
@@ -37,7 +39,13 @@ export interface SidebarItemStyles {
   self?: CSSProp;
 }
 
-function Sidebar({ children, styles, position = "left" }: SidebarProps) {
+function Sidebar({
+  children,
+  styles,
+  position = "left",
+  className,
+  id,
+}: SidebarProps) {
   const { currentTheme } = useTheme();
   const sidebarTheme = currentTheme.sidebar;
 
@@ -99,6 +107,8 @@ function Sidebar({ children, styles, position = "left" }: SidebarProps) {
       )}
 
       <MotionSidebar
+        id={id}
+        className={`coneto-sidebar${className ? ` ${className}` : ""}`}
         $theme={sidebarTheme}
         initial={{ x: position === "left" ? "-100%" : "+100%" }}
         animate={isMobile ? controls : { x: 0 }}
@@ -120,6 +130,8 @@ function Sidebar({ children, styles, position = "left" }: SidebarProps) {
       )}
 
       <DesktopSidebar
+        id={id}
+        className={`coneto-sidebar${className ? ` ${className}` : ""}`}
         $theme={sidebarTheme}
         $position={position}
         $style={styles?.desktopStyle}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -7,7 +7,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { OverlayBlocker } from "./overlay-blocker";
 import { SidebarThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const SidebarPosition = {
   Left: "left",
@@ -98,8 +98,6 @@ function Sidebar({
     trackTouch: true,
   });
 
-  const sidebarClassName = applyConetoClassName("sidebar", className);
-
   return (
     <>
       {isSidebarOpen && isMobile && (
@@ -111,7 +109,7 @@ function Sidebar({
 
       <MotionSidebar
         id={id}
-        className={sidebarClassName}
+        className={applyClassName("sidebar", className)}
         $theme={sidebarTheme}
         initial={{ x: position === "left" ? "-100%" : "+100%" }}
         animate={isMobile ? controls : { x: 0 }}
@@ -134,7 +132,7 @@ function Sidebar({
 
       <DesktopSidebar
         id={id}
-        className={sidebarClassName}
+        className={applyClassName("sidebar", className)}
         $theme={sidebarTheme}
         $position={position}
         $style={styles?.desktopStyle}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -7,6 +7,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { OverlayBlocker } from "./overlay-blocker";
 import { SidebarThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const SidebarPosition = {
   Left: "left",
@@ -97,6 +98,8 @@ function Sidebar({
     trackTouch: true,
   });
 
+  const sidebarClassName = applyConetoClassName("sidebar", className);
+
   return (
     <>
       {isSidebarOpen && isMobile && (
@@ -108,7 +111,7 @@ function Sidebar({
 
       <MotionSidebar
         id={id}
-        className={`coneto-sidebar${className ? ` ${className}` : ""}`}
+        className={sidebarClassName}
         $theme={sidebarTheme}
         initial={{ x: position === "left" ? "-100%" : "+100%" }}
         animate={isMobile ? controls : { x: 0 }}
@@ -131,7 +134,7 @@ function Sidebar({
 
       <DesktopSidebar
         id={id}
-        className={`coneto-sidebar${className ? ` ${className}` : ""}`}
+        className={sidebarClassName}
         $theme={sidebarTheme}
         $position={position}
         $style={styles?.desktopStyle}

--- a/components/signbox.tsx
+++ b/components/signbox.tsx
@@ -11,6 +11,7 @@ import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { SignboxThemeConfig } from "./../theme";
 import { Button } from "./button";
+import { applyConetoClassName } from "./../constants/classname";
 
 interface BaseSignboxProps {
   name?: string;
@@ -341,6 +342,8 @@ function Signbox({
     id,
   });
 
+  const signboxClassName = applyConetoClassName("signbox", className);
+
   return (
     <FieldLane
       id={inputId}
@@ -356,7 +359,7 @@ function Signbox({
       errorIconPosition={errorIconPosition}
       disabled={disabled}
       required={required}
-      className={`coneto-signbox${className ? ` ${className}` : ""}`}
+      className={signboxClassName}
       styles={{
         bodyStyle: styles?.bodyStyle,
         controlStyle: styles?.controlStyle,

--- a/components/signbox.tsx
+++ b/components/signbox.tsx
@@ -333,6 +333,7 @@ function Signbox({
   labelWidth,
   labelPosition,
   required,
+  className,
 }: SignboxProps) {
   const inputId = StatefulForm.sanitizeId({
     prefix: "signbox",
@@ -355,6 +356,7 @@ function Signbox({
       errorIconPosition={errorIconPosition}
       disabled={disabled}
       required={required}
+      className={`coneto-signbox${className ? ` ${className}` : ""}`}
       styles={{
         bodyStyle: styles?.bodyStyle,
         controlStyle: styles?.controlStyle,

--- a/components/signbox.tsx
+++ b/components/signbox.tsx
@@ -11,7 +11,7 @@ import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { SignboxThemeConfig } from "./../theme";
 import { Button } from "./button";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseSignboxProps {
   name?: string;
@@ -342,8 +342,6 @@ function Signbox({
     id,
   });
 
-  const signboxClassName = applyConetoClassName("signbox", className);
-
   return (
     <FieldLane
       id={inputId}
@@ -359,7 +357,7 @@ function Signbox({
       errorIconPosition={errorIconPosition}
       disabled={disabled}
       required={required}
-      className={signboxClassName}
+      className={applyClassName("signbox", className)}
       styles={{
         bodyStyle: styles?.bodyStyle,
         controlStyle: styles?.controlStyle,

--- a/components/split-pane.tsx
+++ b/components/split-pane.tsx
@@ -18,7 +18,7 @@ import { Button, ButtonStyles } from "./button";
 import { Figure, FigureProps } from "./figure";
 import { RiCloseLine } from "@remixicon/react";
 import { useTheme } from "../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const SplitPaneOrientation = {
   Horizontal: "horizontal",
@@ -179,12 +179,10 @@ function SplitPane({
     }
   }, [childrenArray.length]);
 
-  const splitPaneClassName = applyConetoClassName("split-pane", className);
-
   return (
     <Container
       id={id}
-      className={splitPaneClassName}
+      className={applyClassName("split-pane", className)}
       $backgroundColor={splitPaneTheme.backgroundColor}
       $textColor={splitPaneTheme.textColor}
       aria-label="split-pane"

--- a/components/split-pane.tsx
+++ b/components/split-pane.tsx
@@ -34,6 +34,8 @@ export interface SplitPaneProps {
   onResizeComplete?: () => void;
   initialSizeRatio?: number[];
   styles?: SplitPaneStyles;
+  className?: string;
+  id?: string;
 }
 
 export interface SplitPaneStyles {
@@ -68,6 +70,8 @@ function SplitPane({
   onResize,
   onResizeComplete,
   initialSizeRatio,
+  className,
+  id,
 }: SplitPaneProps) {
   const { currentTheme } = useTheme();
   const splitPaneTheme = currentTheme.splitPane;
@@ -176,6 +180,8 @@ function SplitPane({
 
   return (
     <Container
+      id={id}
+      className={`coneto-split-pane${className ? ` ${className}` : ""}`}
       $backgroundColor={splitPaneTheme.backgroundColor}
       $textColor={splitPaneTheme.textColor}
       aria-label="split-pane"

--- a/components/split-pane.tsx
+++ b/components/split-pane.tsx
@@ -18,6 +18,7 @@ import { Button, ButtonStyles } from "./button";
 import { Figure, FigureProps } from "./figure";
 import { RiCloseLine } from "@remixicon/react";
 import { useTheme } from "../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const SplitPaneOrientation = {
   Horizontal: "horizontal",
@@ -178,10 +179,12 @@ function SplitPane({
     }
   }, [childrenArray.length]);
 
+  const splitPaneClassName = applyConetoClassName("split-pane", className);
+
   return (
     <Container
       id={id}
-      className={`coneto-split-pane${className ? ` ${className}` : ""}`}
+      className={splitPaneClassName}
       $backgroundColor={splitPaneTheme.backgroundColor}
       $textColor={splitPaneTheme.textColor}
       aria-label="split-pane"

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -120,6 +120,8 @@ export interface StatefulFormProps<Z extends ZodTypeAny> {
   autoFocusField?: string;
   styles?: StatefulFormStyles;
   disabled?: boolean;
+  className?: string;
+  id?: string;
 }
 
 export interface StatefulFormStyles {
@@ -154,6 +156,7 @@ export type FormFieldRowItemsAligment =
 export interface FormFieldProps {
   name: string;
   id?: string;
+  className?: string;
   title?: string;
   helper?: string;
   required?: boolean;
@@ -210,6 +213,8 @@ function StatefulForm<Z extends ZodTypeAny>({
   styles,
   autoFocusField,
   disabled,
+  className,
+  id,
 }: StatefulFormProps<Z>) {
   const handleFieldChange = (name: keyof TypeOf<Z>, value: FormValueType) => {
     if (disabled) return;
@@ -332,6 +337,8 @@ function StatefulForm<Z extends ZodTypeAny>({
   return (
     <>
       <FormFields
+        id={id}
+        className={className}
         labelSize={labelSize}
         fieldSize={fieldSize}
         control={control}
@@ -418,6 +425,8 @@ interface FormFieldsProps<T extends FieldValues> {
   styles?: StatefulFormStyles;
   rowWithFrame?: boolean;
   disabled?: boolean;
+  className?: string;
+  id?: string;
 }
 
 function FormFields<T extends FieldValues>({
@@ -435,6 +444,8 @@ function FormFields<T extends FieldValues>({
   autoFocusField,
   rowWithFrame,
   disabled,
+  className,
+  id,
 }: FormFieldsProps<T>) {
   const { currentTheme } = useTheme();
   const statefulFormTheme = currentTheme?.statefulForm;
@@ -451,7 +462,11 @@ function FormFields<T extends FieldValues>({
   }, []);
 
   return (
-    <ContainerFormField $style={styles?.containerStyle}>
+    <ContainerFormField
+      id={id}
+      className={`coneto-stateful-form${className ? ` ${className}` : ""}`}
+      $style={styles?.containerStyle}
+    >
       {fields.map((group: FormFieldGroup, indexGroup: number) => {
         const visibleFields = (Array.isArray(group) ? group : [group]).filter(
           (field) => !field.hidden
@@ -510,6 +525,7 @@ function FormFields<T extends FieldValues>({
                     key={index}
                     title={field.title}
                     {...field?.frame}
+                    className={field?.className}
                     styles={{
                       containerStyle: css`
                         margin-top: 10px;
@@ -559,6 +575,7 @@ function FormFields<T extends FieldValues>({
                   key={index}
                   id={field.id}
                   label={field.title}
+                  className={field?.className}
                   type={field.type}
                   labelGap={field.labelGap}
                   labelWidth={field.labelWidth}
@@ -634,6 +651,7 @@ function FormFields<T extends FieldValues>({
                       key={index}
                       id={field.id}
                       name={field.name}
+                      className={field?.className}
                       labelPosition={field.labelPosition}
                       labelGap={field.labelGap}
                       labelWidth={field.labelWidth}
@@ -695,6 +713,7 @@ function FormFields<T extends FieldValues>({
                 <Button
                   key={index}
                   {...field.button}
+                  className={field?.className}
                   id={field.id}
                   title={
                     field.button?.title
@@ -755,6 +774,7 @@ function FormFields<T extends FieldValues>({
                   value={formValues[field.name as keyof T] ?? ""}
                   required={field.required}
                   helper={field.helper}
+                  className={field?.className}
                   {...register(field.name as Path<T>, {
                     onChange: (e) => {
                       if (field.onChange) {
@@ -835,6 +855,7 @@ function FormFields<T extends FieldValues>({
                   labelWidth={field.labelWidth}
                   labelPosition={field.labelPosition}
                   placeholder={field.placeholder}
+                  className={field?.className}
                   value={formValues[field.name as keyof T] ?? ""}
                   required={field.required}
                   helper={field.helper}
@@ -907,6 +928,7 @@ function FormFields<T extends FieldValues>({
                       labelGap={field.labelGap}
                       labelWidth={field.labelWidth}
                       labelPosition={field.labelPosition}
+                      className={field?.className}
                       name={field.name}
                       value={field.name}
                       placeholder={field.placeholder}
@@ -1008,6 +1030,7 @@ function FormFields<T extends FieldValues>({
                       labelGap={field.labelGap}
                       labelWidth={field.labelWidth}
                       labelPosition={field.labelPosition}
+                      className={field?.className}
                       name={field.name}
                       title={field.title}
                       placeholder={field.placeholder}
@@ -1089,6 +1112,7 @@ function FormFields<T extends FieldValues>({
                       labelGap={field.labelGap}
                       labelWidth={field.labelWidth}
                       labelPosition={field.labelPosition}
+                      className={field?.className}
                       required={field.required}
                       ref={(el) => {
                         if (el) refs.current[field.name] = el;
@@ -1173,6 +1197,7 @@ function FormFields<T extends FieldValues>({
                       label={field.title}
                       required={field.required}
                       placeholder={field.placeholder}
+                      className={field?.className}
                       helper={field.helper}
                       labelGap={field.labelGap}
                       labelWidth={field.labelWidth}
@@ -1238,6 +1263,7 @@ function FormFields<T extends FieldValues>({
                   id={field.id}
                   label={field.title}
                   placeholder={field.placeholder}
+                  className={field?.className}
                   labelGap={field.labelGap}
                   labelWidth={field.labelWidth}
                   labelPosition={field.labelPosition}
@@ -1281,6 +1307,7 @@ function FormFields<T extends FieldValues>({
                   labelGap={field.labelGap}
                   labelWidth={field.labelWidth}
                   labelPosition={field.labelPosition}
+                  className={field?.className}
                   label={field.title}
                   placeholder={field.placeholder}
                   required={field.required}
@@ -1352,6 +1379,7 @@ function FormFields<T extends FieldValues>({
                   labelGap={field.labelGap}
                   labelWidth={field.labelWidth}
                   labelPosition={field.labelPosition}
+                  className={field?.className}
                   name={field.name}
                   helper={field.helper}
                   value={formValues[field.name as keyof T] ?? ""}
@@ -1431,6 +1459,7 @@ function FormFields<T extends FieldValues>({
                   labelGap={field.labelGap}
                   labelWidth={field.labelWidth}
                   labelPosition={field.labelPosition}
+                  className={field?.className}
                   helper={field.helper}
                   required={field.required}
                   value={formValues[field.name as keyof T] ?? ""}
@@ -1490,6 +1519,7 @@ function FormFields<T extends FieldValues>({
                       labelGap={field.labelGap}
                       labelWidth={field.labelWidth}
                       labelPosition={field.labelPosition}
+                      className={field?.className}
                       ref={(el) => {
                         if (el) refs.current[field.name] = el;
                         rhf.ref(el);
@@ -1577,6 +1607,7 @@ function FormFields<T extends FieldValues>({
                       label={field.title}
                       helper={field.helper}
                       required={field.required}
+                      className={field?.className}
                       showError={shouldShowError(field.name)}
                       labelGap={field.labelGap}
                       labelWidth={field.labelWidth}
@@ -1658,6 +1689,7 @@ function FormFields<T extends FieldValues>({
                       labelWidth={field.labelWidth}
                       labelPosition={field.labelPosition}
                       placeholder={field.placeholder}
+                      className={field?.className}
                       label={field.title}
                       required={field.required}
                       showError={shouldShowError(field.name)}
@@ -1737,6 +1769,7 @@ function FormFields<T extends FieldValues>({
                       labelGap={field.labelGap}
                       labelWidth={field.labelWidth}
                       labelPosition={field.labelPosition}
+                      className={field?.className}
                       required={field.required}
                       filterPlaceholder={field.placeholder}
                       disabled={field.disabled || disabled}
@@ -1786,6 +1819,7 @@ function FormFields<T extends FieldValues>({
                       labelGap={field.labelGap}
                       labelWidth={field.labelWidth}
                       labelPosition={field.labelPosition}
+                      className={field?.className}
                       label={field.title}
                       helper={field.helper}
                       required={field.required}
@@ -1839,6 +1873,7 @@ function FormFields<T extends FieldValues>({
                       labelGap={field.labelGap}
                       labelWidth={field.labelWidth}
                       labelPosition={field.labelPosition}
+                      className={field?.className}
                       value={controllerField.value ?? false}
                       required={field.required}
                       helper={field.helper}
@@ -1907,6 +1942,7 @@ function FormFields<T extends FieldValues>({
                       labelGap={field.labelGap}
                       labelWidth={field.labelWidth}
                       labelPosition={field.labelPosition}
+                      className={field?.className}
                       placeholder={field.placeholder}
                       checked={controllerField.value ?? false}
                       required={field.required}
@@ -1984,6 +2020,7 @@ function FormFields<T extends FieldValues>({
                       labelGap={field.labelGap}
                       labelWidth={field.labelWidth}
                       labelPosition={field.labelPosition}
+                      className={field?.className}
                       required={field.required}
                       activeTab={controllerField.value}
                       helper={field.helper}
@@ -2066,12 +2103,16 @@ function StatefulFormLabel({
   labelPosition,
   labelWidth,
   disabled,
+  className,
+  id,
   ...props
 }: StatefulFormLabelProps) {
   return (
     <Label
       {...props}
       $disabled={disabled}
+      id={id}
+      className={`coneto-label${className ? ` ${className}` : ""}`}
       $labelPosition={labelPosition}
       $labelWidth={labelWidth}
       $style={styles?.self}

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -44,6 +44,7 @@ import { Pinbox, PinboxProps } from "./pinbox";
 import { FieldLaneProps } from "./field-lane";
 import { Frame, FrameProps } from "./frame";
 import { useTheme } from "./../theme/provider";
+import { applyConetoClassName } from "./../constants/classname";
 
 export type StatefulOnChangeType =
   | ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -461,10 +462,15 @@ function FormFields<T extends FieldValues>({
     return () => clearTimeout(timer);
   }, []);
 
+  const statefulFormClassName = applyConetoClassName(
+    "stateful-form",
+    className
+  );
+
   return (
     <ContainerFormField
       id={id}
-      className={`coneto-stateful-form${className ? ` ${className}` : ""}`}
+      className={statefulFormClassName}
       $style={styles?.containerStyle}
     >
       {fields.map((group: FormFieldGroup, indexGroup: number) => {
@@ -2107,12 +2113,14 @@ function StatefulFormLabel({
   id,
   ...props
 }: StatefulFormLabelProps) {
+  const labelClassName = applyConetoClassName("label", className);
+
   return (
     <Label
       {...props}
       $disabled={disabled}
       id={id}
-      className={`coneto-label${className ? ` ${className}` : ""}`}
+      className={labelClassName}
       $labelPosition={labelPosition}
       $labelWidth={labelWidth}
       $style={styles?.self}

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -44,7 +44,7 @@ import { Pinbox, PinboxProps } from "./pinbox";
 import { FieldLaneProps } from "./field-lane";
 import { Frame, FrameProps } from "./frame";
 import { useTheme } from "./../theme/provider";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export type StatefulOnChangeType =
   | ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -462,15 +462,10 @@ function FormFields<T extends FieldValues>({
     return () => clearTimeout(timer);
   }, []);
 
-  const statefulFormClassName = applyConetoClassName(
-    "stateful-form",
-    className
-  );
-
   return (
     <ContainerFormField
       id={id}
-      className={statefulFormClassName}
+      className={applyClassName("stateful-form", className)}
       $style={styles?.containerStyle}
     >
       {fields.map((group: FormFieldGroup, indexGroup: number) => {
@@ -2113,14 +2108,12 @@ function StatefulFormLabel({
   id,
   ...props
 }: StatefulFormLabelProps) {
-  const labelClassName = applyConetoClassName("label", className);
-
   return (
     <Label
       {...props}
       $disabled={disabled}
       id={id}
-      className={labelClassName}
+      className={applyClassName("label", className)}
       $labelPosition={labelPosition}
       $labelWidth={labelWidth}
       $style={styles?.self}

--- a/components/statusbar.tsx
+++ b/components/statusbar.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from "react";
 import { Button, ButtonProps } from "./button";
 import { useTheme } from "./../theme/provider";
 import { StatusbarThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface StatusbarProps {
   styles?: StatusbarStyles;
@@ -42,12 +42,10 @@ function Statusbar({
   const { currentTheme } = useTheme();
   const statusbarTheme = currentTheme.statusbar;
 
-  const statusBarClassName = applyConetoClassName("status-bar", className);
-
   return (
     <StatusbarWrapper
       id={id}
-      className={statusBarClassName}
+      className={applyClassName("status-bar", className)}
       $theme={statusbarTheme}
       aria-label="statusbar-wrapper"
       $transparent={transparent}

--- a/components/statusbar.tsx
+++ b/components/statusbar.tsx
@@ -12,6 +12,8 @@ export interface StatusbarProps {
   hoverBackgroundColor?: string;
   transparent?: boolean;
   size?: number;
+  className?: string;
+  id?: string;
 }
 
 export interface StatusbarContent {
@@ -33,12 +35,16 @@ function Statusbar({
   hoverBackgroundColor,
   transparent,
   size = 11,
+  className,
+  id,
 }: StatusbarProps) {
   const { currentTheme } = useTheme();
   const statusbarTheme = currentTheme.statusbar;
 
   return (
     <StatusbarWrapper
+      id={id}
+      className={`coneto-status-bar${className ? ` ${className}` : ""}`}
       $theme={statusbarTheme}
       aria-label="statusbar-wrapper"
       $transparent={transparent}

--- a/components/statusbar.tsx
+++ b/components/statusbar.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from "react";
 import { Button, ButtonProps } from "./button";
 import { useTheme } from "./../theme/provider";
 import { StatusbarThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface StatusbarProps {
   styles?: StatusbarStyles;
@@ -41,10 +42,12 @@ function Statusbar({
   const { currentTheme } = useTheme();
   const statusbarTheme = currentTheme.statusbar;
 
+  const statusBarClassName = applyConetoClassName("status-bar", className);
+
   return (
     <StatusbarWrapper
       id={id}
-      className={`coneto-status-bar${className ? ` ${className}` : ""}`}
+      className={statusBarClassName}
       $theme={statusbarTheme}
       aria-label="statusbar-wrapper"
       $transparent={transparent}

--- a/components/stepline.tsx
+++ b/components/stepline.tsx
@@ -5,6 +5,7 @@ import type { CSSProp } from "styled-components";
 import { Tooltip } from "./tooltip";
 import { useTheme } from "./../theme/provider";
 import { SteplineThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface SteplineProps {
   children?: ReactNode;
@@ -32,10 +33,12 @@ function Stepline({
 
   const childArray = Children.toArray(children).filter(isValidElement);
 
+  const steplineClassName = applyConetoClassName("stepline", className);
+
   return (
     <SteplineWrapper
       id={id}
-      className={`coneto-stepline${className ? ` ${className}` : ""}`}
+      className={steplineClassName}
       aria-label="stepline-wrapper"
       $containerStyle={styles?.self}
       $gap={gap}

--- a/components/stepline.tsx
+++ b/components/stepline.tsx
@@ -11,13 +11,22 @@ export interface SteplineProps {
   styles?: SteplineStyles;
   gap?: number;
   collapsed?: boolean;
+  className?: string;
+  id?: string;
 }
 
 export interface SteplineStyles {
   self?: CSSProp;
 }
 
-function Stepline({ children, styles, gap, collapsed }: SteplineProps) {
+function Stepline({
+  children,
+  styles,
+  gap,
+  collapsed,
+  className,
+  id,
+}: SteplineProps) {
   const { currentTheme } = useTheme();
   const steplineTheme = currentTheme.stepline;
 
@@ -25,6 +34,8 @@ function Stepline({ children, styles, gap, collapsed }: SteplineProps) {
 
   return (
     <SteplineWrapper
+      id={id}
+      className={`coneto-stepline${className ? ` ${className}` : ""}`}
       aria-label="stepline-wrapper"
       $containerStyle={styles?.self}
       $gap={gap}

--- a/components/stepline.tsx
+++ b/components/stepline.tsx
@@ -5,7 +5,7 @@ import type { CSSProp } from "styled-components";
 import { Tooltip } from "./tooltip";
 import { useTheme } from "./../theme/provider";
 import { SteplineThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface SteplineProps {
   children?: ReactNode;
@@ -33,12 +33,10 @@ function Stepline({
 
   const childArray = Children.toArray(children).filter(isValidElement);
 
-  const steplineClassName = applyConetoClassName("stepline", className);
-
   return (
     <SteplineWrapper
       id={id}
-      className={steplineClassName}
+      className={applyClassName("stepline", className)}
       aria-label="stepline-wrapper"
       $containerStyle={styles?.self}
       $gap={gap}
@@ -160,6 +158,7 @@ function SteplineItem({
   styles,
   id,
   active,
+  className,
   ...props
 }: SteplineItemProps) {
   const { currentTheme } = useTheme();
@@ -220,7 +219,11 @@ function SteplineItem({
   }
 
   return (
-    <StepItemWrapper id={String(id)} $style={styles?.containerStyle}>
+    <StepItemWrapper
+      className={applyClassName("stepline-item", className)}
+      id={String(id)}
+      $style={styles?.containerStyle}
+    >
       {collapsed ? (
         <Tooltip
           styles={{

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -30,7 +30,7 @@ import { ActionButton, ActionButtonProps } from "./action-button";
 import { OverlayBlocker } from "./overlay-blocker";
 import { useTheme } from "./../theme/provider";
 import { TableThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface TableColumn {
   caption: string;
@@ -325,14 +325,12 @@ function Table({
 
   const hasActions = filteredActions.length > 0;
 
-  const tableClassName = applyConetoClassName("table", className);
-
   return (
     <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
       <TableColumnContext.Provider value={columns}>
         <Wrapper
           id={id}
-          className={tableClassName}
+          className={applyClassName("table", className)}
           $containerStyle={styles?.containerStyle}
         >
           {((selectedData.length > 0 &&
@@ -947,13 +945,11 @@ function TableRowGroup({
 
   const [isOpen, setIsOpen] = useState(true);
 
-  const tableRowGroupClassName = applyConetoClassName(
-    "table-row-group",
-    className
-  );
-
   return (
-    <TableRowGroupContainer id={id} className={tableRowGroupClassName}>
+    <TableRowGroupContainer
+      id={id}
+      className={applyClassName("table-row-group", className)}
+    >
       <TableRowGroupSticky
         $theme={tableTheme}
         onClick={() => setIsOpen(!isOpen)}
@@ -1108,8 +1104,6 @@ function TableRow({
   const { currentTheme } = useTheme();
   const tableTheme = currentTheme.table;
 
-  const tableRowClassName = applyConetoClassName("table-row", className);
-
   const { setDragItem, dragItem } = useContext(DnDContext);
   const {
     openRowId,
@@ -1160,7 +1154,7 @@ function TableRow({
       <TableRowWrapper
         ref={rowRef}
         id={id}
-        className={tableRowClassName}
+        className={applyClassName("table-row", className)}
         $theme={tableTheme}
         $isHovered={isHovered === rowId || openRowId === rowId || !!rowContent}
         $isSelected={isSelected}
@@ -1553,15 +1547,10 @@ function TableRowCell({
   Partial<{
     bold?: boolean;
   }>) {
-  const tableRowCellClassName = applyConetoClassName(
-    "table-row-cell",
-    className
-  );
-
   return (
     <CellContent
       id={id}
-      className={tableRowCellClassName}
+      className={applyClassName("table-row-cell", className)}
       onClick={() => {
         if (onClick) {
           onClick();

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -81,6 +81,8 @@ export interface TableProps {
   sumRow?: TableSummaryRowColumn[];
   styles?: TableStyles;
   searchbox?: TableSearchbox;
+  id?: string;
+  className?: string;
 }
 
 type TableSearchbox = SearchboxProps;
@@ -166,6 +168,8 @@ function Table({
   styles,
   alwaysShowDragIcon = true,
   searchbox,
+  className,
+  id,
 }: TableProps & TableAlwaysShowDragIcon) {
   const { currentTheme } = useTheme();
   const tableTheme = currentTheme.table;
@@ -323,7 +327,11 @@ function Table({
   return (
     <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
       <TableColumnContext.Provider value={columns}>
-        <Wrapper $containerStyle={styles?.containerStyle}>
+        <Wrapper
+          id={id}
+          className={`coneto-table${className ? ` ${className}` : ""}`}
+          $containerStyle={styles?.containerStyle}
+        >
           {((selectedData.length > 0 &&
             labels?.totalSelectedItemText !== null) ||
             showPagination ||
@@ -848,6 +856,7 @@ export interface TableRowGroupProps {
   title?: string;
   subtitle?: string;
   selectable?: boolean;
+  className?: string;
 }
 
 export interface TableRowCellProps {
@@ -855,6 +864,8 @@ export interface TableRowCellProps {
   contentStyle?: CSSProp;
   width?: string;
   onClick?: () => void;
+  className?: string;
+  id?: string;
 }
 
 function TableRowGroup({
@@ -868,6 +879,7 @@ function TableRowGroup({
   isLast,
   onLastRowReached,
   draggable,
+  className,
   ...props
 }: TableRowGroupProps & {
   selectedData?: string[];
@@ -933,7 +945,10 @@ function TableRowGroup({
   const [isOpen, setIsOpen] = useState(true);
 
   return (
-    <TableRowGroupContainer>
+    <TableRowGroupContainer
+      id={id}
+      className={`coneto-table-row-group${className ? ` ${className}` : ""}`}
+    >
       <TableRowGroupSticky
         $theme={tableTheme}
         onClick={() => setIsOpen(!isOpen)}
@@ -1045,6 +1060,8 @@ export interface TableRowProps {
   }) => void;
   groupId?: string;
   styles?: TableRowStyles;
+  id?: string;
+  className?: string;
 }
 
 export interface TableRowStyles {
@@ -1073,6 +1090,8 @@ function TableRow({
   groupId = "default",
   onDropItem,
   draggable,
+  className,
+  id,
   ...props
 }: TableRowProps &
   Partial<{
@@ -1133,6 +1152,8 @@ function TableRow({
     <RowWrapper $style={styles?.containerStyle}>
       <TableRowWrapper
         ref={rowRef}
+        id={id}
+        className={`coneto-table-row${className ? ` ${className}` : ""}`}
         $theme={tableTheme}
         $isHovered={isHovered === rowId || openRowId === rowId || !!rowContent}
         $isSelected={isSelected}
@@ -1519,12 +1540,16 @@ function TableRowCell({
   width,
   onClick,
   bold,
+  id,
+  className,
 }: TableRowCellProps &
   Partial<{
     bold?: boolean;
   }>) {
   return (
     <CellContent
+      id={id}
+      className={`coneto-table-row-cell${className ? ` ${className}` : ""}`}
       onClick={() => {
         if (onClick) {
           onClick();

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -30,6 +30,7 @@ import { ActionButton, ActionButtonProps } from "./action-button";
 import { OverlayBlocker } from "./overlay-blocker";
 import { useTheme } from "./../theme/provider";
 import { TableThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface TableColumn {
   caption: string;
@@ -324,12 +325,14 @@ function Table({
 
   const hasActions = filteredActions.length > 0;
 
+  const tableClassName = applyConetoClassName("table", className);
+
   return (
     <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
       <TableColumnContext.Provider value={columns}>
         <Wrapper
           id={id}
-          className={`coneto-table${className ? ` ${className}` : ""}`}
+          className={tableClassName}
           $containerStyle={styles?.containerStyle}
         >
           {((selectedData.length > 0 &&
@@ -944,11 +947,13 @@ function TableRowGroup({
 
   const [isOpen, setIsOpen] = useState(true);
 
+  const tableRowGroupClassName = applyConetoClassName(
+    "table-row-group",
+    className
+  );
+
   return (
-    <TableRowGroupContainer
-      id={id}
-      className={`coneto-table-row-group${className ? ` ${className}` : ""}`}
-    >
+    <TableRowGroupContainer id={id} className={tableRowGroupClassName}>
       <TableRowGroupSticky
         $theme={tableTheme}
         onClick={() => setIsOpen(!isOpen)}
@@ -1103,6 +1108,8 @@ function TableRow({
   const { currentTheme } = useTheme();
   const tableTheme = currentTheme.table;
 
+  const tableRowClassName = applyConetoClassName("table-row", className);
+
   const { setDragItem, dragItem } = useContext(DnDContext);
   const {
     openRowId,
@@ -1153,7 +1160,7 @@ function TableRow({
       <TableRowWrapper
         ref={rowRef}
         id={id}
-        className={`coneto-table-row${className ? ` ${className}` : ""}`}
+        className={tableRowClassName}
         $theme={tableTheme}
         $isHovered={isHovered === rowId || openRowId === rowId || !!rowContent}
         $isSelected={isSelected}
@@ -1546,10 +1553,15 @@ function TableRowCell({
   Partial<{
     bold?: boolean;
   }>) {
+  const tableRowCellClassName = applyConetoClassName(
+    "table-row-cell",
+    className
+  );
+
   return (
     <CellContent
       id={id}
-      className={`coneto-table-row-cell${className ? ` ${className}` : ""}`}
+      className={tableRowCellClassName}
       onClick={() => {
         if (onClick) {
           onClick();

--- a/components/textarea.tsx
+++ b/components/textarea.tsx
@@ -90,6 +90,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       labelGap,
       labelWidth,
       labelPosition,
+      className,
       ...rest
     } = props;
     const inputId = StatefulForm.sanitizeId({
@@ -108,6 +109,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 
     return (
       <FieldLane
+        className={`coneto-textarea${className ? ` ${className}` : ""}`}
         id={inputId}
         labelGap={labelGap}
         labelWidth={labelWidth}

--- a/components/textarea.tsx
+++ b/components/textarea.tsx
@@ -14,6 +14,7 @@ import {
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { TextareaThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 interface BaseTextareaProps
   extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "style"> {
@@ -107,9 +108,11 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       self: textareaStyles,
     } = styles ?? {};
 
+    const textareaClassName = applyConetoClassName("textarea", className);
+
     return (
       <FieldLane
-        className={`coneto-textarea${className ? ` ${className}` : ""}`}
+        className={textareaClassName}
         id={inputId}
         labelGap={labelGap}
         labelWidth={labelWidth}

--- a/components/textarea.tsx
+++ b/components/textarea.tsx
@@ -14,7 +14,7 @@ import {
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { TextareaThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseTextareaProps
   extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "style"> {
@@ -108,11 +108,9 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       self: textareaStyles,
     } = styles ?? {};
 
-    const textareaClassName = applyConetoClassName("textarea", className);
-
     return (
       <FieldLane
-        className={textareaClassName}
+        className={applyClassName("textarea", className)}
         id={inputId}
         labelGap={labelGap}
         labelWidth={labelWidth}

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -17,7 +17,7 @@ import {
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { TextboxThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseTextboxProps
   extends Omit<
@@ -141,8 +141,6 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
       id: props.id,
     });
 
-    const textboxClassName = applyConetoClassName("textbox", className);
-
     return (
       <FieldLane
         id={inputId}
@@ -158,7 +156,7 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
         labelPosition={labelPosition}
         disabled={disabled}
         required={rest.required}
-        className={textboxClassName}
+        className={applyClassName("textbox", className)}
         styles={{
           bodyStyle: styles?.bodyStyle,
           controlStyle: styles?.controlStyle,

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -17,6 +17,7 @@ import {
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { TextboxThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 interface BaseTextboxProps
   extends Omit<
@@ -140,6 +141,8 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
       id: props.id,
     });
 
+    const textboxClassName = applyConetoClassName("textbox", className);
+
     return (
       <FieldLane
         id={inputId}
@@ -155,7 +158,7 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
         labelPosition={labelPosition}
         disabled={disabled}
         required={rest.required}
-        className={`coneto-textbox${className ? ` ${className}` : ""}`}
+        className={textboxClassName}
         styles={{
           bodyStyle: styles?.bodyStyle,
           controlStyle: styles?.controlStyle,

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -130,6 +130,7 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
       labelPosition,
       labelGap,
       labelWidth,
+      className,
       ...rest
     } = props;
 
@@ -154,6 +155,7 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
         labelPosition={labelPosition}
         disabled={disabled}
         required={rest.required}
+        className={`coneto-textbox${className ? ` ${className}` : ""}`}
         styles={{
           bodyStyle: styles?.bodyStyle,
           controlStyle: styles?.controlStyle,

--- a/components/thumb-field.tsx
+++ b/components/thumb-field.tsx
@@ -11,7 +11,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { ThumbFieldThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseThumbFieldProps {
   value?: boolean | null;
@@ -182,8 +182,6 @@ function ThumbField({
     ...thumbFieldStyles
   } = styles ?? {};
 
-  const thumbFieldClassName = applyConetoClassName("thumb-field", className);
-
   return (
     <FieldLane
       id={inputId}
@@ -197,7 +195,7 @@ function ThumbField({
       disabled={disabled}
       label={label}
       errorIconPosition="none"
-      className={thumbFieldClassName}
+      className={applyClassName("thumb-field", className)}
       required={rest.required}
       styles={{
         bodyStyle,

--- a/components/thumb-field.tsx
+++ b/components/thumb-field.tsx
@@ -11,6 +11,7 @@ import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { ThumbFieldThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 interface BaseThumbFieldProps {
   value?: boolean | null;
@@ -181,6 +182,8 @@ function ThumbField({
     ...thumbFieldStyles
   } = styles ?? {};
 
+  const thumbFieldClassName = applyConetoClassName("thumb-field", className);
+
   return (
     <FieldLane
       id={inputId}
@@ -194,7 +197,7 @@ function ThumbField({
       disabled={disabled}
       label={label}
       errorIconPosition="none"
-      className={`coneto-thumb-field${className ? ` ${className}` : ""}`}
+      className={thumbFieldClassName}
       required={rest.required}
       styles={{
         bodyStyle,

--- a/components/thumb-field.tsx
+++ b/components/thumb-field.tsx
@@ -85,10 +85,7 @@ function BaseThumbField({
   };
 
   return (
-    <InputGroup
-      className={`coneto-thumb-field${className ? ` ${className}` : ""}`}
-      $style={styles?.triggerWrapperStyle}
-    >
+    <InputGroup $style={styles?.triggerWrapperStyle}>
       <input
         aria-label="thumbfield-input"
         ref={thumbInputRef}
@@ -197,6 +194,7 @@ function ThumbField({
       disabled={disabled}
       label={label}
       errorIconPosition="none"
+      className={`coneto-thumb-field${className ? ` ${className}` : ""}`}
       required={rest.required}
       styles={{
         bodyStyle,

--- a/components/thumb-field.tsx
+++ b/components/thumb-field.tsx
@@ -22,6 +22,7 @@ interface BaseThumbFieldProps {
   styles?: BaseThumbFieldStyles;
   id?: string;
   showError?: boolean;
+  className?: string;
 }
 
 interface BaseThumbFieldStyles {
@@ -47,6 +48,7 @@ function BaseThumbField({
   showError,
   styles,
   id,
+  className,
 }: BaseThumbFieldProps) {
   const { currentTheme } = useTheme();
   const thumbFieldTheme = currentTheme.thumbField;
@@ -83,7 +85,10 @@ function BaseThumbField({
   };
 
   return (
-    <InputGroup $style={styles?.triggerWrapperStyle}>
+    <InputGroup
+      className={`coneto-thumb-field${className ? ` ${className}` : ""}`}
+      $style={styles?.triggerWrapperStyle}
+    >
       <input
         aria-label="thumbfield-input"
         ref={thumbInputRef}
@@ -162,6 +167,7 @@ function ThumbField({
   labelGap,
   labelWidth,
   labelPosition,
+  className,
   ...rest
 }: ThumbFieldProps) {
   const inputId = StatefulForm.sanitizeId({

--- a/components/timebox.tsx
+++ b/components/timebox.tsx
@@ -18,6 +18,7 @@ import {
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { TimeboxThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 interface BaseTimeboxProps
   extends Omit<
@@ -416,6 +417,8 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
     const { bodyStyle, containerStyle, controlStyle, labelStyle } =
       styles ?? {};
 
+    const timeboxClassName = applyConetoClassName("timebox", className);
+
     return (
       <FieldLane
         id={inputId}
@@ -430,7 +433,7 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
         helper={helper}
         disabled={disabled}
         required={rest.required}
-        className={`coneto-timebox${className ? ` ${className}` : ""}`}
+        className={timeboxClassName}
         errorIconPosition="relative"
         styles={{
           bodyStyle,

--- a/components/timebox.tsx
+++ b/components/timebox.tsx
@@ -61,6 +61,7 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
       placeholder,
       styles,
       id,
+      className,
     },
     ref
   ) => {
@@ -242,6 +243,7 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
 
     return (
       <InputGroup
+        className={`coneto-timebox${className ? ` ${className}` : ""}`}
         $style={styles?.inputWrapperStyle}
         $focused={isFocused}
         $error={!!showError}

--- a/components/timebox.tsx
+++ b/components/timebox.tsx
@@ -61,7 +61,6 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
       placeholder,
       styles,
       id,
-      className,
     },
     ref
   ) => {
@@ -243,7 +242,6 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
 
     return (
       <InputGroup
-        className={`coneto-timebox${className ? ` ${className}` : ""}`}
         $style={styles?.inputWrapperStyle}
         $focused={isFocused}
         $error={!!showError}
@@ -405,6 +403,7 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
       labelGap,
       labelWidth,
       labelPosition,
+      className,
       ...rest
     } = props;
 
@@ -431,6 +430,7 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
         helper={helper}
         disabled={disabled}
         required={rest.required}
+        className={`coneto-timebox${className ? ` ${className}` : ""}`}
         errorIconPosition="relative"
         styles={{
           bodyStyle,

--- a/components/timebox.tsx
+++ b/components/timebox.tsx
@@ -18,7 +18,7 @@ import {
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { TimeboxThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseTimeboxProps
   extends Omit<
@@ -417,8 +417,6 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
     const { bodyStyle, containerStyle, controlStyle, labelStyle } =
       styles ?? {};
 
-    const timeboxClassName = applyConetoClassName("timebox", className);
-
     return (
       <FieldLane
         id={inputId}
@@ -433,7 +431,7 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
         helper={helper}
         disabled={disabled}
         required={rest.required}
-        className={timeboxClassName}
+        className={applyClassName("timebox", className)}
         errorIconPosition="relative"
         styles={{
           bodyStyle,

--- a/components/timeline.tsx
+++ b/components/timeline.tsx
@@ -9,6 +9,7 @@ import { BaseSteplineItem } from "./../constants/step-component-util";
 import styled, { css, CSSProp } from "styled-components";
 import { useTheme } from "../theme/provider";
 import { TimelineThemeConfig } from "../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface TimelineProps {
   children?: ReactNode;
@@ -29,11 +30,10 @@ function Timeline({
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const childArray = Children.toArray(children).filter(isValidElement);
 
+  const timelineClassName = applyConetoClassName("timeline", className);
+
   return (
-    <TimelineWrapper
-      id={id}
-      className={`coneto-timeline${className ? ` ${className}` : ""}`}
-    >
+    <TimelineWrapper id={id} className={timelineClassName}>
       {childArray.map((child, index) => {
         if (
           !isValidElement<

--- a/components/timeline.tsx
+++ b/components/timeline.tsx
@@ -9,7 +9,7 @@ import { BaseSteplineItem } from "./../constants/step-component-util";
 import styled, { css, CSSProp } from "styled-components";
 import { useTheme } from "../theme/provider";
 import { TimelineThemeConfig } from "../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface TimelineProps {
   children?: ReactNode;
@@ -30,10 +30,8 @@ function Timeline({
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const childArray = Children.toArray(children).filter(isValidElement);
 
-  const timelineClassName = applyConetoClassName("timeline", className);
-
   return (
-    <TimelineWrapper id={id} className={timelineClassName}>
+    <TimelineWrapper id={id} className={applyClassName("timeline", className)}>
       {childArray.map((child, index) => {
         if (
           !isValidElement<
@@ -248,12 +246,14 @@ function TimelineItem({
   styles,
   id,
   variant,
+  className,
 }: TimelineItemProps) {
   const { currentTheme } = useTheme();
   const timelineTheme = currentTheme.timeline;
 
   return (
     <TimelineContainer
+      className={applyClassName("timeline-item", className)}
       aria-label={`timeline-item-${id}`}
       id={String(id)}
       $theme={timelineTheme}

--- a/components/timeline.tsx
+++ b/components/timeline.tsx
@@ -13,9 +13,16 @@ import { TimelineThemeConfig } from "../theme";
 export interface TimelineProps {
   children?: ReactNode;
   isClickable?: boolean;
+  className?: string;
+  id?: string;
 }
 
-function Timeline({ children, isClickable = false }: TimelineProps) {
+function Timeline({
+  children,
+  isClickable = false,
+  className,
+  id,
+}: TimelineProps) {
   const { currentTheme } = useTheme();
   const timelineTheme = currentTheme.timeline;
 
@@ -23,7 +30,10 @@ function Timeline({ children, isClickable = false }: TimelineProps) {
   const childArray = Children.toArray(children).filter(isValidElement);
 
   return (
-    <TimelineWrapper>
+    <TimelineWrapper
+      id={id}
+      className={`coneto-timeline${className ? ` ${className}` : ""}`}
+    >
       {childArray.map((child, index) => {
         if (
           !isValidElement<

--- a/components/tip-menu.tsx
+++ b/components/tip-menu.tsx
@@ -7,7 +7,7 @@ import { useTheme } from "../theme/provider";
 import { TipMenuThemeConfig } from "./../theme";
 import { Tooltip, TooltipRef } from "./tooltip";
 import { RiArrowRightSFill } from "@remixicon/react";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export const TipMenuVariant = {
   Default: "default",
@@ -69,12 +69,10 @@ function TipMenu({
       );
   }, [search, subMenuList]);
 
-  const tipMenuClassName = applyConetoClassName("tip-menu", className);
-
   return (
     <Button.TipMenuContainer
       id={id}
-      className={tipMenuClassName}
+      className={applyClassName("tip-menu", className)}
       aria-label="tip-menu"
       styles={{
         self: styles?.self,
@@ -183,12 +181,10 @@ function TipMenuItem({
     return;
   }
 
-  const tipMenuItemClassName = applyConetoClassName("tip-menu-item", className);
-
   const tipMenuElement = (
     <TipMenuItemWrapper
       id={id}
-      className={tipMenuItemClassName}
+      className={applyClassName("tip-menu-item", className)}
       $variant={variant}
       $size={size}
       aria-label="tip-menu-item"

--- a/components/tip-menu.tsx
+++ b/components/tip-menu.tsx
@@ -7,6 +7,7 @@ import { useTheme } from "../theme/provider";
 import { TipMenuThemeConfig } from "./../theme";
 import { Tooltip, TooltipRef } from "./tooltip";
 import { RiArrowRightSFill } from "@remixicon/react";
+import { applyConetoClassName } from "./../constants/classname";
 
 export const TipMenuVariant = {
   Default: "default",
@@ -68,10 +69,12 @@ function TipMenu({
       );
   }, [search, subMenuList]);
 
+  const tipMenuClassName = applyConetoClassName("tip-menu", className);
+
   return (
     <Button.TipMenuContainer
       id={id}
-      className={`coneto-tip-menu${className ? ` ${className}` : ""}`}
+      className={tipMenuClassName}
       aria-label="tip-menu"
       styles={{
         self: styles?.self,
@@ -180,10 +183,12 @@ function TipMenuItem({
     return;
   }
 
+  const tipMenuItemClassName = applyConetoClassName("tip-menu-item", className);
+
   const tipMenuElement = (
     <TipMenuItemWrapper
       id={id}
-      className={`coneto-tip-menu-item${className ? ` ${className}` : ""}`}
+      className={tipMenuItemClassName}
       $variant={variant}
       $size={size}
       aria-label="tip-menu-item"

--- a/components/tip-menu.tsx
+++ b/components/tip-menu.tsx
@@ -35,6 +35,8 @@ export interface TipMenuProps {
   size?: TipMenuSize;
   withFilter?: boolean;
   styles?: TipMenuStyles;
+  className?: string;
+  id?: string;
 }
 
 export interface TipMenuStyles {
@@ -49,6 +51,8 @@ function TipMenu({
   variant = "default",
   size = "md",
   withFilter,
+  className,
+  id,
 }: TipMenuProps) {
   const [search, setSearch] = useState<string>("");
   const [isHasInteracted, setHasInteracted] = useState<boolean>(false);
@@ -66,6 +70,8 @@ function TipMenu({
 
   return (
     <Button.TipMenuContainer
+      id={id}
+      className={`coneto-tip-menu${className ? ` ${className}` : ""}`}
       aria-label="tip-menu"
       styles={{
         self: styles?.self,
@@ -142,6 +148,8 @@ export interface TipMenuItemProps {
   subMenuList?: TipMenuItemProps[];
   styles?: TipMenuItemStyles;
   disabled?: boolean;
+  className?: string;
+  id?: string;
 }
 export interface TipMenuItemStyles {
   containerStyle?: CSSProp;
@@ -159,6 +167,8 @@ function TipMenuItem({
   styles,
   disabled,
   setIsOpen,
+  className,
+  id,
 }: TipMenuItemProps & {
   setIsOpen?: () => void;
 }) {
@@ -172,6 +182,8 @@ function TipMenuItem({
 
   const tipMenuElement = (
     <TipMenuItemWrapper
+      id={id}
+      className={`coneto-tip-menu-item${className ? ` ${className}` : ""}`}
       $variant={variant}
       $size={size}
       aria-label="tip-menu-item"

--- a/components/toggle.tsx
+++ b/components/toggle.tsx
@@ -7,6 +7,7 @@ import { Figure, FigureProps } from "./figure";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "../theme/provider";
 import { ToggleThemeConfig } from "../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 interface BaseToggleProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "style"> {
@@ -176,10 +177,12 @@ function Toggle({
     ...toggleStyles
   } = styles ?? {};
 
+  const toggleClassName = applyConetoClassName("toggle", className);
+
   return (
     <FieldLane
       id={inputId}
-      className={`coneto-toggle${className ? ` ${className}` : ""}`}
+      className={toggleClassName}
       labelGap={labelGap}
       labelWidth={labelWidth}
       labelPosition={labelPosition}

--- a/components/toggle.tsx
+++ b/components/toggle.tsx
@@ -7,7 +7,7 @@ import { Figure, FigureProps } from "./figure";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "../theme/provider";
 import { ToggleThemeConfig } from "../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseToggleProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "style"> {
@@ -177,12 +177,10 @@ function Toggle({
     ...toggleStyles
   } = styles ?? {};
 
-  const toggleClassName = applyConetoClassName("toggle", className);
-
   return (
     <FieldLane
       id={inputId}
-      className={toggleClassName}
+      className={applyClassName("toggle", className)}
       labelGap={labelGap}
       labelWidth={labelWidth}
       labelPosition={labelPosition}

--- a/components/toggle.tsx
+++ b/components/toggle.tsx
@@ -159,6 +159,7 @@ function Toggle({
   labelWidth,
   labelPosition,
   disabled,
+  className,
   ...rest
 }: ToggleProps) {
   const inputId = StatefulForm.sanitizeId({
@@ -178,6 +179,7 @@ function Toggle({
   return (
     <FieldLane
       id={inputId}
+      className={`coneto-toggle${className ? ` ${className}` : ""}`}
       labelGap={labelGap}
       labelWidth={labelWidth}
       labelPosition={labelPosition}

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -22,7 +22,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { ToolbarThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface ToolbarProps {
   children: ReactNode;
@@ -135,11 +135,9 @@ function Toolbar({ children, styles, big, className, id }: ToolbarProps) {
     return child;
   });
 
-  const toolbarClassName = applyConetoClassName("toolbar", className);
-
   return (
     <ToolbarWrapper
-      className={toolbarClassName}
+      className={applyClassName("toolbar", className)}
       id={id}
       ref={toolbarRef}
       $style={styles?.self}
@@ -285,12 +283,10 @@ function ToolbarMenu({
     `}
   `;
 
-  const toolbarMenuClassName = applyConetoClassName("toolbar-menu", className);
-
   return (
     <ToolbarContainer
       id={id}
-      className={toolbarMenuClassName}
+      className={applyClassName("toolbar-menu", className)}
       aria-label="toolbar-menu"
       ref={containerRef}
     >

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -27,6 +27,8 @@ export interface ToolbarProps {
   children: ReactNode;
   big?: boolean;
   styles?: ToolbarStyles;
+  className?: string;
+  id?: string;
 }
 
 export interface ToolbarStyles {
@@ -71,7 +73,7 @@ const useVariantToolbar = () => {
   return { VARIANT_COLORS };
 };
 
-function Toolbar({ children, styles, big }: ToolbarProps) {
+function Toolbar({ children, styles, big, className, id }: ToolbarProps) {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
 
@@ -133,7 +135,12 @@ function Toolbar({ children, styles, big }: ToolbarProps) {
   });
 
   return (
-    <ToolbarWrapper ref={toolbarRef} $style={styles?.self}>
+    <ToolbarWrapper
+      className={`coneto-toolbar${className ? ` ${className}` : ""}`}
+      id={id}
+      ref={toolbarRef}
+      $style={styles?.self}
+    >
       {childrenWithProps}
     </ToolbarWrapper>
   );

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -22,6 +22,7 @@ import styled, { css, CSSProp } from "styled-components";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { ToolbarThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface ToolbarProps {
   children: ReactNode;
@@ -134,9 +135,11 @@ function Toolbar({ children, styles, big, className, id }: ToolbarProps) {
     return child;
   });
 
+  const toolbarClassName = applyConetoClassName("toolbar", className);
+
   return (
     <ToolbarWrapper
-      className={`coneto-toolbar${className ? ` ${className}` : ""}`}
+      className={toolbarClassName}
       id={id}
       ref={toolbarRef}
       $style={styles?.self}
@@ -282,10 +285,12 @@ function ToolbarMenu({
     `}
   `;
 
+  const toolbarMenuClassName = applyConetoClassName("toolbar-menu", className);
+
   return (
     <ToolbarContainer
       id={id}
-      className={`coneto-toolbar-menu${className ? ` ${className}` : ""}`}
+      className={toolbarMenuClassName}
       aria-label="toolbar-menu"
       ref={containerRef}
     >

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -158,6 +158,8 @@ export interface ToolbarMenuProps {
   styles?: ToolbarMenuStyles;
   variant?: ToolbarVariant;
   iconSize?: number;
+  className?: string;
+  id?: string;
 }
 
 export type ToolbarSubMenuList = TipMenuItemProps;
@@ -180,6 +182,8 @@ function ToolbarMenu({
   onClick,
   styles,
   variant = "default",
+  className,
+  id,
 }: ToolbarMenuProps) {
   const { VARIANT_COLORS } = useVariantToolbar();
   const toolbarTheme = VARIANT_COLORS[variant];
@@ -279,7 +283,12 @@ function ToolbarMenu({
   `;
 
   return (
-    <ToolbarContainer aria-label="toolbar-menu" ref={containerRef}>
+    <ToolbarContainer
+      id={id}
+      className={`coneto-toolbar-menu${className ? ` ${className}` : ""}`}
+      aria-label="toolbar-menu"
+      ref={containerRef}
+    >
       <MenuWrapper
         ref={refs.setReference}
         $style={css`

--- a/components/tooltip.tsx
+++ b/components/tooltip.tsx
@@ -44,6 +44,8 @@ export type TooltipProps = {
   showDelayPeriod?: number;
   styles?: TooltipStyles;
   onClick?: (e: React.MouseEvent) => void;
+  id?: string;
+  className?: string;
 };
 
 export interface TooltipStyles {
@@ -72,6 +74,8 @@ const TooltipBase = forwardRef<TooltipRef, TooltipProps>(
       showDelayPeriod = 0,
       styles,
       onClick,
+      id,
+      className,
     },
     ref
   ) => {
@@ -140,8 +144,18 @@ const TooltipBase = forwardRef<TooltipRef, TooltipProps>(
       };
     }, [isOpen, hideDialogOn, refs.floating, refs.reference]);
 
+    const hasHelper = className?.includes("coneto-helper");
+    const hasNavTabTab = className?.includes("coneto-nav-tab-tab");
+
+    const filteredClassName =
+      hasHelper || hasNavTabTab
+        ? className
+        : ["coneto-tooltip", className].filter(Boolean).join(" ");
+
     return (
       <Wrapper
+        id={id}
+        className={filteredClassName}
         $style={styles?.containerStyle}
         onMouseEnter={() => {
           if (showDialogOn === "hover") {

--- a/components/treelist.tsx
+++ b/components/treelist.tsx
@@ -15,6 +15,7 @@ import { Tooltip } from "./tooltip";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { TreeListThemeConfig } from "./../theme";
+import { applyConetoClassName } from "./../constants/classname";
 
 export interface TreeListProps
   extends Omit<
@@ -245,13 +246,15 @@ function TreeList({
 
   const hasActions = filteredActions.length > 0;
 
+  const treelistClassName = applyConetoClassName("tree-list", className);
+
   return (
     <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
       <TreeListWrapper
         {...props}
         aria-label="tree-list-wrapper"
         id={id}
-        className={`coneto-tree-list${className ? ` ${className}` : ""}`}
+        className={treelistClassName}
         $containerStyle={styles?.containerStyle}
         $textColor={treeListTheme.textColor}
       >

--- a/components/treelist.tsx
+++ b/components/treelist.tsx
@@ -15,7 +15,7 @@ import { Tooltip } from "./tooltip";
 import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { TreeListThemeConfig } from "./../theme";
-import { applyConetoClassName } from "./../constants/classname";
+import { applyClassName } from "./../constants/classname";
 
 export interface TreeListProps
   extends Omit<
@@ -246,15 +246,13 @@ function TreeList({
 
   const hasActions = filteredActions.length > 0;
 
-  const treelistClassName = applyConetoClassName("tree-list", className);
-
   return (
     <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
       <TreeListWrapper
         {...props}
         aria-label="tree-list-wrapper"
         id={id}
-        className={treelistClassName}
+        className={applyClassName("tree-list", className)}
         $containerStyle={styles?.containerStyle}
         $textColor={treeListTheme.textColor}
       >

--- a/components/treelist.tsx
+++ b/components/treelist.tsx
@@ -36,6 +36,7 @@ export interface TreeListProps
   alwaysShowDragIcon?: boolean;
   onDragged?: (props: TreeListOnDragged) => void;
   styles?: TreeListStyles;
+  id?: string;
 }
 
 export interface TreeListStyles {
@@ -73,6 +74,7 @@ export interface TreeListContent {
   items?: TreeListItem[];
   initialState?: TreeListInitialState;
   actions?: TreeListContentAction[];
+  className?: string;
 }
 
 export interface TreeListContentAction
@@ -91,6 +93,7 @@ export interface TreeListItem {
   iconOnActive?: FigureProps["image"];
   iconColor?: string;
   initialState?: TreeListInitialState;
+  className?: string;
 }
 
 export interface TreeListItemAction extends Omit<ContextMenuAction, "onClick"> {
@@ -152,6 +155,8 @@ function TreeList({
   onDragged,
   alwaysShowDragIcon = true,
   styles,
+  className,
+  id,
   ...props
 }: TreeListProps) {
   const { currentTheme } = useTheme();
@@ -245,6 +250,8 @@ function TreeList({
       <TreeListWrapper
         {...props}
         aria-label="tree-list-wrapper"
+        id={id}
+        className={`coneto-tree-list${className ? ` ${className}` : ""}`}
         $containerStyle={styles?.containerStyle}
         $textColor={treeListTheme.textColor}
       >

--- a/constants/classname.ts
+++ b/constants/classname.ts
@@ -1,6 +1,3 @@
-export function applyConetoClassName(
-  component: string = "",
-  className?: string
-) {
+export function applyClassName(component: string = "", className?: string) {
   return `coneto-${component}${className ? ` ${className}` : ""}`;
 }

--- a/constants/classname.ts
+++ b/constants/classname.ts
@@ -1,0 +1,6 @@
+export function applyConetoClassName(
+  component: string = "",
+  className?: string
+) {
+  return `coneto-${component}${className ? ` ${className}` : ""}`;
+}

--- a/constants/step-component-util.ts
+++ b/constants/step-component-util.ts
@@ -28,4 +28,5 @@ export interface BaseSteplineItem {
   active?: boolean;
   onClick?: () => void;
   id?: number | string;
+  className?: string;
 }


### PR DESCRIPTION
Description:
This pull request standardizes `className` handling across all component at the parent level through `coneto-{component}` and introduces a consistent `id` prop to simplify element identification.

Source:
[[Improvement] SYST-659: Add default class for each component and allow defining id](https://linear.app/systatum/issue/SYST-659/add-default-class-for-each-component-and-allow-defining-id)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[] I have created/updated any relevant test code
[x] I have tested it myself