### PR TITLE
[Bug] SYST-672: Fix bug cannot set `id` to rich editor

### DIFF
--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -152,10 +152,9 @@ export interface RichEditorToolbarButtonStyles {
   self?: CSSProp;
 }
 
-interface RichEditorComponent
-  extends React.ForwardRefExoticComponent<
-    RichEditorProps & React.RefAttributes<RichEditorRef>
-  > {
+interface RichEditorComponent extends React.ForwardRefExoticComponent<
+  RichEditorProps & React.RefAttributes<RichEditorRef>
+> {
   ToolbarButton: typeof RichEditorToolbarButton;
   codeLanguage: typeof RichEditorCodeLanguage;
   translatedCodeLanguage: typeof TranslatedRichEditorCodeLanguage;
@@ -1750,9 +1749,11 @@ function BaseRichEditor({
   mode,
   value,
   className,
+  id,
 }: BaseRichEditorProps) {
   return (
     <Wrapper
+      id={id}
       $theme={richEditorTheme}
       className={className}
       aria-label="rich-editor-wrapper"

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -32,6 +32,42 @@ describe("RichEditor", () => {
     );
   }
 
+  context("id", () => {
+    context("code-editor mode", () => {
+      beforeEach(() => {
+        cy.mount(
+          <ProductRichEditor
+            mode="code-editor"
+            value=""
+            codeEditor={{
+              id: "test123",
+            }}
+          />
+        );
+      });
+
+      it("renders the id in the parent", () => {
+        cy.get("#test123").should("exist");
+      });
+    });
+
+    context("non code-editor mode", () => {
+      beforeEach(() => {
+        cy.mount(
+          <ProductRichEditor
+            mode="markdown-editor"
+            value=""
+            id="markdown-editor-21"
+          />
+        );
+      });
+
+      it("renders the id in the parent", () => {
+        cy.get("#markdown-editor-21").should("exist");
+      });
+    });
+  });
+
   context("mode", () => {
     context("with code-editor", () => {
       beforeEach(() => {


### PR DESCRIPTION
Description:
This pull request fixes the `id` in the `RichEditor` so it is properly applied to the parent element. It also ensures the `id` correctly forwarded to the underlying element. 

Source:
[[Bug] SYST-672: Fix bug cannot set `id` to rich editor](https://linear.app/systatum/issue/SYST-672/fix-bug-cannot-set-id-to-rich-editor)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself