### PR TITLE
[Improvement] SYST-679: Remove from coneto: `console.log(action.className)`

### DIFF
--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -418,7 +418,6 @@ function NavTab({
             {actions
               .filter((action) => !action?.hidden)
               .map((action, index) => {
-                console.log(action.className);
                 return (
                   <ActionButton
                     key={index}

--- a/postbuild-inject.js
+++ b/postbuild-inject.js
@@ -15,16 +15,15 @@ for (const file of files) {
     const fullPath = path.join(componentDir, file);
     let content = fs.readFileSync(fullPath, "utf8").trim();
 
+    const hasConsoleLog = /console\.log\s*\(/.test(content);
+
+    if (hasConsoleLog) {
+      console.error(`❌ Build failed: console.log found in ${file}`);
+      process.exit(1);
+    }
+
     let lines = content.split("\n");
     const hasUseClient = lines[0].trim() === useClientDirective;
-
-    lines = lines.filter((line) => {
-      const t = line.trim();
-
-      if (/^console\.(log)\(/.test(t)) return false;
-
-      return true;
-    });
 
     if (!hasUseClient) {
       lines.unshift(useClientDirective);

--- a/postbuild-inject.js
+++ b/postbuild-inject.js
@@ -15,16 +15,22 @@ for (const file of files) {
     const fullPath = path.join(componentDir, file);
     let content = fs.readFileSync(fullPath, "utf8").trim();
 
-    const lines = content.split("\n");
+    let lines = content.split("\n");
     const hasUseClient = lines[0].trim() === useClientDirective;
 
-    const newLines = [...lines];
+    lines = lines.filter((line) => {
+      const t = line.trim();
+
+      if (/^console\.(log)\(/.test(t)) return false;
+
+      return true;
+    });
 
     if (!hasUseClient) {
-      newLines.unshift(useClientDirective);
+      lines.unshift(useClientDirective);
     }
 
-    const finalContent = newLines.join("\n");
+    const finalContent = lines.join("\n");
     fs.writeFileSync(fullPath, finalContent);
     console.log(`✅ Injected into: ${file}`);
   }


### PR DESCRIPTION
Description:
Let's make a script to scan all files before we deploy to npm, to scan for anything that is console. in that file; and if there's such a file, fail abruptly and never allow to publish/submit the package.

Source:
[[Improvement] SYST-679: Remove from coneto: `console.log(action.className);`](https://linear.app/systatum/issue/SYST-679/remove-from-coneto-consolelogactionclassname)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[] I have created/updated any relevant test code
[x] I have tested it myself