### PR TITLE
[Bug] SYST-669: Fix markdown on non-code editor but showing code editor

### DIFF
--- a/components/code-editor.tsx
+++ b/components/code-editor.tsx
@@ -679,13 +679,20 @@ function hydrateFencedCodeEditors(
   if (!editorRef.current) return;
 
   editorRef.current.querySelectorAll("pre").forEach((pre) => {
-    // Skip if already hydrated
     if (pre.dataset.monacoHydrated) return;
-    pre.dataset.monacoHydrated = "true";
 
     const codeEl = pre.querySelector("code");
-    const rawCode = codeEl?.textContent ?? pre.textContent ?? "";
     const langClass = codeEl?.className ?? "";
+    const hasLangClass = /language-\w+/.test(langClass);
+
+    if (!hasLangClass) {
+      pre.dataset.monacoHydrated = "true";
+      return;
+    }
+
+    pre.dataset.monacoHydrated = "true";
+
+    const rawCode = codeEl?.textContent ?? pre.textContent ?? "";
     const langMatch = langClass.match(/language-(\w+)/);
     const lang = langMatch ? langMatch[1] : "plaintext";
 

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -790,60 +790,183 @@ export const LegalDocument: Story = {
       <RichEditor
         height={700}
         mode="view-only"
-        value={`                                Systatum Antrikan License
-                                    Version 1.0, 2026
-                             https://systatum.com/licenses/
+        value={`                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 1.  Definitions.
 
     "License" shall mean the terms and conditions for use, reproduction,
-    and distribution as defined by Sections 1 through 9 of this document.   
+    and distribution as defined by Sections 1 through 9 of this document.
 
-    "Licensor" shall mean Systatum and any entity authorized by Systatum
-    that is granting the License.
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
 
     "Legal Entity" shall mean the union of the acting entity and all
     other entities that control, are controlled by, or are under common
-    control with that entity.
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
 
     "You" (or "Your") shall mean an individual or Legal Entity
     exercising permissions granted by this License.
 
-    "Work" shall mean the software, documentation, or other materials
-    made available under this License by the Licensor.
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
 
-2.  Grant of Copyright License.
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
 
-    Subject to the terms and conditions of this License, the Licensor
-    hereby grants to You a perpetual, worldwide, non-exclusive,
-    no-charge, royalty-free copyright license to reproduce, prepare
-    derivative works of, publicly display, and distribute the Work.
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
 
-3.  Redistribution.
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
 
-    You may reproduce and distribute copies of the Work in any medium,
-    with or without modifications, provided that You meet the following
-    conditions:
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
 
-    (a) You must give any other recipients of the Work a copy of this
-        License; and
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
 
     (b) You must cause any modified files to carry prominent notices
-        stating that You changed the files; and
+    stating that You changed the files; and
 
-    (c) You must retain, in the Work, all copyright, patent, trademark,
-        and attribution notices from the source form of the Work.
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
 
-4.  Limitation of Liability.
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
 
-    In no event shall the Licensor be liable to You for any damages,
-    including any direct, indirect, incidental, or consequential damages
-    of any character arising as a result of this License or out of the
-    use of the Work.
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
 
-END OF TERMS AND CONDITIONS`}
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+`}
       />
     );
   },

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -783,3 +783,68 @@ export default Content
     );
   },
 };
+
+export const ViewOnlyPlainText: Story = {
+  render: () => {
+    return (
+      <RichEditor
+        height={700}
+        mode="view-only-plain-text"
+        value={`                              Systatum Antrikan License
+                                        Version 1.0, 2026
+                             https://systatum.com/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean Systatum and any entity authorized by Systatum
+    that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Work" shall mean the software, documentation, or other materials
+    made available under this License by the Licensor.
+
+2.  Grant of Copyright License.
+
+    Subject to the terms and conditions of this License, the Licensor
+    hereby grants to You a perpetual, worldwide, non-exclusive,
+    no-charge, royalty-free copyright license to reproduce, prepare
+    derivative works of, publicly display, and distribute the Work.
+
+3.  Redistribution.
+
+    You may reproduce and distribute copies of the Work in any medium,
+    with or without modifications, provided that You meet the following
+    conditions:
+
+    (a) You must give any other recipients of the Work a copy of this
+        License; and
+
+    (b) You must cause any modified files to carry prominent notices
+        stating that You changed the files; and
+
+    (c) You must retain, in the Work, all copyright, patent, trademark,
+        and attribution notices from the source form of the Work.
+
+4.  Limitation of Liability.
+
+    In no event shall the Licensor be liable to You for any damages,
+    including any direct, indirect, incidental, or consequential damages
+    of any character arising as a result of this License or out of the
+    use of the Work.
+
+END OF TERMS AND CONDITIONS`}
+      />
+    );
+  },
+};

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -784,14 +784,14 @@ export default Content
   },
 };
 
-export const ViewOnlyPlainText: Story = {
+export const LegalDocument: Story = {
   render: () => {
     return (
       <RichEditor
         height={700}
-        mode="view-only-plain-text"
-        value={`                              Systatum Antrikan License
-                                        Version 1.0, 2026
+        mode="view-only"
+        value={`                                Systatum Antrikan License
+                                    Version 1.0, 2026
                              https://systatum.com/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
@@ -799,7 +799,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 1.  Definitions.
 
     "License" shall mean the terms and conditions for use, reproduction,
-    and distribution as defined by Sections 1 through 9 of this document.
+    and distribution as defined by Sections 1 through 9 of this document.   
 
     "Licensor" shall mean Systatum and any entity authorized by Systatum
     that is granting the License.

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -388,7 +388,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     };
 
     useImperativeHandle(ref, () => ({
-      insertMarkdownContent: async (data: string) => {
+      insertMarkdownContent: async (content: string) => {
         if (!editorRef.current) return;
 
         if (document.activeElement !== editorRef.current) {
@@ -400,7 +400,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         let range = sel?.rangeCount ? sel.getRangeAt(0) : null;
         if (!range) return;
 
-        let html = await marked.parse(value);
+        let html = await marked.parse(content);
 
         html = splitBrIntoParagraphs(html);
 

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -400,22 +400,9 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         let range = sel?.rangeCount ? sel.getRangeAt(0) : null;
         if (!range) return;
 
-        let processedValue = preprocessMarkdown(data);
-
-        let html = await marked.parse(processedValue);
+        let html = await marked.parse(value);
 
         html = splitBrIntoParagraphs(html);
-
-        html = html.replace(
-          new RegExp(`<p>${EMPTY_P_PLACEHOLDER}</p>`, "g"),
-          "<p><br></p>"
-        );
-
-        // Also strip any placeholder that leaked into a text paragraph
-        html = html.replace(
-          new RegExp(EMPTY_P_PLACEHOLDER, "g"),
-          "<br></p><p>"
-        );
 
         const temp = document.createElement("p");
         temp.innerHTML = html;
@@ -563,27 +550,11 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
         let html: string;
 
-        let processedValue = preprocessMarkdown(value);
-        console.log("PROCESSED:", processedValue);
-
-        html = await marked.parse(processedValue);
-        console.log("HTML:", html);
+        html = value?.trim() ? await marked.parse(value) : `<p>${value}</p>`;
 
         if (!isMounted || !editorRef.current) return;
 
         html = splitBrIntoParagraphs(html);
-
-        html = html.replace(
-          new RegExp(`<p>${EMPTY_P_PLACEHOLDER}</p>`, "g"),
-          "<p><br></p>"
-        );
-        html = html.replace(
-          new RegExp(EMPTY_P_PLACEHOLDER, "g"),
-          "<br></p><p>"
-        );
-
-        // replace padding left for legal document
-        html = html.replace(/<p>( {4,})/g, '<p style="padding-left: 0.8rem">');
 
         editorRef.current.innerHTML = String(html);
         document.execCommand("defaultParagraphSeparator", false, "p");
@@ -2029,8 +2000,7 @@ const EditorArea = styled.div<{
 
   pre[data-monaco-hydrated]:not([data-monaco-block-id]),
   pre[data-monaco-hydrated]:not([data-monaco-block-id]) code {
-    font-family: inherit;
-    font-size: inherit;
+    padding-bottom: 0.5rem;
   }
 
   ${({ $mode }) =>
@@ -2066,8 +2036,12 @@ const EditorArea = styled.div<{
   }
 
   li {
-    padding-left: 0 !important;
     display: list-item !important;
+    padding: 0 !important;
+  }
+
+  li p {
+    padding: 0.25rem 0;
   }
 
   h1 {
@@ -2085,8 +2059,9 @@ const EditorArea = styled.div<{
     margin: 0.4em 0;
   }
 
-  p {
+  p:not(li p) {
     min-height: 24px;
+    padding-bottom: 0.5rem;
   }
 
   ${({ $editorStyle }) => $editorStyle};
@@ -2362,40 +2337,6 @@ const applyInlineStyleToWord = (style: "bold" | "italic") => {
       sel.addRange(newRange);
     }
   }
-};
-
-// Processes all input provided in the editor
-const EMPTY_P_PLACEHOLDER = "EMPTY_PARAGRAPH_PLACEHOLDER";
-
-const preprocessMarkdown = (markdown: string) => {
-  const parts = markdown.split(/(```[\s\S]*?```)/g);
-
-  const processed = parts.map((part, i) => {
-    if (i % 2 === 1) return part;
-
-    let result = part;
-
-    // After a code block, strip all leading newlines and replace with
-    // a clean placeholder separator so marked puts them in separate <p>s
-
-    return result
-      .replace(/\n(\n+)/g, (_, extraNewlines) => {
-        const emptyParagraphs = `\n\n${EMPTY_P_PLACEHOLDER}`.repeat(
-          extraNewlines.length
-        );
-        return "\n" + emptyParagraphs;
-      })
-      .replace(
-        new RegExp(`(${EMPTY_P_PLACEHOLDER})\n([a-zA-Z])`, "g"),
-        `$1\n\n$2`
-      )
-      .replace(
-        /^(\s*(?:[*\-+]|\d+\.)\s+[^\n]+)\n(?![\s*\-+\d<\n])([^\n]+)/gm,
-        "$1\n\n$2"
-      );
-  });
-
-  return processed.join("");
 };
 
 const splitBrIntoParagraphs = (html: string): string => {

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -564,7 +564,10 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         let html: string;
 
         let processedValue = preprocessMarkdown(value);
+        console.log("PROCESSED:", processedValue);
+
         html = await marked.parse(processedValue);
+        console.log("HTML:", html);
 
         if (!isMounted || !editorRef.current) return;
 
@@ -578,6 +581,9 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           new RegExp(EMPTY_P_PLACEHOLDER, "g"),
           "<br></p><p>"
         );
+
+        // replace padding left for legal document
+        html = html.replace(/<p>( {4,})/g, '<p style="padding-left: 0.8rem">');
 
         editorRef.current.innerHTML = String(html);
         document.execCommand("defaultParagraphSeparator", false, "p");
@@ -2373,7 +2379,6 @@ const preprocessMarkdown = (markdown: string) => {
     // a clean placeholder separator so marked puts them in separate <p>s
 
     return result
-      .replace(/([^\n])\n(?![ ]{4})([a-zA-Z])/g, "$1\n\n$2")
       .replace(/\n(\n+)/g, (_, extraNewlines) => {
         const emptyParagraphs = `\n\n${EMPTY_P_PLACEHOLDER}`.repeat(
           extraNewlines.length

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -129,7 +129,6 @@ export type RichEditorToolbarPosition =
 
 export const RichEditorMode = {
   ViewOnly: "view-only",
-  ViewOnlyPlainText: "view-only-plain-text",
   PageEditor: "page-editor",
   TextEditor: "text-editor",
   CodeEditor: "code-editor",
@@ -374,8 +373,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     });
 
     marked.use({
-      gfm: false,
-      breaks: true,
+      gfm: true,
+      breaks: false,
     });
 
     CodeEditor.addFencedCodeMarkedExtension();
@@ -498,12 +497,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     });
 
     const updateFormatStates = () => {
-      if (
-        !editorRef.current ||
-        mode === "view-only" ||
-        mode === "view-only-plain-text"
-      )
-        return;
+      if (!editorRef.current || mode === "view-only") return;
 
       const sel = window.getSelection();
       if (!sel || !sel.rangeCount) return;
@@ -530,8 +524,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
     useEffect(() => {
       const editor = editorRef.current;
-      if (!editor || mode === "view-only" || mode === "view-only-plain-text")
-        return;
+      if (!editor || mode === "view-only") return;
 
       const handleSelectionChange = () => {
         setTimeout(updateFormatStates, 0);
@@ -570,36 +563,21 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
         let html: string;
 
-        if (mode === "view-only-plain-text") {
-          html = value
-            .replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .split("\n")
-            .map(
-              (line) =>
-                `<p style="white-space: pre-wrap;">${line || "<br>"}</p>`
-            )
-            .join("");
-        } else {
-          let processedValue = preprocessMarkdown(value);
-          html = await marked.parse(processedValue);
-
-          if (!isMounted || !editorRef.current) return;
-
-          html = splitBrIntoParagraphs(html);
-
-          html = html.replace(
-            new RegExp(`<p>${EMPTY_P_PLACEHOLDER}</p>`, "g"),
-            "<p><br></p>"
-          );
-          html = html.replace(
-            new RegExp(EMPTY_P_PLACEHOLDER, "g"),
-            "<br></p><p>"
-          );
-        }
+        let processedValue = preprocessMarkdown(value);
+        html = await marked.parse(processedValue);
 
         if (!isMounted || !editorRef.current) return;
+
+        html = splitBrIntoParagraphs(html);
+
+        html = html.replace(
+          new RegExp(`<p>${EMPTY_P_PLACEHOLDER}</p>`, "g"),
+          "<p><br></p>"
+        );
+        html = html.replace(
+          new RegExp(EMPTY_P_PLACEHOLDER, "g"),
+          "<br></p><p>"
+        );
 
         editorRef.current.innerHTML = String(html);
         document.execCommand("defaultParagraphSeparator", false, "p");
@@ -643,8 +621,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         }
       }
 
-      const isViewOnly =
-        mode === "view-only" || mode === "view-only-plain-text";
+      const isViewOnly = mode === "view-only";
 
       textNodesToProcess.forEach((textNode) => {
         if (!textNode.parentNode || !textNode.nodeValue) return;
@@ -821,7 +798,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     };
 
     const handleOnKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-      if (mode === "view-only" || mode === "view-only-plain-text") {
+      if (mode === "view-only") {
         const isCopy = (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "c";
 
         if (!isCopy) {
@@ -1634,8 +1611,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           `,
         }}
         leftSidePanel={
-          mode !== "view-only" &&
-          mode !== "view-only-plain-text" && (
+          mode !== "view-only" && (
             <>
               <RichEditorToolbarButton
                 ariaLabel="rich-editor-toolbar-bold"
@@ -1717,7 +1693,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           $height={height}
           $autogrow={autogrow}
           onPaste={(e) => {
-            if (mode === "view-only" || mode === "view-only-plain-text") return;
+            if (mode === "view-only") return;
 
             e.preventDefault();
 
@@ -2035,7 +2011,7 @@ const EditorArea = styled.div<{
         : css`
             padding-bottom: 45px;
           `
-      : $mode !== "view-only" && $mode !== "view-only-plain-text"
+      : $mode !== "view-only"
         ? $toolbarPosition === "top"
           ? css`
               margin-top: 37px;
@@ -2045,8 +2021,14 @@ const EditorArea = styled.div<{
             `
         : ""};
 
+  pre[data-monaco-hydrated]:not([data-monaco-block-id]),
+  pre[data-monaco-hydrated]:not([data-monaco-block-id]) code {
+    font-family: inherit;
+    font-size: inherit;
+  }
+
   ${({ $mode }) =>
-    ($mode === "view-only" || $mode === "view-only-plain-text") &&
+    $mode === "view-only" &&
     css`
       padding: 12px;
       user-select: text;
@@ -2391,13 +2373,13 @@ const preprocessMarkdown = (markdown: string) => {
     // a clean placeholder separator so marked puts them in separate <p>s
 
     return result
+      .replace(/([^\n])\n(?![ ]{4})([a-zA-Z])/g, "$1\n\n$2")
       .replace(/\n(\n+)/g, (_, extraNewlines) => {
         const emptyParagraphs = `\n\n${EMPTY_P_PLACEHOLDER}`.repeat(
           extraNewlines.length
         );
         return "\n" + emptyParagraphs;
       })
-      .replace(/([^\n])\n([a-zA-Z])/g, "$1\n\n$2")
       .replace(
         new RegExp(`(${EMPTY_P_PLACEHOLDER})\n([a-zA-Z])`, "g"),
         `$1\n\n$2`

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -129,6 +129,7 @@ export type RichEditorToolbarPosition =
 
 export const RichEditorMode = {
   ViewOnly: "view-only",
+  ViewOnlyPlainText: "view-only-plain-text",
   PageEditor: "page-editor",
   TextEditor: "text-editor",
   CodeEditor: "code-editor",
@@ -497,7 +498,12 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     });
 
     const updateFormatStates = () => {
-      if (!editorRef.current || mode === "view-only") return;
+      if (
+        !editorRef.current ||
+        mode === "view-only" ||
+        mode === "view-only-plain-text"
+      )
+        return;
 
       const sel = window.getSelection();
       if (!sel || !sel.rangeCount) return;
@@ -524,7 +530,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
     useEffect(() => {
       const editor = editorRef.current;
-      if (!editor || mode === "view-only") return;
+      if (!editor || mode === "view-only" || mode === "view-only-plain-text")
+        return;
 
       const handleSelectionChange = () => {
         setTimeout(updateFormatStates, 0);
@@ -561,21 +568,38 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       const initializeEditor = async () => {
         if (!editorRef.current || editorRef.current.innerHTML.trim()) return;
 
-        let processedValue = preprocessMarkdown(value);
-        let html = await marked.parse(processedValue);
+        let html: string;
+
+        if (mode === "view-only-plain-text") {
+          html = value
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .split("\n")
+            .map(
+              (line) =>
+                `<p style="white-space: pre-wrap;">${line || "<br>"}</p>`
+            )
+            .join("");
+        } else {
+          let processedValue = preprocessMarkdown(value);
+          html = await marked.parse(processedValue);
+
+          if (!isMounted || !editorRef.current) return;
+
+          html = splitBrIntoParagraphs(html);
+
+          html = html.replace(
+            new RegExp(`<p>${EMPTY_P_PLACEHOLDER}</p>`, "g"),
+            "<p><br></p>"
+          );
+          html = html.replace(
+            new RegExp(EMPTY_P_PLACEHOLDER, "g"),
+            "<br></p><p>"
+          );
+        }
 
         if (!isMounted || !editorRef.current) return;
-
-        html = splitBrIntoParagraphs(html);
-
-        html = html.replace(
-          new RegExp(`<p>${EMPTY_P_PLACEHOLDER}</p>`, "g"),
-          "<p><br></p>"
-        );
-        html = html.replace(
-          new RegExp(EMPTY_P_PLACEHOLDER, "g"),
-          "<br></p><p>"
-        );
 
         editorRef.current.innerHTML = String(html);
         document.execCommand("defaultParagraphSeparator", false, "p");
@@ -619,7 +643,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         }
       }
 
-      const isViewOnly = mode === "view-only";
+      const isViewOnly =
+        mode === "view-only" || mode === "view-only-plain-text";
 
       textNodesToProcess.forEach((textNode) => {
         if (!textNode.parentNode || !textNode.nodeValue) return;
@@ -796,7 +821,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     };
 
     const handleOnKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-      if (mode === "view-only") {
+      if (mode === "view-only" || mode === "view-only-plain-text") {
         const isCopy = (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "c";
 
         if (!isCopy) {
@@ -1609,7 +1634,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           `,
         }}
         leftSidePanel={
-          mode !== "view-only" && (
+          mode !== "view-only" &&
+          mode !== "view-only-plain-text" && (
             <>
               <RichEditorToolbarButton
                 ariaLabel="rich-editor-toolbar-bold"
@@ -1690,6 +1716,24 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           $mode={mode}
           $height={height}
           $autogrow={autogrow}
+          onPaste={(e) => {
+            if (mode === "view-only" || mode === "view-only-plain-text") return;
+
+            e.preventDefault();
+
+            const html = e.clipboardData.getData("text/html");
+            const plain = e.clipboardData.getData("text/plain");
+
+            const hasCodeColors = /color\s*:|background(-color)?\s*:/i.test(
+              html
+            );
+
+            if (!html || hasCodeColors) {
+              document.execCommand("insertText", false, plain);
+            } else {
+              document.execCommand("insertHTML", false, html);
+            }
+          }}
           onInput={() => {
             if (mode !== "view-only") {
               if (editorRef.current) {
@@ -1991,7 +2035,7 @@ const EditorArea = styled.div<{
         : css`
             padding-bottom: 45px;
           `
-      : $mode !== "view-only"
+      : $mode !== "view-only" && $mode !== "view-only-plain-text"
         ? $toolbarPosition === "top"
           ? css`
               margin-top: 37px;
@@ -2002,7 +2046,7 @@ const EditorArea = styled.div<{
         : ""};
 
   ${({ $mode }) =>
-    $mode === "view-only" &&
+    ($mode === "view-only" || $mode === "view-only-plain-text") &&
     css`
       padding: 12px;
       user-select: text;

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -70,7 +70,7 @@ describe("RichEditor", () => {
   });
 
   context("mode", () => {
-    context("with view-only-plain-text", () => {
+    context("with view-only", () => {
       const viewOnlyPlainTextValue = `                              Systatum Antrikan License
                                         Version 1.0, 2026
                              https://systatum.com/licenses/
@@ -84,7 +84,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
       beforeEach(() => {
         cy.mount(
           <ProductRichEditor
-            mode="view-only-plain-text"
+            mode="view-only"
             height={400}
             value={viewOnlyPlainTextValue}
           />
@@ -92,12 +92,14 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
         cy.wait(600);
       });
 
-      it("should renders plain text content in view-only mode", () => {
+      it("should not shows code editor", () => {
         cy.findAllByLabelText("rich-editor-content")
           .first()
           .should("contain.text", "Systatum Antrikan License")
           .and("contain.text", "Version 1.0, 2026")
           .and("contain.text", "https://systatum.com/licenses/");
+
+        cy.findAllByLabelText("rich-editor-code").should("not.exist");
       });
 
       context("when typing the editor", () => {

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -7,6 +7,7 @@ import {
 import { useEffect, useState } from "react";
 import { generateSentence } from "./../../lib/text";
 import { RiArrowRightSLine } from "@remixicon/react";
+import { expectTextIncludesOrderedLines } from "./../../test/support/commands";
 
 describe("RichEditor", () => {
   function ProductRichEditor(props: RichEditorProps) {
@@ -69,6 +70,49 @@ describe("RichEditor", () => {
   });
 
   context("mode", () => {
+    context("with view-only-plain-text", () => {
+      const viewOnlyPlainTextValue = `                              Systatum Antrikan License
+                                        Version 1.0, 2026
+                             https://systatum.com/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.`;
+      beforeEach(() => {
+        cy.mount(
+          <ProductRichEditor
+            mode="view-only-plain-text"
+            height={400}
+            value={viewOnlyPlainTextValue}
+          />
+        );
+        cy.wait(600);
+      });
+
+      it("should renders plain text content in view-only mode", () => {
+        cy.findAllByLabelText("rich-editor-content")
+          .first()
+          .should("contain.text", "Systatum Antrikan License")
+          .and("contain.text", "Version 1.0, 2026")
+          .and("contain.text", "https://systatum.com/licenses/");
+      });
+
+      context("when typing the editor", () => {
+        it("should not change the value", () => {
+          cy.findByRole("textbox").type("{selectall}{backspace}test 123");
+
+          cy.findAllByLabelText("rich-editor-content")
+            .first()
+            .should("contain.text", "Systatum Antrikan License")
+            .and("contain.text", "Version 1.0, 2026")
+            .and("contain.text", "https://systatum.com/licenses/");
+        });
+      });
+    });
+
     context("with code-editor", () => {
       beforeEach(() => {
         cy.mount(<ProductRichEditor mode="code-editor" value="" />);

--- a/test/e2e/rich-editor.cy.ts
+++ b/test/e2e/rich-editor.cy.ts
@@ -632,15 +632,24 @@ describe("RichEditor", () => {
             );
             cy.findByRole("textbox").then(($el) => {
               const el = $el[0];
-
               const doc = el.ownerDocument!;
               const sel = doc.getSelection()!;
               const range = doc.createRange();
 
-              const textNode = el.firstChild!;
-              const textLength = textNode.textContent!.length;
+              let textNode: Text | null = null;
 
-              range.setStart(textNode, textLength - 2);
+              const walker = doc.createTreeWalker(
+                el,
+                NodeFilter.SHOW_TEXT,
+                null
+              );
+              textNode = walker.nextNode() as Text | null;
+
+              if (!textNode) return;
+
+              const textLength = textNode.textContent?.length ?? 0;
+
+              range.setStart(textNode, Math.max(0, textLength - 2));
               range.setEnd(textNode, textLength);
 
               sel.removeAllRanges();

--- a/test/e2e/rich-editor.cy.ts
+++ b/test/e2e/rich-editor.cy.ts
@@ -46,18 +46,19 @@ describe("RichEditor", () => {
     context(".insertMarkdownContent", () => {
       it("renders content on editor", () => {
         cy.findByText("Markdown Example").click();
-        const contentHTML = `<h3>Hello there!</h3>
+        const contentHTML = `<p><h3>Hello there!</h3>
 <p>${sentences}</p>
-<p><br></p><p>This is ordered list</p>
+<p>This is ordered list</p>
 <ol>
 <li><input type="checkbox" class="coneto-checkbox-wrapper" contenteditable="false" data-checked="false" style="cursor: pointer;"> test</li>
 <li><input type="checkbox" class="coneto-checkbox-wrapper" contenteditable="false" data-checked="true" style="cursor: pointer;"> test</li>
 </ol>
-<p><br></p><p>This is unordered list</p>
+<p>This is unordered list</p>
 <ul>
 <li>test</li>
 <li>test</li>
-</ul>`;
+</ul>
+</p>`;
         cy.findAllByRole("textbox").eq(0).should("contain.html", contentHTML);
         cy.findAllByRole("button").eq(6).click();
 


### PR DESCRIPTION
Description:
This pull request fixes an issue for `view-only` mode, some content was incorrectly rendered using the  `code-editor`, especially when the content have space more than 4 space at the first character.

Source:
[[Bug] SYST-669: Fix markdown on non-code editor but showing code editor](https://linear.app/systatum/issue/SYST-669/fix-markdown-on-non-code-editor-but-showing-code-editor)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself