### PR TITLE
[Improvement] SYST-693: Add `hidden` to CapsuleTabTab

### DIFF
--- a/components/capsule-tab.tsx
+++ b/components/capsule-tab.tsx
@@ -28,10 +28,11 @@ export interface CapsuleTabTab {
   title: string;
   content: ReactNode;
   className?: string;
+  hidden?: boolean;
 }
 
 function CapsuleTab({
-  tabs,
+  tabs: _tabs,
   styles,
   activeTab = "1",
   activeBackgroundColor,
@@ -42,6 +43,8 @@ function CapsuleTab({
 }: CapsuleTabProps) {
   const { currentTheme } = useTheme();
   const capsuleTabTheme = currentTheme.capsuleTab;
+
+  const tabs = _tabs?.filter((tab) => !tab.hidden);
 
   const [selectedLocal, setSelectedLocal] = useState<string>(activeTab);
 

--- a/test/component/capsule-tab.cy.tsx
+++ b/test/component/capsule-tab.cy.tsx
@@ -15,15 +15,17 @@ describe("Capsule Tab", () => {
   function ProductCapsuleTab({
     withCallback,
     styles,
+    tabs,
   }: {
     styles?: CapsuleTabStyles;
     withCallback?: boolean;
+    tabs?: CapsuleTabTab[];
   }) {
     const [activeTab, setActiveTab] = useState("2");
 
     return (
       <CapsuleTab
-        tabs={TABS_ITEMS}
+        tabs={tabs ? tabs : TABS_ITEMS}
         activeTab={activeTab}
         onTabChange={
           withCallback
@@ -144,6 +146,50 @@ describe("Capsule Tab", () => {
         cy.findByLabelText("capsule")
           .should("have.css", "justify-content", "normal")
           .and("have.css", "width", "458px");
+      });
+    });
+
+    context("hidden", () => {
+      context("when given true", () => {
+        it("should hidden on the tabs", () => {
+          cy.mount(
+            <ProductCapsuleTab
+              tabs={[
+                { id: "1", title: "Write", content: "Write Tab" },
+                {
+                  id: "2",
+                  title: "Review",
+                  content: "Review Tab",
+                  hidden: true,
+                },
+              ]}
+            />
+          );
+
+          cy.findByText("Write").should("exist");
+          cy.findByText("Review").should("not.exist");
+        });
+      });
+
+      context("when given false", () => {
+        it("should renders on the tabs", () => {
+          cy.mount(
+            <ProductCapsuleTab
+              tabs={[
+                { id: "1", title: "Write", content: "Write Tab" },
+                {
+                  id: "2",
+                  title: "Review",
+                  content: "Review Tab",
+                  hidden: false,
+                },
+              ]}
+            />
+          );
+
+          cy.findByText("Write").should("exist");
+          cy.findByText("Review").should("exist");
+        });
       });
     });
   });


### PR DESCRIPTION
Description:
This pull request improves the `CapsuleTab` by adding support for a `hidden` property in the `tabs` field through the `CapsuleTabTab` interface. Tabs with `hidden` set to true will not be rendered, while `tabs` with `hidden` set to false will continue to display as usual.

Source:
[[Improvement] SYST-693: Add `hidden` to CapsuleTabTab](https://linear.app/systatum/issue/SYST-693/add-hidden-to-capsuletabtab)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself