### PR TITLE
[Improvement] SYST-688: Add `mobile` on `combobox`

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,7 +1,10 @@
 <head>
   <meta charset="UTF-8" />
   <title>Systatum Coneto React UI Library</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1, maximum-scale=1"
+  />
   <meta
     name="description"
     content="Deliver apps in half the time with Coneto — a complete React UI library by Systatum, built for speed and modern design."

--- a/components/combobox.stories.tsx
+++ b/components/combobox.stories.tsx
@@ -181,6 +181,50 @@ export const Default: Story = {
   },
 };
 
+export const Mobile: Story = {
+  parameters: {
+    layout: "padded",
+  },
+  render: () => {
+    const [value, setValue] = useState<SelectboxSelectedOptions>([]);
+
+    const FRUIT_OPTIONS: ComboboxOption[] = [
+      { text: "Apple", value: "1" },
+      { text: "Banana", value: "2" },
+      { text: "Orange", value: "3" },
+      { text: "Grape", value: "4" },
+      { text: "Pineapple", value: "5" },
+      { text: "Strawberry", value: "6" },
+      { text: "Watermelon", value: "7" },
+      { text: "Mango", value: "8" },
+      { text: "Blueberry", value: "9" },
+      { text: "Cherry", value: "10" },
+      { text: "Kiwi", value: "11" },
+      { text: "Papaya", value: "12" },
+      { text: "Peach", value: "13" },
+      { text: "Pear", value: "14" },
+      { text: "Lemon", value: "15" },
+      { text: "Coconut", value: "16" },
+    ];
+    return (
+      <div
+        style={{
+          width: "256px",
+        }}
+      >
+        <Combobox
+          label="Mobile Combobox"
+          selectedOptions={value}
+          options={FRUIT_OPTIONS}
+          onChange={setValue}
+          placeholder="Select a fruit..."
+          mobile
+        />
+      </div>
+    );
+  },
+};
+
 export const WithLoading: Story = {
   render: () => {
     const [value, setValue] = useState<SelectboxSelectedOptions>("");

--- a/components/combobox.stories.tsx
+++ b/components/combobox.stories.tsx
@@ -217,6 +217,7 @@ export const Mobile: Story = {
           selectedOptions={value}
           options={FRUIT_OPTIONS}
           onChange={setValue}
+          clearable
           placeholder="Select a fruit..."
           mobile
         />

--- a/components/combobox.stories.tsx
+++ b/components/combobox.stories.tsx
@@ -186,7 +186,9 @@ export const Mobile: Story = {
     layout: "padded",
   },
   render: () => {
-    const [value, setValue] = useState<SelectboxSelectedOptions>([]);
+    const [value1, setValue1] = useState<SelectboxSelectedOptions>([]);
+    const [value2, setValue2] = useState<SelectboxSelectedOptions>([]);
+    const [value3, setValue3] = useState<SelectboxSelectedOptions>([]);
 
     const FRUIT_OPTIONS: ComboboxOption[] = [
       { text: "Apple", value: "1" },
@@ -206,19 +208,154 @@ export const Mobile: Story = {
       { text: "Lemon", value: "15" },
       { text: "Coconut", value: "16" },
     ];
+
+    const CATEGORIZED_FRUIT_OPTIONS: ComboboxOption[] = [
+      {
+        text: "Watery",
+        value: "group-watery",
+        groupOptions: [
+          {
+            text: "Sweet",
+            value: "group-watery-sweet",
+            groupOptions: [
+              {
+                text: "Light",
+                value: "light",
+                groupOptions: [
+                  { text: "Watermelon", value: "item-watermelon" },
+                  { text: "Pear", value: "item-pear" },
+                ],
+              },
+              {
+                text: "Bold",
+                value: "bold",
+                groupOptions: [{ text: "Grape", value: "item-grape" }],
+              },
+            ],
+            groupSetting: { collapsible: true },
+          },
+          {
+            text: "Balanced",
+            value: "group-watery-balanced",
+            groupOptions: [
+              { text: "Apple", value: "item-apple" },
+              { text: "Papaya", value: "item-papaya" },
+            ],
+            groupSetting: { collapsible: true },
+          },
+        ],
+        groupSetting: { collapsible: true },
+      },
+      {
+        text: "Tangy",
+        value: "group-tangy",
+        groupOptions: [
+          {
+            text: "Sweet",
+            value: "group-tangy-sweet",
+            groupOptions: [
+              { text: "Orange", value: "item-orange" },
+              { text: "Pineapple", value: "item-pineapple" },
+              { text: "Lychee", value: "item-lychee" },
+            ],
+            groupSetting: { collapsible: true },
+          },
+          {
+            text: "Balanced",
+            value: "group-tangy-balanced",
+            groupOptions: [
+              { text: "Kiwi", value: "item-kiwi" },
+              { text: "Pomegranate", value: "item-pomegranate" },
+              { text: "Cherry", value: "item-cherry" },
+            ],
+            groupSetting: { collapsible: true },
+          },
+        ],
+        groupSetting: { collapsible: true },
+      },
+      {
+        text: "Creamy",
+        value: "group-creamy",
+        groupOptions: [
+          {
+            text: "Sweet",
+            value: "group-creamy-sweet",
+            groupOptions: [
+              { text: "Banana", value: "item-banana" },
+              { text: "Mango", value: "item-mango" },
+              { text: "Peach", value: "item-peach" },
+            ],
+            groupSetting: { collapsible: true },
+          },
+          {
+            text: "Balanced",
+            value: "group-creamy-balanced",
+            groupOptions: [{ text: "Plum", value: "item-plum" }],
+            groupSetting: { collapsible: true },
+          },
+          { text: "Coconut", value: "item-coconut" },
+        ],
+        groupSetting: { collapsible: true },
+      },
+      {
+        text: "Berry",
+        value: "group-berry",
+        groupOptions: [
+          {
+            text: "Balanced",
+            value: "group-berry-balanced",
+            groupOptions: [
+              { text: "Strawberry", value: "item-strawberry" },
+              { text: "Blueberry", value: "item-blueberry" },
+              { text: "Raspberry", value: "item-raspberry" },
+            ],
+            groupSetting: { collapsible: true },
+          },
+        ],
+        groupSetting: { collapsible: true },
+      },
+      { text: "Peppers", value: "item-peppers" },
+      { text: "Eggplants", value: "item-eggplants", hidden: true },
+    ];
+
     return (
       <div
         style={{
           width: "256px",
+          gap: "8px",
+          display: "flex",
+          flexDirection: "column",
         }}
       >
         <Combobox
-          label="Mobile Combobox"
-          selectedOptions={value}
+          id="mobile-combobox"
+          label="Mobile combobox"
+          selectedOptions={value1}
           options={FRUIT_OPTIONS}
-          onChange={setValue}
+          onChange={setValue1}
           clearable
           placeholder="Select a fruit..."
+          mobile
+        />
+        <Combobox
+          id="selectable-combobox"
+          label="Selectable combobox"
+          selectedOptions={value2}
+          options={FRUIT_OPTIONS}
+          onChange={setValue2}
+          clearable
+          placeholder="Select a fruit..."
+          multiple
+          mobile
+        />
+        <Combobox
+          id="selectable-combobox"
+          label="With grouped options"
+          selectedOptions={value3}
+          options={CATEGORIZED_FRUIT_OPTIONS}
+          onChange={setValue3}
+          placeholder="Select a fruit..."
+          clearable
           mobile
         />
       </div>

--- a/components/combobox.stories.tsx
+++ b/components/combobox.stories.tsx
@@ -365,7 +365,7 @@ export const Mobile: Story = {
           mobile
         />
         <Combobox
-          id="selectable-combobox"
+          id="grouped-combobox"
           label="With grouped options"
           selectedOptions={value3}
           options={CATEGORIZED_FRUIT_OPTIONS}

--- a/components/combobox.stories.tsx
+++ b/components/combobox.stories.tsx
@@ -60,6 +60,7 @@ Combobox makes use of the base Selectbox, featuring searchability, options-group
 ### 📌 Usage Guidelines
 - Use **grouped options** for large datasets
 - Enable \`multiple\` for multi-select use cases
+- Use \`mobile\` for touch-optimized experiences
 - Use \`maxSelectableItems\` to limit selections
         `,
       },
@@ -70,6 +71,21 @@ Combobox makes use of the base Selectbox, featuring searchability, options-group
     selectedOptions: {
       control: "text",
       description: "Currently selected value of the combobox. Example: [5, 6]",
+    },
+    mobile: {
+      control: "boolean",
+      description: `
+Enable mobile drawer mode.
+
+When enabled:
+- Dropdown becomes a bottom drawer
+- Touch targets become larger
+- Mobile spacing & typography are applied
+- Nested items receive mobile indentation
+- Fade overlays appear while scrolling
+
+Recommended for touch-based devices and responsive layouts.
+      `,
     },
     onChange: {
       control: false,

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -1018,7 +1018,11 @@ function ComboboxDrawer({
 
   if (mobile) {
     return (
-      <DrawerContainer aria-label="combobox-drawer-mobile">
+      <DrawerContainer
+        aria-label="combobox-drawer-mobile"
+        $theme={comboboxTheme}
+        $mobile={mobile}
+      >
         <FadeTop
           aria-label="combobox-fade-top"
           $theme={comboboxTheme}
@@ -1037,7 +1041,10 @@ function ComboboxDrawer({
   return mainCombobox;
 }
 
-const DrawerContainer = styled.div`
+const DrawerContainer = styled.div<{
+  $theme?: ComboboxThemeConfig;
+  $mobile?: boolean;
+}>`
   overflow: hidden;
   position: fixed;
   bottom: 10px;
@@ -1048,6 +1055,8 @@ const DrawerContainer = styled.div`
   min-height: 15rem;
   max-height: 15rem;
   border-radius: 14px;
+  background-color: ${({ $mobile, $theme }) =>
+    $mobile ? $theme.mobileBackgroundColor : $theme.backgroundColor};
 `;
 
 const DrawerWrapper = styled.ul<{
@@ -1085,7 +1094,7 @@ const DrawerWrapper = styled.ul<{
     border-radius: 4px;
   }
 
-  ${({ $mobile }) =>
+  ${({ $mobile, $theme }) =>
     $mobile &&
     css`
       width: 100%;
@@ -1094,6 +1103,11 @@ const DrawerWrapper = styled.ul<{
       min-height: 15rem;
       max-height: 15rem;
       border-width: 0.5;
+      padding: 90px 0px;
+
+      background-color: ${$mobile
+        ? $theme.mobileBackgroundColor
+        : $theme.backgroundColor};
     `}
 
   ${({ $style }) => $style}
@@ -1111,14 +1125,16 @@ const rowStyle = ({
   mobile?: boolean;
 }) => css`
   transition: background-color 0ms;
-  background-color: ${theme.backgroundColor};
+  background-color: ${mobile
+    ? theme.mobileBackgroundColor
+    : theme.backgroundColor};
   color: ${theme.textColor};
   min-height: 36px;
 
   ${mobile &&
   css`
     padding: 15px 15px;
-    font-size: 14px;
+    font-size: 21px;
     &[data-first="true"] {
       padding-top: 20px;
     }

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -1053,7 +1053,9 @@ const DrawerWrapper = styled.ul<{
   max-height: 15rem;
   overflow-y: auto;
   border-radius: 4px;
-  border: 1px solid ${({ $theme }) => $theme?.borderColor};
+  border: 1px solid
+    ${({ $theme, $mobile }) =>
+      $mobile ? $theme?.fadeColor : $theme?.borderColor};
   background-color: ${({ $theme }) => $theme?.backgroundColor};
   box-shadow: ${({ $theme }) => $theme?.boxShadow};
   width: ${({ $width }) => ($width ? `${$width}px` : "100%")};

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -821,6 +821,9 @@ function ComboboxDrawer({
         onMouseDown: (e: React.MouseEvent) => {
           e.preventDefault();
         },
+        onClick: (e: React.MouseEvent) => {
+          e.stopPropagation(); // handles touch-generated click on mobile
+        },
       })}
       ref={(node) => {
         if (typeof refs.setFloating === "function") {

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -576,21 +576,25 @@ function ComboboxDrawer({
               styles={{
                 containerStyle: css`
                   margin-top: 2px;
-
-                  ${opt?.render &&
-                  css`
-                    margin-top: 3px;
-                  `}
                   ${mobile &&
                   css`
-                    margin-top: 5px;
+                    margin-top: 7px;
                   `}
+
+                  ${mobile && opt?.render
+                    ? css`
+                        margin-top: 10px;
+                      `
+                    : opt?.render &&
+                      css`
+                        margin-top: 7px;
+                      `}
                 `,
                 iconStyle: css`
                   ${mobile
                     ? css`
-                        width: 14px;
-                        height: 14px;
+                        width: 12px;
+                        height: 12px;
                       `
                     : css`
                         width: 8px;
@@ -600,8 +604,8 @@ function ComboboxDrawer({
                 self: css`
                   ${mobile
                     ? css`
-                        width: 22px;
-                        height: 22px;
+                        width: 20px;
+                        height: 20px;
                       `
                     : css`
                         width: 14px;
@@ -930,7 +934,7 @@ function ComboboxDrawer({
                 return next;
               });
             }}
-            arrowSize={mobile ? 20 : 14}
+            arrowSize={mobile ? 18 : 14}
             maxActionsBeforeCollapsing={1}
             actions={filteredActions}
             styles={{
@@ -1111,8 +1115,8 @@ const DrawerContainer = styled.div<{
   transform: translateX(-50%);
   width: 96dvw;
   z-index: 9992999;
-  min-height: 18rem;
-  max-height: 18rem;
+  min-height: 220px;
+  max-height: 220px;
   border-radius: 14px;
   background-color: ${({ $mobile, $theme }) =>
     $mobile ? $theme.mobileBackgroundColor : $theme.backgroundColor};
@@ -1128,7 +1132,7 @@ const DrawerWrapper = styled.ul<{
 }>`
   position: relative;
   z-index: 9992999;
-  max-height: 18rem;
+  max-height: 220px;
   overflow-y: auto;
   border-radius: 4px;
   border: 1px solid
@@ -1161,13 +1165,13 @@ const DrawerWrapper = styled.ul<{
       width: 100%;
       z-index: 9992999;
       border-radius: 14px;
-      min-height: 18rem;
-      max-height: 18rem;
+      min-height: 220px;
+      max-height: 220px;
       border-width: 0.5;
       ${!$multiple &&
       !$hasNestedOptions &&
       css`
-        padding: 110px 0px;
+        padding: 100px 0px;
       `}
 
       background-color: ${$mobile
@@ -1202,11 +1206,11 @@ const rowStyle = ({
 
   ${mobile &&
   css`
-    padding: 15px 15px;
-    font-size: 21px;
+    padding: 6px 15px;
+    font-size: 22px;
     ${hasNestedOptions &&
     css`
-      padding-left: ${(level ?? 0) * 20 + 30}px;
+      padding-left: ${(level ?? 0) * 14 + 30}px;
     `}
   `}
 

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -403,6 +403,8 @@ function ComboboxDrawer({
 
   const floatingRef = useRef<HTMLUListElement>(null);
 
+  const hasNestedOptions = options.some((opt) => opt.groupOptions?.length);
+
   const finalOptions = useMemo<SelectboxOption[]>(() => {
     return (
       options?.flatMap((item) => {
@@ -521,6 +523,8 @@ function ComboboxDrawer({
                   interactionMode,
                   multiple,
                   theme: comboboxTheme,
+                  mobile,
+                  hasNestedOptions,
                 })}
                 ${action?.styles?.self}
               `,
@@ -821,6 +825,7 @@ function ComboboxDrawer({
         }
         floatingRef.current = node;
       }}
+      $hasNestedOptions={hasNestedOptions}
       style={mobile ? {} : { ...floatingStyles }}
       $theme={comboboxTheme}
       id="combo-list"
@@ -925,7 +930,7 @@ function ComboboxDrawer({
                 return next;
               });
             }}
-            arrowSize={14}
+            arrowSize={mobile ? 20 : 14}
             maxActionsBeforeCollapsing={1}
             actions={filteredActions}
             styles={{
@@ -971,7 +976,9 @@ function ComboboxDrawer({
                   display: flex;
                   align-items: center;
                   justify-content: space-between;
-                  background-color: ${comboboxTheme?.groupBackgroundColor};
+                  background-color: ${mobile
+                    ? comboboxTheme?.mobileGroupBackgroundColor
+                    : comboboxTheme?.groupBackgroundColor};
                   border: 1px solid transparent;
 
                   &[aria-expanded="true"] {
@@ -984,6 +991,7 @@ function ComboboxDrawer({
                   multiple,
                   theme: comboboxTheme,
                   mobile,
+                  hasNestedOptions,
                 })}
 
                 gap: 20px;
@@ -1050,6 +1058,8 @@ function ComboboxDrawer({
                   interactionMode,
                   multiple,
                   theme: comboboxTheme,
+                  mobile,
+                  hasNestedOptions,
                 })}
                 gap: 6px;
               `,
@@ -1100,8 +1110,8 @@ const DrawerContainer = styled.div<{
   transform: translateX(-50%);
   width: 96dvw;
   z-index: 9992999;
-  min-height: 15rem;
-  max-height: 15rem;
+  min-height: 18rem;
+  max-height: 18rem;
   border-radius: 14px;
   background-color: ${({ $mobile, $theme }) =>
     $mobile ? $theme.mobileBackgroundColor : $theme.backgroundColor};
@@ -1113,10 +1123,11 @@ const DrawerWrapper = styled.ul<{
   $style?: CSSProp;
   $mobile?: boolean;
   $multiple?: boolean;
+  $hasNestedOptions?: boolean;
 }>`
   position: relative;
   z-index: 9992999;
-  max-height: 15rem;
+  max-height: 18rem;
   overflow-y: auto;
   border-radius: 4px;
   border: 1px solid
@@ -1143,18 +1154,19 @@ const DrawerWrapper = styled.ul<{
     border-radius: 4px;
   }
 
-  ${({ $mobile, $theme, $multiple }) =>
+  ${({ $mobile, $theme, $multiple, $hasNestedOptions }) =>
     $mobile &&
     css`
       width: 100%;
       z-index: 9992999;
       border-radius: 14px;
-      min-height: 15rem;
-      max-height: 15rem;
+      min-height: 18rem;
+      max-height: 18rem;
       border-width: 0.5;
       ${!$multiple &&
+      !$hasNestedOptions &&
       css`
-        padding: 90px 0px;
+        padding: 110px 0px;
       `}
 
       background-color: ${$mobile
@@ -1170,11 +1182,13 @@ const rowStyle = ({
   multiple,
   theme,
   mobile,
+  hasNestedOptions,
 }: {
   interactionMode?: "mouse" | "keyboard";
   multiple?: boolean;
   theme?: ComboboxThemeConfig;
   mobile?: boolean;
+  hasNestedOptions?: boolean;
 }) => css`
   transition: background-color 0ms;
   background-color: ${mobile
@@ -1187,6 +1201,11 @@ const rowStyle = ({
   css`
     padding: 15px 15px;
     font-size: 21px;
+
+    ${hasNestedOptions &&
+    css`
+      padding-left: calc((attr(data-level number) * 20px) + 30px);
+    `}
   `}
 
   &[data-has-options="false"] {

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -898,6 +898,7 @@ function ComboboxDrawer({
                   interactionMode,
                   multiple,
                   theme: comboboxTheme,
+                  mobile,
                 })}
               `,
 
@@ -971,13 +972,9 @@ function ComboboxDrawer({
 
   if (mobile) {
     return (
-      <DrawerContainer $mobile={mobile}>
-        {mobile && (
-          <>
-            <FadeTop $theme={comboboxTheme} />
-            <FadeBottom $theme={comboboxTheme} />
-          </>
-        )}
+      <DrawerContainer>
+        <FadeTop $theme={comboboxTheme} />
+        <FadeBottom $theme={comboboxTheme} />
         {mainCombobox}
       </DrawerContainer>
     );
@@ -986,23 +983,17 @@ function ComboboxDrawer({
   return mainCombobox;
 }
 
-const DrawerContainer = styled.div<{ $mobile?: boolean }>`
-  position: absolute;
+const DrawerContainer = styled.div`
   overflow: hidden;
-
-  ${({ $mobile }) =>
-    $mobile &&
-    css`
-      position: fixed;
-      bottom: 10px;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 96dvw;
-      z-index: 9992999;
-      min-height: 15rem;
-      max-height: 15rem;
-      border-radius: 14px;
-    `}
+  position: fixed;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 96dvw;
+  z-index: 9992999;
+  min-height: 15rem;
+  max-height: 15rem;
+  border-radius: 14px;
 `;
 
 const DrawerWrapper = styled.ul<{
@@ -1055,15 +1046,29 @@ const rowStyle = ({
   interactionMode,
   multiple,
   theme,
+  mobile,
 }: {
   interactionMode?: "mouse" | "keyboard";
   multiple?: boolean;
   theme?: ComboboxThemeConfig;
+  mobile?: boolean;
 }) => css`
   transition: background-color 0ms;
   background-color: ${theme.backgroundColor};
   color: ${theme.textColor};
   min-height: 36px;
+
+  ${mobile &&
+  css`
+    padding: 15px 15px;
+    font-size: 14px;
+    &[data-first="true"] {
+      padding-top: 20px;
+    }
+    &[data-last="true"] {
+      padding-bottom: 20px;
+    }
+  `}
 
   &[data-has-options="false"] {
     ${interactionMode !== "mouse" &&
@@ -1110,7 +1115,7 @@ const FadeTop = styled.div<{ $style?: CSSProp; $theme: ComboboxThemeConfig }>`
   left: 0;
   right: 0;
   top: 0;
-  height: 32px;
+  height: 28px;
   background: linear-gradient(
     to bottom,
     ${({ $theme }) => $theme.fadeColor} 10%,
@@ -1130,7 +1135,7 @@ const FadeBottom = styled.div<{
   left: 0;
   right: 0;
   bottom: 0;
-  height: 32px;
+  height: 28px;
 
   background: linear-gradient(
     to top,

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -403,7 +403,7 @@ function ComboboxDrawer({
 
   const floatingRef = useRef<HTMLUListElement>(null);
 
-  const hasNestedOptions = options.some((opt) => opt.groupOptions?.length);
+  const hasNestedOptions = options?.some((opt) => opt.groupOptions?.length);
 
   const finalOptions = useMemo<SelectboxOption[]>(() => {
     return (
@@ -835,7 +835,7 @@ function ComboboxDrawer({
       style={mobile ? {} : { ...floatingStyles }}
       $theme={comboboxTheme}
       id="combo-list"
-      aria-label={`combobox-drawer`}
+      aria-label="combobox-drawer"
       role="listbox"
       $width={refs.reference.current?.getBoundingClientRect().width}
       $mobile={mobile}
@@ -1175,9 +1175,11 @@ const DrawerWrapper = styled.ul<{
         padding: 100px 0px;
       `}
 
-      background-color: ${$mobile
-        ? $theme.mobileBackgroundColor
-        : $theme.backgroundColor};
+      background-color: ${$mobile && $hasNestedOptions
+        ? $theme.mobileGroupBackgroundColor
+        : $mobile
+          ? $theme.mobileBackgroundColor
+          : $theme.backgroundColor};
     `}
 
   ${({ $style }) => $style}

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -576,14 +576,32 @@ function ComboboxDrawer({
                   css`
                     margin-top: 3px;
                   `}
+                  ${mobile &&
+                  css`
+                    margin-top: 5px;
+                  `}
                 `,
                 iconStyle: css`
-                  width: 8px;
-                  height: 8px;
+                  ${mobile
+                    ? css`
+                        width: 14px;
+                        height: 14px;
+                      `
+                    : css`
+                        width: 8px;
+                        height: 8px;
+                      `}
                 `,
                 self: css`
-                  width: 14px;
-                  height: 14px;
+                  ${mobile
+                    ? css`
+                        width: 22px;
+                        height: 22px;
+                      `
+                    : css`
+                        width: 14px;
+                        height: 14px;
+                      `}
                 `,
               }}
               type="checkbox"
@@ -811,6 +829,7 @@ function ComboboxDrawer({
       $width={refs.reference.current?.getBoundingClientRect().width}
       $mobile={mobile}
       $style={styles?.drawerStyle}
+      $multiple={multiple}
     >
       {(finalOptions || actions) && (
         <>
@@ -831,10 +850,22 @@ function ComboboxDrawer({
               styles={{
                 containerStyle: css`
                   position: sticky;
-                  top: 0;
-                  background-color: ${comboboxTheme?.backgroundColor};
+                  background-color: ${mobile
+                    ? comboboxTheme?.mobileBackgroundColor
+                    : comboboxTheme?.backgroundColor};
                   z-index: 10000;
                   height: 38px;
+                  top: 0;
+                  ${mobile &&
+                  !multiple &&
+                  css`
+                    transform: translateY(-90px);
+                  `};
+                  ${mobile &&
+                  css`
+                    max-height: 46px;
+                    height: 46px;
+                  `}
                 `,
                 iconStyle: css`
                   left: 16px;
@@ -847,6 +878,14 @@ function ComboboxDrawer({
                   padding-top: 7px;
                   margin-left: 4px;
                   margin-right: 4px;
+                  background-color: ${mobile
+                    ? comboboxTheme?.mobileBackgroundColor
+                    : comboboxTheme?.backgroundColor};
+                  &:focus {
+                    background-color: ${mobile
+                      ? comboboxTheme?.mobileBackgroundColor
+                      : comboboxTheme?.backgroundColor};
+                  }
                 `,
               }}
             />
@@ -946,8 +985,9 @@ function ComboboxDrawer({
                   theme: comboboxTheme,
                   mobile,
                 })}
-              `,
 
+                gap: 20px;
+              `,
               hierarchyLineStyle: css`
                 border-left-width: 2px;
 
@@ -974,7 +1014,13 @@ function ComboboxDrawer({
                 padding: 0px;
                 display: flex;
                 flex-direction: row;
-                gap: 6px;
+                ${mobile
+                  ? css`
+                      gap: 14px;
+                    `
+                  : css`
+                      gap: 6px;
+                    `}
 
                 &[data-has-options="false"] {
                   font-weight: 400;
@@ -1023,11 +1069,13 @@ function ComboboxDrawer({
         $theme={comboboxTheme}
         $mobile={mobile}
       >
-        <FadeTop
-          aria-label="combobox-fade-top"
-          $theme={comboboxTheme}
-          $visible={showFadeTop}
-        />
+        {!multiple && (
+          <FadeTop
+            aria-label="combobox-fade-top"
+            $theme={comboboxTheme}
+            $visible={showFadeTop}
+          />
+        )}
         <FadeBottom
           aria-label="combobox-fade-bottom"
           $theme={comboboxTheme}
@@ -1064,6 +1112,7 @@ const DrawerWrapper = styled.ul<{
   $theme: ComboboxThemeConfig;
   $style?: CSSProp;
   $mobile?: boolean;
+  $multiple?: boolean;
 }>`
   position: relative;
   z-index: 9992999;
@@ -1094,7 +1143,7 @@ const DrawerWrapper = styled.ul<{
     border-radius: 4px;
   }
 
-  ${({ $mobile, $theme }) =>
+  ${({ $mobile, $theme, $multiple }) =>
     $mobile &&
     css`
       width: 100%;
@@ -1103,7 +1152,10 @@ const DrawerWrapper = styled.ul<{
       min-height: 15rem;
       max-height: 15rem;
       border-width: 0.5;
-      padding: 90px 0px;
+      ${!$multiple &&
+      css`
+        padding: 90px 0px;
+      `}
 
       background-color: ${$mobile
         ? $theme.mobileBackgroundColor
@@ -1135,18 +1187,14 @@ const rowStyle = ({
   css`
     padding: 15px 15px;
     font-size: 21px;
-    &[data-first="true"] {
-      padding-top: 20px;
-    }
-    &[data-last="true"] {
-      padding-bottom: 20px;
-    }
   `}
 
   &[data-has-options="false"] {
     ${interactionMode !== "mouse" &&
     css`
-      background-color: ${theme.backgroundColor};
+      background-color: ${mobile
+        ? theme.mobileBackgroundColor
+        : theme.backgroundColor};
     `}
   }
 
@@ -1192,7 +1240,7 @@ const FadeTop = styled.div<{
   left: 0;
   right: 0;
   top: 0;
-  height: 28px;
+  height: 40px;
   opacity: ${({ $visible }) => ($visible ? 1 : 0)};
   transition: opacity 0.2s ease;
   background: linear-gradient(
@@ -1215,7 +1263,7 @@ const FadeBottom = styled.div<{
   left: 0;
   right: 0;
   bottom: 0;
-  height: 28px;
+  height: 40px;
   opacity: ${({ $visible }) => ($visible ? 1 : 0)};
   transition: opacity 0.2s ease;
   background: linear-gradient(

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -822,6 +822,7 @@ function ComboboxDrawer({
           e.preventDefault();
         },
         onClick: (e: React.MouseEvent) => {
+          e.preventDefault();
           e.stopPropagation(); // handles touch-generated click on mobile
         },
       })}

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -777,7 +777,6 @@ function ComboboxDrawer({
    * The fade hides when the selected item's center point comes within
    * `threshold` pixels of that edge, and reappears once it scrolls past.
    */
-
   useEffect(() => {
     const container = floatingRef.current;
     if (!container || !mobile) return;
@@ -1169,7 +1168,6 @@ const DrawerWrapper = styled.ul<{
       max-height: 220px;
       border-width: 0.5;
       ${!$multiple &&
-      !$hasNestedOptions &&
       css`
         padding: 100px 0px;
       `}

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -525,6 +525,7 @@ function ComboboxDrawer({
                   theme: comboboxTheme,
                   mobile,
                   hasNestedOptions,
+                  level: 0,
                 })}
                 ${action?.styles?.self}
               `,
@@ -647,7 +648,6 @@ function ComboboxDrawer({
             withoutSelection();
           }
         },
-
         ...(opt?.groupOptions?.length > 0
           ? {
               items: opt.groupOptions
@@ -990,8 +990,8 @@ function ComboboxDrawer({
                   interactionMode,
                   multiple,
                   theme: comboboxTheme,
-                  mobile,
                   hasNestedOptions,
+                  mobile,
                 })}
 
                 gap: 20px;
@@ -1053,13 +1053,14 @@ function ComboboxDrawer({
               arrowStyle: css`
                 margin-left: 3px;
               `,
-              itemStyle: css`
+              itemStyle: (level?: number) => css`
                 ${rowStyle({
                   interactionMode,
                   multiple,
                   theme: comboboxTheme,
                   mobile,
                   hasNestedOptions,
+                  level,
                 })}
                 gap: 6px;
               `,
@@ -1183,12 +1184,14 @@ const rowStyle = ({
   theme,
   mobile,
   hasNestedOptions,
+  level,
 }: {
   interactionMode?: "mouse" | "keyboard";
   multiple?: boolean;
   theme?: ComboboxThemeConfig;
   mobile?: boolean;
   hasNestedOptions?: boolean;
+  level?: number;
 }) => css`
   transition: background-color 0ms;
   background-color: ${mobile
@@ -1201,10 +1204,9 @@ const rowStyle = ({
   css`
     padding: 15px 15px;
     font-size: 21px;
-
     ${hasNestedOptions &&
     css`
-      padding-left: calc((attr(data-level number) * 20px) + 30px);
+      padding-left: ${(level ?? 0) * 20 + 30}px;
     `}
   `}
 

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -398,6 +398,8 @@ function ComboboxDrawer({
   const treeListTheme = currentTheme?.treelist;
 
   const [hasScrolled, setHasScrolled] = useState(false);
+  const [showFadeTop, setShowFadeTop] = useState(true);
+  const [showFadeBottom, setShowFadeBottom] = useState(true);
 
   const floatingRef = useRef<HTMLUListElement>(null);
 
@@ -430,8 +432,6 @@ function ComboboxDrawer({
       ) + (actions?.length ?? 0),
     [finalOptions, finalSelectedOptions, actions]
   );
-
-  console.log(selectedIndex);
 
   const handleOnChange = (values: string[]) => {
     if (!onChange) return;
@@ -744,6 +744,52 @@ function ComboboxDrawer({
     }
   };
 
+  /**
+   * Dynamically show/hide the top and bottom fade overlays based on the
+   * selected item's position relative to the scrollable container.
+   *
+   * The fade hides when the selected item's center point comes within
+   * `threshold` pixels of that edge, and reappears once it scrolls past.
+   */
+
+  useEffect(() => {
+    const container = floatingRef.current;
+    if (!container || !mobile) return;
+
+    const updateFade = () => {
+      const selectedEl = listRef.current[selectedIndex];
+
+      if (!selectedEl) {
+        setShowFadeTop(true);
+        setShowFadeBottom(true);
+        return;
+      }
+
+      const containerRect = container.getBoundingClientRect();
+      const itemRect = selectedEl.getBoundingClientRect();
+
+      const itemMidY = itemRect.top + itemRect.height / 2;
+
+      const distanceFromTop = itemMidY - containerRect.top;
+      const distanceFromBottom = containerRect.bottom - itemMidY;
+
+      const threshold = 40;
+
+      const itemNearTop = distanceFromTop >= 0 && distanceFromTop <= threshold;
+      const itemNearBottom =
+        distanceFromBottom >= 0 && distanceFromBottom <= threshold;
+
+      setShowFadeTop(!itemNearTop);
+      setShowFadeBottom(!itemNearBottom);
+      setShowFadeBottom(!itemNearBottom);
+    };
+
+    updateFade();
+    container.addEventListener("scroll", updateFade);
+
+    return () => container.removeEventListener("scroll", updateFade);
+  }, [selectedIndex, finalOptions.length]);
+
   const mainCombobox = (
     <DrawerWrapper
       {...getFloatingProps({
@@ -973,8 +1019,8 @@ function ComboboxDrawer({
   if (mobile) {
     return (
       <DrawerContainer>
-        <FadeTop $theme={comboboxTheme} />
-        <FadeBottom $theme={comboboxTheme} />
+        <FadeTop $theme={comboboxTheme} $visible={showFadeTop} />
+        <FadeBottom $theme={comboboxTheme} $visible={showFadeBottom} />
         {mainCombobox}
       </DrawerContainer>
     );
@@ -1037,6 +1083,7 @@ const DrawerWrapper = styled.ul<{
       border-radius: 14px;
       min-height: 15rem;
       max-height: 15rem;
+      border-width: 0.5;
     `}
 
   ${({ $style }) => $style}
@@ -1109,13 +1156,19 @@ const rowStyle = ({
   }
 `;
 
-const FadeTop = styled.div<{ $style?: CSSProp; $theme: ComboboxThemeConfig }>`
+const FadeTop = styled.div<{
+  $style?: CSSProp;
+  $theme: ComboboxThemeConfig;
+  $visible?: boolean;
+}>`
   pointer-events: none;
   position: absolute;
   left: 0;
   right: 0;
   top: 0;
   height: 28px;
+  opacity: ${({ $visible }) => ($visible ? 1 : 0)};
+  transition: opacity 0.2s ease;
   background: linear-gradient(
     to bottom,
     ${({ $theme }) => $theme.fadeColor} 10%,
@@ -1129,6 +1182,7 @@ const FadeTop = styled.div<{ $style?: CSSProp; $theme: ComboboxThemeConfig }>`
 const FadeBottom = styled.div<{
   $style?: CSSProp;
   $theme: ComboboxThemeConfig;
+  $visible?: boolean;
 }>`
   pointer-events: none;
   position: absolute;
@@ -1136,7 +1190,8 @@ const FadeBottom = styled.div<{
   right: 0;
   bottom: 0;
   height: 28px;
-
+  opacity: ${({ $visible }) => ($visible ? 1 : 0)};
+  transition: opacity 0.2s ease;
   background: linear-gradient(
     to top,
     ${({ $theme }) => $theme.fadeColor} 10%,

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -806,7 +806,7 @@ function ComboboxDrawer({
       style={mobile ? {} : { ...floatingStyles }}
       $theme={comboboxTheme}
       id="combo-list"
-      aria-label={`combobox-drawer-${name}`}
+      aria-label={`combobox-drawer`}
       role="listbox"
       $width={refs.reference.current?.getBoundingClientRect().width}
       $mobile={mobile}
@@ -1018,9 +1018,17 @@ function ComboboxDrawer({
 
   if (mobile) {
     return (
-      <DrawerContainer>
-        <FadeTop $theme={comboboxTheme} $visible={showFadeTop} />
-        <FadeBottom $theme={comboboxTheme} $visible={showFadeBottom} />
+      <DrawerContainer aria-label="combobox-drawer-mobile">
+        <FadeTop
+          aria-label="combobox-fade-top"
+          $theme={comboboxTheme}
+          $visible={showFadeTop}
+        />
+        <FadeBottom
+          aria-label="combobox-fade-bottom"
+          $theme={comboboxTheme}
+          $visible={showFadeBottom}
+        />
         {mainCombobox}
       </DrawerContainer>
     );

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -1069,23 +1069,21 @@ const rowStyle = ({
     ${interactionMode !== "mouse" &&
     css`
       background-color: ${theme.backgroundColor};
-      &:hover {
-        background-color: ${theme.backgroundColor};
-      }
     `}
   }
+
+  ${interactionMode === "mouse" &&
+  css`
+    &:hover {
+      background-color: ${theme.highlightBackgroundColor};
+    }
+  `}
 
   &[data-highlighted="true"] {
     ${interactionMode !== "mouse" &&
     css`
       background-color: ${theme.highlightBackgroundColor};
     `}
-  }
-
-  &[data-has-options="false"] {
-    &:hover {
-      background-color: ${theme.highlightBackgroundColor};
-    }
   }
 
   &[data-action-opened="true"] {

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -114,7 +114,8 @@ type ComboboxDrawerProps = Omit<DrawerProps, "refs"> &
   };
 
 export interface ComboboxProps
-  extends BaseComboboxProps,
+  extends
+    BaseComboboxProps,
     Omit<FieldLaneProps, "styles" | "type" | "children" | "actions"> {}
 
 const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
@@ -976,9 +977,24 @@ const DrawerWrapper = styled.ul<{
   box-shadow: ${({ $theme }) => $theme?.boxShadow};
   width: ${({ $width }) => ($width ? `${$width}px` : "100%")};
 
+  scroll-behavior: smooth;
+  overscroll-behavior: contain;
+
+  scrollbar-width: thin;
+  scrollbar-color: ${({ $theme }) => $theme?.scrollThumbColor || "#52525b"}
+    transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
   &::-webkit-scrollbar-thumb {
-    background-color: ${({ $theme }) => $theme?.scrollThumbColor || "#3f3f46"};
-    border-radius: 999px;
+    background-color: #d1d5db;
+    border-radius: 4px;
   }
 
   ${({ $style }) => $style}

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -55,6 +55,7 @@ interface BaseComboboxProps {
   navigableOptions?: SelectboxOption[];
   isLoading?: boolean;
   labels?: ComboboxLabelsProps;
+  mobile?: boolean;
 }
 
 export const ComboboxGroupInitialState = {
@@ -151,6 +152,7 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       isLoading,
       labels,
       className,
+      mobile,
     },
     ref
   ) => {
@@ -224,6 +226,7 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         ref={ref}
         className={applyClassName("combobox", className)}
         isLoading={isLoading}
+        mobile={mobile}
         helper={helper}
         errorIconPosition={errorIconPosition}
         dropdowns={dropdowns}
@@ -334,6 +337,7 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
             <ComboboxDrawer
               {...props}
               styles={styles}
+              mobile={mobile}
               navigableOptions={filteredNavigableOptions}
               inputRef={props.ref}
               name={name}
@@ -387,6 +391,7 @@ function ComboboxDrawer({
   setOpenedCategoryGroup,
   styles,
   navigableOptions,
+  mobile,
 }: ComboboxDrawerProps) {
   const { mode, currentTheme } = useTheme();
   const comboboxTheme = currentTheme?.combobox;
@@ -425,6 +430,8 @@ function ComboboxDrawer({
       ) + (actions?.length ?? 0),
     [finalOptions, finalSelectedOptions, actions]
   );
+
+  console.log(selectedIndex);
 
   const handleOnChange = (values: string[]) => {
     if (!onChange) return;
@@ -737,7 +744,7 @@ function ComboboxDrawer({
     }
   };
 
-  return (
+  const mainCombobox = (
     <DrawerWrapper
       {...getFloatingProps({
         onMouseDown: (e: React.MouseEvent) => {
@@ -750,12 +757,13 @@ function ComboboxDrawer({
         }
         floatingRef.current = node;
       }}
+      style={mobile ? {} : { ...floatingStyles }}
       $theme={comboboxTheme}
       id="combo-list"
       aria-label={`combobox-drawer-${name}`}
       role="listbox"
       $width={refs.reference.current?.getBoundingClientRect().width}
-      style={{ ...floatingStyles }}
+      $mobile={mobile}
       $style={styles?.drawerStyle}
     >
       {(finalOptions || actions) && (
@@ -960,14 +968,50 @@ function ComboboxDrawer({
       )}
     </DrawerWrapper>
   );
+
+  if (mobile) {
+    return (
+      <DrawerContainer $mobile={mobile}>
+        {mobile && (
+          <>
+            <FadeTop $theme={comboboxTheme} />
+            <FadeBottom $theme={comboboxTheme} />
+          </>
+        )}
+        {mainCombobox}
+      </DrawerContainer>
+    );
+  }
+
+  return mainCombobox;
 }
+
+const DrawerContainer = styled.div<{ $mobile?: boolean }>`
+  position: absolute;
+  overflow: hidden;
+
+  ${({ $mobile }) =>
+    $mobile &&
+    css`
+      position: fixed;
+      bottom: 10px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 96dvw;
+      z-index: 9992999;
+      min-height: 15rem;
+      max-height: 15rem;
+      border-radius: 14px;
+    `}
+`;
 
 const DrawerWrapper = styled.ul<{
   $width?: number;
   $theme: ComboboxThemeConfig;
   $style?: CSSProp;
+  $mobile?: boolean;
 }>`
-  position: absolute;
+  position: relative;
   z-index: 9992999;
   max-height: 15rem;
   overflow-y: auto;
@@ -976,9 +1020,6 @@ const DrawerWrapper = styled.ul<{
   background-color: ${({ $theme }) => $theme?.backgroundColor};
   box-shadow: ${({ $theme }) => $theme?.boxShadow};
   width: ${({ $width }) => ($width ? `${$width}px` : "100%")};
-
-  scroll-behavior: smooth;
-  overscroll-behavior: contain;
 
   scrollbar-width: thin;
   scrollbar-color: ${({ $theme }) => $theme?.scrollThumbColor || "#52525b"}
@@ -996,6 +1037,16 @@ const DrawerWrapper = styled.ul<{
     background-color: #d1d5db;
     border-radius: 4px;
   }
+
+  ${({ $mobile }) =>
+    $mobile &&
+    css`
+      width: 100%;
+      z-index: 9992999;
+      border-radius: 14px;
+      min-height: 15rem;
+      max-height: 15rem;
+    `}
 
   ${({ $style }) => $style}
 `;
@@ -1053,6 +1104,44 @@ const rowStyle = ({
       }
     `}
   }
+`;
+
+const FadeTop = styled.div<{ $style?: CSSProp; $theme: ComboboxThemeConfig }>`
+  pointer-events: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 32px;
+  background: linear-gradient(
+    to bottom,
+    ${({ $theme }) => $theme.fadeColor} 10%,
+    transparent 100%
+  );
+  z-index: 99999999;
+
+  ${({ $style }) => $style}
+`;
+
+const FadeBottom = styled.div<{
+  $style?: CSSProp;
+  $theme: ComboboxThemeConfig;
+}>`
+  pointer-events: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 32px;
+
+  background: linear-gradient(
+    to top,
+    ${({ $theme }) => $theme.fadeColor} 10%,
+    transparent 100%
+  );
+  z-index: 99999999;
+
+  ${({ $style }) => $style}
 `;
 
 export { Combobox };

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -45,6 +45,7 @@ export interface FieldLaneProps {
   required?: boolean;
   className?: string;
   id?: string;
+  mobile?: boolean;
 }
 
 export interface FieldLaneStyles {
@@ -103,6 +104,7 @@ function FieldLane({
   labelWidth,
   required,
   className,
+  mobile,
 }: FieldLaneProps) {
   const { currentTheme } = useTheme();
   const fieldLaneTheme = currentTheme.fieldLane;
@@ -380,6 +382,10 @@ function FieldLane({
       }
       $disabled={disabled}
       $style={css`
+        ${mobile &&
+        css`
+          user-select: none;
+        `}
         ${styles?.containerStyle}
       `}
     >

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -155,6 +155,8 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
     const { currentTheme } = useTheme();
     const selectboxTheme = currentTheme?.selectbox;
 
+    const mobileJustOpenedRef = useRef(false);
+
     const finalOptions = useMemo(
       () => (Array.isArray(options) ? options : []),
       [options]
@@ -530,6 +532,12 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           }}
           readOnly={multiple || (mobile && !isOpen)}
           onMouseDown={() => {
+            if (mobile && !isOpen) {
+              mobileJustOpenedRef.current = true;
+              setIsOpen(true);
+              return;
+            }
+
             if (strict) {
               if (!isOpen) {
                 setIsOpen(true);
@@ -542,7 +550,10 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           }}
           onFocus={() => {
             if (type === "calendar" || selectedOptionsLocal) setIsFocused(true);
-
+            if (mobileJustOpenedRef.current) {
+              mobileJustOpenedRef.current = false;
+              return;
+            }
             setIsOpen(true);
           }}
           onBlur={() => {

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -40,8 +40,10 @@ import { applyClassName } from "./../constants/classname";
 
 export type SelectboxSelectedOptions = number | string | number[] | string[];
 
-interface BaseSelectboxProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "children"> {
+interface BaseSelectboxProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "onChange" | "children"
+> {
   options?: SelectboxOption[];
   navigableOptions?: SelectboxOption[];
   selectedOptions?: SelectboxSelectedOptions;
@@ -406,12 +408,29 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
       }
     };
 
+    // Sync highlightedIndex to the selected option's position when the dropdown open
+    useEffect(() => {
+      if (isOpen) {
+        if (finalSelectedOptions.length > 0) {
+          const offset = actions?.length ?? 0;
+          const idx = (navigableOptions ?? finalOptions).findIndex(
+            (opt) => String(opt.value) === finalSelectedOptions[0]
+          );
+          setHighlightedIndex(idx !== -1 ? idx + offset : 0);
+        } else {
+          setHighlightedIndex(0);
+        }
+      }
+    }, [isOpen]);
+
+    // Scroll the highlighted item into view on keyboard navigation
     useEffect(() => {
       if (isOpen && listRef.current[highlightedIndex]) {
         listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });
       }
     }, [highlightedIndex, isOpen]);
 
+    // Reset search text when the dropdown closes in multiple mode
     useEffect(() => {
       if (!isOpen && multiple) {
         setSelectedOptionsLocal({
@@ -620,7 +639,8 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
 );
 
 export interface SelectboxProps
-  extends Omit<BaseSelectboxProps, "styles">,
+  extends
+    Omit<BaseSelectboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "actions" | "children"> {
   styles?: SelectboxStyles;
 }

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -155,8 +155,6 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
     const { currentTheme } = useTheme();
     const selectboxTheme = currentTheme?.selectbox;
 
-    const [isReadOnly, setIsReadOnly] = useState(true);
-
     const finalOptions = useMemo(
       () => (Array.isArray(options) ? options : []),
       [options]
@@ -429,10 +427,14 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
 
     // Scroll the highlighted item into view on keyboard navigation
     useEffect(() => {
-      if (isOpen && listRef.current[highlightedIndex]) {
+      if (
+        isOpen &&
+        listRef.current[highlightedIndex] &&
+        finalSelectedOptions?.length > 0
+      ) {
         listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });
       }
-    }, [highlightedIndex, isOpen]);
+    }, [highlightedIndex, isOpen, finalSelectedOptions]);
 
     // Reset search text when the dropdown closes in multiple mode
     useEffect(() => {
@@ -526,17 +528,8 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           onKeyDown={(e) => {
             handleKeyDown(e);
           }}
-          readOnly={multiple || (mobile ? isReadOnly : false)}
+          readOnly={multiple}
           onMouseDown={() => {
-            if (mobile) {
-              if (!isOpen) {
-                setIsOpen(true);
-              } else {
-                setIsReadOnly(false);
-              }
-              return;
-            }
-
             if (strict) {
               if (!isOpen) {
                 setIsOpen(true);
@@ -554,7 +547,6 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           }}
           onBlur={() => {
             setIsFocused(false);
-            if (mobile) setIsReadOnly(true);
 
             if (!multiple) {
               setHasInteracted(false);

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -528,7 +528,7 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           onKeyDown={(e) => {
             handleKeyDown(e);
           }}
-          readOnly={multiple}
+          readOnly={multiple || (mobile && !isOpen)}
           onMouseDown={() => {
             if (strict) {
               if (!isOpen) {

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -63,6 +63,7 @@ interface BaseSelectboxProps extends Omit<
   showError?: boolean;
   maxSelectableItems?: number | undefined;
   isLoading?: boolean;
+  mobile?: boolean;
   children?: (
     props: DrawerProps &
       InteractionModeProps & {
@@ -146,12 +147,15 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
       disabled,
       className,
       navigableOptions,
+      mobile,
       ...props
     },
     ref
   ) => {
     const { currentTheme } = useTheme();
     const selectboxTheme = currentTheme?.selectbox;
+
+    const isFirstFocusRef = useRef(true);
 
     const finalOptions = useMemo(
       () => (Array.isArray(options) ? options : []),
@@ -536,10 +540,19 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           }}
           onFocus={() => {
             if (type === "calendar" || selectedOptionsLocal) setIsFocused(true);
+            if (mobile) {
+              if (isFirstFocusRef.current) {
+                isFirstFocusRef.current = false;
+                return;
+              }
+            }
+
             setIsOpen(true);
           }}
           onBlur={() => {
             setIsFocused(false);
+            isFirstFocusRef.current = true;
+
             if (!multiple) {
               setHasInteracted(false);
             }
@@ -664,6 +677,7 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
       labelWidth,
       labelPosition,
       className,
+      mobile,
       ...rest
     } = props;
     const inputId = StatefulForm.sanitizeId({
@@ -681,6 +695,7 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
         labelGap={labelGap}
         labelWidth={labelWidth}
         labelPosition={labelPosition}
+        mobile={mobile}
         className={
           hasCombo || hasDatebox
             ? className
@@ -707,6 +722,7 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
           id={inputId}
           actions={actions}
           showError={showError}
+          mobile={mobile}
           disabled={disabled}
           styles={{
             self: css`

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -530,7 +530,7 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           }}
           readOnly={multiple || mobile}
           onMouseDown={() => {
-            if (strict) {
+            if (strict || mobile) {
               if (!isOpen) {
                 setIsOpen(true);
               }

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -155,7 +155,7 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
     const { currentTheme } = useTheme();
     const selectboxTheme = currentTheme?.selectbox;
 
-    const isFirstFocusRef = useRef(true);
+    const [isReadOnly, setIsReadOnly] = useState(true);
 
     const finalOptions = useMemo(
       () => (Array.isArray(options) ? options : []),
@@ -526,8 +526,17 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           onKeyDown={(e) => {
             handleKeyDown(e);
           }}
-          readOnly={multiple}
+          readOnly={multiple || (mobile ? isReadOnly : false)}
           onMouseDown={() => {
+            if (mobile) {
+              if (!isOpen) {
+                setIsOpen(true);
+              } else {
+                setIsReadOnly(false);
+              }
+              return;
+            }
+
             if (strict) {
               if (!isOpen) {
                 setIsOpen(true);
@@ -540,18 +549,12 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           }}
           onFocus={() => {
             if (type === "calendar" || selectedOptionsLocal) setIsFocused(true);
-            if (mobile) {
-              if (isFirstFocusRef.current) {
-                isFirstFocusRef.current = false;
-                return;
-              }
-            }
 
             setIsOpen(true);
           }}
           onBlur={() => {
             setIsFocused(false);
-            isFirstFocusRef.current = true;
+            if (mobile) setIsReadOnly(true);
 
             if (!multiple) {
               setHasInteracted(false);

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -155,8 +155,6 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
     const { currentTheme } = useTheme();
     const selectboxTheme = currentTheme?.selectbox;
 
-    const mobileJustOpenedRef = useRef(false);
-
     const finalOptions = useMemo(
       () => (Array.isArray(options) ? options : []),
       [options]
@@ -530,14 +528,8 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           onKeyDown={(e) => {
             handleKeyDown(e);
           }}
-          readOnly={multiple || (mobile && !isOpen)}
+          readOnly={multiple || mobile}
           onMouseDown={() => {
-            if (mobile && !isOpen) {
-              mobileJustOpenedRef.current = true;
-              setIsOpen(true);
-              return;
-            }
-
             if (strict) {
               if (!isOpen) {
                 setIsOpen(true);
@@ -550,10 +542,7 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           }}
           onFocus={() => {
             if (type === "calendar" || selectedOptionsLocal) setIsFocused(true);
-            if (mobileJustOpenedRef.current) {
-              mobileJustOpenedRef.current = false;
-              return;
-            }
+
             setIsOpen(true);
           }}
           onBlur={() => {

--- a/components/treelist.tsx
+++ b/components/treelist.tsx
@@ -896,7 +896,7 @@ interface TreeListItemComponent<T extends TreeListItem> {
 }
 
 export interface TreeListItemStyles {
-  itemStyle?: CSSProp;
+  itemStyle?: ((level: number) => CSSProp) | CSSProp;
   emptyItemSlateStyle?: CSSProp;
   arrowStyle?: CSSProp;
   hierarchyLineStyle?: CSSProp;
@@ -1024,7 +1024,11 @@ function TreeListItem<T extends TreeListItem>({
         role="button"
         data-group-id={groupId}
         aria-label="tree-list-item"
-        $style={styles?.itemStyle}
+        $style={
+          typeof styles?.itemStyle === "function"
+            ? styles?.itemStyle(level)
+            : styles?.itemStyle
+        }
         $isSelected={isSelected.includes(item.id)}
         aria-expanded={isOpen[item.id]}
         $showHierarchyLine={showHierarchyLine}
@@ -1369,7 +1373,10 @@ function TreeListItem<T extends TreeListItem>({
                   <TreeListItem
                     key={index}
                     styles={{
-                      itemStyle: styles?.itemStyle,
+                      itemStyle:
+                        typeof styles?.itemStyle === "function"
+                          ? styles?.itemStyle(level + 1)
+                          : styles?.itemStyle,
                       titleItemStyle: styles?.titleItemStyle,
                       highlightedTextStyle: styles?.highlightedTextStyle,
                       emptyItemSlateStyle: styles?.emptyItemSlateStyle,

--- a/components/treelist.tsx
+++ b/components/treelist.tsx
@@ -1373,10 +1373,7 @@ function TreeListItem<T extends TreeListItem>({
                   <TreeListItem
                     key={index}
                     styles={{
-                      itemStyle:
-                        typeof styles?.itemStyle === "function"
-                          ? styles?.itemStyle(level + 1)
-                          : styles?.itemStyle,
+                      itemStyle: styles?.itemStyle,
                       titleItemStyle: styles?.titleItemStyle,
                       highlightedTextStyle: styles?.highlightedTextStyle,
                       emptyItemSlateStyle: styles?.emptyItemSlateStyle,

--- a/components/treelist.tsx
+++ b/components/treelist.tsx
@@ -536,6 +536,7 @@ function TreeList({
                       onMouseEnter?.({ event: e, item });
                       setIsHovered(item.id);
                     }}
+                    data-level={0}
                   >
                     <Title
                       role="option"
@@ -1159,6 +1160,7 @@ function TreeListItem<T extends TreeListItem>({
           onMouseEnterItem?.({ event: e, item });
         }}
         $level={level + 1}
+        data-level={level}
       >
         {item.iconOnActive && isSelected.includes(item.id) ? (
           <item.iconOnActive

--- a/components/treelist.tsx
+++ b/components/treelist.tsx
@@ -18,17 +18,16 @@ import { TreeListThemeConfig } from "./../theme";
 import { BaseAction } from "../constants/action";
 import { applyClassName } from "./../constants/classname";
 
-export interface TreeListProps
-  extends Omit<
-    HTMLAttributes<HTMLDivElement>,
-    | "style"
-    | "onChange"
-    | "content"
-    | "onMouseDown"
-    | "onMouseMove"
-    | "onKeyDown"
-    | "onMouseEnter"
-  > {
+export interface TreeListProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  | "style"
+  | "onChange"
+  | "content"
+  | "onMouseDown"
+  | "onMouseMove"
+  | "onKeyDown"
+  | "onMouseEnter"
+> {
   content: TreeListContent[];
   children?: ReactNode;
   emptySlate?: ReactNode;
@@ -136,8 +135,10 @@ export interface TreeListContent {
   collapsible?: boolean;
 }
 
-export interface TreeListContentAction
-  extends Omit<ContextMenuAction, "onClick"> {
+export interface TreeListContentAction extends Omit<
+  ContextMenuAction,
+  "onClick"
+> {
   onClick?: (id?: string) => void;
 }
 
@@ -510,6 +511,8 @@ function TreeList({
                     data-has-options={item?.className?.includes(
                       "has-group-options"
                     )}
+                    data-first={index === 0}
+                    data-last={index === content.length - 1}
                     data-action-opened={item.id === openRowId}
                     data-selected={selectedItems?.includes(item.id)}
                     data-highlighted={item?.className?.includes(
@@ -1027,6 +1030,8 @@ function TreeListItem<T extends TreeListItem>({
         data-selected={isSelected.includes(item.id)}
         data-has-options={item?.className?.includes("has-group-options")}
         data-highlighted={item?.className?.includes("is-highlighted")}
+        data-first={index === 0}
+        data-last={index === item?.items?.length - 1}
         onKeyDown={(e) => {
           onKeyDownItem?.({ event: e, item });
         }}

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -214,6 +214,25 @@ describe("Combobox", () => {
           "Apple"
         );
       });
+
+      context("when clicking the selectbox again", () => {
+        it("should expand again (same behavior on the strict)", () => {
+          cy.findByPlaceholderText("Select a fruit...").should(
+            "have.value",
+            ""
+          );
+          cy.findByText("Apple").click();
+          cy.findByPlaceholderText("Select a fruit...").should(
+            "have.value",
+            "Apple"
+          );
+
+          cy.findByLabelText("combobox-drawer").should("not.exist");
+
+          cy.findByPlaceholderText("Select a fruit...").click();
+          cy.findByLabelText("combobox-drawer").should("exist");
+        });
+      });
     });
 
     context("fade", () => {

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -135,6 +135,86 @@ describe("Combobox", () => {
     );
   }
 
+  context("mobile", () => {
+    beforeEach(() => {
+      cy.window().then((win) => {
+        cy.spy(win.console, "log").as("consoleLog");
+      });
+
+      cy.mount(<ProductCombobox options={FRUIT_OPTIONS} mobile />);
+
+      cy.findByPlaceholderText("Select a fruit...").click();
+    });
+
+    it("renders on the bottom screen", () => {
+      cy.findByLabelText("combobox-drawer-mobile")
+        .should("have.css", "bottom", "10px")
+        .and("have.css", "position", "fixed");
+    });
+
+    it("renders with 96dvw", () => {
+      cy.viewport(500, 700);
+
+      cy.window().then((win) => {
+        const expectedWidth = `${win.innerWidth * 0.96}px`;
+
+        cy.findByLabelText("combobox-drawer-mobile").should(
+          "have.css",
+          "width",
+          expectedWidth
+        );
+      });
+    });
+
+    context("when selecting an option", () => {
+      it("should update the selected value", () => {
+        cy.findByPlaceholderText("Select a fruit...").should("have.value", "");
+        cy.findByText("Apple").click();
+        cy.findByPlaceholderText("Select a fruit...").should(
+          "have.value",
+          "Apple"
+        );
+      });
+    });
+
+    context("fade", () => {
+      it("shows on the top and bottom", () => {
+        cy.findByLabelText("combobox-fade-top").should("exist");
+        cy.findByLabelText("combobox-fade-bottom").should("exist");
+      });
+
+      context("when selected option near at the fade top", () => {
+        it("should not shows the fade top", () => {
+          cy.findByLabelText("combobox-fade-top").should("exist");
+          cy.findByLabelText("combobox-fade-bottom").should("exist");
+
+          cy.findByText("Apple").click();
+          cy.findByPlaceholderText("Select a fruit...").click();
+
+          cy.wait(300);
+
+          cy.findByLabelText("combobox-fade-top").should("not.be.visible");
+          cy.findByLabelText("combobox-fade-bottom").should("exist");
+        });
+      });
+
+      context("when selected option near at the fade bottom", () => {
+        it("should not shows the fade bottom", () => {
+          cy.findByLabelText("combobox-fade-top").should("exist");
+          cy.findByLabelText("combobox-fade-bottom").should("exist");
+
+          cy.findByText("Pineapple").click();
+          cy.findByPlaceholderText("Select a fruit...").click();
+
+          cy.wait(300);
+
+          cy.findByLabelText("combobox-fade-top").should("exist");
+          cy.findByLabelText("combobox-fade-bottom").should("not.be.visible");
+        });
+      });
+    });
+  });
+
   context("option with actions", () => {
     context("with single option", () => {
       beforeEach(() => {

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -152,7 +152,14 @@ describe("Combobox", () => {
         .and("have.css", "position", "fixed");
     });
 
-    it("renders with 96dvw", () => {
+    it("renders the item with height 47px, padding-x 6px and padding-y 15px", () => {
+      cy.findAllByLabelText("tree-list-group-title")
+        .eq(0)
+        .should("have.css", "height", "45px")
+        .and("have.css", "padding", "6px 15px");
+    });
+
+    it("renders with 96dvw and height 220px", () => {
       cy.viewport(500, 700);
 
       cy.window().then((win) => {
@@ -163,6 +170,38 @@ describe("Combobox", () => {
           "width",
           expectedWidth
         );
+
+        cy.findByLabelText("combobox-drawer-mobile").should(
+          "have.css",
+          "height",
+          "220px"
+        );
+      });
+    });
+
+    context("multiple", () => {
+      context("when given true", () => {
+        it("should not given padding top and bottom (not centered)", () => {
+          cy.mount(<ProductCombobox options={FRUIT_OPTIONS} mobile multiple />);
+
+          cy.findByPlaceholderText("Select a fruit...").click();
+
+          cy.findByLabelText("combobox-drawer")
+            .should("have.css", "padding-top", "0px")
+            .and("have.css", "padding-bottom", "0px");
+        });
+      });
+
+      context("when given false", () => {
+        it("should given padding top and bottom (centered)", () => {
+          cy.mount(<ProductCombobox options={FRUIT_OPTIONS} mobile />);
+
+          cy.findByPlaceholderText("Select a fruit...").click();
+
+          cy.findByLabelText("combobox-drawer")
+            .should("have.css", "padding-top", "100px")
+            .and("have.css", "padding-bottom", "100px");
+        });
       });
     });
 
@@ -183,33 +222,116 @@ describe("Combobox", () => {
         cy.findByLabelText("combobox-fade-bottom").should("exist");
       });
 
-      context("when selected option near at the fade top", () => {
-        it("should not shows the fade top", () => {
-          cy.findByLabelText("combobox-fade-top").should("exist");
-          cy.findByLabelText("combobox-fade-bottom").should("exist");
+      context("when clicking item and open again", () => {
+        it("should shows the fade top and bottom", () => {
+          cy.findByLabelText("combobox-fade-top").should(
+            "have.css",
+            "opacity",
+            "1"
+          );
+          cy.findByLabelText("combobox-fade-bottom").should(
+            "have.css",
+            "opacity",
+            "1"
+          );
 
-          cy.findByText("Apple").click();
+          cy.findByText("Orange").click();
           cy.findByPlaceholderText("Select a fruit...").click();
 
           cy.wait(300);
 
-          cy.findByLabelText("combobox-fade-top").should("not.be.visible");
-          cy.findByLabelText("combobox-fade-bottom").should("exist");
+          cy.findByLabelText("combobox-fade-top").should(
+            "have.css",
+            "opacity",
+            "1"
+          );
+          cy.findByLabelText("combobox-fade-bottom").should(
+            "have.css",
+            "opacity",
+            "1"
+          );
         });
-      });
 
-      context("when selected option near at the fade bottom", () => {
-        it("should not shows the fade bottom", () => {
-          cy.findByLabelText("combobox-fade-top").should("exist");
-          cy.findByLabelText("combobox-fade-bottom").should("exist");
+        context("when scrolling item selected until fade top", () => {
+          it("should not shows the fade top", () => {
+            cy.findByLabelText("combobox-fade-top").should(
+              "have.css",
+              "opacity",
+              "1"
+            );
+            cy.findByLabelText("combobox-fade-bottom").should(
+              "have.css",
+              "opacity",
+              "1"
+            );
 
-          cy.findByText("Pineapple").click();
-          cy.findByPlaceholderText("Select a fruit...").click();
+            cy.findByText("Orange").click();
+            cy.findByPlaceholderText("Select a fruit...").click();
 
-          cy.wait(300);
+            cy.wait(300);
 
-          cy.findByLabelText("combobox-fade-top").should("exist");
-          cy.findByLabelText("combobox-fade-bottom").should("not.be.visible");
+            cy.findByLabelText("combobox-fade-top").should(
+              "have.css",
+              "opacity",
+              "1"
+            );
+            cy.findByLabelText("combobox-fade-bottom").should(
+              "have.css",
+              "opacity",
+              "1"
+            );
+
+            // scroll behavior into top fade
+            cy.get("#combo-list").contains("Orange").scrollIntoView();
+
+            cy.findByLabelText("combobox-fade-top").should(
+              "have.css",
+              "opacity",
+              "0"
+            );
+          });
+        });
+
+        context("when scrolling item selected until fade bottom", () => {
+          it("should not shows the fade bottom", () => {
+            cy.findByLabelText("combobox-fade-top").should(
+              "have.css",
+              "opacity",
+              "1"
+            );
+            cy.findByLabelText("combobox-fade-bottom").should(
+              "have.css",
+              "opacity",
+              "1"
+            );
+
+            cy.findByText("Orange").click();
+            cy.findByPlaceholderText("Select a fruit...").click();
+
+            cy.wait(300);
+
+            cy.findByLabelText("combobox-fade-top").should(
+              "have.css",
+              "opacity",
+              "1"
+            );
+            cy.findByLabelText("combobox-fade-bottom").should(
+              "have.css",
+              "opacity",
+              "1"
+            );
+
+            // scroll behavior into top fade
+            cy.get("#combo-list")
+              .contains("Orange")
+              .scrollIntoView({ offset: { top: -999, left: 0 } });
+
+            cy.findByLabelText("combobox-fade-bottom").should(
+              "have.css",
+              "opacity",
+              "0"
+            );
+          });
         });
       });
     });

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -236,6 +236,7 @@ describe("Combobox", () => {
           );
 
           cy.findByText("Orange").click();
+          cy.get("body").click("right");
           cy.findByPlaceholderText("Select a fruit...").click();
 
           cy.wait(300);
@@ -266,6 +267,8 @@ describe("Combobox", () => {
             );
 
             cy.findByText("Orange").click();
+            cy.get("body").click("right");
+
             cy.findByPlaceholderText("Select a fruit...").click();
 
             cy.wait(300);

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -182,6 +182,7 @@ export interface ComboboxThemeConfig extends BodyThemeConfig {
 
   scrollThumbColor?: string;
 
+  mobileBackgroundColor?: string;
   fadeColor?: string;
 }
 

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -44,8 +44,10 @@ export interface ActionButtonThemeConfig extends BodyThemeConfig {
 }
 
 // avatar.tsx
-export interface AvatarThemeConfig
-  extends Omit<BodyThemeConfig, "backgroundColor"> {
+export interface AvatarThemeConfig extends Omit<
+  BodyThemeConfig,
+  "backgroundColor"
+> {
   overlayBackgroundColor?: string;
   overlayIconColor?: string;
 }
@@ -141,16 +143,20 @@ export interface ChipsThemeConfig extends BodyThemeConfig {
 }
 
 // choice-group.tsx
-export interface ChoiceGroupThemeConfig
-  extends Omit<BodyThemeConfig, "textColor"> {
+export interface ChoiceGroupThemeConfig extends Omit<
+  BodyThemeConfig,
+  "textColor"
+> {
   dividerColor?: string;
   labelColor?: string;
   descriptionColor?: string;
 }
 
 // checkbox.tsx
-export interface CheckboxThemeConfig
-  extends Omit<BodyThemeConfig, "textColor"> {
+export interface CheckboxThemeConfig extends Omit<
+  BodyThemeConfig,
+  "textColor"
+> {
   checkedBorderColor?: string;
   checkedBackgroundColor?: string;
   iconColor?: string;
@@ -175,6 +181,8 @@ export interface ComboboxThemeConfig extends BodyThemeConfig {
   boxShadow?: string;
 
   scrollThumbColor?: string;
+
+  fadeColor?: string;
 }
 
 // colorbox.tsx
@@ -193,8 +201,10 @@ export interface ColorboxThemeConfig extends BodyThemeConfig {
 }
 
 // crumb.tsx
-export interface CrumbThemeConfig
-  extends Omit<BodyThemeConfig, "borderColor" | "backgroundColor"> {
+export interface CrumbThemeConfig extends Omit<
+  BodyThemeConfig,
+  "borderColor" | "backgroundColor"
+> {
   hoverColor?: string;
   lastTextColor?: string;
   arrowColor?: string;
@@ -209,8 +219,10 @@ export interface DialogThemeConfig extends BodyThemeConfig {
 }
 
 // document-viewer.tsx
-export interface DocumentViewerThemeConfig
-  extends Omit<BodyThemeConfig, "borderColor"> {
+export interface DocumentViewerThemeConfig extends Omit<
+  BodyThemeConfig,
+  "borderColor"
+> {
   toolbarBackgroundColor?: string;
   errorColor?: string;
   hoverBoxTextColor?: string;
@@ -243,8 +255,10 @@ export interface ErrorSlateThemeConfig {
 }
 
 // field-lane.tsx
-export interface FieldLaneThemeConfig
-  extends Omit<BodyThemeConfig, "backgroundColor"> {
+export interface FieldLaneThemeConfig extends Omit<
+  BodyThemeConfig,
+  "backgroundColor"
+> {
   buttonTextColor?: string;
   buttonBorderColor?: string;
   buttonErrorTextColor?: string;
@@ -376,8 +390,10 @@ export interface LoadingSpinnerThemeConfig {
 }
 
 // messagebox.tsx
-export interface MessageboxVariantTheme
-  extends Omit<BodyThemeConfig, "borderColor"> {
+export interface MessageboxVariantTheme extends Omit<
+  BodyThemeConfig,
+  "borderColor"
+> {
   activeColor: string;
 }
 
@@ -593,8 +609,10 @@ export interface StatusbarThemeConfig extends BodyThemeConfig {
   };
 }
 
-export interface StatefulFormThemeConfig
-  extends Omit<BodyThemeConfig, "borderColor"> {
+export interface StatefulFormThemeConfig extends Omit<
+  BodyThemeConfig,
+  "borderColor"
+> {
   rowFrameBackgroundColor: string;
 }
 
@@ -721,8 +739,10 @@ export interface ToolbarThemeConfig extends BodyThemeConfig {
 }
 
 // tip-menu.tsx
-export interface TipMenuThemeConfig
-  extends Omit<BodyThemeConfig, "borderColor"> {
+export interface TipMenuThemeConfig extends Omit<
+  BodyThemeConfig,
+  "borderColor"
+> {
   hoverBackgroundColor?: string;
   activeBackgroundColor?: string;
   focusBackgroundColor?: string;
@@ -730,8 +750,10 @@ export interface TipMenuThemeConfig
 }
 
 // treelist.tsx
-export interface TreeListThemeConfig
-  extends Omit<BodyThemeConfig, "borderColor"> {
+export interface TreeListThemeConfig extends Omit<
+  BodyThemeConfig,
+  "borderColor"
+> {
   hoverBackgroundColor?: string;
   selectedBackgroundColor?: string;
 
@@ -745,8 +767,10 @@ export interface TreeListThemeConfig
 }
 
 // split-pane.tsx
-export interface SplitPaneThemeConfig
-  extends Omit<BodyThemeConfig, "borderColor"> {
+export interface SplitPaneThemeConfig extends Omit<
+  BodyThemeConfig,
+  "borderColor"
+> {
   dividerColor?: string;
 }
 

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -169,6 +169,7 @@ export interface CheckboxThemeConfig extends Omit<
 // combobox.tsx
 export interface ComboboxThemeConfig extends BodyThemeConfig {
   groupBackgroundColor?: string;
+  mobileGroupBackgroundColor?: string;
 
   highlightBackgroundColor?: string;
   selectedBackgroundColor?: string;

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -567,6 +567,7 @@ export function createComboboxTheme(
     scrollThumbColor: "#9ca3af",
 
     fadeColor: "#efefef",
+    mobileBackgroundColor: "#ffffff",
   };
 
   return { ...defaultTheme, ...custom };

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -567,6 +567,8 @@ export function createComboboxTheme(
     scrollThumbColor: "#9ca3af",
 
     fadeColor: "#efefef",
+
+    mobileGroupBackgroundColor: "#ffffff",
     mobileBackgroundColor: "#ffffff",
   };
 

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -565,6 +565,8 @@ export function createComboboxTheme(
     groupBackgroundColor: "rgb(249, 250, 251)",
 
     scrollThumbColor: "#9ca3af",
+
+    fadeColor: "#efefef",
   };
 
   return { ...defaultTheme, ...custom };

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -569,7 +569,7 @@ export function createComboboxTheme(
     fadeColor: "#efefef",
 
     mobileGroupBackgroundColor: "#ffffff",
-    mobileBackgroundColor: "#ffffff",
+    mobileBackgroundColor: "rgb(249, 250, 251)",
   };
 
   return { ...defaultTheme, ...custom };

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -341,6 +341,7 @@ const darkCombobox = createComboboxTheme(darkBody, darkFieldLane, {
   scrollThumbColor: "#52525b",
   fadeColor: "#2c2c2e",
   mobileBackgroundColor: "#2c2c2e",
+  mobileGroupBackgroundColor: "#2a2a2d",
 });
 
 export const darkCrumb = createCrumbTheme(darkBody, {

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -339,6 +339,7 @@ const darkCombobox = createComboboxTheme(darkBody, darkFieldLane, {
   selectedTextColor: darkBody.textColor,
   groupBackgroundColor: "rgb(35 37 41)",
   scrollThumbColor: "#52525b",
+  fadeColor: "#2c2c2e",
 });
 
 export const darkCrumb = createCrumbTheme(darkBody, {

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -341,7 +341,7 @@ const darkCombobox = createComboboxTheme(darkBody, darkFieldLane, {
   scrollThumbColor: "#52525b",
   fadeColor: "#2c2c2e",
   mobileBackgroundColor: "#2c2c2e",
-  mobileGroupBackgroundColor: "#2a2a2d",
+  mobileGroupBackgroundColor: "#2a2a2a",
 });
 
 export const darkCrumb = createCrumbTheme(darkBody, {

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -340,6 +340,7 @@ const darkCombobox = createComboboxTheme(darkBody, darkFieldLane, {
   groupBackgroundColor: "rgb(35 37 41)",
   scrollThumbColor: "#52525b",
   fadeColor: "#2c2c2e",
+  mobileBackgroundColor: "#2c2c2e",
 });
 
 export const darkCrumb = createCrumbTheme(darkBody, {


### PR DESCRIPTION
Description:
This pull request introduces `mobile` mode on the `Combobox`, providing a bottom screen appearance similar to the Timebox (wheel), including `fade up` and `fade bottom` effects. It also ensures all related visual appearances are properly implemented in the component.

Source:
[[Improvement] SYST-688: Add `mobile` on `combobox`](https://linear.app/systatum/issue/SYST-688/add-mobile-on-combobox)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself