### PR TITLE
[Bug] SYST-685: `SplitPane` shows doubled on the `actions` in once declared.

### DIFF
--- a/components/split-pane.tsx
+++ b/components/split-pane.tsx
@@ -300,6 +300,10 @@ const SplitPaneCell = forwardRef<HTMLDivElement, SplitPaneCellProps>(
             {filteredActions.map((action, index) => (
               <Button
                 {...action}
+                icon={{
+                  ...action.icon,
+                  image: action?.icon?.image ?? RiCloseLine,
+                }}
                 variant="ghost"
                 key={index}
                 aria-label="split-pane-button"
@@ -328,14 +332,7 @@ const SplitPaneCell = forwardRef<HTMLDivElement, SplitPaneCellProps>(
                     ${action?.styles?.self}
                   `,
                 }}
-              >
-                {action.icon && (
-                  <Figure
-                    {...action.icon}
-                    image={action?.icon?.image ?? RiCloseLine}
-                  />
-                )}
-              </Button>
+              />
             ))}
           </ActionContainer>
         )}

--- a/test/component/split-pane.cy.tsx
+++ b/test/component/split-pane.cy.tsx
@@ -2,7 +2,7 @@ import { css } from "styled-components";
 import { SplitPane } from "../../components/split-pane";
 import { Textarea } from "./../../components/textarea";
 import { useRef, useState } from "react";
-import { RiCloseFill, RiEdit2Fill } from "@remixicon/react";
+import { RiEdit2Fill } from "@remixicon/react";
 
 describe("SplitPane", () => {
   context("style", () => {
@@ -42,7 +42,7 @@ describe("SplitPane", () => {
             {
               hidden: true,
               icon: {
-                image: RiCloseFill,
+                image: RiEdit2Fill,
               },
             },
             {
@@ -57,7 +57,15 @@ describe("SplitPane", () => {
       );
     }
     context("actions", () => {
-      context("when given with hidden", () => {
+      it("should renders by given", () => {
+        cy.mount(<SplitPaneCellDefault />);
+        cy.findAllByLabelText("split-pane-button").should("have.length", 1);
+
+        // icon must have only one icon.
+        cy.findAllByLabelText("action-button-icon").should("have.length", 1);
+      });
+
+      context("when given hidden", () => {
         it("should ignore hidden actions", () => {
           cy.mount(<SplitPaneCellDefault />);
           cy.findAllByLabelText("split-pane-button").should("have.length", 1);

--- a/test/component/split-pane.cy.tsx
+++ b/test/component/split-pane.cy.tsx
@@ -62,7 +62,7 @@ describe("SplitPane", () => {
         cy.findAllByLabelText("split-pane-button").should("have.length", 1);
 
         // icon must have only one icon.
-        cy.findAllByLabelText("action-button-icon").should("have.length", 1);
+        cy.get("svg").should("have.length", 1);
       });
 
       context("when given hidden", () => {

--- a/test/component/split-pane.cy.tsx
+++ b/test/component/split-pane.cy.tsx
@@ -1,5 +1,5 @@
 import { css } from "styled-components";
-import { SplitPane } from "../../components/split-pane";
+import { SplitPane, SplitPaneCellProps } from "../../components/split-pane";
 import { Textarea } from "./../../components/textarea";
 import { useRef, useState } from "react";
 import { RiEdit2Fill } from "@remixicon/react";
@@ -32,7 +32,7 @@ describe("SplitPane", () => {
   });
 
   context("SplitPane.Cell", () => {
-    function SplitPaneCellDefault() {
+    function SplitPaneCellDefault(props: SplitPaneCellProps) {
       return (
         <SplitPane.Cell
           onMouseEnter={() => console.log("now is hovering split-pane-cell")}
@@ -51,6 +51,7 @@ describe("SplitPane", () => {
               },
             },
           ]}
+          {...props}
         >
           Test
         </SplitPane.Cell>
@@ -63,6 +64,93 @@ describe("SplitPane", () => {
 
         // icon must have only one icon.
         cy.get("svg").should("have.length", 1);
+      });
+
+      context("when given 3 actions", () => {
+        it("should render all actions", () => {
+          cy.mount(
+            <SplitPaneCellDefault
+              actions={[
+                {
+                  icon: {
+                    image: RiEdit2Fill,
+                    onClick: () => console.log("Edit 1 was clicked"),
+                  },
+                },
+                {
+                  icon: {
+                    image: RiEdit2Fill,
+                    onClick: () => console.log("Edit 2 was clicked"),
+                  },
+                },
+                {
+                  icon: {
+                    image: RiEdit2Fill,
+                    onClick: () => console.log("Edit 3 was clicked"),
+                  },
+                },
+              ]}
+            />
+          );
+          cy.findAllByLabelText("split-pane-button").should("have.length", 3);
+
+          cy.get("svg").should("have.length", 3);
+        });
+
+        context("when clicking", () => {
+          it("should renders the console.log", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+
+            cy.mount(
+              <SplitPaneCellDefault
+                actions={[
+                  {
+                    icon: {
+                      image: RiEdit2Fill,
+                      onClick: () => console.log("Edit 1 was clicked"),
+                    },
+                  },
+                  {
+                    icon: {
+                      image: RiEdit2Fill,
+                      onClick: () => console.log("Edit 2 was clicked"),
+                    },
+                  },
+                  {
+                    icon: {
+                      image: RiEdit2Fill,
+                      onClick: () => console.log("Edit 3 was clicked"),
+                    },
+                  },
+                ]}
+              />
+            );
+            [1, 2, 3].map((number) => {
+              cy.get("@consoleLog").should(
+                "not.have.been.calledWith",
+                `Edit ${number} was clicked`
+              );
+            });
+
+            cy.findAllByLabelText("split-pane-button").should("have.length", 3);
+            cy.get("svg").should("have.length", 3);
+
+            [1, 2, 3].map((number) => {
+              cy.findAllByLabelText("split-pane-button")
+                .eq(number - 1)
+                .click();
+            });
+
+            [1, 2, 3].map((number) => {
+              cy.get("@consoleLog").should(
+                "have.been.calledWith",
+                `Edit ${number} was clicked`
+              );
+            });
+          });
+        });
       });
 
       context("when given hidden", () => {


### PR DESCRIPTION
Description:
Previously, the SplitPane had incorrect logic in the button actions, especially around icons, which caused icons to be rendered twice when included in the actions.

<img width="630" height="420" alt="Screenshot 2026-05-15 at 12 36 05" src="https://github.com/user-attachments/assets/af7d3abf-4b79-477c-bf2d-dba7e66868b6" />

This pull request fixes the issue so that SplitPane renders actions only as explicitly provided.

Source:
[[Bug] SYST-685: `SplitPane` shows doubled on the `actions` in once declared.](https://linear.app/systatum/issue/SYST-685/splitpane-shows-doubled-on-the-actions-in-once-declared)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself