### PR TITLE
[Mobile] SYST-707: Make it easy to set how large is the `drawer` on `combobox mobile` mode

### DIFF
--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -56,7 +56,11 @@ interface BaseComboboxProps {
   navigableOptions?: SelectboxOption[];
   isLoading?: boolean;
   labels?: ComboboxLabelsProps;
-  mobile?: boolean;
+  mobile?: boolean | ComboboxMobile;
+}
+
+export interface ComboboxMobile {
+  drawerHeight?: string;
 }
 
 export const ComboboxGroupInitialState = {
@@ -117,7 +121,10 @@ type ComboboxDrawerProps = Omit<DrawerProps, "refs"> &
 
 export interface ComboboxProps
   extends BaseComboboxProps,
-    Omit<FieldLaneProps, "styles" | "type" | "children" | "actions"> {}
+    Omit<
+      FieldLaneProps,
+      "mobile" | "styles" | "type" | "children" | "actions"
+    > {}
 
 const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
   (
@@ -226,7 +233,7 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         ref={ref}
         className={applyClassName("combobox", className)}
         isLoading={isLoading}
-        mobile={mobile}
+        mobile={!!mobile}
         helper={helper}
         errorIconPosition={errorIconPosition}
         dropdowns={dropdowns}
@@ -523,7 +530,7 @@ function ComboboxDrawer({
                   interactionMode,
                   multiple,
                   theme: comboboxTheme,
-                  mobile,
+                  mobile: !!mobile,
                   hasNestedOptions,
                   level: 0,
                 })}
@@ -998,7 +1005,7 @@ function ComboboxDrawer({
                   multiple,
                   theme: comboboxTheme,
                   hasNestedOptions,
-                  mobile,
+                  mobile: !!mobile,
                 })}
 
                 gap: 20px;
@@ -1065,7 +1072,7 @@ function ComboboxDrawer({
                   interactionMode,
                   multiple,
                   theme: comboboxTheme,
-                  mobile,
+                  mobile: !!mobile,
                   hasNestedOptions,
                   level,
                 })}
@@ -1110,8 +1117,9 @@ function ComboboxDrawer({
 
 const DrawerContainer = styled.div<{
   $theme?: ComboboxThemeConfig;
-  $mobile?: boolean;
+  $mobile?: boolean | ComboboxMobile;
 }>`
+  box-sizing: border-box;
   overflow: hidden;
   position: fixed;
   bottom: 10px;
@@ -1119,8 +1127,6 @@ const DrawerContainer = styled.div<{
   transform: translateX(-50%);
   width: 96dvw;
   z-index: 9992999;
-  min-height: 220px;
-  max-height: 220px;
   border-radius: 14px;
   background-color: ${({ $mobile, $theme }) =>
     $mobile ? $theme.mobileBackgroundColor : $theme.backgroundColor};
@@ -1130,17 +1136,17 @@ const DrawerWrapper = styled.ul<{
   $width?: number;
   $theme: ComboboxThemeConfig;
   $style?: CSSProp;
-  $mobile?: boolean;
+  $mobile?: boolean | ComboboxMobile;
   $multiple?: boolean;
   $hasNestedOptions?: boolean;
 }>`
+  box-sizing: border-box;
   list-style: none;
   margin: 0;
   padding: 0;
 
   position: relative;
   z-index: 9992999;
-  max-height: 220px;
   overflow-y: auto;
   border-radius: 4px;
   border: 1px solid
@@ -1173,12 +1179,20 @@ const DrawerWrapper = styled.ul<{
       width: 100%;
       z-index: 9992999;
       border-radius: 14px;
-      min-height: 220px;
-      max-height: 220px;
+      min-height: ${typeof $mobile === "object"
+        ? $mobile?.drawerHeight
+        : "220px"};
+      max-height: ${typeof $mobile === "object"
+        ? $mobile?.drawerHeight
+        : "220px"};
       border-width: 0.5;
       ${!$multiple &&
       css`
-        padding: 100px 0px;
+        padding: calc(
+            ${typeof $mobile === "object" ? $mobile.drawerHeight : "220px"} *
+              0.4545
+          )
+          0;
       `}
 
       background-color: ${$mobile && $hasNestedOptions

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -1119,14 +1119,18 @@ const DrawerContainer = styled.div<{
   $theme?: ComboboxThemeConfig;
   $mobile?: boolean | ComboboxMobile;
 }>`
-  box-sizing: border-box;
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+  }
   overflow: hidden;
   position: fixed;
   bottom: 10px;
   left: 50%;
   transform: translateX(-50%);
   width: 96dvw;
-  z-index: 9992999;
+  z-index: 99939999;
   border-radius: 14px;
   background-color: ${({ $mobile, $theme }) =>
     $mobile ? $theme.mobileBackgroundColor : $theme.backgroundColor};
@@ -1140,7 +1144,11 @@ const DrawerWrapper = styled.ul<{
   $multiple?: boolean;
   $hasNestedOptions?: boolean;
 }>`
-  box-sizing: border-box;
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+  }
   list-style: none;
   margin: 0;
   padding: 0;

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -180,6 +180,37 @@ describe("Combobox", () => {
       });
     });
 
+    context("object", () => {
+      context("drawerHeight", () => {
+        context("when given 60dvh", () => {
+          it("should render with px", () => {
+            cy.viewport(500, 700);
+
+            cy.mount(
+              <ProductCombobox
+                options={FRUIT_OPTIONS}
+                mobile={{
+                  drawerHeight: "60dvh",
+                }}
+              />
+            );
+
+            cy.findByRole("textbox").click();
+
+            cy.window().then((win) => {
+              const expectedHeight = `${win.innerHeight * 0.6}px`;
+
+              cy.findByLabelText("combobox-drawer-mobile").should(
+                "have.css",
+                "height",
+                expectedHeight
+              );
+            });
+          });
+        });
+      });
+    });
+
     context("when inside of fixed content", () => {
       it("should be centered in the screen", () => {
         cy.viewport(500, 700);
@@ -233,9 +264,13 @@ describe("Combobox", () => {
 
           cy.findByPlaceholderText("Select a fruit...").click();
 
+          // automatic padding calculation
           cy.findByLabelText("combobox-drawer")
-            .should("have.css", "padding-top", "100px")
-            .and("have.css", "padding-bottom", "100px");
+            .invoke("css", "padding-top")
+            .then((value) => {
+              const paddingTop = Number.parseFloat(String(value));
+              expect(paddingTop).to.be.closeTo(100, 0.1);
+            });
         });
       });
     });
@@ -698,7 +733,9 @@ describe("Combobox", () => {
           const allTexts = flattenOptions(
             MIX_FRUIT_OPTIONS_WITH_COLLAPSIBLE_FALSE
           );
-          cy.get("#combo-list").scrollTo("bottom");
+          cy.get("#combo-list").scrollTo("bottom", {
+            ensureScrollable: false,
+          });
 
           allTexts.forEach((text) => {
             cy.get("#combo-list")
@@ -761,7 +798,9 @@ describe("Combobox", () => {
           const allTexts = flattenOptions(
             MIX_FRUIT_OPTIONS_WITH_COLLAPSIBLE_FALSE
           );
-          cy.get("#combo-list").scrollTo("bottom");
+          cy.get("#combo-list").scrollTo("bottom", {
+            ensureScrollable: false,
+          });
           allTexts.forEach((text) => {
             cy.get("#combo-list")
               .contains(text)
@@ -775,7 +814,9 @@ describe("Combobox", () => {
             const allTexts = flattenOptions(
               MIX_FRUIT_OPTIONS_WITH_COLLAPSIBLE_FALSE
             );
-            cy.get("#combo-list").scrollTo("bottom");
+            cy.get("#combo-list").scrollTo("bottom", {
+              ensureScrollable: false,
+            });
             allTexts.forEach((text) => {
               cy.get("#combo-list")
                 .contains(text)
@@ -797,7 +838,9 @@ describe("Combobox", () => {
             const allTexts = flattenOptions(
               MIX_FRUIT_OPTIONS_WITH_COLLAPSIBLE_FALSE
             );
-            cy.get("#combo-list").scrollTo("bottom");
+            cy.get("#combo-list").scrollTo("bottom", {
+              ensureScrollable: false,
+            });
             allTexts.forEach((text) => {
               cy.get("#combo-list")
                 .contains(text)


### PR DESCRIPTION
Description:
This pull request enhances the `mobile` prop of `Combobox` to support both a `boolean` or `object` value. Previously, the prop only accepted a boolean.

This approach provides a simple and scalable API, allowing future mobile-specific customizations to be introduced through a simple prop without adding additional configuration props.

```tsx
<Combobox mobile={{ name: "A" }} />
```

The existing boolean usage remains fully supported:

```tsx
<Combobox mobile />
```

It also ensures this approach works correctly, and introduces a `drawerHeight` inside of the `mobile` props.

Source:
[[Mobile] SYST-707: Make it easy to set how large is the drawer on combobox mobile mode](https://linear.app/systatum/issue/SYST-707/make-it-easy-to-set-how-large-is-the-drawer-on-combobox-mobile-mode)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself