### PR TITLE
[Bug] SYST-680: Do not restrict what can be the children of a table

### DIFF
--- a/components/table.tsx
+++ b/components/table.tsx
@@ -1002,7 +1002,7 @@ function TableRowGroup({
             <TableRowGroupSubtitle
               aria-label="table-row-group-subtitle"
               $style={styles?.subtitleStyle}
-              color={tableTheme?.rowSubtitleTextColor}
+              $color={tableTheme?.rowGroupSubtitleTextColor}
             >
               {subtitle}
             </TableRowGroupSubtitle>

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -235,10 +235,9 @@ function Table({
     setSelectedData(newData);
     onItemsSelected?.(newData);
   };
+  const flatChildren = resolveChildren(children);
 
-  const rowChildren = Children.map(children, (child, index) => {
-    if (!isValidElement<TableRowProps | TableRowGroupProps>(child)) return null;
-
+  const rowChildren = flatChildren.map((child, index) => {
     const hasRowGroup = child.type === TableRowGroup;
     const hasRow = child.type === TableRow;
 
@@ -1697,6 +1696,25 @@ function getRowActionsFromChildren(children: ReactNode): TipMenuItemProps[] {
         (action): action is TipMenuItemProps => Boolean(action)
       );
       result.push(...validActions);
+    }
+  });
+
+  return result;
+}
+
+function resolveChildren(
+  children: ReactNode
+): ReactElement<TableRowProps | TableRowGroupProps>[] {
+  const result: ReactElement<TableRowProps | TableRowGroupProps>[] = [];
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+
+    if (child.type === TableRow || child.type === TableRowGroup) {
+      result.push(child as ReactElement<TableRowProps | TableRowGroupProps>);
+    } else if (typeof child.type === "function") {
+      const rendered = (child.type as Function)(child.props);
+      result.push(...resolveChildren(rendered));
     }
   });
 

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -1708,7 +1708,6 @@ function getRowActionsFromChildren(children: ReactNode): TipMenuItemProps[] {
  * This allows wrapper components (e.g. <GetRows />, <Testing />) to be passed as children
  * to <Table> and still be recognized correctly, instead of returning null.
  */
-
 function resolveChildren(
   children: ReactNode
 ): ReactElement<TableRowProps | TableRowGroupProps>[] {

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -909,7 +909,7 @@ function TableRowGroup({
 
   const { dragItem, setDragItem, onDragged } = useContext(DnDContext);
 
-  const rowChildren = Children.map(children, (child, index) => {
+  const rowChildren = resolveRowChildren(children).map((child, index) => {
     if (!isValidElement<TableRowProps & TableRowOpenWithId>(child)) return null;
     if (child.type === TableRow) {
       const props = child.props as TableRowProps & TableRowOpenWithId;
@@ -1702,6 +1702,13 @@ function getRowActionsFromChildren(children: ReactNode): TipMenuItemProps[] {
   return result;
 }
 
+/**
+ * Recursively resolves React children into a flat array of TableRow or TableRowGroup elements.
+ *
+ * This allows wrapper components (e.g. <GetRows />, <Testing />) to be passed as children
+ * to <Table> and still be recognized correctly, instead of returning null.
+ */
+
 function resolveChildren(
   children: ReactNode
 ): ReactElement<TableRowProps | TableRowGroupProps>[] {
@@ -1713,8 +1720,29 @@ function resolveChildren(
     if (child.type === TableRow || child.type === TableRowGroup) {
       result.push(child as ReactElement<TableRowProps | TableRowGroupProps>);
     } else if (typeof child.type === "function") {
+      // Unwrap wrapper components recursively until we find TableRow or TableRowGroup elements
       const rendered = (child.type as Function)(child.props);
       result.push(...resolveChildren(rendered));
+    }
+  });
+
+  return result;
+}
+
+function resolveRowChildren(
+  children: ReactNode
+): ReactElement<TableRowProps>[] {
+  const result: ReactElement<TableRowProps>[] = [];
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+
+    if (child.type === TableRow) {
+      result.push(child as ReactElement<TableRowProps>);
+    } else if (typeof child.type === "function") {
+      // Unwrap wrapper components recursively until we find TableRow elements
+      const rendered = (child.type as Function)(child.props);
+      result.push(...resolveRowChildren(rendered));
     }
   });
 

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -22,7 +22,7 @@ import { css } from "styled-components";
 import { CapsuleTab } from "./../../components/capsule";
 import { Button } from "./../../components/button";
 import { Card } from "./../../components/card";
-import { useState } from "react";
+import { ReactNode, useState } from "react";
 import { generateSentence } from "./../../lib/text";
 interface TableSummaryProps {
   id?: string;
@@ -186,20 +186,13 @@ describe("Table", () => {
     );
   }
 
-  context("separate content with function", () => {
-    function TableSeparateContent({ isGroup = false }: { isGroup?: boolean }) {
+  context("when children with function", () => {
+    type SeparateMode = "row" | "group" | "group-separate-row";
+
+    function TableSeparateContent({ mode = "row" }: { mode?: SeparateMode }) {
       const columns: TableColumn[] = [
-        {
-          id: "itemId",
-          caption: "Item ID",
-          sortable: true,
-        },
-        {
-          id: "name",
-          caption: "Name",
-          sortable: true,
-          width: "60%",
-        },
+        { id: "itemId", caption: "Item ID", sortable: true },
+        { id: "name", caption: "Name", sortable: true, width: "60%" },
       ];
 
       function TableSeparateRow({ test }: { test: boolean }) {
@@ -209,35 +202,53 @@ describe("Table", () => {
       function TableSeparateGroup({ test }: { test: boolean }) {
         return (
           <Table.Row.Group title="Group Title" subtitle="Group Subtitle">
-            <Table.Row content={["02", "Test 123"]} />;
+            <Table.Row content={["02", "Test 123"]} />
           </Table.Row.Group>
         );
       }
 
-      return (
-        <Table columns={columns}>
-          {isGroup ? (
-            <TableSeparateGroup test={true} />
-          ) : (
+      function TableSeparateGroupSeparateRow({ test }: { test: boolean }) {
+        return (
+          <Table.Row.Group title="Group Title" subtitle="Group Subtitle">
             <TableSeparateRow test={true} />
-          )}
-        </Table>
-      );
+          </Table.Row.Group>
+        );
+      }
+
+      const contentMap: Record<SeparateMode, ReactNode> = {
+        row: <TableSeparateRow test={true} />,
+        group: <TableSeparateGroup test={true} />,
+        "group-separate-row": <TableSeparateGroupSeparateRow test={true} />,
+      };
+
+      return <Table columns={columns}>{contentMap[mode]}</Table>;
     }
 
-    it("can resolve the table with separate content", () => {
+    it("should still resolve and render the row content correctly", () => {
       cy.mount(<TableSeparateContent />);
 
       cy.findByText("02").should("exist");
       cy.findByText("Test 123").should("exist");
     });
 
-    context("when the table is grouped", () => {
-      it("shows the group title and subtitle", () => {
-        cy.mount(<TableSeparateContent isGroup />);
+    context("with separate group function", () => {
+      it("should render the group title and subtitle", () => {
+        cy.mount(<TableSeparateContent mode="group" />);
 
         cy.findByText("Group Title").should("exist");
         cy.findByText("Group Subtitle").should("exist");
+      });
+    });
+
+    context("when separate group, and separate row function", () => {
+      it("should render the group text, and row content", () => {
+        cy.mount(<TableSeparateContent mode="group-separate-row" />);
+
+        cy.findByText("Group Title").should("exist");
+        cy.findByText("Group Subtitle").should("exist");
+
+        cy.findByText("02").should("exist");
+        cy.findByText("Test 123").should("exist");
       });
     });
   });

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -185,6 +185,63 @@ describe("Table", () => {
       </Table>
     );
   }
+
+  context("separate content with function", () => {
+    function TableSeparateContent({ isGroup = false }: { isGroup?: boolean }) {
+      const columns: TableColumn[] = [
+        {
+          id: "itemId",
+          caption: "Item ID",
+          sortable: true,
+        },
+        {
+          id: "name",
+          caption: "Name",
+          sortable: true,
+          width: "60%",
+        },
+      ];
+
+      function TableSeparateRow({ test }: { test: boolean }) {
+        return <Table.Row content={["02", "Test 123"]} />;
+      }
+
+      function TableSeparateGroup({ test }: { test: boolean }) {
+        return (
+          <Table.Row.Group title="Group Title" subtitle="Group Subtitle">
+            <Table.Row content={["02", "Test 123"]} />;
+          </Table.Row.Group>
+        );
+      }
+
+      return (
+        <Table columns={columns}>
+          {isGroup ? (
+            <TableSeparateGroup test={true} />
+          ) : (
+            <TableSeparateRow test={true} />
+          )}
+        </Table>
+      );
+    }
+
+    it("can resolve the table with separate content", () => {
+      cy.mount(<TableSeparateContent />);
+
+      cy.findByText("02").should("exist");
+      cy.findByText("Test 123").should("exist");
+    });
+
+    context("when the table is grouped", () => {
+      it("shows the group title and subtitle", () => {
+        cy.mount(<TableSeparateContent isGroup />);
+
+        cy.findByText("Group Title").should("exist");
+        cy.findByText("Group Subtitle").should("exist");
+      });
+    });
+  });
+
   context("isLoading", () => {
     context("when given true", () => {
       it("renders spinner ~14px from top and left relative to overlay", () => {

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -207,6 +207,10 @@ describe("Table", () => {
         );
       }
 
+      /**
+       * very rare case, but just to make sure that when both separate group
+       * and row function are given, it should still render the content correctly/
+       */
       function TableSeparateGroupSeparateRow({ test }: { test: boolean }) {
         return (
           <Table.Row.Group title="Group Title" subtitle="Group Subtitle">

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -609,8 +609,8 @@ export interface TableThemeConfig extends Omit<BodyThemeConfig, "borderColor"> {
   headerBorderColor?: string;
 
   rowGroupBackgroundColor?: string;
+  rowGroupSubtitleTextColor?: string;
 
-  rowSubtitleTextColor?: string;
   rowBackgroundColor?: string;
   rowBorderColor?: string;
   rowHoverBackgroundColor?: string;

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1453,10 +1453,10 @@ export function createTableTheme(
     headerBorderColor: "rgb(229, 231, 235)",
 
     rowGroupBackgroundColor: "rgb(249, 250, 251)",
+    rowGroupSubtitleTextColor: "#1f2937",
 
     rowBackgroundColor: "rgb(249, 250, 251)",
     rowBorderColor: "#e5e7eb",
-    rowSubtitleTextColor: "#1f2937",
     rowHoverBackgroundColor: "#e7f2fc",
     rowSelectedBackgroundColor: "#dbeafe",
     rowContentBackgroundColor:

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -668,12 +668,12 @@ const darkTable = createTableTheme(darkBody, {
   headerBorderColor: "rgb(39, 39, 48)",
 
   rowGroupBackgroundColor: "rgb(31, 31, 31)",
+  rowGroupSubtitleTextColor: "#838891",
 
   rowBackgroundColor: "rgb(26, 26, 26)",
   rowBorderColor: "rgb(39, 39, 48)",
   rowHoverBackgroundColor: "#292c2e",
   rowSelectedBackgroundColor: "#303438",
-  rowSubtitleTextColor: "#d1d5db",
   rowContentBackgroundColor:
     "linear-gradient(to bottom, #1a1a1a 0%, #222222 35%, #1f1f1f 100%)",
   rowContentBoxShadow: "rgba(0, 0, 0, 0.15) 0px 4px 5px inset",


### PR DESCRIPTION
Description:
This pull request fixes the `table` when the `content` was wrapped inside a separated component

Use case:
```tsx
    const columns: TableColumn[] = [
      {
        id: "itemId",
        caption: "Item ID",
        sortable: true,
      },
      {
        id: "name",
        caption: "Name",
        sortable: true,
        width: "60%",
      },
    ];

    function TableSeparateRow({ test }: { test: boolean }) {
      return <Table.Row content={["02", "Test 123"]} />;
    }

    return (
      <Table columns={columns}>
        <TableSeparateRow test={true} /> // previously rendered nothing
      </Table>
    );
```

Previously, `<TableSeparateRow />` would render nothing because `Table` only recognized direct `Table.Row` or `Table.Row.Group` elements as valid children.

Fixed by adding `resolveChildren()` which recursively unwraps wrapper components before processing.

It also fix the coloring the subtitle on the table.

Source:
[[Bug] SYST-680: Do not restrict what can be the children of a table](https://linear.app/systatum/issue/SYST-680/do-not-restrict-what-can-be-the-children-of-a-table)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself

