### PR TITLE
[Improvement] SYST-703: Improves the `RichEditor` markdown to html result.

### DIFF
--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -280,7 +280,6 @@ export const Default: Story = {
       {
         title: "Markdown Example",
         content: `### Hello there!
-
 ${sentences}
 
 This is ordered list
@@ -419,7 +418,6 @@ export const Autogrow: Story = {
       {
         title: "Markdown Example",
         content: `### Hello there!
-
 ${sentences}
 
 This is ordered list
@@ -746,9 +744,7 @@ export const ViewOnly: Story = {
       () => generateSentence({ minLen: 30, maxLen: 40, seed: 12345 }),
       [generateSentence]
     );
-    const [value, setValue] = useState(
-      `### Hello there!
-
+    const [value, setValue] = useState(`### Hello there!
 ${sentences}
 
 This is ordered list
@@ -769,8 +765,7 @@ function Content(){
 
 export default Content
 \`\`\`
-`
-    );
+`);
 
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -246,6 +246,9 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => {
+    const { currentTheme } = useTheme();
+    const richEditorTheme = currentTheme?.richEditor;
+
     const [value, setValue] = useState("");
     const [printValue, setPrintValue] = useState("");
 
@@ -277,6 +280,7 @@ export const Default: Story = {
       {
         title: "Markdown Example",
         content: `### Hello there!
+
 ${sentences}
 
 This is ordered list
@@ -366,7 +370,7 @@ This is unordered list
           <pre
             style={{
               padding: 28,
-              background: "#D3D3D3",
+              background: richEditorTheme?.preBackgroundColor,
               wordBreak: "break-word",
               whiteSpace: "pre-wrap",
             }}
@@ -381,6 +385,9 @@ This is unordered list
 
 export const Autogrow: Story = {
   render: () => {
+    const { currentTheme } = useTheme();
+    const richEditorTheme = currentTheme?.richEditor;
+
     const [value, setValue] = useState("");
     const [printValue, setPrintValue] = useState("");
 
@@ -412,6 +419,7 @@ export const Autogrow: Story = {
       {
         title: "Markdown Example",
         content: `### Hello there!
+
 ${sentences}
 
 This is ordered list
@@ -513,7 +521,7 @@ export default Content
           <pre
             style={{
               padding: 28,
-              background: "#D3D3D3",
+              background: richEditorTheme?.preBackgroundColor,
               wordBreak: "break-word",
               whiteSpace: "pre-wrap",
             }}
@@ -573,6 +581,9 @@ export const PageEditor: Story = {
     layout: "fullscreen",
   },
   render: () => {
+    const { currentTheme } = useTheme();
+    const richEditorTheme = currentTheme?.richEditor;
+
     const [value, setValue] = useState("");
     const [printValue, setPrintValue] = useState("");
 
@@ -600,7 +611,7 @@ export const PageEditor: Story = {
           <pre
             style={{
               padding: 28,
-              background: "#D3D3D3",
+              background: richEditorTheme?.preBackgroundColor,
               whiteSpace: "pre-wrap",
               wordBreak: "break-word",
             }}
@@ -737,6 +748,7 @@ export const ViewOnly: Story = {
     );
     const [value, setValue] = useState(
       `### Hello there!
+
 ${sentences}
 
 This is ordered list

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -219,7 +219,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       replacement: function (content, node) {
         const hLevel = Number((node as HTMLElement).nodeName.charAt(1));
         const prefix = "#".repeat(hLevel);
-        return `${prefix} ${content}\n`;
+        return `${prefix} ${content}\n\n`;
       },
     });
 
@@ -423,9 +423,13 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             if (/^[ \t]+/.test(firstLine)) return;
 
             const match = src.match(/^([^\n]+)(\n(?!\n)[^\n]+)*(?=\n\n|\n?$)/);
-
             if (match && match[0].includes("\n")) {
               const lines = match[0].split("\n");
+
+              const looksLikeWrappedParagraph =
+                lines.length > 1 && lines.every((l) => l.length > 20);
+
+              if (looksLikeWrappedParagraph) return;
 
               if (lines.some((l) => /^`{3,}/.test(l.trim()))) return;
               if (lines.some((l) => /^ {4,}/.test(l))) return;

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -388,8 +388,6 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             return src.indexOf("\n\n");
           },
           tokenizer(src, tokens) {
-            if (isLegal) return;
-
             const prevToken = tokens?.[tokens.length - 1];
             if (prevToken?.type === "list") return;
 
@@ -407,6 +405,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
+            if (isLegal) return;
+
             return "<p><br></p>".repeat(token.count);
           },
         },
@@ -417,8 +417,6 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             return src.indexOf("\n");
           },
           tokenizer(src, tokens) {
-            if (isLegal) return;
-
             const isHeading = /^#{1,6}\s/.test(src);
             if (isHeading) return;
 
@@ -451,6 +449,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
+            if (isLegal) return;
             return token.lines
               .map((line: string) => `<p>${line}</p>`)
               .join("\n");

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -152,9 +152,10 @@ export interface RichEditorToolbarButtonStyles {
   self?: CSSProp;
 }
 
-interface RichEditorComponent extends React.ForwardRefExoticComponent<
-  RichEditorProps & React.RefAttributes<RichEditorRef>
-> {
+interface RichEditorComponent
+  extends React.ForwardRefExoticComponent<
+    RichEditorProps & React.RefAttributes<RichEditorRef>
+  > {
   ToolbarButton: typeof RichEditorToolbarButton;
   codeLanguage: typeof RichEditorCodeLanguage;
   translatedCodeLanguage: typeof TranslatedRichEditorCodeLanguage;
@@ -372,12 +373,75 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       },
     });
 
-    marked.use({
-      gfm: true,
-      breaks: false,
-    });
-
     CodeEditor.addFencedCodeMarkedExtension();
+
+    marked.use({
+      gfm: false,
+      breaks: true,
+      extensions: [
+        {
+          name: "emptyParagraph",
+          level: "block",
+          start(src) {
+            return src.indexOf("\n\n");
+          },
+          tokenizer(src, tokens) {
+            const isListContext = /^[ \t]*([-*+]|\d+\.)\s/m.test(src);
+            if (isListContext) return;
+
+            const match = src.match(/^(\n{2,})/);
+            if (match) {
+              // 7 blank lines = 8 \n chars
+              const blankLines = match[0].length - 1; // 7
+              return {
+                type: "emptyParagraph",
+                raw: match[0],
+                count: blankLines,
+              };
+            }
+          },
+          renderer(token) {
+            console.log(token);
+            // 1 blank line → normal separation, no extra
+            // 2 blank lines → 2 empty paragraphs
+            // 7 blank lines → 7 empty paragraphs
+            if (token.count <= 1) return "";
+            return "<p><br></p>".repeat(token.count - 1);
+          },
+        },
+        {
+          name: "lineSeparated",
+          level: "block",
+          start(src) {
+            return src.indexOf("\n");
+          },
+          tokenizer(src) {
+            const isIndented = /^ {4,}/.test(src);
+            const isListContext = /^[ \t]*([-*+]|\d+\.)\s/m.test(src);
+            const isCodeFence = /^`{3,}/.test(src);
+            if (isIndented || isListContext || isCodeFence) return;
+
+            const match = src.match(/^([^\n]+)(\n(?!\n)[^\n]+)+(?!\n)/);
+            if (match) {
+              // Also bail if any matched line starts a code fence
+              if (match[0].split("\n").some((l) => /^`{3,}/.test(l.trim())))
+                return;
+
+              return {
+                type: "lineSeparated",
+                raw: match[0],
+                lines: match[0].split("\n").filter((l) => l.trim() !== ""),
+              };
+            }
+          },
+          renderer(token) {
+            return token.lines
+              .map((line: string) => `<p>${line}</p>`)
+              .join("\n");
+          },
+        },
+      ],
+    });
 
     const editorRef = useRef<HTMLDivElement>(null);
     const savedSelection = useRef<Range | null>(null);
@@ -1963,6 +2027,11 @@ const EditorArea = styled.div<{
   $height?: number;
   $theme: RichEditorThemeConfig;
 }>`
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+  }
   padding: 8px;
   outline: none;
   background-color: ${({ $theme }) => $theme.backgroundColor};
@@ -2377,6 +2446,12 @@ const splitBrIntoParagraphs = (html: string): string => {
   });
 
   container.querySelectorAll("p").forEach((p) => {
+    // Skip empty paragraphs — already correct, don't re-split them
+    const isEmptyParagraph =
+      p.childNodes.length === 0 ||
+      (p.childNodes.length === 1 && p.firstChild?.nodeName === "BR");
+    if (isEmptyParagraph) return;
+
     if (p.querySelector("ul, ol, h1, h2, h3, h4, h5, h6, pre, input")) return;
 
     const fragments: Node[][] = [[]];

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -219,7 +219,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       replacement: function (content, node) {
         const hLevel = Number((node as HTMLElement).nodeName.charAt(1));
         const prefix = "#".repeat(hLevel);
-        return `${prefix} ${content}\n\n`;
+        return `${prefix} ${content}\n`;
       },
     });
 
@@ -380,7 +380,36 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     marked.use({
       gfm: false,
       breaks: true,
+      walkTokens(token) {
+        if (token.type === "space" && token.raw.length >= 2) {
+          const blankLines = token.raw.length;
+          token.type = "emptyParagraph";
+          (token as any).count = blankLines;
+        }
+      },
       extensions: [
+        {
+          name: "heading",
+          level: "block",
+          start(src) {
+            return src.indexOf("#");
+          },
+          tokenizer(src) {
+            const match = src.match(/^(#{1,6}) ([^\n]+)\n?/);
+            if (match) {
+              return {
+                type: "heading",
+                raw: match[0],
+                depth: match[1].length,
+                text: match[2],
+                tokens: [],
+              };
+            }
+          },
+          renderer(token) {
+            return `<h${token.depth}>${token.text}</h${token.depth}>`;
+          },
+        },
         {
           name: "emptyParagraph",
           level: "block",
@@ -405,8 +434,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
-            if (isLegal) return;
-
+            if (isLegal) return "";
             return "<p><br></p>".repeat(token.count);
           },
         },
@@ -449,7 +477,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
-            if (isLegal) return;
+            if (isLegal) return "";
             return token.lines
               .map((line: string) => `<p>${line}</p>`)
               .join("\n");

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -375,6 +375,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
     CodeEditor.addFencedCodeMarkedExtension();
 
+    const isLegal = isLegalDocument(value);
+
     marked.use({
       gfm: false,
       breaks: true,
@@ -386,13 +388,17 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             return src.indexOf("\n\n");
           },
           tokenizer(src, tokens) {
+            if (isLegal) return;
+
+            const prevToken = tokens?.[tokens.length - 1];
+            if (prevToken?.type === "list") return;
+
             const isListContext = /^[ \t]*([-*+]|\d+\.)\s/m.test(src);
             if (isListContext) return;
 
             const match = src.match(/^(\n{2,})/);
             if (match) {
-              // 7 blank lines = 8 \n chars
-              const blankLines = match[0].length - 1; // 7
+              const blankLines = match[0].length - 1;
               return {
                 type: "emptyParagraph",
                 raw: match[0],
@@ -401,7 +407,6 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
-            if (token.count <= 1) return "";
             return "<p><br></p>".repeat(token.count);
           },
         },
@@ -412,6 +417,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             return src.indexOf("\n");
           },
           tokenizer(src, tokens) {
+            if (isLegal) return;
+
             const isHeading = /^#{1,6}\s/.test(src);
             if (isHeading) return;
 
@@ -2489,6 +2496,12 @@ const splitBrIntoParagraphs = (html: string): string => {
   });
 
   return container.innerHTML;
+};
+
+const isLegalDocument = (src: string) => {
+  return /^(MIT License|Apache License|GNU |BSD |ISC License|Copyright \(c\)|TERMS AND CONDITIONS|END OF TERMS)/im.test(
+    src
+  );
 };
 
 RichEditor.ToolbarButton = RichEditorToolbarButton;

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -631,6 +631,10 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
         html = value?.trim() ? await marked.parse(value) : `<p>${value}</p>`;
 
+        if (!html.trim().startsWith("<")) {
+          html = `<p>${html}</p>`;
+        }
+
         if (!isMounted || !editorRef.current) return;
 
         html = splitBrIntoParagraphs(html);

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -382,6 +382,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     marked.use({
       gfm: false,
       breaks: true,
+      // Track previous token so we can detect
+      // blank lines that appear immediately after headings.
       walkTokens(token) {
         if (
           token.type === "space" &&
@@ -389,6 +391,9 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           prevWalkToken?.type === "heading"
         ) {
           const blankLines = token.raw.length - 1;
+
+          // Convert heading-following spaces into a custom
+          // emptyParagraph token so we can preserve spacing.
           token.type = "emptyParagraph";
           (token as any).count = blankLines;
         }
@@ -396,6 +401,11 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       },
       extensions: [
         {
+          /**
+           * Custom heading tokenizer.
+           * Ensures markdown headings are parsed consistently
+           * and rendered as native h1-h6 elements.
+           */
           name: "heading",
           level: "block",
           start(src) {
@@ -418,6 +428,14 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           },
         },
         {
+          /**
+           * Preserves multiple blank lines by converting them
+           * into explicit empty paragraph elements.
+           *
+           * Skipped for:
+           * - list contexts
+           * - legal document rendering
+           */
           name: "emptyParagraph",
           level: "block",
           start(src) {
@@ -433,6 +451,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             const match = src.match(/^(\n{2,})/);
             if (match) {
               const isAfterHeading = prevToken?.type === "heading";
+              // Add an extra line when spacing follows a heading.
               const blankLines = match[0].length - 1 + (isAfterHeading ? 1 : 0);
               return {
                 type: "emptyParagraph",
@@ -448,6 +467,25 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           },
         },
         {
+          /**
+           * Converts consecutive single-line breaks into
+           * individual paragraph elements.
+           *
+           * Example:
+           *   Line A
+           *   Line B
+           *
+           * Becomes:
+           *   <p>Line A</p>
+           *   <p>Line B</p>
+           *
+           * Skipped for:
+           * - headings
+           * - code fences
+           * - lists
+           * - indented blocks
+           * - wrapped paragraphs
+           */
           name: "lineSeparated",
           level: "block",
           start(src) {
@@ -468,6 +506,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             if (match && match[0].includes("\n")) {
               const lines = match[0].split("\n");
 
+              // Treat long consecutive lines as a wrapped paragraph,
+              // not as separate paragraphs.
               const looksLikeWrappedParagraph =
                 lines.length > 1 && lines.every((l) => l.length > 20);
 

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -227,7 +227,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       filter: ["ul", "ol"],
       replacement: function (content, node) {
         const parentIsParagraph = node.parentElement?.tagName === "P";
-        return parentIsParagraph ? content : `${content}\n`;
+        return parentIsParagraph ? content : `${content}\n\n`;
       },
     });
 
@@ -297,7 +297,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           nextSibling &&
           (nextSibling.tagName === "UL" || nextSibling.tagName === "OL")
         ) {
-          return content + "\n";
+          return "\n\n" + content + "\n";
         }
 
         if (
@@ -306,7 +306,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           nextSibling &&
           (nextSibling.tagName === "UL" || nextSibling.tagName === "OL")
         ) {
-          return content.trim() ? content : "\n";
+          return content.trim() ? "\n" + content + "\n" : "\n";
         }
 
         if (hasBrOnly) {
@@ -401,12 +401,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
-            console.log(token);
-            // 1 blank line → normal separation, no extra
-            // 2 blank lines → 2 empty paragraphs
-            // 7 blank lines → 7 empty paragraphs
             if (token.count <= 1) return "";
-            return "<p><br></p>".repeat(token.count - 1);
+            return "<p><br></p>".repeat(token.count);
           },
         },
         {
@@ -415,22 +411,31 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           start(src) {
             return src.indexOf("\n");
           },
-          tokenizer(src) {
-            const isIndented = /^ {4,}/.test(src);
-            const isListContext = /^[ \t]*([-*+]|\d+\.)\s/m.test(src);
-            const isCodeFence = /^`{3,}/.test(src);
-            if (isIndented || isListContext || isCodeFence) return;
+          tokenizer(src, tokens) {
+            const isHeading = /^#{1,6}\s/.test(src);
+            if (isHeading) return;
 
-            const match = src.match(/^([^\n]+)(\n(?!\n)[^\n]+)+(?!\n)/);
-            if (match) {
-              // Also bail if any matched line starts a code fence
-              if (match[0].split("\n").some((l) => /^`{3,}/.test(l.trim())))
-                return;
+            const isCodeFence = /^`{3,}/.test(src);
+            if (isCodeFence) return;
+
+            const firstLine = src.split("\n")[0];
+            if (/^[ \t]*([-*+]|\d+\.)\s/.test(firstLine)) return;
+            if (/^[ \t]+/.test(firstLine)) return;
+
+            const match = src.match(/^([^\n]+)(\n(?!\n)[^\n]+)*(?=\n\n|\n?$)/);
+
+            if (match && match[0].includes("\n")) {
+              const lines = match[0].split("\n");
+
+              if (lines.some((l) => /^`{3,}/.test(l.trim()))) return;
+              if (lines.some((l) => /^ {4,}/.test(l))) return;
+              if (lines.some((l) => /^[ \t]+\S/.test(l))) return;
+              if (lines.some((l) => /^[ \t]*([-*+]|\d+\.)\s/.test(l))) return;
 
               return {
                 type: "lineSeparated",
                 raw: match[0],
-                lines: match[0].split("\n").filter((l) => l.trim() !== ""),
+                lines: lines.filter((l) => l.trim() !== ""),
               };
             }
           },

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -377,15 +377,22 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
     const isLegal = isLegalDocument(value);
 
+    let prevWalkToken: any = null;
+
     marked.use({
       gfm: false,
       breaks: true,
       walkTokens(token) {
-        if (token.type === "space" && token.raw.length >= 2) {
-          const blankLines = token.raw.length;
+        if (
+          token.type === "space" &&
+          token.raw.length >= 2 &&
+          prevWalkToken?.type === "heading"
+        ) {
+          const blankLines = token.raw.length - 1;
           token.type = "emptyParagraph";
           (token as any).count = blankLines;
         }
+        prevWalkToken = token;
       },
       extensions: [
         {
@@ -395,7 +402,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             return src.indexOf("#");
           },
           tokenizer(src) {
-            const match = src.match(/^(#{1,6}) ([^\n]+)\n?/);
+            const match = src.match(/^(#{1,6}) ([^\n]+)/);
             if (match) {
               return {
                 type: "heading",
@@ -425,7 +432,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
             const match = src.match(/^(\n{2,})/);
             if (match) {
-              const blankLines = match[0].length - 1;
+              const isAfterHeading = prevToken?.type === "heading";
+              const blankLines = match[0].length - 1 + (isAfterHeading ? 1 : 0);
               return {
                 type: "emptyParagraph",
                 raw: match[0],
@@ -435,6 +443,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           },
           renderer(token) {
             if (isLegal) return "";
+
             return "<p><br></p>".repeat(token.count);
           },
         },

--- a/shared.css
+++ b/shared.css
@@ -1,3 +1,10 @@
+*,
+::before,
+::after {
+  box-sizing: border-box;
+  border-width: 0;
+}
+
 html,
 :host {
   line-height: 1.5;

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -5,9 +5,8 @@ import {
   RichEditorProps,
 } from "./../../components/rich-editor";
 import { useEffect, useState } from "react";
-import { generateSentence } from "./../../lib/text";
 import { RiArrowRightSLine } from "@remixicon/react";
-import { expectTextIncludesOrderedLines } from "./../../test/support/commands";
+import { generateSentence } from "./../../lib/text";
 
 describe("RichEditor", () => {
   function ProductRichEditor(props: RichEditorProps) {
@@ -72,15 +71,15 @@ describe("RichEditor", () => {
   context("mode", () => {
     context("with view-only", () => {
       const viewOnlyPlainTextValue = `                              Systatum Antrikan License
-                                        Version 1.0, 2026
-                             https://systatum.com/licenses/
+                                          Version 1.0, 2026
+                               https://systatum.com/licenses/
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+  TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-1.  Definitions.
+  1.  Definitions.
 
-    "License" shall mean the terms and conditions for use, reproduction,
-    and distribution as defined by Sections 1 through 9 of this document.`;
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.`;
       beforeEach(() => {
         cy.mount(
           <ProductRichEditor
@@ -162,11 +161,11 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
         it("should renders the value code", () => {
           const code = `import { Button } from "@systatum/coneto/button"
 
-function Content(){
-  return <Button variant="primary">Your caption</Button>
-}
+  function Content(){
+    return <Button variant="primary">Your caption</Button>
+  }
 
-export default Content`;
+  export default Content`;
           cy.mount(<ProductRichEditor mode="code-editor" value={code} />);
           cy.shouldHaveEditorFromValue("rich-editor-code", code);
         });
@@ -365,7 +364,7 @@ export default Content`;
         cy.findByLabelText("rich-editor-content").should(
           "have.css",
           "height",
-          "472px"
+          "480px"
         );
       });
 
@@ -378,14 +377,14 @@ export default Content`;
             />
           );
           cy.findByLabelText("rich-editor-content")
-            .should("have.css", "height", "472px")
+            .should("have.css", "height", "480px")
             .click()
             .type("{enter}{enter}{enter}");
 
           cy.findByLabelText("rich-editor-content").should(
             "have.css",
             "height",
-            "544px"
+            "576px"
           );
         });
       });
@@ -565,7 +564,7 @@ Paragraph line 2`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
             .invoke("text")
-            .should("eq", "Paragraph line 1\n\nParagraph line 2\n");
+            .should("eq", "Paragraph line 1\nParagraph line 2\n");
         });
       });
 
@@ -580,7 +579,7 @@ Paragraph line 4`;
             .invoke("text")
             .should(
               "eq",
-              "Paragraph line 1\nParagraph line 2\nParagraph line 3\nParagraph line 4\n"
+              "Paragraph line 1\nParagraph line 2\nParagraph line 3\nParagraph line 4"
             );
         });
       });
@@ -588,6 +587,8 @@ Paragraph line 4`;
       context("when the next line is paragraph", () => {
         it("should render exactly as the expected value", () => {
           const input = `Paragraph line 1
+
+
 Paragraph line 2`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
@@ -601,6 +602,7 @@ Paragraph line 2`;
       context("when the next line is paragraph", () => {
         it("should render normally", () => {
           const input = `- Unordered list
+
 Paragraph line`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -554,6 +554,33 @@ describe("RichEditor", () => {
   });
 
   context("preprocessed value", () => {
+    context("heading", () => {
+      context("when the next line have empty space", () => {
+        it("should add the empty space", () => {
+          const input = `### Heading line 1
+
+Paragraph line 3`;
+          cy.mount(<RichEditor value={input} />);
+          cy.findByRole("textbox")
+            .find("p")
+            .eq(0)
+            .should("contain.html", "<br>");
+        });
+      });
+
+      context("when the next line is paragraph", () => {
+        it("should not have empty space", () => {
+          const input = `### Heading line 1
+Paragraph line 2`;
+          cy.mount(<RichEditor value={input} />);
+          cy.findByRole("textbox")
+            .find("p")
+            .eq(0)
+            .should("not.contain.html", "<br>");
+        });
+      });
+    });
+
     context("paragraph", () => {
       context("when the next line have empty space", () => {
         it("should render exactly as the expected value", () => {

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -71,8 +71,8 @@ describe("RichEditor", () => {
   context("mode", () => {
     context("with view-only", () => {
       const viewOnlyPlainTextValue = `                              Systatum Antrikan License
-                                          Version 1.0, 2026
-                               https://systatum.com/licenses/
+                                            Version 1.0, 2026
+                                 https://systatum.com/licenses/
 
   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -161,11 +161,11 @@ describe("RichEditor", () => {
         it("should renders the value code", () => {
           const code = `import { Button } from "@systatum/coneto/button"
 
-  function Content(){
-    return <Button variant="primary">Your caption</Button>
-  }
+    function Content(){
+      return <Button variant="primary">Your caption</Button>
+    }
 
-  export default Content`;
+    export default Content`;
           cy.mount(<ProductRichEditor mode="code-editor" value={code} />);
           cy.shouldHaveEditorFromValue("rich-editor-code", code);
         });
@@ -590,8 +590,12 @@ Paragraph line 2`;
 Paragraph line 2`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
-            .invoke("text")
-            .should("eq", "Paragraph line 1\nParagraph line 2\n");
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should(
+              "eq",
+              "<p>Paragraph line 1</p><p><br></p><p><br></p><p>Paragraph line 2</p>"
+            );
         });
       });
 
@@ -603,24 +607,12 @@ Paragraph line 3
 Paragraph line 4`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
-            .invoke("text")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
             .should(
               "eq",
-              "Paragraph line 1\nParagraph line 2\nParagraph line 3\nParagraph line 4"
+              "<p>Paragraph line 1</p><p>Paragraph line 2</p><p>Paragraph line 3</p><p>Paragraph line 4</p>"
             );
-        });
-      });
-
-      context("when the next line is paragraph", () => {
-        it("should render exactly as the expected value", () => {
-          const input = `Paragraph line 1
-
-
-Paragraph line 2`;
-          cy.mount(<RichEditor value={input} />);
-          cy.findByRole("textbox")
-            .invoke("text")
-            .should("eq", "Paragraph line 1\nParagraph line 2\n");
         });
       });
     });
@@ -633,8 +625,12 @@ Paragraph line 2`;
 Paragraph line`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
-            .invoke("text")
-            .should("eq", "\nUnordered list\n\nParagraph line\n");
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should(
+              "eq",
+              "<ul><li>Unordered list</li></ul><p>Paragraph line</p>"
+            );
         });
       });
 
@@ -645,10 +641,11 @@ Paragraph line`;
 - Unordered list 3`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
-            .invoke("text")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
             .should(
               "eq",
-              "\nUnordered list 1\nUnordered list 2\nUnordered list 3\n\n"
+              "<ul><li>Unordered list 1</li><li>Unordered list 2</li><li>Unordered list 3</li></ul>"
             );
         });
       });


### PR DESCRIPTION
Description:
This pull request improves the consistency and reliability of the `markdown-to-html` conversion process. Previously, some markdown content was not rendered correctly due to incomplete filtering and structural inconsistencies.

Changes:
1. Adjust list spacing for more consistent rendering.
2. Fix legal document rendering without `preprocessingMarkdown` by relying on `marked` with the `markdown-live` rules.
3. Update the styling of `pre` elements in Storybook stories.
4. Add a safeguard to ensure content is always wrapped in a paragraph container when necessary.
5. Standardize paragraph and heading generation so that HTML and Markdown structures remain aligned one-to-one.
6. Ensure the Rich Editor correctly handles paragraphs, headings, ordered lists, and unordered lists across all conversion flows.


Source:
[[Improvement] SYST-703: Improves the `RichEditor` markdown to html result.](https://linear.app/systatum/issue/SYST-703/improves-the-richeditor-markdown-to-html-result)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself