### PR TITLE
[Bug] SYST-578: Allow overflowing row group content

### DIFF
--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -2006,9 +2006,7 @@ export const WithRowGroup: Story = {
               item.category.toLowerCase().includes(search.toLowerCase()) ||
               item.author.toLowerCase().includes(search.toLowerCase())
           )
-          .filter((item) =>
-            activeTab.category === "taken" ? item.taken : item
-          )
+          .filter((item) => (activeTab.taken === "taken" ? item.taken : item))
           .filter((item) => {
             const active = activeTab.category.toLowerCase();
 
@@ -2059,6 +2057,7 @@ export const WithRowGroup: Story = {
               border-radius: 4px;
               max-height: 500px;
               overflow: auto;
+              background-color: white;
 
               scrollbar-width: thin;
 

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -858,6 +858,17 @@ export interface TableRowGroupProps {
   subtitle?: string;
   selectable?: boolean;
   className?: string;
+  styles?: TableRowGroupStyles;
+}
+
+export interface TableRowGroupStyles {
+  containerStyle?: CSSProp;
+  headerStyle?: CSSProp;
+  bodyStyle?: CSSProp;
+  chevronStyle?: CSSProp;
+  textWrapperStyle?: CSSProp;
+  subtitleStyle?: CSSProp;
+  titleStyle?: CSSProp;
 }
 
 export interface TableRowCellProps {
@@ -881,6 +892,7 @@ function TableRowGroup({
   onLastRowReached,
   draggable,
   className,
+  styles,
   ...props
 }: TableRowGroupProps & {
   selectedData?: string[];
@@ -949,65 +961,89 @@ function TableRowGroup({
     <TableRowGroupContainer
       id={id}
       className={applyClassName("table-row-group", className)}
+      $style={styles?.containerStyle}
     >
       <TableRowGroupSticky
         $theme={tableTheme}
         onClick={() => setIsOpen(!isOpen)}
+        $style={styles?.headerStyle}
       >
-        <RotatingIcon $isOpen={isOpen}>
+        <RotatingIcon $isOpen={isOpen} $style={styles?.chevronStyle}>
           <RiArrowDownSLine />
         </RotatingIcon>
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-          }}
-        >
-          {title && <span>{title}</span>}
+        <TableRowGroupTextWrapper $style={styles?.textWrapperStyle}>
+          {title && (
+            <TableRowGroupTitle $style={styles?.titleStyle}>
+              {title}
+            </TableRowGroupTitle>
+          )}
           {subtitle && (
-            <span
-              style={{
-                fontSize: "14px",
-                color: tableTheme?.rowSubtitleTextColor || "#1f2937",
-              }}
+            <TableRowGroupSubtitle
+              $style={styles?.subtitleStyle}
+              color={tableTheme?.rowSubtitleTextColor}
             >
               {subtitle}
-            </span>
+            </TableRowGroupSubtitle>
           )}
-        </div>
+        </TableRowGroupTextWrapper>
       </TableRowGroupSticky>
 
       <AnimatePresence initial={false}>
         {isOpen && (
-          <motion.div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              overflow: "hidden",
-            }}
+          <TableRowGroupBody
+            $style={styles?.bodyStyle}
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.3, ease: "easeInOut" }}
           >
             {rowChildren}
-          </motion.div>
+          </TableRowGroupBody>
         )}
       </AnimatePresence>
     </TableRowGroupContainer>
   );
 }
 
-const TableRowGroupContainer = styled.div`
+const TableRowGroupTextWrapper = styled.div<{ $style?: CSSProp }>`
+  display: flex;
+  flex-direction: column;
+  ${({ $style }) => $style}
+`;
+
+const TableRowGroupTitle = styled.span<{ $style?: CSSProp }>`
+  ${({ $style }) => $style}
+`;
+
+const TableRowGroupSubtitle = styled.span<{
+  $color?: string;
+  $style?: CSSProp;
+}>`
+  font-size: 14px;
+  color: ${({ $color }) => $color || "#1f2937"};
+  ${({ $style }) => $style}
+`;
+
+const TableRowGroupContainer = styled.div<{ $style?: CSSProp }>`
   display: flex;
   flex-direction: column;
   position: relative;
   width: 100%;
   height: 100%;
   overflow-y: visible;
+  ${({ $style }) => $style}
 `;
 
-const TableRowGroupSticky = styled.div<{ $theme?: TableThemeConfig }>`
+const TableRowGroupBody = styled(motion.div)<{ $style?: CSSProp }>`
+  display: flex;
+  flex-direction: column;
+  ${({ $style }) => $style}
+`;
+
+const TableRowGroupSticky = styled.div<{
+  $theme?: TableThemeConfig;
+  $style?: CSSProp;
+}>`
   display: flex;
   flex-direction: row;
   cursor: pointer;
@@ -1030,16 +1066,20 @@ const TableRowGroupSticky = styled.div<{ $theme?: TableThemeConfig }>`
   contain: layout style paint;
   -webkit-transform: translateZ(0);
   -webkit-backface-visibility: hidden;
+
+  ${({ $style }) => $style}
 `;
 
-const RotatingIcon = styled.span<{ $isOpen?: boolean }>`
+const RotatingIcon = styled.span<{ $isOpen?: boolean; $style?: CSSProp }>`
   transition: transform 300ms;
   margin-left: 2px;
   ${(props) =>
     props.$isOpen &&
     css`
       transform: rotate(-180deg);
-    `}
+    `};
+
+  ${({ $style }) => $style}
 `;
 
 export type TableRowAction = TipMenuItemProps;

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -31,6 +31,7 @@ import { OverlayBlocker } from "./overlay-blocker";
 import { useTheme } from "./../theme/provider";
 import { TableThemeConfig } from "./../theme";
 import { applyClassName } from "./../constants/classname";
+import { Figure } from "./figure";
 
 export interface TableColumn {
   caption: string;
@@ -963,22 +964,44 @@ function TableRowGroup({
       className={applyClassName("table-row-group", className)}
       $style={styles?.containerStyle}
     >
-      <TableRowGroupSticky
+      <TableRowGroupHeader
         $theme={tableTheme}
+        aria-label="table-row-group-header"
         onClick={() => setIsOpen(!isOpen)}
         $style={styles?.headerStyle}
       >
-        <RotatingIcon $isOpen={isOpen} $style={styles?.chevronStyle}>
-          <RiArrowDownSLine />
-        </RotatingIcon>
-        <TableRowGroupTextWrapper $style={styles?.textWrapperStyle}>
+        <Figure
+          styles={{
+            self: css`
+              transition: transform 300ms;
+              margin-left: 6px;
+              ${isOpen &&
+              css`
+                transform: rotate(-180deg);
+              `};
+              ${styles?.chevronStyle}
+            `,
+          }}
+          size={20}
+          aria-label="table-row-group-chevron"
+          image={RiArrowDownSLine}
+        />
+
+        <TableRowGroupTextWrapper
+          aria-label="table-row-group-text-wrapper"
+          $style={styles?.textWrapperStyle}
+        >
           {title && (
-            <TableRowGroupTitle $style={styles?.titleStyle}>
+            <TableRowGroupTitle
+              aria-label="table-row-group-title"
+              $style={styles?.titleStyle}
+            >
               {title}
             </TableRowGroupTitle>
           )}
           {subtitle && (
             <TableRowGroupSubtitle
+              aria-label="table-row-group-subtitle"
               $style={styles?.subtitleStyle}
               color={tableTheme?.rowSubtitleTextColor}
             >
@@ -986,11 +1009,12 @@ function TableRowGroup({
             </TableRowGroupSubtitle>
           )}
         </TableRowGroupTextWrapper>
-      </TableRowGroupSticky>
+      </TableRowGroupHeader>
 
       <AnimatePresence initial={false}>
         {isOpen && (
           <TableRowGroupBody
+            aria-label="table-row-group-body"
             $style={styles?.bodyStyle}
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
@@ -1037,10 +1061,11 @@ const TableRowGroupContainer = styled.div<{ $style?: CSSProp }>`
 const TableRowGroupBody = styled(motion.div)<{ $style?: CSSProp }>`
   display: flex;
   flex-direction: column;
-  ${({ $style }) => $style}
+
+  ${({ $style }) => $style};
 `;
 
-const TableRowGroupSticky = styled.div<{
+const TableRowGroupHeader = styled.div<{
   $theme?: TableThemeConfig;
   $style?: CSSProp;
 }>`
@@ -1066,18 +1091,6 @@ const TableRowGroupSticky = styled.div<{
   contain: layout style paint;
   -webkit-transform: translateZ(0);
   -webkit-backface-visibility: hidden;
-
-  ${({ $style }) => $style}
-`;
-
-const RotatingIcon = styled.span<{ $isOpen?: boolean; $style?: CSSProp }>`
-  transition: transform 300ms;
-  margin-left: 2px;
-  ${(props) =>
-    props.$isOpen &&
-    css`
-      transform: rotate(-180deg);
-    `};
 
   ${({ $style }) => $style}
 `;

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -15,6 +15,7 @@ import {
   TableAction,
   TableProps,
   TableRowProps,
+  TableRowGroupProps,
 } from "./../../components/table";
 import { TipMenuItemProps } from "./../../components/tip-menu";
 import { css } from "styled-components";
@@ -23,6 +24,74 @@ import { Button } from "./../../components/button";
 import { Card } from "./../../components/card";
 import { useState } from "react";
 import { generateSentence } from "./../../lib/text";
+interface TableSummaryProps {
+  id?: string;
+  title: string;
+  subtitle?: string;
+  items: {
+    itemId?: string;
+    name: string;
+    cost: string;
+    quantity: string;
+  }[];
+}
+
+const TABLE_SUMMARY: TableSummaryProps[] = [
+  {
+    id: "food",
+    title: "Food",
+    subtitle: "List of Food Items",
+    items: [
+      {
+        itemId: "F1583",
+        name: "Ayam Geprek",
+        cost: "5,000",
+        quantity: "5",
+      },
+      {
+        itemId: "F9311",
+        name: "Laksa Singapore",
+        cost: "4,500",
+        quantity: "1",
+      },
+      { itemId: "F2210", name: "Nasi Lemak", cost: "3,500", quantity: "2" },
+      {
+        itemId: "F7721",
+        name: "Soto Betawi",
+        cost: "4,000",
+        quantity: "1",
+      },
+      {
+        itemId: "F6622",
+        name: "Bakso Malang",
+        cost: "6,000",
+        quantity: "4",
+      },
+    ],
+  },
+  {
+    id: "beverages",
+    title: "Beverages",
+    subtitle: "Cold and Hot Refreshments",
+    items: [
+      { itemId: "B1010", name: "Iced Tea", cost: "1,000", quantity: "3" },
+      {
+        itemId: "B3911",
+        name: "Mineral Water",
+        cost: "500",
+        quantity: "1",
+      },
+      { itemId: "B5512", name: "Lemonade", cost: "2,000", quantity: "2" },
+      { itemId: "B6619", name: "Hot Coffee", cost: "3,000", quantity: "1" },
+      {
+        itemId: "B8821",
+        name: "Orange Juice",
+        cost: "2,500",
+        quantity: "2",
+      },
+    ],
+  },
+];
 
 interface TableItemProps {
   title: string;
@@ -267,7 +336,199 @@ describe("Table", () => {
     });
   });
 
+  function TableGroup(props: TableRowGroupProps) {
+    return (
+      <Table
+        styles={{
+          tableBodyStyle: css`
+            max-height: 400px;
+          `,
+        }}
+        columns={columns}
+        searchable
+      >
+        {TABLE_SUMMARY?.map((groupValue, groupIndex) => (
+          <Table.Row.Group
+            key={groupIndex}
+            title={groupValue.title}
+            subtitle={groupValue.subtitle}
+            {...props}
+          >
+            {groupValue.items.map((rowValue, rowIndex) => (
+              <Table.Row
+                key={rowIndex}
+                rowId={`${groupValue.id}-${rowValue.cost}-${rowValue.itemId}-${rowValue.name}-${rowValue.quantity}`}
+                content={[
+                  rowValue.itemId,
+                  rowValue.name,
+                  rowValue.cost,
+                  rowValue.quantity,
+                ]}
+                actions={ROW_ACTIONS}
+              />
+            ))}
+          </Table.Row.Group>
+        ))}
+      </Table>
+    );
+  }
+
   context("styles", () => {
+    context("table row group", () => {
+      context("bodyStyle", () => {
+        context("when given max-height 150px", () => {
+          it("renders the table group with height 150px", () => {
+            cy.mount(
+              <TableGroup
+                styles={{
+                  bodyStyle: css`
+                    max-height: 150px;
+                  `,
+                }}
+              />
+            );
+
+            cy.findAllByLabelText("table-row-group-body")
+              .eq(0)
+              .should("have.css", "height", "150px");
+          });
+        });
+      });
+
+      context("chevronStyle", () => {
+        context("when given margin left 20px", () => {
+          it("renders the margin left with 20px", () => {
+            cy.mount(
+              <TableGroup
+                styles={{
+                  chevronStyle: css`
+                    margin-left: 20px;
+                  `,
+                }}
+              />
+            );
+
+            cy.findAllByLabelText("table-row-group-chevron")
+              .eq(0)
+              .parent()
+              .should("have.css", "margin-left", "20px");
+          });
+        });
+      });
+
+      context("titleStyle", () => {
+        it("renders the title with size 16px", () => {
+          cy.mount(<TableGroup />);
+
+          cy.findAllByLabelText("table-row-group-title")
+            .eq(0)
+            .should("have.css", "font-size", "16px");
+        });
+
+        context("when given size 25px", () => {
+          it("renders the title with size 25px", () => {
+            cy.mount(
+              <TableGroup
+                styles={{
+                  titleStyle: css`
+                    font-size: 25px;
+                  `,
+                }}
+              />
+            );
+
+            cy.findAllByLabelText("table-row-group-title")
+              .eq(0)
+              .should("have.css", "font-size", "25px");
+          });
+        });
+      });
+
+      context("subtitleStyle", () => {
+        it("renders the title 14px", () => {
+          cy.mount(<TableGroup />);
+
+          cy.findAllByLabelText("table-row-group-subtitle")
+            .eq(0)
+            .should("have.css", "font-size", "14px");
+        });
+
+        context("when given size 25px", () => {
+          it("renders the title with size 25px", () => {
+            cy.mount(
+              <TableGroup
+                styles={{
+                  subtitleStyle: css`
+                    font-size: 25px;
+                  `,
+                }}
+              />
+            );
+
+            cy.findAllByLabelText("table-row-group-subtitle")
+              .eq(0)
+              .should("have.css", "font-size", "25px");
+          });
+        });
+      });
+
+      context("headerStyle", () => {
+        it("renders with padding 12px", () => {
+          cy.mount(<TableGroup />);
+
+          cy.findAllByLabelText("table-row-group-header")
+            .eq(0)
+            .should("have.css", "padding", "12px");
+        });
+
+        context("when given padding 25px", () => {
+          it("renders the header with padding 25px", () => {
+            cy.mount(
+              <TableGroup
+                styles={{
+                  headerStyle: css`
+                    padding: 25px;
+                  `,
+                }}
+              />
+            );
+
+            cy.findAllByLabelText("table-row-group-header")
+              .eq(0)
+              .should("have.css", "padding", "25px");
+          });
+        });
+      });
+
+      context("headerStyle", () => {
+        it("renders with normal gap", () => {
+          cy.mount(<TableGroup />);
+
+          cy.findAllByLabelText("table-row-group-text-wrapper")
+            .eq(0)
+            .should("have.css", "gap", "normal");
+        });
+
+        context("when given gap 10px", () => {
+          it("renders the wrapper text with gap 10px", () => {
+            cy.mount(
+              <TableGroup
+                styles={{
+                  textWrapperStyle: css`
+                    gap: 10px;
+                  `,
+                }}
+              />
+            );
+
+            cy.findAllByLabelText("table-row-group-text-wrapper")
+              .eq(0)
+              .should("have.css", "gap", "10px");
+          });
+        });
+      });
+    });
+
     context("tableBodyStyle", () => {
       context("when given max-height 250px", () => {
         it("should render the table body with a height of 250px", () => {
@@ -349,63 +610,6 @@ describe("Table", () => {
         quantity: string;
       }[];
     }
-
-    const TABLE_SUMMARY: TableSummaryProps[] = [
-      {
-        id: "food",
-        title: "Food",
-        subtitle: "List of Food Items",
-        items: [
-          {
-            itemId: "F1583",
-            name: "Ayam Geprek",
-            cost: "5,000",
-            quantity: "5",
-          },
-          {
-            itemId: "F9311",
-            name: "Laksa Singapore",
-            cost: "4,500",
-            quantity: "1",
-          },
-          { itemId: "F2210", name: "Nasi Lemak", cost: "3,500", quantity: "2" },
-          {
-            itemId: "F7721",
-            name: "Soto Betawi",
-            cost: "4,000",
-            quantity: "1",
-          },
-          {
-            itemId: "F6622",
-            name: "Bakso Malang",
-            cost: "6,000",
-            quantity: "4",
-          },
-        ],
-      },
-      {
-        id: "beverages",
-        title: "Beverages",
-        subtitle: "Cold and Hot Refreshments",
-        items: [
-          { itemId: "B1010", name: "Iced Tea", cost: "1,000", quantity: "3" },
-          {
-            itemId: "B3911",
-            name: "Mineral Water",
-            cost: "500",
-            quantity: "1",
-          },
-          { itemId: "B5512", name: "Lemonade", cost: "2,000", quantity: "2" },
-          { itemId: "B6619", name: "Hot Coffee", cost: "3,000", quantity: "1" },
-          {
-            itemId: "B8821",
-            name: "Orange Juice",
-            cost: "2,500",
-            quantity: "2",
-          },
-        ],
-      },
-    ];
 
     function parseCost(val: string) {
       return Number(val.replace(/,/g, ""));


### PR DESCRIPTION
Description:
This pull request introduces a `styles` prop in `Table.Row.Group`, allowing customization and flexible `styling` at the group level. It also answer an issue from user for implementation `row-group`.

Answer:
We can adjust by the `max-height` and `height` in the parent level through `tableBodyStyle`. The height it depends on the user, some user might want just have 400px in height, and another user want 80 viewport (80dvh).

Source:
[[Bug] SYST-578: Allow overflowing row group content](https://linear.app/systatum/issue/SYST-578/allow-overflowing-row-group-content)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself