### PR TITLE
[Mobile] SYST-696: Add PullRefresher

### DIFF
--- a/components/pull-refresher.stories.tsx
+++ b/components/pull-refresher.stories.tsx
@@ -14,7 +14,75 @@ const meta: Meta<typeof PullRefresher> = {
     docs: {
       description: {
         component: `
- `,
+🧲 **PullRefresher** is a mobile-friendly pull-to-refresh container that detects drag gestures and triggers async loading when a threshold is reached.
+
+It provides full control over the pull interaction UI via custom slots for both preloading and loading states.
+
+---
+
+### ✨ Features
+- 🖐 Supports mouse and touch pull gestures
+- 🎯 Configurable activation threshold via \`activatedAt\`
+- 🔄 Built-in loading state management
+- 🎨 Fully customizable UI via slots
+- ⚡ Smooth pull resistance effect after threshold
+- 🧩 Controlled async loading via \`onLoading\`
+
+---
+
+### 📦 Slots
+
+#### preloadingSlot
+A render function or ReactNode used during the pulling phase before loading starts.
+
+\`\`\`ts
+(isReady: boolean) => ReactNode
+isReady = false → user is still below threshold
+isReady = true → threshold reached, ready to trigger refresh
+\`\`\`
+
+If a function is provided, it receives the current pull state and updates in real time.
+
+### ⏳ loadingSlot
+
+Rendered when the refresh action is triggered after the user releases at or above the threshold.
+
+If not provided, a default \`Loading Spinner\` will be displayed.
+
+### 🛠 Usage
+\`\`\`ts
+<PullRefresher
+  activatedAt="100px"
+  onLoading={({ stopLoading }) => {
+    setTimeout(() => stopLoading(), 2000);
+  }}
+  preloadingSlot={(isReady) => (
+    <div>
+      {isReady ? "Release to refresh" : "Pull to refresh"}
+    </div>
+  )}
+  loadingSlot={<div>Loading...</div>}
+>
+  <div>Your scroll content</div>
+</PullRefresher>
+\`\`\`
+
+
+### 🧠 Behavior
+
+- User drags downward from idle state
+- preloadingSlot is shown during pulling
+- Once pull distance exceeds activatedAt, isReady = true
+- Releasing after threshold triggers onLoading
+- While loading, loadingSlot is rendered
+- Call stopLoading() to return to idle state
+
+### 📝 Notes
+- Works with both touch and mouse input
+- Includes natural resistance after threshold is passed
+- Content remains independently scrollable
+- Designed for mobile-first pull-to-refresh UX
+`,
       },
     },
   },

--- a/components/pull-refresher.stories.tsx
+++ b/components/pull-refresher.stories.tsx
@@ -1,0 +1,208 @@
+import { Meta, StoryObj } from "@storybook/react/*";
+import { PullRefresher } from "./pull-refresher";
+import { Card } from "./card";
+import { css } from "styled-components";
+import { useTheme } from "./../theme";
+import { List } from "./list";
+import { useState } from "react";
+
+const meta: Meta<typeof PullRefresher> = {
+  title: "Mobile/Pull Refresher",
+  component: PullRefresher,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+ `,
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PullRefresher>;
+
+export const Default: Story = {
+  render: () => {
+    const { currentTheme } = useTheme();
+    const cardTheme = currentTheme.card;
+
+    const CHATS = [
+      {
+        id: "1",
+        name: "Alim Naufal",
+        time: "20:31",
+        message: "Finished the PullRefresher component 🎉",
+      },
+      {
+        id: "2",
+        name: "Adam Noto",
+        time: "20:15",
+        message: "Can you review my PR when you have time?",
+      },
+      {
+        id: "3",
+        name: "John Doe",
+        time: "19:48",
+        message: "The deployment completed successfully.",
+      },
+      {
+        id: "4",
+        name: "Emma Wilson",
+        time: "18:22",
+        message: "Let's sync tomorrow morning.",
+      },
+    ];
+
+    const [items, setItems] = useState(CHATS);
+
+    const messages = [
+      "Hey, are you available?",
+      "The build passed successfully.",
+      "Can you review this component?",
+      "Nice work on the design system!",
+      "Storybook docs look great.",
+      "The mobile version feels smoother now.",
+      "Pull to refresh is working perfectly.",
+    ];
+
+    const randomMessage = messages[Math.floor(Math.random() * messages.length)];
+
+    const FIRST_NAMES = [
+      "Adam",
+      "Alim",
+      "Sarah",
+      "Michael",
+      "Emma",
+      "Daniel",
+      "Sophia",
+      "Olivia",
+      "Noah",
+      "Lucas",
+      "Mia",
+      "Ethan",
+      "Ava",
+      "James",
+      "Grace",
+      "Henry",
+    ];
+
+    const LAST_NAMES = [
+      "Noto",
+      "Wilson",
+      "Naufal",
+      "Johnson",
+      "Anderson",
+      "Taylor",
+      "Brown",
+      "Martinez",
+      "Kim",
+      "Chen",
+      "Park",
+      "Lee",
+      "Clark",
+      "Walker",
+      "Scott",
+      "Davis",
+    ];
+
+    const randomName = () => {
+      const first = FIRST_NAMES[Math.floor(Math.random() * FIRST_NAMES.length)];
+
+      const last = LAST_NAMES[Math.floor(Math.random() * LAST_NAMES.length)];
+
+      return `${first} ${last}`;
+    };
+
+    const fetchNewData = () => {
+      const name = randomName();
+      setItems((prev) => [
+        {
+          id: crypto.randomUUID(),
+          name,
+          avatar: `https://picsum.photos/seed/${Date.now()}/200`,
+          time: "Just now",
+          message: randomMessage,
+        },
+        ...prev,
+      ]);
+    };
+
+    return (
+      <Card
+        styles={{
+          containerStyle: css`
+            width: 100%;
+          `,
+          titleStyle: css`
+            text-align: center;
+            justify-content: center;
+          `,
+          headerStyle: css`
+            border-bottom: 1px solid ${cardTheme?.borderColor};
+          `,
+          contentStyle: css`
+            overflow: auto;
+            display: flex;
+          `,
+        }}
+        title="Pull Refresher"
+      >
+        <PullRefresher
+          onLoading={async ({ stopLoading }) => {
+            setTimeout(() => {
+              fetchNewData();
+
+              stopLoading();
+            }, 1000);
+          }}
+        >
+          {items.map((chat) => (
+            <List.Item
+              key={chat.id}
+              id={chat.id}
+              icon={{
+                image: `https://picsum.photos/seed/${encodeURIComponent(chat.name)}/200`,
+                size: 30,
+                styles: {
+                  self: css`
+                    border-radius: 9999px;
+                    overflow: hidden;
+
+                    img {
+                      transform: scale(1.2);
+                    }
+                  `,
+                },
+              }}
+              styles={{
+                titleStyle: css`
+                  display: flex;
+                  flex-direction: row;
+                  gap: 2px;
+                  justify-content: space-between;
+                `,
+              }}
+              title={
+                <>
+                  <div>{chat.name}</div>
+                  <div
+                    style={{
+                      color: cardTheme.subtitleColor,
+                      fontSize: "12px",
+                    }}
+                  >
+                    {chat.time}
+                  </div>
+                </>
+              }
+              subtitle={chat.message}
+            />
+          ))}
+        </PullRefresher>
+      </Card>
+    );
+  },
+};

--- a/components/pull-refresher.tsx
+++ b/components/pull-refresher.tsx
@@ -7,14 +7,17 @@ import React, {
 } from "react";
 import styled, { CSSProp, keyframes } from "styled-components";
 import { LoadingSpinner } from "./loading-spinner";
+import { applyClassName } from "./../constants/classname";
 
 export interface PullRefresherProps {
   activatedAt?: string | number;
-  preloadingSlot?: (isThresholdReached?: boolean) => ReactNode | ReactNode;
+  preloadingSlot?: ((isReady?: boolean) => ReactNode) | ReactNode;
   loadingSlot?: ReactNode;
   onLoading: (ctx: { stopLoading: () => void }) => void;
   children: ReactNode;
   styles?: PullRefresherStyles;
+  id?: string;
+  className?: string;
 }
 
 type Phase = "idle" | "pulling" | "loading";
