### PR TITLE
[Improvement] SYST-670: Change tooltip default background color on the body to match the cap

### DIFF
--- a/test/component/tooltip.cy.tsx
+++ b/test/component/tooltip.cy.tsx
@@ -3,6 +3,49 @@ import { Tooltip, TooltipDialogPlacement } from "./../../components/tooltip";
 import { css } from "styled-components";
 
 describe("Tooltip", () => {
+  context("theme", () => {
+    context("light", () => {
+      it("renders tooltip with rgb(185, 186, 188)", () => {
+        cy.clock();
+        cy.mount(
+          <Tooltip dialog={"This is a delay tooltip with 2 second."}>
+            This tooltip
+          </Tooltip>
+        );
+        cy.findByText("This tooltip").realHover();
+        cy.tick(400);
+
+        cy.findByLabelText("tooltip-drawer")
+          .should("exist")
+          .and("have.css", "background-color", "rgb(185, 186, 188)");
+        cy.findByLabelText("tooltip-arrow")
+          .should("exist")
+          .and("have.css", "background-color", "rgb(185, 186, 188)");
+      });
+    });
+
+    context("dark", () => {
+      it("renders tooltip with rgb(62, 65, 67)", () => {
+        cy.clock();
+        cy.mount(
+          <Tooltip dialog={"This is a delay tooltip with 2 second."}>
+            This tooltip
+          </Tooltip>,
+          { mode: "dark" }
+        );
+        cy.findByText("This tooltip").realHover();
+        cy.tick(400);
+
+        cy.findByLabelText("tooltip-drawer")
+          .should("exist")
+          .and("have.css", "background-color", "rgb(62, 65, 67)");
+        cy.findByLabelText("tooltip-arrow")
+          .should("exist")
+          .and("have.css", "background-color", "rgb(62, 65, 67)");
+      });
+    });
+  });
+
   context("dialogPlacement", () => {
     const ALL_PLACEMENTS: TooltipDialogPlacement[] = [
       "top-left",

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1718,9 +1718,9 @@ export function createTooltipTheme(
   customTheme: Partial<TooltipThemeConfig> = {}
 ): TooltipThemeConfig {
   const defaultTheme: TooltipThemeConfig = {
-    literalStringBackgroundColor: "#e7e7e7",
+    literalStringBackgroundColor: "#b9babc",
     literalStringTextColor: "#111827",
-    nodeElementBackgroundColor: "#e7e7e7",
+    nodeElementBackgroundColor: "#b9babc",
     nodeElementTextColor: "#111827",
     boxShadow: "0 1px 2px rgba(0,0,0,0.1)",
     arrowBackgroundColor: "#b9babc",

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -752,8 +752,8 @@ const darkToolbar = createToolbarTheme({
 
 const darkTooltip = createTooltipTheme({
   arrowBackgroundColor: "#3e4143",
-  literalStringBackgroundColor: "#292c2e",
-  nodeElementBackgroundColor: "#292c2e",
+  literalStringBackgroundColor: "#3e4143",
+  nodeElementBackgroundColor: "#3e4143",
   literalStringTextColor: darkBody?.textColor,
   nodeElementTextColor: darkBody?.textColor,
 });


### PR DESCRIPTION
Description:
This pull request improves the `Tooltip` component to ensure consistent colors between the `arrow` and `background` in both `light` and `dark` modes by using the cap (arrow) color as the reference.

It also adds component tests to verify the color consistency behavior.

Source:
[[Improvement] SYST-670: Change tooltip default background color on the body to match the cap](https://linear.app/systatum/issue/SYST-670/change-tooltip-default-background-color-on-the-body-to-match-the-cap)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself