### PR TITLE
[Mobile] SYST-632: Add `ScreenTransition`

### DIFF
--- a/components/screen-transition.stories.tsx
+++ b/components/screen-transition.stories.tsx
@@ -1,9 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import {
-  ScreenTransition,
-  ScreenProps,
-  ScreenNavigator,
-} from "./screen-transition";
+import { ScreenTransition, ScreenProps } from "./screen-transition";
 import { Title } from "./title";
 import { RiArrowLeftSLine } from "@remixicon/react";
 import { css } from "styled-components";
@@ -37,7 +33,10 @@ export const Default: Story = {
                   {
                     styles: {
                       toggleActionStyle: css`
-                        padding: 10px;
+                        padding: 4px;
+                        height: 30px;
+                        width: 30px;
+                        border-radius: 4px;
                       `,
                     },
                     type: "actions",
@@ -61,6 +60,7 @@ export const Default: Story = {
               height: 53px;
               justify-content: center;
               align-items: center;
+              padding: 0 6px;
             `,
             textContainerStyle: css`
               align-items: center;
@@ -81,7 +81,7 @@ export const Default: Story = {
 
     function PageC() {
       return (
-        <ScreenTransition prevScreen={PageB}>
+        <ScreenTransition>
           {({ gotoPrevScreen }) => (
             <>
               <PageTitle text="Page C" gotoPrevScreen={gotoPrevScreen} />
@@ -93,7 +93,7 @@ export const Default: Story = {
 
     function PageB() {
       return (
-        <ScreenTransition prevScreen={PageA} nextScreen={PageC}>
+        <ScreenTransition nextScreen={PageC}>
           {({ gotoPrevScreen, gotoNextScreen }) => (
             <>
               <PageTitle text="Page B" gotoPrevScreen={gotoPrevScreen} />
@@ -135,6 +135,6 @@ export const Default: Story = {
       );
     }
 
-    return <ScreenNavigator initial={PageA} />;
+    return <PageA />;
   },
 };

--- a/components/screen-transition.stories.tsx
+++ b/components/screen-transition.stories.tsx
@@ -4,6 +4,7 @@ import { Title } from "./title";
 import { RiArrowLeftSLine } from "@remixicon/react";
 import { css } from "styled-components";
 import { Button } from "./button";
+import { useTheme } from "./../theme";
 
 const meta: Meta<typeof ScreenTransition> = {
   title: "Mobile/ScreenTransition",
@@ -18,6 +19,9 @@ type Story = StoryObj<typeof ScreenTransition>;
 
 export const Default: Story = {
   render: () => {
+    const { currentTheme, mode } = useTheme();
+    const bodyTheme = currentTheme?.body;
+
     function PageTitle({
       text,
       gotoPrevScreen = null,
@@ -56,7 +60,7 @@ export const Default: Story = {
           text={text}
           styles={{
             containerStyle: css`
-              border-bottom: 1px solid #ececec;
+              border-bottom: 1px solid ${bodyTheme?.borderColor || "#ececec"};
               height: 53px;
               justify-content: center;
               align-items: center;
@@ -67,6 +71,7 @@ export const Default: Story = {
             `,
             titleStyle: css`
               justify-content: center;
+              font-size: 20px;
 
               ${gotoPrevScreen &&
               css`
@@ -122,7 +127,7 @@ export const Default: Story = {
               <Button
                 styles={{
                   containerStyle: css`
-                    margin-top: 10px;
+                    margin-top: 14px;
                   `,
                 }}
                 onClick={gotoNextScreen ?? undefined}

--- a/components/screen-transition.stories.tsx
+++ b/components/screen-transition.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { ScreenTransition, ScreenProps } from "./screen-transition";
 import { Title } from "./title";
 import { RiArrowLeftSLine } from "@remixicon/react";
-import { css } from "styled-components";
+import styled, { css } from "styled-components";
 import { Button } from "./button";
 import { useTheme } from "./../theme";
 
@@ -88,9 +88,9 @@ export const Default: Story = {
       return (
         <ScreenTransition>
           {({ gotoPrevScreen }) => (
-            <>
+            <Wrapper>
               <PageTitle text="Page C" gotoPrevScreen={gotoPrevScreen} />
-            </>
+            </Wrapper>
           )}
         </ScreenTransition>
       );
@@ -100,19 +100,12 @@ export const Default: Story = {
       return (
         <ScreenTransition nextScreen={PageC}>
           {({ gotoPrevScreen, gotoNextScreen }) => (
-            <>
+            <Wrapper>
               <PageTitle text="Page B" gotoPrevScreen={gotoPrevScreen} />
-              <Button
-                styles={{
-                  containerStyle: css`
-                    margin-top: 10px;
-                  `,
-                }}
-                onClick={gotoNextScreen ?? undefined}
-              >
+              <Button onClick={gotoNextScreen ?? undefined}>
                 Go to Page C
               </Button>
-            </>
+            </Wrapper>
           )}
         </ScreenTransition>
       );
@@ -122,19 +115,12 @@ export const Default: Story = {
       return (
         <ScreenTransition nextScreen={PageB}>
           {({ gotoNextScreen }) => (
-            <>
+            <Wrapper>
               <PageTitle text="Page A" gotoPrevScreen={null} />
-              <Button
-                styles={{
-                  containerStyle: css`
-                    margin-top: 14px;
-                  `,
-                }}
-                onClick={gotoNextScreen ?? undefined}
-              >
+              <Button onClick={gotoNextScreen ?? undefined}>
                 Go to Page B
               </Button>
-            </>
+            </Wrapper>
           )}
         </ScreenTransition>
       );
@@ -143,3 +129,9 @@ export const Default: Story = {
     return <PageA />;
   },
 };
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+`;

--- a/components/screen-transition.stories.tsx
+++ b/components/screen-transition.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof ScreenTransition>;
 
 export const Default: Story = {
   render: () => {
-    const { currentTheme, mode } = useTheme();
+    const { currentTheme } = useTheme();
     const bodyTheme = currentTheme?.body;
 
     function PageTitle({

--- a/components/screen-transition.stories.tsx
+++ b/components/screen-transition.stories.tsx
@@ -1,0 +1,140 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  ScreenTransition,
+  ScreenProps,
+  ScreenNavigator,
+} from "./screen-transition";
+import { Title } from "./title";
+import { RiArrowLeftSLine } from "@remixicon/react";
+import { css } from "styled-components";
+import { Button } from "./button";
+
+const meta: Meta<typeof ScreenTransition> = {
+  title: "Mobile/ScreenTransition",
+  component: ScreenTransition,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ScreenTransition>;
+
+export const Default: Story = {
+  render: () => {
+    function PageTitle({
+      text,
+      gotoPrevScreen = null,
+    }: {
+      text?: string;
+    } & Partial<ScreenProps>) {
+      return (
+        <Title
+          size="md"
+          leftSection={
+            gotoPrevScreen
+              ? [
+                  {
+                    styles: {
+                      toggleActionStyle: css`
+                        padding: 10px;
+                      `,
+                    },
+                    type: "actions",
+                    actions: [
+                      {
+                        caption: "back",
+                        icon: { image: RiArrowLeftSLine },
+                        onClick: () => {
+                          gotoPrevScreen();
+                        },
+                      },
+                    ],
+                  },
+                ]
+              : []
+          }
+          text={text}
+          styles={{
+            containerStyle: css`
+              border-bottom: 1px solid #ececec;
+              height: 53px;
+              justify-content: center;
+              align-items: center;
+            `,
+            textContainerStyle: css`
+              align-items: center;
+            `,
+            titleStyle: css`
+              justify-content: center;
+
+              ${gotoPrevScreen &&
+              css`
+                padding-right: 40px;
+              `}
+              align-items: center;
+            `,
+          }}
+        />
+      );
+    }
+
+    function PageC() {
+      return (
+        <ScreenTransition prevScreen={PageB}>
+          {({ gotoPrevScreen }) => (
+            <>
+              <PageTitle text="Page C" gotoPrevScreen={gotoPrevScreen} />
+            </>
+          )}
+        </ScreenTransition>
+      );
+    }
+
+    function PageB() {
+      return (
+        <ScreenTransition prevScreen={PageA} nextScreen={PageC}>
+          {({ gotoPrevScreen, gotoNextScreen }) => (
+            <>
+              <PageTitle text="Page B" gotoPrevScreen={gotoPrevScreen} />
+              <Button
+                styles={{
+                  containerStyle: css`
+                    margin-top: 10px;
+                  `,
+                }}
+                onClick={gotoNextScreen ?? undefined}
+              >
+                Go to Page C
+              </Button>
+            </>
+          )}
+        </ScreenTransition>
+      );
+    }
+
+    function PageA() {
+      return (
+        <ScreenTransition nextScreen={PageB}>
+          {({ gotoNextScreen }) => (
+            <>
+              <PageTitle text="Page A" gotoPrevScreen={null} />
+              <Button
+                styles={{
+                  containerStyle: css`
+                    margin-top: 10px;
+                  `,
+                }}
+                onClick={gotoNextScreen ?? undefined}
+              >
+                Go to Page B
+              </Button>
+            </>
+          )}
+        </ScreenTransition>
+      );
+    }
+
+    return <ScreenNavigator initial={PageA} />;
+  },
+};

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -1,260 +1,56 @@
-import React, {
-  createContext,
-  useContext,
-  useState,
-  useCallback,
-  ComponentType,
-  ReactElement,
-  cloneElement,
-  Children,
-} from "react";
-import styled from "styled-components";
-
+import React, { createContext, ReactNode, useContext, useRef } from "react";
+import { PaperDialog, PaperDialogRef } from "./paper-dialog";
 export interface ScreenProps {
   gotoNextScreen: (() => void) | null;
   gotoPrevScreen: (() => void) | null;
 }
 
-export type ScreenComponent = ComponentType<any>;
-
 export interface ScreenTransitionProps {
-  /** The child element (your page component). It will receive `ScreenProps` injected automatically. */
-  children: ReactElement | ((props: ScreenProps) => ReactElement);
-  /**
-   * A **function** that returns the JSX of the next screen.
-   * Pass the exported `*Screen` wrapper, not the raw page component.
-   */
-  nextScreen?: ScreenComponent | null;
-  /**
-   * A **function** that returns the JSX of the previous screen.
-   * Pass the exported `*Screen` wrapper, not the raw page component.
-   */
-  prevScreen?: ScreenComponent | null;
-  /** Extra props forwarded to the child page component. */
-  pageProps?: Record<string, unknown>;
+  children: ReactNode | ((props: ScreenProps) => ReactNode);
+  nextScreen?: React.ComponentType | null;
 }
 
-type Direction = "forward" | "backward" | "none";
-
-interface NavEntry {
-  Screen: ScreenComponent;
-  props?: Record<string, unknown>;
-}
-
-interface NavContextValue {
-  push: (Screen: ScreenComponent, props?: Record<string, unknown>) => void;
-  pop: () => void;
-  canPop: boolean;
-}
-
-const NavContext = createContext<NavContextValue | null>(null);
-
-export function ScreenNavigator({
-  initial,
-  initialProps,
-}: {
-  initial: ScreenComponent;
-  initialProps?: Record<string, unknown>;
-}) {
-  const [stack, setStack] = useState<NavEntry[]>([
-    { Screen: initial, props: initialProps },
-  ]);
-  const [direction, setDirection] = useState<Direction>("none");
-  const [transitioning, setTransitioning] = useState(false);
-  const [phase, setPhase] = useState<"idle" | "exit" | "enter">("idle");
-
-  const current = stack[stack.length - 1];
-  const [incoming, setIncoming] = useState<NavEntry | null>(null);
-
-  const DURATION = 320;
-
-  const push = useCallback(
-    (Screen: ScreenComponent, props?: Record<string, unknown>) => {
-      if (transitioning) return;
-      setIncoming({ Screen, props });
-      setDirection("forward");
-      setPhase("exit");
-      setTransitioning(true);
-
-      setTimeout(() => {
-        setStack((s) => [...s, { Screen, props }]);
-        setIncoming(null);
-        setPhase("enter");
-        setTimeout(() => {
-          setPhase("idle");
-          setTransitioning(false);
-        }, DURATION);
-      }, DURATION);
-    },
-    [transitioning]
-  );
-
-  const pop = useCallback(() => {
-    if (transitioning || stack.length <= 1) return;
-    const prev = stack[stack.length - 2];
-    setIncoming(prev);
-    setDirection("backward");
-    setPhase("exit");
-    setTransitioning(true);
-
-    setTimeout(() => {
-      setStack((s) => s.slice(0, -1));
-      setIncoming(null);
-      setPhase("enter");
-      setTimeout(() => {
-        setPhase("idle");
-        setTransitioning(false);
-      }, DURATION);
-    }, DURATION);
-  }, [transitioning, stack]);
-
-  const canPop = stack.length > 1;
-
-  const ctx: NavContextValue = { push, pop, canPop };
-
-  const currentTransform = (() => {
-    if (phase === "idle") return "translateX(0)";
-    if (phase === "exit")
-      return direction === "forward" ? "translateX(-100%)" : "translateX(100%)";
-    if (phase === "enter") return "translateX(0)";
-    return "translateX(0)";
-  })();
-
-  const incomingTransform = (() => {
-    if (phase === "exit")
-      return direction === "forward" ? "translateX(100%)" : "translateX(-100%)";
-    if (phase === "enter") return "translateX(0)";
-    return "translateX(100%)";
-  })();
-
-  const { Screen: CurrentScreen, props: currentProps } = current;
-
-  return (
-    <NavContext.Provider value={ctx}>
-      <Root>
-        <ScreenSlot
-          key={stack.length}
-          style={{
-            transform: currentTransform,
-            transition:
-              phase !== "idle"
-                ? `transform ${DURATION}ms cubic-bezier(0.4, 0, 0.2, 1)`
-                : "none",
-            zIndex: direction === "forward" ? 1 : 2,
-          }}
-        >
-          <CurrentScreen {...(currentProps ?? {})} />
-        </ScreenSlot>
-
-        {incoming && (
-          <ScreenSlot
-            key={`incoming-${stack.length}`}
-            style={{
-              transform: incomingTransform,
-              transition: `transform ${DURATION}ms cubic-bezier(0.4, 0, 0.2, 1)`,
-              zIndex: direction === "forward" ? 2 : 1,
-            }}
-          >
-            <incoming.Screen {...(incoming.props ?? {})} />
-          </ScreenSlot>
-        )}
-      </Root>
-    </NavContext.Provider>
-  );
-}
+const ParentDialogContext =
+  createContext<React.RefObject<PaperDialogRef | null> | null>(null);
 
 function ScreenTransition({
   children,
-  nextScreen = null,
-  prevScreen = null,
-  pageProps = {},
+  nextScreen: NextScreen,
 }: ScreenTransitionProps) {
-  const nav = useContext(NavContext);
+  const parentDialogRef = useContext(ParentDialogContext);
 
-  if (!nav) {
-    const RootScreen: ScreenComponent = () => (
-      <ScreenTransitionInner
-        nextScreen={nextScreen}
-        prevScreen={prevScreen}
-        pageProps={pageProps}
-      >
-        {children}
-      </ScreenTransitionInner>
-    );
-
-    return <ScreenNavigator initial={RootScreen} />;
-  }
+  const dialogRef = useRef<PaperDialogRef>(null);
 
   return (
-    <ScreenTransitionInner
-      nextScreen={nextScreen}
-      prevScreen={prevScreen}
-      pageProps={pageProps}
-    >
-      {children}
-    </ScreenTransitionInner>
+    <ParentDialogContext.Provider value={dialogRef}>
+      {typeof children === "function"
+        ? children({
+            gotoNextScreen: NextScreen
+              ? () => {
+                  dialogRef?.current?.openDialog();
+                }
+              : null,
+            gotoPrevScreen: () => {
+              parentDialogRef?.current?.minimizeDialog();
+
+              setTimeout(() => {
+                parentDialogRef?.current?.closeDialog();
+              }, 400);
+            },
+          })
+        : children}
+      <PaperDialog
+        ref={dialogRef}
+        closable={false}
+        controls={[]}
+        width={"100dvw"}
+        height={"100dvh"}
+      >
+        {NextScreen && <NextScreen />}
+        test
+      </PaperDialog>
+    </ParentDialogContext.Provider>
   );
 }
-
-function ScreenTransitionInner({
-  children,
-  nextScreen,
-  prevScreen,
-  pageProps = {},
-}: Omit<ScreenTransitionProps, "children"> & {
-  children:
-    | ReactElement<Record<string, any>>
-    | ((props: ScreenProps) => ReactElement);
-}) {
-  const nav = useContext(NavContext)!;
-
-  const gotoNextScreen = nextScreen ? () => nav.push(nextScreen) : null;
-
-  const gotoPrevScreen = prevScreen
-    ? () => nav.push(prevScreen)
-    : nav.canPop
-      ? () => nav.pop()
-      : null;
-
-  const injected: ScreenProps = { gotoNextScreen, gotoPrevScreen };
-
-  const rendered =
-    typeof children === "function"
-      ? children(injected)
-      : cloneElement(children, {
-          ...injected,
-          ...pageProps,
-          ...children.props,
-        });
-
-  return <Page>{rendered}</Page>;
-}
-
-const Root = styled.div`
-  position: relative;
-  width: 100%;
-  height: 100dvh;
-  overflow: hidden;
-  isolation: isolate;
-`;
-
-const ScreenSlot = styled.div`
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: hidden;
-  will-change: transform;
-  backface-visibility: hidden;
-`;
-
-const Page = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100dvh;
-  overflow: hidden;
-`;
 
 export { ScreenTransition };

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -47,7 +47,6 @@ function ScreenTransition({
         height={"100dvh"}
       >
         {NextScreen && <NextScreen />}
-        test
       </PaperDialog>
     </ParentDialogContext.Provider>
   );

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -1,5 +1,14 @@
-import React, { createContext, ReactNode, useContext, useRef } from "react";
+import React, {
+  cloneElement,
+  createContext,
+  isValidElement,
+  ReactNode,
+  useContext,
+  useRef,
+} from "react";
 import { PaperDialog, PaperDialogRef } from "./paper-dialog";
+import { css } from "styled-components";
+
 export interface ScreenProps {
   gotoNextScreen: (() => void) | null;
   gotoPrevScreen: (() => void) | null;
@@ -21,25 +30,36 @@ function ScreenTransition({
 
   const dialogRef = useRef<PaperDialogRef>(null);
 
+  const injectedProps: ScreenProps = {
+    gotoNextScreen: NextScreen
+      ? () => {
+          dialogRef?.current?.openDialog();
+        }
+      : null,
+    gotoPrevScreen: parentDialogRef
+      ? () => {
+          parentDialogRef?.current?.minimizeDialog();
+
+          setTimeout(() => {
+            parentDialogRef?.current?.closeDialog();
+          }, 400);
+        }
+      : null,
+  };
+
   return (
     <ParentDialogContext.Provider value={dialogRef}>
       {typeof children === "function"
-        ? children({
-            gotoNextScreen: NextScreen
-              ? () => {
-                  dialogRef?.current?.openDialog();
-                }
-              : null,
-            gotoPrevScreen: () => {
-              parentDialogRef?.current?.minimizeDialog();
-
-              setTimeout(() => {
-                parentDialogRef?.current?.closeDialog();
-              }, 400);
-            },
-          })
-        : children}
+        ? children(injectedProps)
+        : isValidElement(children)
+          ? cloneElement(children, injectedProps)
+          : children}
       <PaperDialog
+        styles={{
+          contentStyle: css`
+            gap: 0px;
+          `,
+        }}
         ref={dialogRef}
         closable={false}
         controls={[]}

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -1,0 +1,260 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  ComponentType,
+  ReactElement,
+  cloneElement,
+  Children,
+} from "react";
+import styled from "styled-components";
+
+export interface ScreenProps {
+  gotoNextScreen: (() => void) | null;
+  gotoPrevScreen: (() => void) | null;
+}
+
+export type ScreenComponent = ComponentType<any>;
+
+export interface ScreenTransitionProps {
+  /** The child element (your page component). It will receive `ScreenProps` injected automatically. */
+  children: ReactElement | ((props: ScreenProps) => ReactElement);
+  /**
+   * A **function** that returns the JSX of the next screen.
+   * Pass the exported `*Screen` wrapper, not the raw page component.
+   */
+  nextScreen?: ScreenComponent | null;
+  /**
+   * A **function** that returns the JSX of the previous screen.
+   * Pass the exported `*Screen` wrapper, not the raw page component.
+   */
+  prevScreen?: ScreenComponent | null;
+  /** Extra props forwarded to the child page component. */
+  pageProps?: Record<string, unknown>;
+}
+
+type Direction = "forward" | "backward" | "none";
+
+interface NavEntry {
+  Screen: ScreenComponent;
+  props?: Record<string, unknown>;
+}
+
+interface NavContextValue {
+  push: (Screen: ScreenComponent, props?: Record<string, unknown>) => void;
+  pop: () => void;
+  canPop: boolean;
+}
+
+const NavContext = createContext<NavContextValue | null>(null);
+
+export function ScreenNavigator({
+  initial,
+  initialProps,
+}: {
+  initial: ScreenComponent;
+  initialProps?: Record<string, unknown>;
+}) {
+  const [stack, setStack] = useState<NavEntry[]>([
+    { Screen: initial, props: initialProps },
+  ]);
+  const [direction, setDirection] = useState<Direction>("none");
+  const [transitioning, setTransitioning] = useState(false);
+  const [phase, setPhase] = useState<"idle" | "exit" | "enter">("idle");
+
+  const current = stack[stack.length - 1];
+  const [incoming, setIncoming] = useState<NavEntry | null>(null);
+
+  const DURATION = 320;
+
+  const push = useCallback(
+    (Screen: ScreenComponent, props?: Record<string, unknown>) => {
+      if (transitioning) return;
+      setIncoming({ Screen, props });
+      setDirection("forward");
+      setPhase("exit");
+      setTransitioning(true);
+
+      setTimeout(() => {
+        setStack((s) => [...s, { Screen, props }]);
+        setIncoming(null);
+        setPhase("enter");
+        setTimeout(() => {
+          setPhase("idle");
+          setTransitioning(false);
+        }, DURATION);
+      }, DURATION);
+    },
+    [transitioning]
+  );
+
+  const pop = useCallback(() => {
+    if (transitioning || stack.length <= 1) return;
+    const prev = stack[stack.length - 2];
+    setIncoming(prev);
+    setDirection("backward");
+    setPhase("exit");
+    setTransitioning(true);
+
+    setTimeout(() => {
+      setStack((s) => s.slice(0, -1));
+      setIncoming(null);
+      setPhase("enter");
+      setTimeout(() => {
+        setPhase("idle");
+        setTransitioning(false);
+      }, DURATION);
+    }, DURATION);
+  }, [transitioning, stack]);
+
+  const canPop = stack.length > 1;
+
+  const ctx: NavContextValue = { push, pop, canPop };
+
+  const currentTransform = (() => {
+    if (phase === "idle") return "translateX(0)";
+    if (phase === "exit")
+      return direction === "forward" ? "translateX(-100%)" : "translateX(100%)";
+    if (phase === "enter") return "translateX(0)";
+    return "translateX(0)";
+  })();
+
+  const incomingTransform = (() => {
+    if (phase === "exit")
+      return direction === "forward" ? "translateX(100%)" : "translateX(-100%)";
+    if (phase === "enter") return "translateX(0)";
+    return "translateX(100%)";
+  })();
+
+  const { Screen: CurrentScreen, props: currentProps } = current;
+
+  return (
+    <NavContext.Provider value={ctx}>
+      <Root>
+        <ScreenSlot
+          key={stack.length}
+          style={{
+            transform: currentTransform,
+            transition:
+              phase !== "idle"
+                ? `transform ${DURATION}ms cubic-bezier(0.4, 0, 0.2, 1)`
+                : "none",
+            zIndex: direction === "forward" ? 1 : 2,
+          }}
+        >
+          <CurrentScreen {...(currentProps ?? {})} />
+        </ScreenSlot>
+
+        {incoming && (
+          <ScreenSlot
+            key={`incoming-${stack.length}`}
+            style={{
+              transform: incomingTransform,
+              transition: `transform ${DURATION}ms cubic-bezier(0.4, 0, 0.2, 1)`,
+              zIndex: direction === "forward" ? 2 : 1,
+            }}
+          >
+            <incoming.Screen {...(incoming.props ?? {})} />
+          </ScreenSlot>
+        )}
+      </Root>
+    </NavContext.Provider>
+  );
+}
+
+function ScreenTransition({
+  children,
+  nextScreen = null,
+  prevScreen = null,
+  pageProps = {},
+}: ScreenTransitionProps) {
+  const nav = useContext(NavContext);
+
+  if (!nav) {
+    const RootScreen: ScreenComponent = () => (
+      <ScreenTransitionInner
+        nextScreen={nextScreen}
+        prevScreen={prevScreen}
+        pageProps={pageProps}
+      >
+        {children}
+      </ScreenTransitionInner>
+    );
+
+    return <ScreenNavigator initial={RootScreen} />;
+  }
+
+  return (
+    <ScreenTransitionInner
+      nextScreen={nextScreen}
+      prevScreen={prevScreen}
+      pageProps={pageProps}
+    >
+      {children}
+    </ScreenTransitionInner>
+  );
+}
+
+function ScreenTransitionInner({
+  children,
+  nextScreen,
+  prevScreen,
+  pageProps = {},
+}: Omit<ScreenTransitionProps, "children"> & {
+  children:
+    | ReactElement<Record<string, any>>
+    | ((props: ScreenProps) => ReactElement);
+}) {
+  const nav = useContext(NavContext)!;
+
+  const gotoNextScreen = nextScreen ? () => nav.push(nextScreen) : null;
+
+  const gotoPrevScreen = prevScreen
+    ? () => nav.push(prevScreen)
+    : nav.canPop
+      ? () => nav.pop()
+      : null;
+
+  const injected: ScreenProps = { gotoNextScreen, gotoPrevScreen };
+
+  const rendered =
+    typeof children === "function"
+      ? children(injected)
+      : cloneElement(children, {
+          ...injected,
+          ...pageProps,
+          ...children.props,
+        });
+
+  return <Page>{rendered}</Page>;
+}
+
+const Root = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100dvh;
+  overflow: hidden;
+  isolation: isolate;
+`;
+
+const ScreenSlot = styled.div`
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  will-change: transform;
+  backface-visibility: hidden;
+`;
+
+const Page = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100dvh;
+  overflow: hidden;
+`;
+
+export { ScreenTransition };

--- a/test/component/screen-transition.cy.tsx
+++ b/test/component/screen-transition.cy.tsx
@@ -1,0 +1,374 @@
+import { useTheme } from "./../../theme";
+import {
+  ScreenProps,
+  ScreenTransition,
+} from "./../../components/screen-transition";
+import styled, { css } from "styled-components";
+import { RiArrowLeftSLine } from "@remixicon/react";
+import { Title } from "./../../components/title";
+import { Button } from "./../../components/button";
+
+describe("Screen Transition", () => {
+  //   with function children
+  function ProductTransition() {
+    const { currentTheme } = useTheme();
+    const bodyTheme = currentTheme?.body;
+
+    function PageTitle({
+      text,
+      gotoPrevScreen = null,
+    }: {
+      text?: string;
+    } & Partial<ScreenProps>) {
+      return (
+        <Title
+          size="md"
+          leftSection={
+            gotoPrevScreen
+              ? [
+                  {
+                    styles: {
+                      toggleActionStyle: css`
+                        padding: 4px;
+                        height: 30px;
+                        width: 30px;
+                        border-radius: 4px;
+                      `,
+                    },
+                    type: "actions",
+                    actions: [
+                      {
+                        caption: "back",
+                        icon: { image: RiArrowLeftSLine },
+                        onClick: () => {
+                          gotoPrevScreen();
+                        },
+                      },
+                    ],
+                  },
+                ]
+              : []
+          }
+          text={text}
+          styles={{
+            containerStyle: css`
+              border-bottom: 1px solid ${bodyTheme?.borderColor || "#ececec"};
+              height: 53px;
+              justify-content: center;
+              align-items: center;
+              padding: 0 6px;
+            `,
+            textContainerStyle: css`
+              align-items: center;
+            `,
+            titleStyle: css`
+              justify-content: center;
+              font-size: 20px;
+
+              ${gotoPrevScreen &&
+              css`
+                padding-right: 40px;
+              `}
+              align-items: center;
+            `,
+          }}
+        />
+      );
+    }
+
+    function PageC() {
+      return (
+        <ScreenTransition>
+          {({ gotoPrevScreen }) => (
+            <Wrapper aria-label="wrapper">
+              <PageTitle text="Page C" gotoPrevScreen={gotoPrevScreen} />
+            </Wrapper>
+          )}
+        </ScreenTransition>
+      );
+    }
+
+    function PageB() {
+      return (
+        <ScreenTransition nextScreen={PageC}>
+          {({ gotoPrevScreen, gotoNextScreen }) => (
+            <Wrapper aria-label="wrapper">
+              <PageTitle text="Page B" gotoPrevScreen={gotoPrevScreen} />
+              <Button onClick={gotoNextScreen ?? undefined}>
+                Go to Page C
+              </Button>
+            </Wrapper>
+          )}
+        </ScreenTransition>
+      );
+    }
+
+    function PageA() {
+      return (
+        <ScreenTransition nextScreen={PageB}>
+          {({ gotoNextScreen }) => (
+            <Wrapper aria-label="wrapper">
+              <PageTitle text="Page A" gotoPrevScreen={null} />
+              <Button onClick={gotoNextScreen ?? undefined}>
+                Go to Page B
+              </Button>
+            </Wrapper>
+          )}
+        </ScreenTransition>
+      );
+    }
+
+    return <PageA />;
+  }
+
+  //   with separate children
+  function ProductWithSeparateChildren() {
+    const { currentTheme } = useTheme();
+    const bodyTheme = currentTheme?.body;
+
+    function PageTitle({
+      text,
+      gotoPrevScreen = null,
+    }: {
+      text?: string;
+    } & Partial<ScreenProps>) {
+      return (
+        <Title
+          size="md"
+          leftSection={
+            gotoPrevScreen
+              ? [
+                  {
+                    styles: {
+                      toggleActionStyle: css`
+                        padding: 4px;
+                        height: 30px;
+                        width: 30px;
+                        border-radius: 4px;
+                      `,
+                    },
+                    type: "actions",
+                    actions: [
+                      {
+                        caption: "back",
+                        icon: { image: RiArrowLeftSLine },
+                        onClick: () => {
+                          gotoPrevScreen();
+                        },
+                      },
+                    ],
+                  },
+                ]
+              : []
+          }
+          text={text}
+          styles={{
+            containerStyle: css`
+              border-bottom: 1px solid ${bodyTheme?.borderColor || "#ececec"};
+              height: 53px;
+              justify-content: center;
+              align-items: center;
+              padding: 0 6px;
+            `,
+            textContainerStyle: css`
+              align-items: center;
+            `,
+            titleStyle: css`
+              justify-content: center;
+              font-size: 20px;
+
+              ${gotoPrevScreen &&
+              css`
+                padding-right: 40px;
+              `}
+              align-items: center;
+            `,
+          }}
+        />
+      );
+    }
+
+    function PageCScreen({ gotoPrevScreen }: Partial<ScreenProps>) {
+      return (
+        <Wrapper aria-label="wrapper">
+          <PageTitle text="Page C" gotoPrevScreen={gotoPrevScreen} />
+        </Wrapper>
+      );
+    }
+
+    function PageC() {
+      return (
+        <ScreenTransition>
+          <PageCScreen />
+        </ScreenTransition>
+      );
+    }
+
+    function PageBScreen({
+      gotoPrevScreen,
+      gotoNextScreen,
+    }: Partial<ScreenProps>) {
+      return (
+        <Wrapper aria-label="wrapper">
+          <PageTitle text="Page B" gotoPrevScreen={gotoPrevScreen} />
+
+          <Button onClick={gotoNextScreen ?? undefined}>Go to Page C</Button>
+        </Wrapper>
+      );
+    }
+
+    function PageB() {
+      return (
+        <ScreenTransition nextScreen={PageC}>
+          <PageBScreen />
+        </ScreenTransition>
+      );
+    }
+
+    function PageAScreen({ gotoNextScreen }: Partial<ScreenProps>) {
+      return (
+        <Wrapper aria-label="wrapper">
+          <PageTitle text="Page A" gotoPrevScreen={null} />
+
+          <Button onClick={gotoNextScreen ?? undefined}>Go to Page B</Button>
+        </Wrapper>
+      );
+    }
+
+    function PageA() {
+      return (
+        <ScreenTransition nextScreen={PageB}>
+          <PageAScreen />
+        </ScreenTransition>
+      );
+    }
+
+    return <PageA />;
+  }
+
+  context("when clicking next button", () => {
+    it("should move to the page B", () => {
+      cy.mount(<ProductTransition />);
+      cy.findByLabelText("title-title").should("not.have.text", "Page B");
+      cy.findAllByLabelText("wrapper")
+        .eq(0)
+        .then(() => {
+          cy.findByText("Go to Page B").should("be.visible").click();
+        });
+
+      cy.wait(700);
+      cy.findAllByLabelText("title-title").eq(1).should("have.text", "Page B");
+      cy.findAllByLabelText("wrapper")
+        .eq(1)
+        .then(() => {
+          cy.findByText("Go to Page C").should("be.visible");
+        });
+    });
+
+    context("when clicking next button", () => {
+      it("should move to the page C", () => {
+        cy.mount(<ProductTransition />);
+        cy.findByLabelText("title-title").should("not.have.text", "Page B");
+        cy.findAllByLabelText("wrapper")
+          .eq(0)
+          .then(() => {
+            cy.findByText("Go to Page B").should("be.visible").click();
+          });
+
+        cy.wait(700);
+        cy.findAllByLabelText("title-title")
+          .eq(1)
+          .should("have.text", "Page B");
+        cy.findAllByLabelText("wrapper")
+          .eq(1)
+          .then(() => {
+            cy.findByText("Go to Page C").should("be.visible").click();
+          });
+
+        cy.wait(700);
+        cy.findAllByLabelText("title-title")
+          .eq(2)
+          .should("have.text", "Page C");
+        cy.findAllByLabelText("wrapper").eq(2).should("exist");
+      });
+    });
+
+    context("when clicking chevron icon", () => {
+      it("should move to the page A", () => {
+        cy.mount(<ProductTransition />);
+        cy.findByLabelText("title-title").should("not.have.text", "Page B");
+        cy.findAllByLabelText("wrapper")
+          .eq(0)
+          .then(() => {
+            cy.findByText("Go to Page B").should("be.visible").click();
+          });
+
+        cy.wait(700);
+        cy.findAllByLabelText("title-title")
+          .eq(1)
+          .should("have.text", "Page B");
+        cy.findAllByLabelText("wrapper")
+          .eq(1)
+          .then(() => {
+            cy.findByLabelText("action-button").click();
+          });
+
+        cy.wait(700);
+        cy.findAllByLabelText("wrapper").eq(1).should("not.exist");
+        cy.findAllByLabelText("title-title").eq(1).should("not.exist");
+      });
+    });
+  });
+
+  context("children", () => {
+    context("when using function", () => {
+      it("still can use next and previous function", () => {
+        cy.mount(<ProductTransition />);
+        cy.findByLabelText("title-title").should("not.have.text", "Page B");
+        cy.findAllByLabelText("wrapper")
+          .eq(0)
+          .then(() => {
+            cy.findByText("Go to Page B").should("be.visible").click();
+          });
+
+        cy.wait(700);
+        cy.findAllByLabelText("title-title")
+          .eq(1)
+          .should("have.text", "Page B");
+        cy.findAllByLabelText("wrapper")
+          .eq(1)
+          .then(() => {
+            cy.findByText("Go to Page C").should("be.visible");
+          });
+      });
+    });
+
+    context("when using separate children", () => {
+      it("still can use next and previous function", () => {
+        cy.mount(<ProductWithSeparateChildren />);
+        cy.findByLabelText("title-title").should("not.have.text", "Page B");
+        cy.findAllByLabelText("wrapper")
+          .eq(0)
+          .then(() => {
+            cy.findByText("Go to Page B").should("be.visible").click();
+          });
+
+        cy.wait(700);
+        cy.findAllByLabelText("title-title")
+          .eq(1)
+          .should("have.text", "Page B");
+        cy.findAllByLabelText("wrapper")
+          .eq(1)
+          .then(() => {
+            cy.findByText("Go to Page C").should("be.visible");
+          });
+      });
+    });
+  });
+});
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+`;


### PR DESCRIPTION
Description:
This pull request introduces a `ScreenTransition` component designed for mobile navigation behavior when transition between pages.

This component provides `mobile-style` screen navigation using nested `PaperDialog` instances.

It injects `gotoNextScreen` and `gotoPrevScreen` props into children, allowing screen to navigate forward and backward without manually managing dialog state.

Source:
[[Mobile] SYST-632: Add `ScreenTransition`](https://linear.app/systatum/issue/SYST-632/add-screentransition)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself