### PR TITLE
[Bug] SYST-699: Fix combobox showing the option off the screen

### DIFF
--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -33,6 +33,7 @@ import {
 } from "./treelist";
 import { Searchbox } from "./searchbox";
 import { Checkbox } from "./checkbox";
+import { createPortal } from "react-dom";
 
 interface BaseComboboxProps {
   selectedOptions?: SelectboxSelectedOptions;
@@ -1081,7 +1082,7 @@ function ComboboxDrawer({
   );
 
   if (mobile) {
-    return (
+    return createPortal(
       <DrawerContainer
         aria-label="combobox-drawer-mobile"
         $theme={comboboxTheme}
@@ -1100,7 +1101,8 @@ function ComboboxDrawer({
           $visible={showFadeBottom}
         />
         {mainCombobox}
-      </DrawerContainer>
+      </DrawerContainer>,
+      document.body
     );
   }
 

--- a/shared.css
+++ b/shared.css
@@ -1,10 +1,3 @@
-*,
-::before,
-::after {
-  box-sizing: border-box;
-  border-width: 0;
-}
-
 html,
 :host {
   line-height: 1.5;

--- a/shared.css
+++ b/shared.css
@@ -1,3 +1,10 @@
+*,
+::before,
+::after {
+  box-sizing: border-box;
+  border-width: 0;
+}
+
 html,
 :host {
   line-height: 1.5;

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -16,6 +16,7 @@ import {
   RiUser2Line,
 } from "@remixicon/react";
 import { useState } from "react";
+import { Sidebar } from "./../../components/sidebar";
 
 const flattenOptions = (items: ComboboxOption[]): string[] =>
   items.flatMap((item) =>
@@ -176,6 +177,40 @@ describe("Combobox", () => {
           "height",
           "220px"
         );
+      });
+    });
+
+    context("when inside of fixed content", () => {
+      it("should be centered in the screen", () => {
+        cy.viewport(500, 700);
+
+        cy.mount(
+          <Sidebar>
+            <ProductCombobox options={FRUIT_OPTIONS} mobile />
+          </Sidebar>
+        );
+
+        cy.findByRole("button").click();
+
+        cy.findByRole("textbox").click();
+
+        // Ensures the combobox takes 96% of the viewport width
+        // when wrapped in a fixed-position container
+        cy.window().then((win) => {
+          const expectedWidth = `${win.innerWidth * 0.96}px`;
+
+          cy.findByLabelText("combobox-drawer-mobile").should(
+            "have.css",
+            "width",
+            expectedWidth
+          );
+
+          cy.findByLabelText("combobox-drawer-mobile").should(
+            "have.css",
+            "height",
+            "220px"
+          );
+        });
       });
     });
 

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -578,7 +578,8 @@ export function createComboboxTheme(
       boxShadow:
         "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)",
       groupBackgroundColor: "rgb(249, 250, 251)",
-      scrollThumbColor: "#9ca3af",
+      scrollThumbColor: "#b9bfc8",
+      fadeColor: "#f4f5f8",
     },
     ...themeConfigurations
   );


### PR DESCRIPTION
Description:
This pull request fixes an issue where the `combobox` was always centered, even the rendered inside `fixed` content. 

It also ensures the `combobox` position correctly scoped to it's container and uses 96% from the viewport (`96dvw`).

Source:
[[Bug] SYST-699: Fix combobox showing the option off the screen](https://linear.app/systatum/issue/SYST-699/fix-combobox-showing-the-option-off-the-screen)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself