### PR TITLE
[Improvement] SYST-694: Add `pretitle` to `Card`

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -182,9 +182,7 @@ function Card({
               color: ${cardTheme?.subtitleColor ?? "#6b7280"};
               ${styles?.subtitleStyle}
             `,
-            pretitleStyle: css`
-              ${styles?.pretitleStyle}
-            `,
+            pretitleStyle: styles?.pretitleStyle,
             textContainerStyle: css`
               gap: 2px;
               ${styles?.textContainerStyle}

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -52,13 +52,16 @@ export const CardPadding = {
 
 export type CardPadding = (typeof CardPadding)[keyof typeof CardPadding];
 
-export interface CardProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "title" | "style"> {
+export interface CardProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "title" | "style"
+> {
   shadow?: CardShadow;
   radius?: CardBorderRadius;
   padding?: CardPadding;
   children: ReactNode;
   title?: ReactNode;
+  pretitle?: ReactNode;
   subtitle?: ReactNode;
   footerContent?: ReactNode;
   closable?: boolean;
@@ -78,6 +81,7 @@ export interface CardStyles {
   headerStyle?: CSSProp;
   footerStyle?: CSSProp;
   titleStyle?: CSSProp;
+  pretitleStyle?: CSSProp;
   subtitleStyle?: CSSProp;
 }
 
@@ -98,6 +102,7 @@ function Card({
   open = true,
   id,
   className,
+  pretitle,
   ...props
 }: CardProps) {
   const { currentTheme } = useTheme();
@@ -150,10 +155,11 @@ function Card({
       $containerStyle={styles?.containerStyle}
       $theme={cardTheme}
     >
-      {(title || subtitle || headerActions) && (
+      {(title || subtitle || pretitle || headerActions) && (
         <Title
-          text={title}
           size="sm"
+          text={title}
+          pretitle={pretitle}
           subtitle={subtitle}
           styles={{
             containerStyle: css`
@@ -175,6 +181,9 @@ function Card({
             subtitleStyle: css`
               color: ${cardTheme?.subtitleColor ?? "#6b7280"};
               ${styles?.subtitleStyle}
+            `,
+            pretitleStyle: css`
+              ${styles?.pretitleStyle}
             `,
             textContainerStyle: css`
               gap: 2px;

--- a/test/component/card.cy.tsx
+++ b/test/component/card.cy.tsx
@@ -12,6 +12,7 @@ describe("Card", () => {
 
     return (
       <Card
+        pretitle="Food & Dining"
         title="Systatum Food Services"
         subtitle="Fueling innovation with every bite."
         headerActions={[
@@ -53,6 +54,28 @@ describe("Card", () => {
             "have.css",
             "width",
             "700px"
+          );
+        });
+      });
+    });
+
+    context("pretitle", () => {
+      context("when given font-size 40px", () => {
+        it("renders pre title with font-size 40px", () => {
+          cy.mount(
+            <ProductCard
+              styles={{
+                pretitleStyle: css`
+                  font-size: 40px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("title-pretitle").should(
+            "have.css",
+            "font-size",
+            "40px"
           );
         });
       });
@@ -398,7 +421,7 @@ describe("Card", () => {
               pretitleStyle: css`
                 width: 100%;
               `,
-              textContainerStyle: css`
+              headerTitleSectionStyle: css`
                 width: 100%;
               `,
               containerStyle: css`

--- a/test/component/card.cy.tsx
+++ b/test/component/card.cy.tsx
@@ -136,12 +136,13 @@ describe("Card", () => {
 
   context("with header", () => {
     const value = {
+      pretitle: "Organization Structure",
       title: "Department",
       subtitle: "Departments and their leaders",
     };
 
     const renderDormantTextField = (
-      name: "title" | "subtitle",
+      name: "title" | "subtitle" | "pretitle",
       sizeText?: number
     ) => {
       return (
@@ -200,6 +201,51 @@ describe("Card", () => {
       it("should render the text", () => {
         cy.mount(<Card title="Systatum Food Services">Test`</Card>);
         cy.findByText("Systatum Food Services").should("exist");
+      });
+    });
+
+    context("with pretitle", () => {
+      it("can be given ReactNode to render", () => {
+        cy.mount(
+          <Card
+            pretitle={renderDormantTextField("pretitle")}
+            styles={{
+              pretitleStyle: css`
+                width: 100%;
+              `,
+              textContainerStyle: css`
+                width: 100%;
+              `,
+              containerStyle: css`
+                padding-left: 0px;
+                padding-right: 0px;
+                min-width: 1000px;
+                padding-bottom: 0px;
+              `,
+              headerStyle: css`
+                padding-left: 15px;
+                padding-right: 15px;
+              `,
+            }}
+          >
+            test
+          </Card>
+        );
+
+        cy.get("input[type='text']").should("not.exist");
+        cy.findByText("Organization Structure").click();
+        cy.get("input[type='text']")
+          .should("exist")
+          .and("have.value", "Organization Structure");
+      });
+
+      it("should render the text", () => {
+        cy.mount(
+          <Card pretitle="Food & Dining" title="Systatum Food Services">
+            Test
+          </Card>
+        );
+        cy.findByText("Food & Dining").should("exist");
       });
     });
 


### PR DESCRIPTION
Description:
This pull request adds a `pretitle` prop to the `Card` component, since the `Title` component already support a `pretitle` element. It also enables the `pretitle` prop to accept a `ReactNode` and supports custom styling within the `Card` component for great flexibility.

Source:
[[Improvement] SYST-694: Add `pretitle` to `Card`](https://linear.app/systatum/issue/SYST-694/add-pretitle-to-card)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself