### PR TITLE
[Improvement] SYST-666: Rename `textContainerStyle` on `Card` to `headerTitleSectionStyle`

### DIFF
--- a/components/card.stories.tsx
+++ b/components/card.stories.tsx
@@ -148,7 +148,7 @@ Custom styles for different sections of the Card component:
 - **footerStyle**: Styles for the footer section
 - **titleStyle**: Styles for the title text
 - **subtitleStyle**: Styles for the subtitle text
-- **textContainerStyle**: Styles for the title/subtitle wrapper
+- **headerTitleSectionStyle**: Styles for the title/subtitle wrapper
 - **actionContainerStyle**: Styles for the header actions wrapper
       `,
     },
@@ -998,7 +998,7 @@ export const WithFullWidthContent: Story = {
           titleStyle: css`
             width: 100%;
           `,
-          textContainerStyle: css`
+          headerTitleSectionStyle: css`
             width: 100%;
           `,
           containerStyle: css`

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -52,8 +52,10 @@ export const CardPadding = {
 
 export type CardPadding = (typeof CardPadding)[keyof typeof CardPadding];
 
-export interface CardProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "title" | "style"> {
+export interface CardProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "title" | "style"
+> {
   shadow?: CardShadow;
   radius?: CardBorderRadius;
   padding?: CardPadding;
@@ -71,7 +73,7 @@ export interface CardProps
 }
 
 export interface CardStyles {
-  textContainerStyle?: CSSProp;
+  headerTitleSectionStyle?: CSSProp;
   actionContainerStyle?: CSSProp;
   containerStyle?: CSSProp;
   contentStyle?: CSSProp;
@@ -178,7 +180,7 @@ function Card({
             `,
             textContainerStyle: css`
               gap: 2px;
-              ${styles?.textContainerStyle}
+              ${styles?.headerTitleSectionStyle}
             `,
           }}
           rightSection={renderHeaderActions}

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -143,6 +143,7 @@ function Card({
 
   return (
     <CardContainer
+      aria-label="card-container"
       {...props}
       $shadow={shadow}
       $radius={radius}

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -2408,7 +2408,7 @@ export const WithRowAppendix: Story = {
             containerStyle: css`
               background-color: transparent;
             `,
-            textContainerStyle: css`
+            headerTitleSectionStyle: css`
               width: 100%;
             `,
             titleStyle: css`

--- a/test/component/card.cy.tsx
+++ b/test/component/card.cy.tsx
@@ -170,7 +170,7 @@ describe("Card", () => {
               titleStyle: css`
                 width: 100%;
               `,
-              textContainerStyle: css`
+              headerTitleSectionStyle: css`
                 width: 100%;
               `,
               containerStyle: css`
@@ -212,7 +212,7 @@ describe("Card", () => {
               titleStyle: css`
                 width: 100%;
               `,
-              textContainerStyle: css`
+              headerTitleSectionStyle: css`
                 width: 100%;
               `,
               containerStyle: css`

--- a/test/component/card.cy.tsx
+++ b/test/component/card.cy.tsx
@@ -22,7 +22,6 @@ describe("Card", () => {
             },
           },
         ]}
-        aria-label="card"
         onMouseEnter={() => console.log("now is hovering card")}
         onMouseLeave={() => console.log("now is leaving card")}
         onClick={() => console.log("now is clicking card")}
@@ -35,6 +34,192 @@ describe("Card", () => {
       </Card>
     );
   }
+
+  context("styles", () => {
+    context("containerStyle", () => {
+      context("when given width 700px", () => {
+        it("renders card container with width 700px", () => {
+          cy.mount(
+            <ProductCard
+              styles={{
+                containerStyle: css`
+                  width: 700px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("card-container").should(
+            "have.css",
+            "width",
+            "700px"
+          );
+        });
+      });
+    });
+
+    context("headerStyle", () => {
+      context("when given gap 20px", () => {
+        it("renders the header container with gap 20px", () => {
+          cy.mount(
+            <ProductCard
+              title="Product Title"
+              toggleable
+              styles={{
+                headerStyle: css`
+                  gap: 20px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("title-container").should(
+            "have.css",
+            "gap",
+            "20px"
+          );
+        });
+      });
+    });
+
+    context("headerTitleSectionStyle", () => {
+      context("when given gap 12px", () => {
+        it("renders the title text container with gap 12px", () => {
+          cy.mount(
+            <ProductCard
+              styles={{
+                headerTitleSectionStyle: css`
+                  gap: 12px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("title-text-container").should(
+            "have.css",
+            "gap",
+            "12px"
+          );
+        });
+      });
+    });
+
+    context("actionContainerStyle", () => {
+      context("when given padding 10px", () => {
+        it("renders the right section with padding 10px", () => {
+          cy.mount(
+            <ProductCard
+              styles={{
+                actionContainerStyle: css`
+                  padding: 10px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("title-right-section").should(
+            "have.css",
+            "padding",
+            "10px"
+          );
+        });
+      });
+    });
+
+    context("contentStyle", () => {
+      context("when given background red", () => {
+        it("renders content with custom background", () => {
+          cy.mount(
+            <ProductCard
+              title="Product Title"
+              styles={{
+                contentStyle: css`
+                  background: red;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("card-content").should(
+            "have.css",
+            "background-color",
+            "rgb(255, 0, 0)"
+          );
+        });
+      });
+    });
+
+    context("footerStyle", () => {
+      context("when given justify-content center", () => {
+        it("renders footer with centered content", () => {
+          cy.mount(
+            <ProductCard
+              title="Product Title"
+              footerContent="Footer"
+              styles={{
+                footerStyle: css`
+                  justify-content: center;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("card-footer").should(
+            "have.css",
+            "justify-content",
+            "center"
+          );
+        });
+      });
+    });
+
+    context("titleStyle", () => {
+      context("when given font-size 30px", () => {
+        it("renders title with font-size 30px", () => {
+          cy.mount(
+            <ProductCard
+              title="Product Title"
+              styles={{
+                titleStyle: css`
+                  font-size: 30px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("title-title").should(
+            "have.css",
+            "font-size",
+            "30px"
+          );
+        });
+      });
+    });
+
+    context("subtitleStyle", () => {
+      context("when given opacity 0.5", () => {
+        it("renders subtitle with opacity 0.5", () => {
+          cy.mount(
+            <ProductCard
+              title="Product Title"
+              subtitle="Subtitle"
+              styles={{
+                subtitleStyle: css`
+                  opacity: 0.5;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("title-subtitle").should(
+            "have.css",
+            "opacity",
+            "0.5"
+          );
+        });
+      });
+    });
+  });
 
   context("toggleable", () => {
     context("when given", () => {
@@ -84,7 +269,7 @@ describe("Card", () => {
         });
 
         cy.mount(<ProductCard />);
-        cy.findByLabelText("card").trigger("mouseover");
+        cy.findByLabelText("card-container").trigger("mouseover");
 
         cy.get("@consoleLog").should(
           "have.been.calledWith",
@@ -102,7 +287,9 @@ describe("Card", () => {
         });
 
         cy.mount(<ProductCard />);
-        cy.findByLabelText("card").trigger("mouseover").trigger("mouseout");
+        cy.findByLabelText("card-container")
+          .trigger("mouseover")
+          .trigger("mouseout");
 
         cy.get("@consoleLog").should(
           "have.been.calledWith",
@@ -124,7 +311,7 @@ describe("Card", () => {
         });
 
         cy.mount(<ProductCard />);
-        cy.findByLabelText("card").click();
+        cy.findByLabelText("card-container").click();
 
         cy.get("@consoleLog").should(
           "have.been.calledWith",
@@ -164,7 +351,7 @@ describe("Card", () => {
     context("with title", () => {
       it("can be given ReactNode to render", () => {
         cy.mount(
-          <Card
+          <ProductCard
             title={renderDormantTextField("title")}
             styles={{
               titleStyle: css`
@@ -185,9 +372,7 @@ describe("Card", () => {
                 border-bottom: 1px solid #d1d5db;
               `,
             }}
-          >
-            test
-          </Card>
+          />
         );
 
         cy.get("input[type='text']").should("not.exist");

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -761,7 +761,7 @@ describe("Table", () => {
             containerStyle: css`
               background-color: transparent;
             `,
-            textContainerStyle: css`
+            headerTitleSectionStyle: css`
               width: 100%;
             `,
             titleStyle: css`


### PR DESCRIPTION
Description:
This pull request renames the `Card` title wrapper style from `textContainerStyle` to `headerTitleSectionStyle`, for better naming clarity.

Source:
[[Improvement] SYST-666: Rename `textContainerStyle` on `Card` to `headerContentStyle`
](https://linear.app/systatum/issue/SYST-666/rename-textcontainerstyle-on-card-to-headercontentstyle)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself