### PR TITLE
[Bug] SYST-675: `Draggable` in `TreeList` not works correctly.

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -15,6 +15,7 @@ if (typeof window !== "undefined") {
     }
   );
 }
+
 const preview: Preview = {
   initialGlobals: {
     theme: "dark",
@@ -38,7 +39,11 @@ const preview: Preview = {
   },
   decorators: [
     (Story, context) => {
-      const mode = context.globals.theme || "dark";
+      const isCypress =
+        typeof window !== "undefined" &&
+        (window as Window & { Cypress?: unknown }).Cypress;
+
+      const mode = isCypress ? "light" : context.globals.theme || "dark";
 
       document.body.setAttribute("data-theme", mode);
 

--- a/components/treelist.tsx
+++ b/components/treelist.tsx
@@ -567,9 +567,15 @@ function TreeList({
                             onOpen={(prop: boolean) => {
                               setOpenRowId(prop ? item.id : null);
                             }}
-                            activeBackgroundColor="rgb(193, 214, 241)"
-                            focusBackgroundColor="rgb(193, 214, 241)"
-                            hoverBackgroundColor="rgb(193, 214, 241)"
+                            activeBackgroundColor={
+                              treeListTheme.rowActionBackgroundColor
+                            }
+                            focusBackgroundColor={
+                              treeListTheme.rowActionBackgroundColor
+                            }
+                            hoverBackgroundColor={
+                              treeListTheme.rowActionBackgroundColor
+                            }
                             open={openRowId === item.id}
                             maxActionsBeforeCollapsing={
                               maxActionsBeforeCollapsing
@@ -1025,7 +1031,6 @@ function TreeListItem<T extends TreeListItem>({
           onKeyDownItem?.({ event: e, item });
         }}
         onMouseDown={async (e) => {
-          e.preventDefault();
           let prevent = false;
           let withoutSelection = false;
 
@@ -1416,6 +1421,7 @@ function TreeListItem<T extends TreeListItem>({
                     onDragOver={(e) => e.preventDefault()}
                     onDrop={(e) => {
                       e.preventDefault();
+                      e.stopPropagation();
                       if (dragItem && draggable) {
                         const {
                           id: draggedId,

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -716,6 +716,8 @@ export interface TreeListThemeConfig
   dividerHierarchyColor?: string;
   dividerHierarchySelectedColor?: string;
   dividerHierarchyRelatedColor?: string;
+
+  rowActionBackgroundColor?: string;
 }
 
 // split-pane.tsx

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1708,6 +1708,8 @@ export function createTreeListTheme(
     dividerHierarchyColor: "rgb(243 243 243)",
     dividerHierarchyRelatedColor: "#d7d6d6",
     dividerHierarchySelectedColor: "#3b82f6",
+
+    rowActionBackgroundColor: "rgb(193, 214, 241)",
   };
 
   return {

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -748,6 +748,8 @@ const darkTreeList = createTreeListTheme(darkBody, {
   dividerHierarchyColor: "rgba(63, 62, 62, 0.35)",
   dividerHierarchyRelatedColor: "rgb(115, 115, 115)",
   dividerHierarchySelectedColor: "#485c7d",
+
+  rowActionBackgroundColor: "#1e3a5f",
 });
 
 const darkSplitPane = createSplitPaneTheme(darkBody, {


### PR DESCRIPTION
Description:
After refactoring the `Combobox` , the `TreeList` started ignoring `draggable` behavior due to the `onMouseDown` handler inside of the `TreeList` component. This pull request fixes the issue and also adds the `row actions` coloring for `dark` and `light` mode.

Source:
[[Bug] SYST-675: Draggable in TreeList not works correctly.](https://linear.app/systatum/issue/SYST-675/draggable-in-treelist-not-works-correctly)


<img width="1123" height="710" alt="Screenshot 2026-05-11 at 13 57 55" src="https://github.com/user-attachments/assets/c46cf902-6d9b-4497-a1ef-20531c139e63" />


Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[] I have created/updated any relevant test code
[x] I have tested it myself