@@ -34,6 +37,8 @@ function PullRefresher({
   onLoading,
   children,
   styles,
+  className,
+  id,
 }: PullRefresherProps) {
   const threshold = parsePx(activatedAt, 100);
 
@@ -175,21 +180,29 @@ function PullRefresher({
 
   return (
     <Container
+      id={id}
+      className={applyClassName("pull-refresher", className)}
       $style={styles?.containerStyle}
       onMouseDown={handleMouseDown}
       onTouchStart={handleTouchStart}
+      aria-label="pull-refresher-container"
     >
       <SlotWrapper
         $height={slotHeight}
         $animated={animated}
-        aria-label={phase === "loading" ? "Refreshing content" : undefined}
+        aria-label="pull-refresher-slot-loader"
         $style={styles?.slotWrapperStyle}
       >
         {slotHeight > 0 &&
           (phase === "loading" ? resolvedLoading : resolvedPreloading)}
       </SlotWrapper>
 
-      <Content $style={styles?.contentStyle}>{children}</Content>
+      <Content
+        aria-label="pull-refresher-content"
+        $style={styles?.contentStyle}
+      >
+        {children}
+      </Content>
     </Container>
   );
 }
@@ -243,22 +256,20 @@ const Arrow = styled.svg<{ $flipped: boolean }>`
 const DefaultPreloadingSlot: React.FC<{ activated: boolean }> = ({
   activated,
 }) => (
-  <>
-    <Arrow
-      $flipped={activated}
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <polyline points="6 9 12 15 18 9" />
-    </Arrow>
-  </>
+  <Arrow
+    $flipped={activated}
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <polyline points="6 9 12 15 18 9" />
+  </Arrow>
 );
 
 function parsePx(value: string | number | undefined, fallback: number): number {

--- a/components/pull-refresher.tsx
+++ b/components/pull-refresher.tsx
@@ -10,7 +10,7 @@ import { LoadingSpinner } from "./loading-spinner";
 
 export interface PullRefresherProps {
   activatedAt?: string | number;
-  preloadingSlot?: ReactNode;
+  preloadingSlot?: (isThresholdReached?: boolean) => ReactNode | ReactNode;
   loadingSlot?: ReactNode;
   onLoading: (ctx: { stopLoading: () => void }) => void;
   children: ReactNode;
@@ -161,11 +161,14 @@ function PullRefresher({
     };
   }, [applyPull, threshold, triggerLoading]);
 
-  const resolvedPreloading = preloadingSlot ? (
-    preloadingSlot
-  ) : (
-    <DefaultPreloadingSlot activated={activated} />
-  );
+  const resolvedPreloading =
+    typeof preloadingSlot === "function" ? (
+      preloadingSlot(activated)
+    ) : preloadingSlot ? (
+      preloadingSlot
+    ) : (
+      <DefaultPreloadingSlot activated={activated} />
+    );
 
   const resolvedLoading =
     loadingSlot !== undefined ? loadingSlot : <LoadingSpinner iconSize={30} />;

--- a/components/pull-refresher.tsx
+++ b/components/pull-refresher.tsx
@@ -1,0 +1,268 @@
+import React, {
+  useRef,
+  useState,
+  useCallback,
+  useEffect,
+  ReactNode,
+} from "react";
+import styled, { CSSProp, keyframes } from "styled-components";
+import { LoadingSpinner } from "./loading-spinner";
+
+export interface PullRefresherProps {
+  activatedAt?: string | number;
+  preloadingSlot?: ReactNode;
+  loadingSlot?: ReactNode;
+  onLoading: (ctx: { stopLoading: () => void }) => void;
+  children: ReactNode;
+  styles?: PullRefresherStyles;
+}
+
+type Phase = "idle" | "pulling" | "loading";
+
+export interface PullRefresherStyles {
+  containerStyle?: CSSProp;
+  slotWrapperStyle?: CSSProp;
+  contentStyle?: CSSProp;
+}
+
+const SLOT_DISPLAY_HEIGHT = 64;
+
+function PullRefresher({
+  activatedAt = "100px",
+  preloadingSlot,
+  loadingSlot,
+  onLoading,
+  children,
+  styles,
+}: PullRefresherProps) {
+  const threshold = parsePx(activatedAt, 100);
+
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [slotHeight, setSlotHeight] = useState(0);
+  const [animated, setAnimated] = useState(false);
+  const [activated, setActivated] = useState(false);
+
+  const startYRef = useRef<number | null>(null);
+  const currentPullRef = useRef(0);
+  const phaseRef = useRef<Phase>("idle");
+
+  useEffect(() => {
+    phaseRef.current = phase;
+  }, [phase]);
+
+  const applyPull = useCallback(
+    (rawDelta: number) => {
+      if (rawDelta <= 0) {
+        setSlotHeight(0);
+        setActivated(false);
+        return;
+      }
+      const pull =
+        rawDelta > threshold
+          ? threshold + (rawDelta - threshold) * 0.3
+          : rawDelta;
+      currentPullRef.current = pull;
+      setSlotHeight(pull);
+      setActivated(pull >= threshold);
+    },
+    [threshold]
+  );
+
+  const stopLoading = useCallback(() => {
+    setAnimated(true);
+    setSlotHeight(0);
+    setPhase("idle");
+    phaseRef.current = "idle";
+    setTimeout(() => setAnimated(false), 450);
+  }, []);
+
+  const triggerLoading = useCallback(() => {
+    setPhase("loading");
+    phaseRef.current = "loading";
+    setAnimated(true);
+    setSlotHeight(SLOT_DISPLAY_HEIGHT);
+    setTimeout(() => setAnimated(false), 450);
+    onLoading({ stopLoading });
+  }, [onLoading, stopLoading]);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (phaseRef.current !== "idle") return;
+    startYRef.current = e.clientY;
+    setPhase("pulling");
+    phaseRef.current = "pulling";
+    currentPullRef.current = 0;
+  }, []);
+
+  useEffect(() => {
+    const onMouseMove = (e: MouseEvent) => {
+      if (phaseRef.current !== "pulling" || startYRef.current === null) return;
+      applyPull(e.clientY - startYRef.current);
+    };
+
+    const onMouseUp = () => {
+      if (phaseRef.current !== "pulling") return;
+      if (currentPullRef.current >= threshold) {
+        triggerLoading();
+      } else {
+        setAnimated(true);
+        setSlotHeight(0);
+        setActivated(false);
+        setPhase("idle");
+        phaseRef.current = "idle";
+        setTimeout(() => setAnimated(false), 450);
+      }
+      startYRef.current = null;
+      currentPullRef.current = 0;
+    };
+
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+    return () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+    };
+  }, [applyPull, threshold, triggerLoading]);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (phaseRef.current !== "idle") return;
+    startYRef.current = e.touches[0].clientY;
+    setPhase("pulling");
+    phaseRef.current = "pulling";
+    currentPullRef.current = 0;
+  }, []);
+
+  useEffect(() => {
+    const onTouchMove = (e: TouchEvent) => {
+      if (phaseRef.current !== "pulling" || startYRef.current === null) return;
+      applyPull(e.touches[0].clientY - startYRef.current);
+    };
+
+    const onTouchEnd = () => {
+      if (phaseRef.current !== "pulling") return;
+      if (currentPullRef.current >= threshold) {
+        triggerLoading();
+      } else {
+        setAnimated(true);
+        setSlotHeight(0);
+        setActivated(false);
+        setPhase("idle");
+        phaseRef.current = "idle";
+        setTimeout(() => setAnimated(false), 450);
+      }
+      startYRef.current = null;
+      currentPullRef.current = 0;
+    };
+
+    window.addEventListener("touchmove", onTouchMove, { passive: true });
+    window.addEventListener("touchend", onTouchEnd);
+    return () => {
+      window.removeEventListener("touchmove", onTouchMove);
+      window.removeEventListener("touchend", onTouchEnd);
+    };
+  }, [applyPull, threshold, triggerLoading]);
+
+  const resolvedPreloading = preloadingSlot ? (
+    preloadingSlot
+  ) : (
+    <DefaultPreloadingSlot activated={activated} />
+  );
+
+  const resolvedLoading =
+    loadingSlot !== undefined ? loadingSlot : <LoadingSpinner iconSize={30} />;
+
+  return (
+    <Container
+      $style={styles?.containerStyle}
+      onMouseDown={handleMouseDown}
+      onTouchStart={handleTouchStart}
+    >
+      <SlotWrapper
+        $height={slotHeight}
+        $animated={animated}
+        aria-label={phase === "loading" ? "Refreshing content" : undefined}
+        $style={styles?.slotWrapperStyle}
+      >
+        {slotHeight > 0 &&
+          (phase === "loading" ? resolvedLoading : resolvedPreloading)}
+      </SlotWrapper>
+
+      <Content $style={styles?.contentStyle}>{children}</Content>
+    </Container>
+  );
+}
+
+const SlotWrapper = styled.div<{
+  $height: number;
+  $animated: boolean;
+  $style?: CSSProp;
+}>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  font-size: 13px;
+  height: ${({ $height }) => $height}px;
+  transition: ${({ $animated }) =>
+    $animated ? "height 0.4s cubic-bezier(0.4, 0, 0.2, 1)" : "none"};
+
+  ${({ $style }) => $style}
+`;
+
+const Container = styled.div<{ $style?: CSSProp }>`
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  user-select: none;
+  height: 80dvh;
+  max-height: 80dvh;
+
+  ${({ $style }) => $style}
+`;
+
+const Content = styled.div<{ $style?: CSSProp }>`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  overflow: auto;
+  max-height: 80dvh;
+
+  ${({ $style }) => $style}
+`;
+
+const Arrow = styled.svg<{ $flipped: boolean }>`
+  transition: transform 0.2s ease;
+  transform: ${({ $flipped }) =>
+    $flipped ? "rotate(180deg)" : "rotate(0deg)"};
+`;
+
+const DefaultPreloadingSlot: React.FC<{ activated: boolean }> = ({
+  activated,
+}) => (
+  <>
+    <Arrow
+      $flipped={activated}
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </Arrow>
+  </>
+);
+
+function parsePx(value: string | number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (typeof value === "number") return value;
+  const n = parseFloat(value);
+  return isNaN(n) ? fallback : n;
+}
+
+export { PullRefresher };

--- a/test/component/pull-refresher.cy.tsx
+++ b/test/component/pull-refresher.cy.tsx
@@ -251,6 +251,30 @@ describe("PullRefresher", () => {
       });
     });
 
+    context("slotWrapperStyle", () => {
+      context("when given background-color red", () => {
+        it("renders background color with rgb(255, 0, 0)", () => {
+          cy.mount(
+            <ProductPullRefresher
+              styles={{
+                slotWrapperStyle: css`
+                  background-color: red;
+                `,
+              }}
+            />
+          );
+
+          pull(80);
+
+          cy.findByLabelText("pull-refresher-slot-loader").should(
+            "have.css",
+            "background-color",
+            "rgb(255, 0, 0)"
+          );
+        });
+      });
+    });
+
     context("content", () => {
       context("when given padding 20px", () => {
         it("should render container with padding 20px", () => {

--- a/test/component/pull-refresher.cy.tsx
+++ b/test/component/pull-refresher.cy.tsx
@@ -30,34 +30,71 @@ describe("PullRefresher", () => {
   }
 
   context("activatedAt", () => {
-    context("when given 200px", () => {
-      context("when scrolling pass the height", () => {
-        it("should activate the loading", () => {
-          cy.mount(
-            <ProductPullRefresher
-              activatedAt="200px"
-              loadingSlot={<div>Loading...</div>}
-            />
-          );
+    context("with string", () => {
+      context("when given 25dvh (187.5px)", () => {
+        context("when scrolling pass the height", () => {
+          it("should activate the loading", () => {
+            cy.viewport(550, 750);
+            cy.mount(
+              <ProductPullRefresher
+                activatedAt="25dvh"
+                loadingSlot={<div>Loading...</div>}
+              />
+            );
 
-          pull(250);
+            pull(188);
 
-          cy.contains("Loading...").should("exist");
+            cy.contains("Loading...").should("exist");
+          });
+        });
+
+        context("when scrolling not pass the height", () => {
+          it("should not activate the loading", () => {
+            cy.mount(
+              <ProductPullRefresher
+                activatedAt="25dvh"
+                loadingSlot={<div>Loading...</div>}
+              />
+            );
+
+            pull(184);
+
+            cy.contains("Loading...").should("not.exist");
+          });
         });
       });
+    });
 
-      context("when scrolling not pass the height", () => {
-        it("should not activate the loading", () => {
-          cy.mount(
-            <ProductPullRefresher
-              activatedAt="200px"
-              loadingSlot={<div>Loading...</div>}
-            />
-          );
+    context("with number", () => {
+      context("when given 200", () => {
+        context("when scrolling pass the height", () => {
+          it("should activate the loading", () => {
+            cy.mount(
+              <ProductPullRefresher
+                activatedAt={200}
+                loadingSlot={<div>Loading...</div>}
+              />
+            );
 
-          pull(190);
+            pull(250);
 
-          cy.contains("Loading...").should("not.exist");
+            cy.contains("Loading...").should("exist");
+          });
+        });
+
+        context("when scrolling not pass the height", () => {
+          it("should not activate the loading", () => {
+            cy.mount(
+              <ProductPullRefresher
+                activatedAt={200}
+                loadingSlot={<div>Loading...</div>}
+              />
+            );
+
+            pull(190);
+
+            cy.contains("Loading...").should("not.exist");
+          });
         });
       });
     });

--- a/test/component/pull-refresher.cy.tsx
+++ b/test/component/pull-refresher.cy.tsx
@@ -1,0 +1,239 @@
+import { css } from "styled-components";
+import {
+  PullRefresher,
+  PullRefresherProps,
+} from "./../../components/pull-refresher";
+
+describe("PullRefresher", () => {
+  function ProductPullRefresher(props: Partial<PullRefresherProps>) {
+    return (
+      <PullRefresher
+        onLoading={({ stopLoading }) => {
+          console.log("is loading");
+          setTimeout(() => {
+            stopLoading();
+            console.log("is stopped");
+          }, 400);
+        }}
+        {...props}
+      >
+        {props?.children ?? "Test"}
+      </PullRefresher>
+    );
+  }
+
+  function pull(distance: number) {
+    cy.contains("Test").parent().trigger("mousedown", { clientY: 0 });
+
+    cy.window().trigger("mousemove", { clientY: distance });
+    cy.window().trigger("mouseup");
+  }
+
+  context("activatedAt", () => {
+    context("when given 200px", () => {
+      context("when scrolling pass the height", () => {
+        it("should activate the loading", () => {
+          cy.mount(
+            <ProductPullRefresher
+              activatedAt="200px"
+              loadingSlot={<div>Loading...</div>}
+            />
+          );
+
+          pull(250);
+
+          cy.contains("Loading...").should("exist");
+        });
+      });
+
+      context("when scrolling not pass the height", () => {
+        it("should not activate the loading", () => {
+          cy.mount(
+            <ProductPullRefresher
+              activatedAt="200px"
+              loadingSlot={<div>Loading...</div>}
+            />
+          );
+
+          pull(190);
+
+          cy.contains("Loading...").should("not.exist");
+        });
+      });
+    });
+  });
+
+  context("preloadingSlot", () => {
+    context("when given by function", () => {
+      beforeEach(() => {
+        cy.mount(
+          <ProductPullRefresher
+            activatedAt="200px"
+            preloadingSlot={(activated) => (
+              <div>{activated ? "Release to refresh" : "Pull to refresh"}</div>
+            )}
+          />
+        );
+      });
+
+      context("when scrolling and not passing the height", () => {
+        it("renders non-activated state", () => {
+          cy.contains("Test").parent().trigger("mousedown", { clientY: 0 });
+
+          cy.window().trigger("mousemove", { clientY: 190 });
+
+          cy.contains("Pull to refresh").should("exist");
+        });
+      });
+
+      context("when scrolling and passing the height", () => {
+        it("renders activated state when threshold is reached", () => {
+          cy.contains("Test").parent().trigger("mousedown", { clientY: 0 });
+
+          cy.window().trigger("mousemove", { clientY: 210 });
+
+          cy.contains("Release to refresh").should("exist");
+        });
+      });
+    });
+
+    context("when given by reactnode", () => {
+      it("renders custom node", () => {
+        cy.mount(
+          <ProductPullRefresher preloadingSlot={<div>Custom preload</div>} />
+        );
+
+        cy.contains("Test").parent().trigger("mousedown", { clientY: 0 });
+
+        cy.window().trigger("mousemove", { clientY: 50 });
+
+        cy.contains("Custom preload").should("exist");
+      });
+    });
+  });
+
+  context("loadingSlot", () => {
+    it("renders custom loading slot", () => {
+      cy.mount(
+        <ProductPullRefresher loadingSlot={<div>Custom loading</div>} />
+      );
+
+      pull(150);
+
+      cy.contains("Custom loading").should("exist");
+    });
+
+    context("when given timeout with 400ms", () => {
+      it("removes loading slot after stopLoading", () => {
+        cy.mount(
+          <ProductPullRefresher loadingSlot={<div>Custom loading</div>} />
+        );
+
+        pull(150);
+
+        cy.contains("Custom loading").should("exist");
+
+        cy.wait(500);
+
+        cy.contains("Custom loading").should("not.exist");
+      });
+    });
+  });
+
+  context("onLoading", () => {
+    it("calls loading callback", () => {
+      cy.window().then((win) => {
+        cy.spy(win.console, "log").as("consoleLog");
+      });
+      cy.mount(<ProductPullRefresher />);
+
+      pull(150);
+
+      cy.get("@consoleLog").should("have.been.calledWith", "is loading");
+    });
+
+    context("onLoading", () => {
+      it("calls loading callback", () => {
+        cy.window().then((win) => {
+          cy.spy(win.console, "log").as("consoleLog");
+        });
+        cy.mount(<ProductPullRefresher />);
+
+        pull(150);
+
+        cy.get("@consoleLog").should("have.been.calledWith", "is loading");
+      });
+
+      context("when given stopLoading", () => {
+        it("should stop the loading", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
+          });
+          cy.mount(<ProductPullRefresher />);
+
+          pull(150);
+
+          cy.get("@consoleLog").should("have.been.calledWith", "is loading");
+          cy.wait(500);
+          cy.get("@consoleLog").should("have.been.calledWith", "is stopped");
+        });
+      });
+    });
+  });
+
+  context("children", () => {
+    it("renders children", () => {
+      cy.mount(
+        <ProductPullRefresher>
+          <div>Hello World</div>
+        </ProductPullRefresher>
+      );
+
+      cy.contains("Hello World").should("exist");
+    });
+  });
+
+  context("styles", () => {
+    context("containerStyle", () => {
+      context("when given background-color red", () => {
+        it("renders background color with rgb(255, 0, 0)", () => {
+          cy.mount(
+            <ProductPullRefresher
+              styles={{
+                containerStyle: css`
+                  background-color: red;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("pull-refresher-container")
+
+            .should("have.css", "background-color", "rgb(255, 0, 0)");
+        });
+      });
+    });
+
+    context("content", () => {
+      context("when given padding 20px", () => {
+        it("should render container with padding 20px", () => {
+          cy.mount(
+            <ProductPullRefresher
+              styles={{
+                contentStyle: css`
+                  padding: 20px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("pull-refresher-content").should(
+            "have.css",
+            "padding-top",
+            "20px"
+          );
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Description:
This pull request introduces a `PullRefresher` component that provides a pull-to-refresh for `mobile` mode.

How it works:
1. The user pulls the content downward.
2. Once the pull distance reaches the `threshold` defined by the `activatedAt` prop, the refresher becomes activated.
3. Releasing the gesture after the threshold is reached triggers the `onLoading` callback.
4. While loading, the loadingSlot is displayed.
5. Call `stopLoading()` to return the component to its idle state.

The usage should be follow like this:
```ts
<PullRefresher
  activatedAt="100px"
  onLoading={({ stopLoading }) => {
    setTimeout(() => stopLoading(), 2000);
  }}
  preloadingSlot={(isReady) => (
    <div>
      {isReady ? "Release to refresh" : "Pull to refresh"}
    </div>
  )}
  loadingSlot={<div>Loading...</div>}
>
  <div>Your scroll content</div>
</PullRefresher>
```

### Props

- `activatedAt` — Defines the pull distance required to activate the refresh action.
 
  ```ts
  activatedAt?: string | number;
  ```
- `preloadingSlot` — Custom content displayed while the user is pulling. When provided as a function, it receives a boolean indicating whether the threshold has been reached.

  ```ts
  preloadingSlot?: (
    isThresholdReached?: boolean
  ) => ReactNode | ReactNode;
  ```
- `loadingSlot` — Custom content displayed while loading is in progress.

  ```ts
  loadingSlot?: ReactNode;
  ```
- `onLoading` — Called when the user releases after reaching the activation threshold. Provides a `stopLoading()` function to return the component to its idle state.

  ```ts
  onLoading: (ctx: {
    stopLoading: () => void;
  }) => void;
  ```
- `children` — The content rendered inside the refresher.

  ```ts
  children: ReactNode;
  ```
- `styles` — Custom styles for internal component elements.
  ```ts
  styles?: {
    containerStyle?: CSSProp;
    slotWrapperStyle?: CSSProp;
    contentStyle?: CSSProp;
  };
  ```

Source:
[[Mobile] SYST-696: Add PullRefresher](https://linear.app/systatum/issue/SYST-696/add-pullrefresher)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself