### PR TITLE
[Chore] SYST-660: Make coneto docs default to `dark`

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,8 +1,24 @@
 import type { Preview } from "@storybook/react";
+import { addons } from "@storybook/preview-api";
 import "../shared.css";
 import { ThemeProvider } from "./../theme/provider";
+import { GLOBALS_UPDATED } from "@storybook/core-events";
 
+if (typeof window !== "undefined") {
+  const channel = addons.getChannel();
+  channel.on(
+    GLOBALS_UPDATED,
+    ({ globals }: { globals: { theme?: string } }) => {
+      const mode = globals.theme ?? "dark";
+      document.body.setAttribute("data-theme", mode);
+      localStorage.setItem("sb-theme", mode);
+    }
+  );
+}
 const preview: Preview = {
+  initialGlobals: {
+    theme: "dark",
+  },
   parameters: {
     options: {
       storySort: {
@@ -22,7 +38,7 @@ const preview: Preview = {
   },
   decorators: [
     (Story, context) => {
-      const mode = context.globals.theme || "light";
+      const mode = context.globals.theme || "dark";
 
       document.body.setAttribute("data-theme", mode);
 
@@ -37,7 +53,7 @@ const preview: Preview = {
     theme: {
       name: "Theme",
       description: "Global theme mode",
-      defaultValue: "light",
+      defaultValue: "dark",
       toolbar: {
         icon: "circlehollow",
         items: [

--- a/package.json
+++ b/package.json
@@ -375,6 +375,7 @@
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-storysource": "^8.6.14",
     "@storybook/blocks": "^8.6.14",
+    "@storybook/core-events": "^8.6.14",
     "@storybook/manager-api": "^8.6.14",
     "@storybook/preview-api": "^8.6.14",
     "@storybook/react": "^8.6.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@storybook/blocks':
         specifier: ^8.6.14
         version: 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/core-events':
+        specifier: ^8.6.14
+        version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
       '@storybook/manager-api':
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
@@ -827,6 +830,11 @@ packages:
 
   '@storybook/components@8.6.14':
     resolution: {integrity: sha512-HNR2mC5I4Z5ek8kTrVZlIY/B8gJGs5b3XdZPBPBopTIN6U/YHXiDyOjY3JlaS4fSG1fVhp/Qp1TpMn1w/9m1pw==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/core-events@8.6.14':
+    resolution: {integrity: sha512-RrJ95u3HuIE4Nk8VmZP0tc/u0vYoE2v9fYlMw6K2GUSExzKDITs3voy6WMIY7Q3qbQun8XUXVlmqkuFzTEy/pA==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
@@ -3782,6 +3790,10 @@ snapshots:
       vite: 6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)
 
   '@storybook/components@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+    dependencies:
+      storybook: 8.6.14(prettier@3.6.2)
+
+  '@storybook/core-events@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 


### PR DESCRIPTION
Description:
This pull request updates the default `theme` in docs from `light` to `dark` to improve the initial viewing experience when opening Coneto, providing a more comfortable visual experience.

Source:
[[Chore] SYST-660: Make coneto docs default to `dark`](https://linear.app/systatum/issue/SYST-660/make-coneto-docs-default-to-dark)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself