### PR TITLE
[Mobile] SYST-613: Add `mobile` mode to `Dialog`

### DIFF
--- a/components/dialog.stories.tsx
+++ b/components/dialog.stories.tsx
@@ -147,6 +147,7 @@ export const Default: Story = {
         { id: "archive", caption: "Archive", variant: "primary" },
       ],
     };
+
     return (
       <div
         style={{
@@ -163,13 +164,23 @@ export const Default: Story = {
         <Button onClick={() => updateArgs({ isOpen: !isOpen })}>
           Open Dialog
         </Button>
-
         <Button
           onClick={() => {
             Dialog.show(args);
           }}
         >
           Open Dialog with show()
+        </Button>
+
+        <Button
+          onClick={() => {
+            Dialog.show({
+              ...args,
+              mobile: true,
+            });
+          }}
+        >
+          Open Dialog mobile-mode
         </Button>
       </div>
     );

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -238,7 +238,7 @@ function Dialog({
                 },
               ]
             }
-            icon={icon}
+            icon={{ ...icon, size: icon?.size ?? 28 }}
             text={title}
             subtitle={subtitle}
           />

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -223,6 +223,8 @@ function Dialog({
                     toggleActionStyle: css`
                       width: 20px;
                       height: 20px;
+                      padding: 10px;
+                      border-radius: 4px;
                     `,
                   },
                   type: "actions",

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -54,6 +54,7 @@ export interface DialogProps {
   icon?: FigureProps;
   onClosed?: () => void;
   className?: string;
+  mobile?: boolean;
   id?: string;
 }
 
@@ -70,8 +71,7 @@ export interface DialogStyles {
 }
 
 export interface DialogAction
-  extends Omit<BaseAction, "onClick">,
-    Pick<ButtonVariants, "variant"> {
+  extends Omit<BaseAction, "onClick">, Pick<ButtonVariants, "variant"> {
   id: string;
   isLoading?: boolean;
   styles?: ButtonStyles;
@@ -91,9 +91,10 @@ function Dialog({
   icon,
   onClosed,
   className,
+  mobile,
   id,
 }: DialogProps) {
-  const { currentTheme, mode } = useTheme();
+  const { currentTheme } = useTheme();
   const dialogTheme = currentTheme.dialog;
 
   const [isVisible, setIsVisible] = useState(false);
@@ -158,7 +159,14 @@ function Dialog({
         $theme={dialogTheme}
         aria-label="dialog-wrapper"
         $isOpen={isOpen}
-        $style={styles?.containerStyle}
+        $style={css`
+          ${mobile &&
+          css`
+            padding: 0px;
+            gap: 0px;
+          `}
+          ${styles?.containerStyle};
+        `}
       >
         {(icon || title || subtitle) && (
           <Title
@@ -170,6 +178,10 @@ function Dialog({
                 ${styles?.headerStyle}
               `,
               textWrapperStyle: css`
+                ${mobile &&
+                css`
+                  gap: 4px;
+                `};
                 flex-direction: column;
                 justify-content: center;
                 align-items: center;
@@ -196,6 +208,12 @@ function Dialog({
                 cursor: pointer;
                 border-radius: 2px;
                 padding: 2px;
+              `,
+              containerStyle: css`
+                ${mobile &&
+                css`
+                  padding: 20px 30px;
+                `};
               `,
             }}
             rightSection={
@@ -231,7 +249,15 @@ function Dialog({
         )}
 
         {actions && (
-          <Footer $style={styles?.actionWrapperStyle}>
+          <Footer
+            $style={css`
+              ${mobile &&
+              css`
+                gap: 0px;
+              `};
+              ${styles?.actionWrapperStyle}
+            `}
+          >
             {actions.map((action, index) => {
               if (action.disabled) return;
               return (
@@ -245,8 +271,22 @@ function Dialog({
                   }
                   styles={{
                     ...action?.styles,
+                    containerStyle: css`
+                      ${mobile &&
+                      css`
+                        width: 100%;
+                      `};
+                      ${action?.styles?.containerStyle};
+                    `,
                     self: css`
+                      ${mobile &&
+                      css`
+                        width: 100%;
+                        height: 44px;
+                        border-radius: 0px;
+                      `};
                       min-width: 100px;
+
                       ${action?.styles?.self}
                     `,
                   }}

--- a/components/title.tsx
+++ b/components/title.tsx
@@ -78,7 +78,7 @@ function Title({
     textWrapperStyle: styles?.textWrapperStyle,
   };
 
-  const hasText = text || subtitle || pretitle;
+  const hasText = text || subtitle || pretitle || icon;
   const hasSections = leftSection || centerSection || rightSection;
 
   return (
@@ -312,20 +312,21 @@ const Section = styled.div<{
   ${({ $style }) => $style}
 `;
 
-interface BaseAllTextProps
-  extends Pick<TitleProps, "text" | "pretitle" | "subtitle" | "icon" | "size"> {
+interface BaseAllTextProps extends Pick<
+  TitleProps,
+  "text" | "pretitle" | "subtitle" | "icon" | "size"
+> {
   styles?: BaseAllTextStyles;
 }
 
-interface BaseAllTextStyles
-  extends Pick<
-    TitleStyles,
-    | "textContainerStyle"
-    | "textWrapperStyle"
-    | "titleStyle"
-    | "pretitleStyle"
-    | "subtitleStyle"
-  > {}
+interface BaseAllTextStyles extends Pick<
+  TitleStyles,
+  | "textContainerStyle"
+  | "textWrapperStyle"
+  | "titleStyle"
+  | "pretitleStyle"
+  | "subtitleStyle"
+> {}
 
 interface TextVariant {
   as?: ElementType;

--- a/test/component/dialog.cy.tsx
+++ b/test/component/dialog.cy.tsx
@@ -68,6 +68,107 @@ describe("Dialog", () => {
     });
   });
 
+  context("mobile", () => {
+    it("renders wrapper without padding", () => {
+      cy.mount(
+        <ProductDialog
+          icon={{
+            image: RiAB,
+          }}
+          mobile
+        />
+      );
+
+      cy.findByLabelText("dialog-wrapper").should("have.css", "padding", "0px");
+    });
+
+    context("actions", () => {
+      it("renders button full width", () => {
+        cy.mount(
+          <ProductDialog
+            icon={{
+              image: RiAB,
+            }}
+            actions={[{ id: "cancel", caption: "Cancel" }]}
+            mobile
+          />
+        );
+
+        cy.findByLabelText("dialog-wrapper").should(
+          "have.css",
+          "width",
+          "380px"
+        );
+        cy.findAllByRole("button")
+          .eq(1)
+          .should("exist")
+          .and("have.css", "width", "380px");
+      });
+
+      context("when clicking", () => {
+        it("should render on the console", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
+          });
+
+          cy.get("@consoleLog").should(
+            "not.have.been.calledWith",
+            "cancel was clicked"
+          );
+
+          cy.mount(
+            <ProductDialog
+              icon={{
+                image: RiAB,
+              }}
+              actions={[{ id: "cancel", caption: "Cancel" }]}
+              onClick={({ buttonId }) => console.log(`${buttonId} was clicked`)}
+              mobile
+            />
+          );
+
+          cy.findAllByRole("button").eq(1).click();
+
+          cy.get("@consoleLog").should(
+            "have.been.calledWith",
+            "cancel was clicked"
+          );
+        });
+      });
+
+      context("when given more than one button", () => {
+        it("separate all with for each button", () => {
+          cy.mount(
+            <ProductDialog
+              icon={{
+                image: RiAB,
+              }}
+              actions={[
+                { id: "cancel", caption: "Cancel" },
+                { id: "archive", caption: "Archive", variant: "primary" },
+              ]}
+              mobile
+            />
+          );
+
+          cy.findByLabelText("dialog-wrapper").should(
+            "have.css",
+            "width",
+            "380px"
+          );
+          cy.findAllByRole("button")
+            .eq(1)
+            .should("exist")
+            .and("have.css", "width", "190px");
+          cy.findAllByRole("button")
+            .eq(2)
+            .should("exist")
+            .and("have.css", "width", "190px");
+        });
+      });
+    });
+  });
+
   context("when given icon", () => {
     it("renders icon 28px (by default)", () => {
       cy.mount(


### PR DESCRIPTION
Description:
This pull request introduces a `mobile` mode for the `Dialog` component. In this mode, the dialog button take full width (100%) and no longer applies gap spacing by default. 

This ensures the `Dialog` has a consistent and expected appearance on mobile devices.  

Source:
[[Mobile] SYST-613: Add `mobile` mode to `Dialog`](https://linear.app/systatum/issue/SYST-613/add-mobile-mode-to-dialog)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself