### PR TITLE
[Mobile] SYST-698: Add `mobile` to button

### DIFF
--- a/components/button.stories.tsx
+++ b/components/button.stories.tsx
@@ -298,6 +298,37 @@ export const Default: Story = {
   },
 };
 
+export const Mobile: Story = {
+  args: {
+    children: "Button",
+  },
+  render: (args) => {
+    const VARIANTS: ButtonVariants["variant"][] = [
+      "link",
+      "outline-default",
+      "outline-primary",
+      "outline-danger",
+      "outline-success",
+      "default",
+      "primary",
+      "danger",
+      "secondary",
+      "ghost",
+      "success",
+    ] as const;
+
+    return (
+      <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+        {VARIANTS.map((variant) => (
+          <Button key={variant} {...args} mobile variant={variant}>
+            {variant.charAt(0).toUpperCase() + variant.slice(1)}
+          </Button>
+        ))}
+      </div>
+    );
+  },
+};
+
 export const Pressed: Story = {
   args: {
     variant: "default",

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -681,6 +681,7 @@ const BaseButton = styled.button<{
             `}
 
             &:active {
+              color: ${textColor};
               background-color: ${activeBg};
               box-shadow:
                 inset 0 0.5px 4px rgba(0, 0, 0, 0.2),

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -682,7 +682,7 @@ const BaseButton = styled.button<{
 
             &:active {
               color: ${textColor};
-              background-color: ${activeBg};
+              background-color: ${$mobile ? hoverBg : activeBg};
               box-shadow:
                 inset 0 0.5px 4px rgba(0, 0, 0, 0.2),
                 inset 0 -0.5px 0.5px ${getActiveColor($theme, $variant)};

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -101,6 +101,7 @@ export type ButtonProps = Omit<React.ComponentProps<"button">, "style"> &
     hoverBackgroundColor?: string;
     showSubMenuOn?: ButtonShowSubMenuPosition;
     labelMode?: ButtonLabelMode;
+    mobile?: boolean;
   };
 
 export type ButtonDialogPlacement = DialogPlacement;
@@ -137,6 +138,7 @@ function Button({
   hoverBackgroundColor,
   labelMode = "ellipsis",
   className,
+  mobile,
   ...props
 }: ButtonProps) {
   const { currentTheme } = useTheme();
@@ -241,6 +243,7 @@ function Button({
       className={applyClassName("button", className)}
     >
       <BaseButton
+        $mobile={mobile}
         $theme={buttonTheme}
         onClick={(e) => {
           if (onClick && showSubMenuOn === "caret") {
@@ -517,7 +520,6 @@ const getVariantTextColor = (variant: string) => {
   if (variant.startsWith("outline")) return "white";
   return undefined;
 };
-
 const SIZE_STYLES: Record<NonNullable<ButtonProps["size"]>, CSSProp> = {
   xs: css`
     height: 28px;
@@ -542,8 +544,39 @@ const SIZE_STYLES: Record<NonNullable<ButtonProps["size"]>, CSSProp> = {
   `,
 };
 
-const getSizeStyles = (size?: ButtonProps["size"]) => {
-  return SIZE_STYLES[size ?? "md"];
+const MOBILE_SIZE_STYLES: Partial<
+  Record<NonNullable<ButtonProps["size"]>, CSSProp>
+> = {
+  xs: css`
+    height: 36px;
+    padding: 0 12px;
+  `,
+  sm: css`
+    height: 40px;
+    padding: 0 16px;
+  `,
+  md: css`
+    height: 44px;
+    padding: 0 20px;
+  `,
+  lg: css`
+    height: 48px;
+    padding: 0 28px;
+  `,
+  icon: css`
+    width: 44px;
+    height: 44px;
+  `,
+};
+
+const getSizeStyles = (size?: ButtonProps["size"], mobile?: boolean) => {
+  const currentSize = size ?? "md";
+
+  if (mobile) {
+    return MOBILE_SIZE_STYLES[currentSize];
+  }
+
+  return SIZE_STYLES[currentSize];
 };
 
 const BaseButton = styled.button<{
@@ -557,13 +590,14 @@ const BaseButton = styled.button<{
   $pressed?: boolean;
   $hoverBackgroundColor?: string;
   $theme: AppTheme["button"];
+  $mobile?: boolean;
 }>`
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
 
-  font-size: 14px;
+  font-size: ${({ $mobile }) => ($mobile ? "16px" : "14px")};
   font-weight: 500;
   white-space: nowrap;
 
@@ -578,7 +612,7 @@ const BaseButton = styled.button<{
   opacity: ${({ $disabled }) => ($disabled ? 0.6 : 1)};
   pointer-events: ${({ $disabled }) => ($disabled ? "none" : "auto")};
 
-  ${({ $size }) => getSizeStyles($size)}
+  ${({ $size, $mobile }) => getSizeStyles($size, $mobile)}
 
   ${({
     $variant,
@@ -587,6 +621,7 @@ const BaseButton = styled.button<{
     $hoverBackgroundColor,
     $pressed,
     $theme,
+    $mobile,
   }) => {
     const { backgroundColor, color, textDecoration } = getButtonColors(
       $theme,
@@ -637,6 +672,7 @@ const BaseButton = styled.button<{
           `
         : css`
             ${!$isOpen &&
+            !$mobile &&
             css`
               &:hover {
                 background-color: ${hoverBg};

--- a/test/component/button.cy.tsx
+++ b/test/component/button.cy.tsx
@@ -161,6 +161,22 @@ describe("Button", () => {
           });
       });
     });
+
+    context("when clicking button", () => {
+      it("should changes the background to the hover clor", () => {
+        cy.mount(<ButtonWithIcon maxOptions={1} mobile />);
+
+        cy.get("button")
+          .eq(0)
+          .should("have.css", "background-color", "rgba(0, 0, 0, 0)")
+          .realMouseDown();
+
+        cy.wait(100);
+        cy.get("button")
+          .eq(0)
+          .should("have.css", "background-color", "rgb(42, 115, 195)");
+      });
+    });
   });
 
   context("styles", () => {

--- a/test/component/button.cy.tsx
+++ b/test/component/button.cy.tsx
@@ -20,56 +20,148 @@ import { TipMenuItemProps } from "./../../components/tip-menu";
 import { useState } from "react";
 import { FigureProps } from "./../../components/figure";
 
+interface ButtonWithIconOptions {
+  icon?: FigureProps;
+  variant?: ButtonVariants["variant"];
+}
+
+const OPTIONS_BUTTON: ButtonWithIconOptions[] = [
+  { variant: "link", icon: { image: RiAddLine } },
+  { variant: "outline-default", icon: { image: RiSearchLine } },
+  { variant: "outline-primary", icon: { image: RiHeartLine } },
+  { variant: "outline-danger", icon: { image: RiStarLine } },
+  { variant: "outline-success", icon: { image: RiAddLine } },
+  { variant: "default", icon: { image: RiSearchLine } },
+  { variant: "primary", icon: { image: RiHeartLine } },
+  { variant: "danger", icon: { image: RiStarLine } },
+  { variant: "secondary", icon: { image: RiAddLine } },
+  { variant: "ghost", icon: { image: RiSearchLine } },
+  { variant: "success", icon: { image: RiStarLine } },
+];
+
+const TIP_MENU_ITEMS: TipMenuItemProps[] = [
+  {
+    caption: "Report Phishing",
+    icon: { image: RiSpam2Line, color: "blue" },
+    onClick: () => console.log("Phishing reported"),
+  },
+  {
+    caption: "Report Junk",
+    icon: { image: RiForbid2Line, color: "red" },
+    onClick: () => console.log("Junk reported"),
+  },
+  {
+    caption: "Block Sender",
+    icon: { image: RiShieldLine, color: "orange" },
+    variant: "danger",
+    onClick: () => console.log("Sender blocked"),
+  },
+  {
+    caption: "Mark as Read",
+    icon: { image: RiCheckLine, color: "green" },
+    onClick: () => console.log("Marked as read"),
+  },
+  {
+    caption: "Move to Spam",
+    icon: { image: RiInboxArchiveLine, color: "purple" },
+    onClick: () => console.log("Moved to spam"),
+  },
+  {
+    caption: "Download Attachment",
+    icon: { image: RiDownloadLine, color: "teal" },
+    onClick: () => console.log("Downloading"),
+  },
+  {
+    caption: "Copy Link",
+    icon: { image: RiLink, color: "gray" },
+    onClick: () => console.log("Link copied"),
+  },
+  {
+    caption: "Share",
+    icon: { image: RiShareLine, color: "indigo" },
+    variant: "danger",
+    onClick: () => console.log("Shared"),
+  },
+  {
+    caption: "Edit",
+    icon: { image: RiEditLine, color: "yellow" },
+    onClick: () => console.log("Edit mode"),
+  },
+];
+
 describe("Button", () => {
-  const TIP_MENU_ITEMS: TipMenuItemProps[] = [
-    {
-      caption: "Report Phishing",
-      icon: { image: RiSpam2Line, color: "blue" },
-      onClick: () => console.log("Phishing reported"),
-    },
-    {
-      caption: "Report Junk",
-      icon: { image: RiForbid2Line, color: "red" },
-      onClick: () => console.log("Junk reported"),
-    },
-    {
-      caption: "Block Sender",
-      icon: { image: RiShieldLine, color: "orange" },
-      variant: "danger",
-      onClick: () => console.log("Sender blocked"),
-    },
-    {
-      caption: "Mark as Read",
-      icon: { image: RiCheckLine, color: "green" },
-      onClick: () => console.log("Marked as read"),
-    },
-    {
-      caption: "Move to Spam",
-      icon: { image: RiInboxArchiveLine, color: "purple" },
-      onClick: () => console.log("Moved to spam"),
-    },
-    {
-      caption: "Download Attachment",
-      icon: { image: RiDownloadLine, color: "teal" },
-      onClick: () => console.log("Downloading"),
-    },
-    {
-      caption: "Copy Link",
-      icon: { image: RiLink, color: "gray" },
-      onClick: () => console.log("Link copied"),
-    },
-    {
-      caption: "Share",
-      icon: { image: RiShareLine, color: "indigo" },
-      variant: "danger",
-      onClick: () => console.log("Shared"),
-    },
-    {
-      caption: "Edit",
-      icon: { image: RiEditLine, color: "yellow" },
-      onClick: () => console.log("Edit mode"),
-    },
-  ];
+  function ButtonWithIcon(
+    props: ButtonProps & {
+      maxOptions?: number;
+    }
+  ) {
+    const filteredOptions = OPTIONS_BUTTON?.slice(0, props.maxOptions);
+
+    return (
+      <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+        {filteredOptions.map((option, index) => (
+          <Button
+            key={index}
+            variant={option.variant}
+            icon={option.icon}
+            {...props}
+          >
+            {option.variant.charAt(0).toUpperCase() + option.variant.slice(1)}
+          </Button>
+        ))}
+      </div>
+    );
+  }
+
+  context("mobile", () => {
+    it("renders taller than the default button", () => {
+      cy.mount(
+        <>
+          <ButtonWithIcon maxOptions={1} mobile />
+          <ButtonWithIcon maxOptions={1} />
+        </>
+      );
+
+      cy.get("button").should("have.length", 2);
+
+      cy.get("button")
+        .eq(0)
+        .invoke("outerHeight")
+        .then((mobileHeight) => {
+          cy.get("button")
+            .eq(1)
+            .invoke("outerHeight")
+            .then((defaultHeight) => {
+              expect(mobileHeight).to.be.greaterThan(defaultHeight);
+            });
+        });
+    });
+
+    it("renders with 16px font size", () => {
+      cy.mount(<ButtonWithIcon maxOptions={1} mobile />);
+
+      cy.get("button").should("have.css", "font-size", "16px");
+    });
+
+    context("when hovering button", () => {
+      it("should not changes the button", () => {
+        cy.mount(<ButtonWithIcon maxOptions={1} mobile />);
+
+        cy.get("button")
+          .eq(0)
+          .should("have.css", "background-color", "rgba(0, 0, 0, 0)")
+          .realHover()
+          .then(($el) => {
+            cy.wait(200);
+            cy.wrap($el).should(
+              "not.have.css",
+              "background-color",
+              "rgb(42, 115, 195)"
+            );
+          });
+      });
+    });
+  });
 
   context("styles", () => {
     context("self", () => {
@@ -99,41 +191,6 @@ describe("Button", () => {
   });
 
   context("icon", () => {
-    function ButtonWithIcon(props: ButtonProps) {
-      interface ButtonWithIconOptions {
-        icon?: FigureProps;
-        variant?: ButtonVariants["variant"];
-      }
-
-      const OPTIONS_BUTTON: ButtonWithIconOptions[] = [
-        { variant: "link", icon: { image: RiAddLine } },
-        { variant: "outline-default", icon: { image: RiSearchLine } },
-        { variant: "outline-primary", icon: { image: RiHeartLine } },
-        { variant: "outline-danger", icon: { image: RiStarLine } },
-        { variant: "outline-success", icon: { image: RiAddLine } },
-        { variant: "default", icon: { image: RiSearchLine } },
-        { variant: "primary", icon: { image: RiHeartLine } },
-        { variant: "danger", icon: { image: RiStarLine } },
-        { variant: "secondary", icon: { image: RiAddLine } },
-        { variant: "ghost", icon: { image: RiSearchLine } },
-        { variant: "success", icon: { image: RiStarLine } },
-      ];
-
-      return (
-        <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
-          {OPTIONS_BUTTON.map((option, index) => (
-            <Button
-              key={index}
-              variant={option.variant}
-              icon={option.icon}
-              {...props}
-            >
-              {option.variant.charAt(0).toUpperCase() + option.variant.slice(1)}
-            </Button>
-          ))}
-        </div>
-      );
-    }
     it("renders buttons with icons", () => {
       cy.mount(<ButtonWithIcon />);
 

--- a/test/component/button.cy.tsx
+++ b/test/component/button.cy.tsx
@@ -163,7 +163,7 @@ describe("Button", () => {
     });
 
     context("when clicking button", () => {
-      it("should changes the background to the hover clor", () => {
+      it("should changes the background to the hover color", () => {
         cy.mount(<ButtonWithIcon maxOptions={1} mobile />);
 
         cy.get("button")


### PR DESCRIPTION
Description:
This pull request introduces a `mobile` mode for the `Button` component. It adds mobile-specific customization, including disabling hover effects and rendering the button slighly larger by adjusting properties such as `font-size` and `height`. 

Source:
[[Mobile] SYST-698: Add `mobile` to button](https://linear.app/systatum/issue/SYST-698/add-mobile-to-button)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself