### PR TITLE
[Research] SYST-702: Investigate how to extend RichEditor

### DIFF
--- a/components/badge.tsx
+++ b/components/badge.tsx
@@ -16,10 +16,8 @@ export const BadgeVariant = {
 
 export type BadgeVariant = (typeof BadgeVariant)[keyof typeof BadgeVariant];
 
-export interface BadgeProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  "style"
-> {
+export interface BadgeProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "style"> {
   id?: string;
   metadata?: Record<string, unknown>;
   variant?: BadgeVariant;
@@ -28,9 +26,7 @@ export interface BadgeProps extends Omit<
   backgroundColor?: string;
   textColor?: string;
   circleColor?: string;
-  onClick?: (
-    e?: ChangeEvent<HTMLInputElement> | MouseEvent<HTMLDivElement>
-  ) => void;
+  onClick?: (e?: MouseEvent<HTMLSpanElement>) => void;
   actions?: BadgeAction[];
   styles?: BadgeStyles;
 }
@@ -246,7 +242,7 @@ function Badge({
   );
 }
 
-const BadgeIconWrapper = styled.div<{
+const BadgeIconWrapper = styled.span<{
   $style?: CSSProp;
 }>`
   display: flex;
@@ -256,7 +252,7 @@ const BadgeIconWrapper = styled.div<{
   ${({ $style }) => $style};
 `;
 
-const BadgeWrapper = styled.div<{
+const BadgeWrapper = styled.span<{
   $backgroundColor: string;
   $textColor: string;
   $theme?: BadgeThemeConfig;
@@ -296,7 +292,7 @@ const BadgeLabel = styled.span`
   flex: 1;
 `;
 
-const BadgeContent = styled.div<{ $withCircle?: boolean }>`
+const BadgeContent = styled.span<{ $withCircle?: boolean }>`
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -579,6 +579,7 @@ export const CustomTokenRenderer: Story = {
   render: () => {
     const { currentTheme } = useTheme();
     const richEditorTheme = currentTheme?.richEditor;
+    const editorRef = useRef<RichEditorRef>(null);
 
     const [value, setValue] = useState(
       `### Sprint Planning Notes
@@ -602,11 +603,10 @@ Reminder: deployment is owned by <{["devops-team"]}>. Ping them if the pipeline 
       </RichEditor.ToolbarButton>
     );
 
-    const dispatchTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
-
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
         <RichEditor
+          ref={editorRef}
           onChange={(e) => setValue(e)}
           onKeyDown={(e) => {
             if (e.key !== "[") return;
@@ -674,21 +674,12 @@ Reminder: deployment is owned by <{["devops-team"]}>. Ping them if the pipeline 
                       ).closest<HTMLElement>("[data-token-start]");
 
                       if (tokenSpan) {
-                        // Update data-token-word immediately — no caret jump from this
                         tokenSpan.dataset.tokenWord = `"${text}"`;
-
-                        // Debounce the dispatchEvent after 1.5 second
-                        clearTimeout(dispatchTimerRef.current);
-                        dispatchTimerRef.current = setTimeout(() => {
-                          tokenSpan
-                            .closest<HTMLElement>(
-                              "[aria-label='rich-editor-content']"
-                            )
-                            ?.dispatchEvent(
-                              new Event("input", { bubbles: true })
-                            );
-                        }, 1500);
                       }
+                    }}
+                    onBlur={() => {
+                      // Always sync immediately on blur — no debounce needed
+                      editorRef.current?.syncTokens();
                     }}
                     onClick={(e) => {
                       e.stopPropagation();

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -577,6 +577,9 @@ export default Content
 
 export const CustomTokenRenderer: Story = {
   render: () => {
+    const { currentTheme } = useTheme();
+    const richEditorTheme = currentTheme?.richEditor;
+
     const [value, setValue] = useState(
       `### Sprint Planning Notes
 The authentication redesign has been assigned to <{["alim"]}> . Please review the latest mockups before the standup.
@@ -704,7 +707,7 @@ Reminder: deployment is owned by <{["devops-team"]}>. Ping them if the pipeline 
           <pre
             style={{
               padding: 28,
-              background: "#D3D3D3",
+              background: richEditorTheme?.preBackgroundColor,
               whiteSpace: "pre-wrap",
               wordBreak: "break-word",
             }}

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -583,9 +583,7 @@ export const CustomTokenRenderer: Story = {
 
     const [value, setValue] = useState(
       `### Sprint Planning Notes
-The authentication redesign has been assigned to <{["alim"]}> . Please review the latest mockups before the standup.
-
-Blocking issues should be escalated to <{["carol"]}>. She will coordinate with the backend team on the API contract.
+The authentication redesign has been assigned to <{["alim"]}> . Please review the latest mockups before the standup. Blocking issues should be escalated to <{["carol"]}>. She will coordinate with the backend team on the API contract.
 
 Reminder: deployment is owned by <{["devops-team"]}>. Ping them if the pipeline fails.`
     );

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -663,6 +663,7 @@ Reminder: deployment is owned by <{["devops-team"]}>. Ping them if the pipeline 
                 return (
                   <Badge
                     contentEditable
+                    suppressContentEditableWarning
                     onInput={(e) => {
                       const text =
                         (e.currentTarget as HTMLElement).innerText

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -599,10 +599,57 @@ Reminder: deployment is owned by <{["devops-team"]}>. Ping them if the pipeline 
       </RichEditor.ToolbarButton>
     );
 
+    const dispatchTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
         <RichEditor
           onChange={(e) => setValue(e)}
+          onKeyDown={(e) => {
+            if (e.key !== "[") return;
+
+            const sel = window.getSelection();
+            if (!sel || !sel.rangeCount) return;
+
+            const range = sel.getRangeAt(0);
+            const node = range.startContainer;
+            if (node.nodeType !== Node.TEXT_NODE) return;
+
+            const beforeCaret = (node.textContent ?? "").slice(
+              0,
+              range.startOffset
+            );
+            if (!beforeCaret.endsWith("<{")) return;
+
+            e.preventDefault();
+
+            const delRange = document.createRange();
+            delRange.setStart(node, range.startOffset - 2);
+            delRange.setEnd(node, range.startOffset);
+            delRange.deleteContents();
+
+            const tokenSpan = document.createElement("span");
+            tokenSpan.dataset.tokenStart = "<{[";
+            tokenSpan.dataset.tokenEnd = "]}>";
+            tokenSpan.dataset.tokenWord = '"mention"';
+            tokenSpan.dataset.tokenType = "custom-token-";
+
+            const inner = document.createElement("span");
+            inner.contentEditable = "false";
+            tokenSpan.appendChild(inner);
+
+            const zws = document.createTextNode("\u200B");
+
+            const currentRange = sel.getRangeAt(0);
+            currentRange.insertNode(zws);
+            currentRange.insertNode(tokenSpan);
+
+            const afterRange = document.createRange();
+            afterRange.setStartAfter(zws);
+            afterRange.collapse(true);
+            sel.removeAllRanges();
+            sel.addRange(afterRange);
+          }}
           value={value}
           tokenRenderers={{
             "<{[": {
@@ -613,6 +660,33 @@ Reminder: deployment is owned by <{["devops-team"]}>. Ping them if the pipeline 
                 return (
                   <Badge
                     contentEditable
+                    onInput={(e) => {
+                      const text =
+                        (e.currentTarget as HTMLElement).innerText
+                          ?.trim()
+                          .replace(/^@/, "") ?? "";
+
+                      const tokenSpan = (
+                        e.currentTarget as HTMLElement
+                      ).closest<HTMLElement>("[data-token-start]");
+
+                      if (tokenSpan) {
+                        // Update data-token-word immediately — no caret jump from this
+                        tokenSpan.dataset.tokenWord = `"${text}"`;
+
+                        // Debounce the dispatchEvent after 1.5 second
+                        clearTimeout(dispatchTimerRef.current);
+                        dispatchTimerRef.current = setTimeout(() => {
+                          tokenSpan
+                            .closest<HTMLElement>(
+                              "[aria-label='rich-editor-content']"
+                            )
+                            ?.dispatchEvent(
+                              new Event("input", { bubbles: true })
+                            );
+                        }, 1500);
+                      }
+                    }}
                     onClick={(e) => {
                       e.stopPropagation();
                       console.log("Mention clicked:", username);

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -280,7 +280,6 @@ export const Default: Story = {
       {
         title: "Markdown Example",
         content: `### Hello there!
-
 ${sentences}
 
 This is ordered list
@@ -419,7 +418,6 @@ export const Autogrow: Story = {
       {
         title: "Markdown Example",
         content: `### Hello there!
-
 ${sentences}
 
 This is ordered list
@@ -746,9 +744,7 @@ export const ViewOnly: Story = {
       () => generateSentence({ minLen: 30, maxLen: 40, seed: 12345 }),
       [generateSentence]
     );
-    const [value, setValue] = useState(
-      `### Hello there!
-
+    const [value, setValue] = useState(`### Hello there!
 ${sentences}
 
 This is ordered list
@@ -769,8 +765,7 @@ function Content(){
 
 export default Content
 \`\`\`
-`
-    );
+`);
 
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -575,6 +575,74 @@ export default Content
   },
 };
 
+export const CustomTokenRenderer: Story = {
+  render: () => {
+    const [value, setValue] = useState(
+      `### Sprint Planning Notes
+The authentication redesign has been assigned to <{["alim"]}> . Please review the latest mockups before the standup.
+
+Blocking issues should be escalated to <{["carol"]}>. She will coordinate with the backend team on the API contract.
+
+Reminder: deployment is owned by <{["devops-team"]}>. Ping them if the pipeline fails.`
+    );
+    const [printValue, setPrintValue] = useState("");
+
+    const TOOLBAR_RIGHT_PANEL_ACTIONS = (
+      <RichEditor.ToolbarButton
+        icon={{ image: RiPrinterFill }}
+        onClick={() => {
+          setPrintValue(value);
+          console.log(value);
+        }}
+      >
+        Print
+      </RichEditor.ToolbarButton>
+    );
+
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <RichEditor
+          onChange={(e) => setValue(e)}
+          value={value}
+          tokenRenderers={{
+            "<{[": {
+              endToken: "]}>",
+              render: (word) => {
+                const parsed = JSON.parse(`[${word}]`);
+                const [username] = parsed;
+                return (
+                  <Badge
+                    contentEditable
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      console.log("Mention clicked:", username);
+                    }}
+                    withCircle
+                    caption={`@${username}`}
+                  />
+                );
+              },
+            },
+          }}
+          toolbarRightPanel={TOOLBAR_RIGHT_PANEL_ACTIONS}
+        />
+        {printValue !== "" && (
+          <pre
+            style={{
+              padding: 28,
+              background: "#D3D3D3",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+            }}
+          >
+            {printValue}
+          </pre>
+        )}
+      </div>
+    );
+  },
+};
+
 export const ToolbarPositionBottom: Story = {
   render: () => {
     const [value, setValue] = useState("");

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -205,6 +205,49 @@ Supports embedded Monaco code blocks.
 
 ---
 
+
+### 🧩 Token Renderers (\`tokenRenderers\`)
+
+Extend the editor with custom inline token rendering. Tokens are parsed from Markdown and rendered as interactive React components inside the editor.
+
+\`\`\`tsx
+<RichEditor
+  tokenRenderers={{
+    "<{[": {
+      endToken: "]}>",
+      render: (word) => {
+        const parsed = JSON.parse(\`[\${word}]\`);
+        const [surah, ayah] = parsed;
+        return <Badge caption={\`\${surah}:\${ayah}\`} />;
+      },
+    },
+  }}
+/>
+\`\`\`
+
+Token syntax in Markdown:
+\`\`\`
+<{["Q", "17:32"]}>
+\`\`\`
+
+
+#### Token delimiter rules
+
+- Start token is the object key (e.g. \`"<{["\`)
+- End token is \`endToken\` (e.g. \`"]}>"\`  )
+- Content between delimiters can include any character **except** the full end token sequence
+- Tokens are parsed as **inline** elements — they flow naturally within paragraphs alongside regular text
+
+
+### Notes for tokenRenderers
+
+- Multiple token types can be registered simultaneously
+- Token content is **HTML-attribute-safe encoded** in the DOM (\`"\` → \`&quot;\`) and automatically decoded before being passed to \`render\`
+- Tokens survive editor operations: Enter, Backspace, bold/italic, list formatting
+
+---
+
+
 ### 🎯 Imperative API
 
 - \`insertPlainText(text)\`

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -246,6 +246,9 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => {
+    const { currentTheme } = useTheme();
+    const richEditorTheme = currentTheme?.richEditor;
+
     const [value, setValue] = useState("");
     const [printValue, setPrintValue] = useState("");
 
@@ -277,6 +280,7 @@ export const Default: Story = {
       {
         title: "Markdown Example",
         content: `### Hello there!
+
 ${sentences}
 
 This is ordered list
@@ -366,7 +370,7 @@ This is unordered list
           <pre
             style={{
               padding: 28,
-              background: "#D3D3D3",
+              background: richEditorTheme?.preBackgroundColor,
               wordBreak: "break-word",
               whiteSpace: "pre-wrap",
             }}
@@ -381,6 +385,9 @@ This is unordered list
 
 export const Autogrow: Story = {
   render: () => {
+    const { currentTheme } = useTheme();
+    const richEditorTheme = currentTheme?.richEditor;
+
     const [value, setValue] = useState("");
     const [printValue, setPrintValue] = useState("");
 
@@ -412,6 +419,7 @@ export const Autogrow: Story = {
       {
         title: "Markdown Example",
         content: `### Hello there!
+
 ${sentences}
 
 This is ordered list
@@ -513,7 +521,7 @@ export default Content
           <pre
             style={{
               padding: 28,
-              background: "#D3D3D3",
+              background: richEditorTheme?.preBackgroundColor,
               wordBreak: "break-word",
               whiteSpace: "pre-wrap",
             }}
@@ -573,6 +581,9 @@ export const PageEditor: Story = {
     layout: "fullscreen",
   },
   render: () => {
+    const { currentTheme } = useTheme();
+    const richEditorTheme = currentTheme?.richEditor;
+
     const [value, setValue] = useState("");
     const [printValue, setPrintValue] = useState("");
 
@@ -600,7 +611,7 @@ export const PageEditor: Story = {
           <pre
             style={{
               padding: 28,
-              background: "#D3D3D3",
+              background: richEditorTheme?.preBackgroundColor,
               whiteSpace: "pre-wrap",
               wordBreak: "break-word",
             }}
@@ -737,6 +748,7 @@ export const ViewOnly: Story = {
     );
     const [value, setValue] = useState(
       `### Hello there!
+
 ${sentences}
 
 This is ordered list

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -2,6 +2,7 @@ import React, {
   forwardRef,
   KeyboardEvent,
   ReactNode,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -2715,44 +2716,96 @@ function buildTurndownRules(tokenRenderers: Record<string, TokenRenderer>) {
 
 function useTokenPortals(
   editorRef: React.RefObject<HTMLDivElement>,
-  tokenRenderers?: Record<
-    string,
-    { endToken: string; render: (word: string) => ReactNode }
-  >
+  tokenRenderers?: Record<string, TokenRenderer>
 ) {
   const [portals, setPortals] = useState<React.ReactPortal[]>([]);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+  // Track which nodes already have a portal mounted
+  const mountedNodes = useRef<Set<HTMLElement>>(new Set());
+
+  const scanAndRender = useCallback(
+    (source?: MutationRecord[]) => {
+      if (!editorRef.current || !tokenRenderers) return;
+
+      // If mutation came only from characterData inside a token, skip re-render
+      // — the onInput handler on Badge already updated data-token-word directly
+      if (source?.length) {
+        const allInsideToken = source.every((m) =>
+          (m.target as HTMLElement).closest?.("[data-token-start]")
+        );
+        if (allInsideToken) return;
+      }
+
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        const nodes = editorRef.current?.querySelectorAll<HTMLElement>(
+          "[data-token-start] > span[contenteditable='false']"
+        );
+        if (!nodes) return;
+
+        let changed = false;
+        const newPortals = Array.from(nodes).map((node) => {
+          const outer = node.closest<HTMLElement>("[data-token-start]")!;
+          const startToken = outer.dataset.tokenStart!;
+          const word = outer.dataset.tokenWord!;
+          const renderer = tokenRenderers[startToken];
+          if (!renderer) return null;
+
+          // Skip re-render if this node already has a portal
+          if (mountedNodes.current.has(node)) {
+            // Return existing portal — find it from current state
+            return (
+              portals.find((p) => (p as any).containerInfo === node) ?? null
+            );
+          }
+
+          changed = true;
+          mountedNodes.current.add(node);
+
+          return createPortal(
+            <span style={{ display: "inline-flex", alignItems: "center" }}>
+              {renderer.render(word)}
+            </span>,
+            node
+          );
+        });
+
+        // Clean up nodes that are no longer in the DOM
+        mountedNodes.current.forEach((n) => {
+          if (!editorRef.current?.contains(n)) {
+            mountedNodes.current.delete(n);
+            changed = true;
+          }
+        });
+
+        if (changed) {
+          setPortals(newPortals.filter(Boolean) as React.ReactPortal[]);
+        }
+      }, 50);
+    },
+    [tokenRenderers]
+  );
 
   useEffect(() => {
     if (!editorRef.current || !tokenRenderers) return;
 
-    clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => {
-      const nodes = editorRef.current?.querySelectorAll<HTMLElement>(
-        "[data-token-start] > span[contenteditable='false']"
-      );
-      if (!nodes) return;
+    scanAndRender();
 
-      const newPortals = Array.from(nodes).map((node) => {
-        const outer = node.closest<HTMLElement>("[data-token-start]")!;
-        const startToken = outer.dataset.tokenStart!;
-        const word = outer.dataset.tokenWord!;
-        const renderer = tokenRenderers[startToken];
-        if (!renderer) return null;
+    const observer = new MutationObserver((mutations) =>
+      scanAndRender(mutations)
+    );
+    observer.observe(editorRef.current, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
 
-        return createPortal(
-          <span style={{ display: "inline-flex", alignItems: "center" }}>
-            {renderer.render(word)}
-          </span>,
-          node
-        );
-      });
-
-      setPortals(newPortals.filter(Boolean) as React.ReactPortal[]);
-    }, 50);
-
-    return () => clearTimeout(timerRef.current);
-  }, []);
+    return () => {
+      observer.disconnect();
+      clearTimeout(timerRef.current);
+      mountedNodes.current.clear();
+    };
+  }, [scanAndRender]);
 
   return portals;
 }

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -179,6 +179,7 @@ interface RichEditorComponent
 export interface RichEditorRef {
   insertPlainText: (data: string) => void;
   insertMarkdownContent: (data: string) => void;
+  syncTokens: () => void;
 }
 
 const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
@@ -812,6 +813,14 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         handleFilteringCheckbox();
 
         handleEditorChange();
+      },
+      syncTokens: () => {
+        if (!editorRef.current) return;
+        const html = editorRef.current.innerHTML.replace(/\u00A0/g, "");
+        const cleanedHTML = cleanupHtml(html);
+        const markdown = turndownService.turndown(cleanedHTML);
+        const cleanedMarkdown = cleanSpacing(markdown);
+        onChange?.(cleanedMarkdown);
       },
     }));
 

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -1137,6 +1137,14 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         }
       }
 
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "z") {
+        // Let the browser perform its native undo, then re-sync tokens and emit onChange
+        setTimeout(() => {
+          handleEditorChange();
+        }, 200);
+        return;
+      }
+
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "u") {
         e.preventDefault();
         return;

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -29,6 +29,7 @@ import { RichEditorThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
 import { CodeEditor, CodeEditorAction, CodeEditorOption } from "./code-editor";
 import { applyClassName } from "./../constants/classname";
+import { createPortal } from "react-dom";
 
 export interface RichEditorProps {
   value?: string;
@@ -42,6 +43,16 @@ export interface RichEditorProps {
   actions?: RichEditorAction[];
   codeEditor?: RichEditorCode;
   id?: string;
+  className?: string;
+  tokenRenderers?: RichEditorTokenRenderer;
+  onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
+}
+
+export type RichEditorTokenRenderer = Record<string, TokenRenderer>;
+
+export interface TokenRenderer {
+  endToken: string;
+  render: (word: string) => ReactNode;
   className?: string;
 }
 
@@ -184,6 +195,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       codeEditor,
       className,
       id,
+      tokenRenderers,
+      onKeyDown,
     },
     ref
   ) => {
@@ -534,6 +547,19 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         },
       ],
     });
+
+    if (tokenRenderers) {
+      // build turndown rules
+      const rules = buildTurndownRules(tokenRenderers);
+      rules.forEach(({ name, filter, replacement }) => {
+        turndownService.addRule(name, { filter, replacement });
+        turndownServiceRef.current.addRule(name, { filter, replacement });
+      });
+
+      // build extensions
+      const extensions = buildMarkedExtensions(tokenRenderers);
+      marked.use({ extensions });
+    }
 
     const editorRef = useRef<HTMLDivElement>(null);
     const savedSelection = useRef<Range | null>(null);
@@ -935,6 +961,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     };
 
     const handleOnKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+      onKeyDown?.(e);
+
       if (mode === "view-only") {
         const isCopy = (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "c";
 
@@ -1682,6 +1710,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       },
     ];
 
+    const portals = useTokenPortals(editorRef, tokenRenderers);
+
     useEffect(() => {
       function handleClickOutside(event: MouseEvent) {
         if (
@@ -1732,143 +1762,151 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     }
 
     return (
-      <BaseRichEditor
-        actions={actions}
-        value={value}
-        mode={mode}
-        id={id}
-        className={applyClassName("rich-editor", className)}
-        styles={{
-          ...styles,
-          toolbarStyle: css`
-            padding-left: 8px;
-            padding-right: 8px;
-            z-index: 10;
-            ${styles?.toolbarStyle}
-          `,
-        }}
-        leftSidePanel={
-          mode !== "view-only" && (
-            <>
-              <RichEditorToolbarButton
-                ariaLabel="rich-editor-toolbar-bold"
-                isActive={formatStates.bold}
-                icon={{ image: RiBold }}
-                onClick={() => handleCommand("bold")}
-              />
-
-              <RichEditorToolbarButton
-                ariaLabel="rich-editor-toolbar-italic"
-                isActive={formatStates.italic}
-                icon={{ image: RiItalic }}
-                onClick={() => handleCommand("italic")}
-              />
-
-              <RichEditorToolbarButton
-                ariaLabel="rich-editor-toolbar-ordered-list"
-                icon={{ image: RiListOrdered }}
-                onClick={() => handleCommand("insertOrderedList")}
-              />
-
-              <RichEditorToolbarButton
-                ariaLabel="rich-editor-toolbar-unordered-list"
-                icon={{ image: RiListUnordered }}
-                onClick={() => handleCommand("insertUnorderedList")}
-              />
-
-              <RichEditorToolbarButton
-                ariaLabel="rich-editor-toolbar-checkbox"
-                icon={{ image: RiCheckboxLine }}
-                onClick={() => handleCommand("checkbox")}
-              />
-
-              {mode === "markdown-editor" && (
+      <>
+        <BaseRichEditor
+          actions={actions}
+          value={value}
+          mode={mode}
+          id={id}
+          className={applyClassName("rich-editor", className)}
+          styles={{
+            ...styles,
+            toolbarStyle: css`
+              padding-left: 8px;
+              padding-right: 8px;
+              z-index: 10;
+              ${styles?.toolbarStyle}
+            `,
+          }}
+          leftSidePanel={
+            mode !== "view-only" && (
+              <>
                 <RichEditorToolbarButton
-                  ariaLabel="rich-editor-toolbar-code-block"
-                  icon={{ image: RiCodeSSlashLine }}
-                  onClick={() => handleCommand("codeBlock")}
+                  ariaLabel="rich-editor-toolbar-bold"
+                  isActive={formatStates.bold}
+                  icon={{ image: RiBold }}
+                  onClick={() => handleCommand("bold")}
                 />
-              )}
 
-              <RichEditorToolbarButton
-                ariaLabel="rich-editor-toolbar-heading-menu"
-                icon={{ image: RiHeading }}
-                isOpen={isOpen}
-                onClick={() => {
-                  const sel = window.getSelection();
-                  if (sel && sel.rangeCount > 0) {
-                    savedSelection.current = sel.getRangeAt(0).cloneRange();
-                  }
-                  setIsOpen(!isOpen);
-                }}
-              />
+                <RichEditorToolbarButton
+                  ariaLabel="rich-editor-toolbar-italic"
+                  isActive={formatStates.italic}
+                  icon={{ image: RiItalic }}
+                  onClick={() => handleCommand("italic")}
+                />
 
-              {isOpen && (
-                <MenuWrapper ref={menuRef} $toolbarPosition={toolbarPosition}>
-                  <TipMenu
-                    setIsOpen={() => setIsOpen(false)}
-                    subMenuList={TIP_MENU_RICH_EDITOR}
+                <RichEditorToolbarButton
+                  ariaLabel="rich-editor-toolbar-ordered-list"
+                  icon={{ image: RiListOrdered }}
+                  onClick={() => handleCommand("insertOrderedList")}
+                />
+
+                <RichEditorToolbarButton
+                  ariaLabel="rich-editor-toolbar-unordered-list"
+                  icon={{ image: RiListUnordered }}
+                  onClick={() => handleCommand("insertUnorderedList")}
+                />
+
+                <RichEditorToolbarButton
+                  ariaLabel="rich-editor-toolbar-checkbox"
+                  icon={{ image: RiCheckboxLine }}
+                  onClick={() => handleCommand("checkbox")}
+                />
+
+                {mode === "markdown-editor" && (
+                  <RichEditorToolbarButton
+                    ariaLabel="rich-editor-toolbar-code-block"
+                    icon={{ image: RiCodeSSlashLine }}
+                    onClick={() => handleCommand("codeBlock")}
                   />
-                </MenuWrapper>
-              )}
-            </>
-          )
-        }
-        rightSidePanel={toolbarRightPanel}
-        toolbarPosition={toolbarPosition}
-        theme={richEditorTheme}
-      >
-        <EditorArea
-          ref={editorRef}
-          role="textbox"
-          $theme={richEditorTheme}
-          aria-label="rich-editor-content"
-          contentEditable
-          $editorStyle={styles?.editorStyle}
-          $toolbarPosition={toolbarPosition}
-          $mode={mode}
-          $height={height}
-          $autogrow={autogrow}
-          onPaste={(e) => {
-            if (mode === "view-only") return;
+                )}
 
-            e.preventDefault();
+                <RichEditorToolbarButton
+                  ariaLabel="rich-editor-toolbar-heading-menu"
+                  icon={{ image: RiHeading }}
+                  isOpen={isOpen}
+                  onClick={() => {
+                    const sel = window.getSelection();
+                    if (sel && sel.rangeCount > 0) {
+                      savedSelection.current = sel.getRangeAt(0).cloneRange();
+                    }
+                    setIsOpen(!isOpen);
+                  }}
+                />
 
-            const html = e.clipboardData.getData("text/html");
-            const plain = e.clipboardData.getData("text/plain");
+                {isOpen && (
+                  <MenuWrapper ref={menuRef} $toolbarPosition={toolbarPosition}>
+                    <TipMenu
+                      setIsOpen={() => setIsOpen(false)}
+                      subMenuList={TIP_MENU_RICH_EDITOR}
+                    />
+                  </MenuWrapper>
+                )}
+              </>
+            )
+          }
+          rightSidePanel={toolbarRightPanel}
+          toolbarPosition={toolbarPosition}
+          theme={richEditorTheme}
+        >
+          <EditorArea
+            ref={editorRef}
+            role="textbox"
+            $theme={richEditorTheme}
+            aria-label="rich-editor-content"
+            contentEditable
+            $editorStyle={styles?.editorStyle}
+            $toolbarPosition={toolbarPosition}
+            $mode={mode}
+            $height={height}
+            $autogrow={autogrow}
+            onPaste={(e) => {
+              if (mode === "view-only") return;
 
-            const hasCodeColors = /color\s*:|background(-color)?\s*:/i.test(
-              html
-            );
+              e.preventDefault();
 
-            if (!html || hasCodeColors) {
-              document.execCommand("insertText", false, plain);
-            } else {
-              document.execCommand("insertHTML", false, html);
-            }
-          }}
-          onInput={() => {
-            if (mode !== "view-only") {
-              if (editorRef.current) {
-                syncCheckboxStates(editorRef.current);
+              const html = e.clipboardData.getData("text/html");
+              const plain = e.clipboardData.getData("text/plain");
+
+              const hasCodeColors = /color\s*:|background(-color)?\s*:/i.test(
+                html
+              );
+
+              if (!html || hasCodeColors) {
+                document.execCommand("insertText", false, plain);
+              } else {
+                document.execCommand("insertHTML", false, html);
               }
+            }}
+            onInput={() => {
+              if (mode !== "view-only") {
+                if (editorRef.current) {
+                  syncCheckboxStates(editorRef.current);
+                }
 
-              const html =
-                editorRef.current?.innerHTML.replace(/\u00A0/g, "") || "";
-              const cleanedHTML = cleanupHtml(html);
+                const html =
+                  editorRef.current?.innerHTML.replace(/\u00A0/g, "") || "";
+                const cleanedHTML = cleanupHtml(html);
 
-              const markdown = turndownService.turndown(cleanedHTML);
-              const cleanedMarkdown = cleanSpacing(markdown);
-              if (onChange) {
-                onChange(cleanedMarkdown);
+                const markdown = turndownService.turndown(cleanedHTML);
+                const cleanedMarkdown = cleanSpacing(markdown);
+                if (onChange) {
+                  onChange(cleanedMarkdown);
+                }
+
+                CodeEditor.serializeAndEmit(
+                  editorRef,
+                  turndownService,
+                  onChange
+                );
               }
+            }}
+            onKeyDown={handleOnKeyDown}
+          />
+        </BaseRichEditor>
 
-              CodeEditor.serializeAndEmit(editorRef, turndownService, onChange);
-            }
-          }}
-          onKeyDown={handleOnKeyDown}
-        />
-      </BaseRichEditor>
+        {portals}
+      </>
     );
   }
 ) as RichEditorComponent;
@@ -2340,6 +2378,7 @@ function createCheckboxWrapper(
 // - Collapsing multiple spaces into a single space elsewhere
 const cleanSpacing = (text: string): string => {
   return text
+    .replace(/\u200B/g, "")
     .replace(/\u00A0/g, " ")
     .replace(/\[(x| )\]\s+/gi, "[$1] ")
     .split("\n")
@@ -2368,6 +2407,8 @@ const cleanupHtml = (html: string): string => {
   container.innerHTML = html;
 
   Array.from(container.querySelectorAll("div")).forEach((div) => {
+    if (div.closest("[data-token-start]")) return;
+
     if (div.querySelector("ul, ol")) {
       const frag = document.createDocumentFragment();
       while (div.firstChild) {
@@ -2392,7 +2433,11 @@ const cleanupHtml = (html: string): string => {
   });
 
   Array.from(container.querySelectorAll("p")).forEach((p) => {
-    if (p.querySelector("ul, ol, h1, h2, h3, h4, h5, h6, b, i, input, strong"))
+    if (
+      p.querySelector(
+        "ul, ol, h1, h2, h3, h4, h5, h6, b, i, input, strong, [data-token-start]"
+      )
+    )
       return;
 
     const frag = document.createDocumentFragment();
@@ -2426,6 +2471,9 @@ const cleanupHtml = (html: string): string => {
   });
 
   Array.from(container.querySelectorAll("span")).forEach((span) => {
+    if (span.hasAttribute("data-token-start")) return;
+    if (span.closest("[data-token-start]")) return;
+
     const style = span.getAttribute("style") || "";
 
     const hasOnlyFontStyling =
@@ -2449,6 +2497,7 @@ const cleanupHtml = (html: string): string => {
   });
 
   container.normalize();
+
   return container.innerHTML;
 };
 
@@ -2542,6 +2591,8 @@ const splitBrIntoParagraphs = (html: string): string => {
   });
 
   container.querySelectorAll("p").forEach((p) => {
+    if (p.querySelector("[data-token-start]")) return;
+
     // Skip empty paragraphs — already correct, don't re-split them
     const isEmptyParagraph =
       p.childNodes.length === 0 ||
@@ -2583,6 +2634,126 @@ const isLegalDocument = (src: string) => {
     src
   );
 };
+
+function buildMarkedExtensions(tokenRenderers: Record<string, TokenRenderer>) {
+  return Object.entries(tokenRenderers).map(
+    ([startToken, { endToken, className }]) => {
+      const escapedStart = escapeRegex(startToken);
+      const escapedEnd = escapeRegex(endToken);
+      const safeClass =
+        className ?? `custom-token-${startToken.replace(/[^a-z0-9]/gi, "")}`;
+
+      return {
+        name: safeClass,
+        level: "inline" as const,
+        start(src: string) {
+          return src.indexOf(startToken);
+        },
+        tokenizer(src: string) {
+          const rule = new RegExp(
+            `^${escapedStart}((?:(?!${escapedEnd}).)+?)${escapedEnd}`
+          );
+          const match = rule.exec(src);
+
+          if (match) {
+            return {
+              type: safeClass,
+              raw: match[0],
+              word: match[1],
+            };
+          }
+        },
+        renderer(token: any) {
+          const safeWord = token.word
+            .replace(/&/g, "&amp;")
+            .replace(/"/g, "&quot;");
+
+          return `<span data-token-start="${startToken}" data-token-end="${endToken}" data-token-word="${safeWord}" data-token-type="${safeClass}"><span contenteditable="false"></span></span>&#8203;`;
+        },
+      };
+    }
+  );
+}
+
+function buildTurndownRules(tokenRenderers: Record<string, TokenRenderer>) {
+  return Object.entries(tokenRenderers).map(
+    ([startToken, { endToken, className }]) => {
+      const safeClass =
+        className ?? `custom-token-${startToken.replace(/[^a-z0-9]/gi, "")}`;
+
+      return {
+        name: safeClass,
+        filter(node: HTMLElement) {
+          return (
+            node.nodeName === "SPAN" &&
+            node.dataset.tokenStart === startToken &&
+            node.dataset.tokenEnd === endToken
+          );
+        },
+        replacement(_content: string, node: HTMLElement) {
+          const word = node.dataset.tokenWord ?? node.textContent ?? "";
+
+          const next = node.nextSibling;
+          if (
+            next?.nodeType === Node.TEXT_NODE &&
+            next.textContent === "\u200B"
+          ) {
+            next.textContent = "";
+          }
+          return `${startToken}${word}${endToken}`;
+        },
+      };
+    }
+  );
+}
+
+function useTokenPortals(
+  editorRef: React.RefObject<HTMLDivElement>,
+  tokenRenderers?: Record<
+    string,
+    { endToken: string; render: (word: string) => ReactNode }
+  >
+) {
+  const [portals, setPortals] = useState<React.ReactPortal[]>([]);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => {
+    if (!editorRef.current || !tokenRenderers) return;
+
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      const nodes = editorRef.current?.querySelectorAll<HTMLElement>(
+        "[data-token-start] > span[contenteditable='false']"
+      );
+      if (!nodes) return;
+
+      const newPortals = Array.from(nodes).map((node) => {
+        const outer = node.closest<HTMLElement>("[data-token-start]")!;
+        const startToken = outer.dataset.tokenStart!;
+        const word = outer.dataset.tokenWord!;
+        const renderer = tokenRenderers[startToken];
+        if (!renderer) return null;
+
+        return createPortal(
+          <span style={{ display: "inline-flex", alignItems: "center" }}>
+            {renderer.render(word)}
+          </span>,
+          node
+        );
+      });
+
+      setPortals(newPortals.filter(Boolean) as React.ReactPortal[]);
+    }, 50);
+
+    return () => clearTimeout(timerRef.current);
+  }, []);
+
+  return portals;
+}
+
+function escapeRegex(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 RichEditor.ToolbarButton = RichEditorToolbarButton;
 RichEditor.codeLanguage = RichEditorCodeLanguage;

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -2691,7 +2691,13 @@ function buildTurndownRules(tokenRenderers: Record<string, TokenRenderer>) {
           );
         },
         replacement(_content: string, node: HTMLElement) {
-          const word = node.dataset.tokenWord ?? node.textContent ?? "";
+          const raw = node.dataset.tokenWord ?? "";
+          const decoded = raw
+            .replace(/&quot;/g, '"')
+            .replace(/&amp;/g, "&")
+            .replace(/&#39;/g, "'");
+
+          const word = (decoded || node.dataset.tokenWord) ?? "";
 
           const next = node.nextSibling;
           if (

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -219,7 +219,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       replacement: function (content, node) {
         const hLevel = Number((node as HTMLElement).nodeName.charAt(1));
         const prefix = "#".repeat(hLevel);
-        return `${prefix} ${content}\n`;
+        return `${prefix} ${content}\n\n`;
       },
     });
 
@@ -423,9 +423,13 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             if (/^[ \t]+/.test(firstLine)) return;
 
             const match = src.match(/^([^\n]+)(\n(?!\n)[^\n]+)*(?=\n\n|\n?$)/);
-
             if (match && match[0].includes("\n")) {
               const lines = match[0].split("\n");
+
+              const looksLikeWrappedParagraph =
+                lines.length > 1 && lines.every((l) => l.length > 20);
+
+              if (looksLikeWrappedParagraph) return;
 
               if (lines.some((l) => /^`{3,}/.test(l.trim()))) return;
               if (lines.some((l) => /^ {4,}/.test(l))) return;

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -388,8 +388,6 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             return src.indexOf("\n\n");
           },
           tokenizer(src, tokens) {
-            if (isLegal) return;
-
             const prevToken = tokens?.[tokens.length - 1];
             if (prevToken?.type === "list") return;
 
@@ -407,6 +405,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
+            if (isLegal) return;
+
             return "<p><br></p>".repeat(token.count);
           },
         },
@@ -417,8 +417,6 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             return src.indexOf("\n");
           },
           tokenizer(src, tokens) {
-            if (isLegal) return;
-
             const isHeading = /^#{1,6}\s/.test(src);
             if (isHeading) return;
 
@@ -451,6 +449,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
+            if (isLegal) return;
             return token.lines
               .map((line: string) => `<p>${line}</p>`)
               .join("\n");

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -152,9 +152,10 @@ export interface RichEditorToolbarButtonStyles {
   self?: CSSProp;
 }
 
-interface RichEditorComponent extends React.ForwardRefExoticComponent<
-  RichEditorProps & React.RefAttributes<RichEditorRef>
-> {
+interface RichEditorComponent
+  extends React.ForwardRefExoticComponent<
+    RichEditorProps & React.RefAttributes<RichEditorRef>
+  > {
   ToolbarButton: typeof RichEditorToolbarButton;
   codeLanguage: typeof RichEditorCodeLanguage;
   translatedCodeLanguage: typeof TranslatedRichEditorCodeLanguage;
@@ -372,12 +373,75 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       },
     });
 
-    marked.use({
-      gfm: true,
-      breaks: false,
-    });
-
     CodeEditor.addFencedCodeMarkedExtension();
+
+    marked.use({
+      gfm: false,
+      breaks: true,
+      extensions: [
+        {
+          name: "emptyParagraph",
+          level: "block",
+          start(src) {
+            return src.indexOf("\n\n");
+          },
+          tokenizer(src, tokens) {
+            const isListContext = /^[ \t]*([-*+]|\d+\.)\s/m.test(src);
+            if (isListContext) return;
+
+            const match = src.match(/^(\n{2,})/);
+            if (match) {
+              // 7 blank lines = 8 \n chars
+              const blankLines = match[0].length - 1; // 7
+              return {
+                type: "emptyParagraph",
+                raw: match[0],
+                count: blankLines,
+              };
+            }
+          },
+          renderer(token) {
+            console.log(token);
+            // 1 blank line → normal separation, no extra
+            // 2 blank lines → 2 empty paragraphs
+            // 7 blank lines → 7 empty paragraphs
+            if (token.count <= 1) return "";
+            return "<p><br></p>".repeat(token.count - 1);
+          },
+        },
+        {
+          name: "lineSeparated",
+          level: "block",
+          start(src) {
+            return src.indexOf("\n");
+          },
+          tokenizer(src) {
+            const isIndented = /^ {4,}/.test(src);
+            const isListContext = /^[ \t]*([-*+]|\d+\.)\s/m.test(src);
+            const isCodeFence = /^`{3,}/.test(src);
+            if (isIndented || isListContext || isCodeFence) return;
+
+            const match = src.match(/^([^\n]+)(\n(?!\n)[^\n]+)+(?!\n)/);
+            if (match) {
+              // Also bail if any matched line starts a code fence
+              if (match[0].split("\n").some((l) => /^`{3,}/.test(l.trim())))
+                return;
+
+              return {
+                type: "lineSeparated",
+                raw: match[0],
+                lines: match[0].split("\n").filter((l) => l.trim() !== ""),
+              };
+            }
+          },
+          renderer(token) {
+            return token.lines
+              .map((line: string) => `<p>${line}</p>`)
+              .join("\n");
+          },
+        },
+      ],
+    });
 
     const editorRef = useRef<HTMLDivElement>(null);
     const savedSelection = useRef<Range | null>(null);
@@ -1963,6 +2027,11 @@ const EditorArea = styled.div<{
   $height?: number;
   $theme: RichEditorThemeConfig;
 }>`
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+  }
   padding: 8px;
   outline: none;
   background-color: ${({ $theme }) => $theme.backgroundColor};
@@ -2377,6 +2446,12 @@ const splitBrIntoParagraphs = (html: string): string => {
   });
 
   container.querySelectorAll("p").forEach((p) => {
+    // Skip empty paragraphs — already correct, don't re-split them
+    const isEmptyParagraph =
+      p.childNodes.length === 0 ||
+      (p.childNodes.length === 1 && p.firstChild?.nodeName === "BR");
+    if (isEmptyParagraph) return;
+
     if (p.querySelector("ul, ol, h1, h2, h3, h4, h5, h6, pre, input")) return;
 
     const fragments: Node[][] = [[]];

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -219,7 +219,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       replacement: function (content, node) {
         const hLevel = Number((node as HTMLElement).nodeName.charAt(1));
         const prefix = "#".repeat(hLevel);
-        return `${prefix} ${content}\n\n`;
+        return `${prefix} ${content}\n`;
       },
     });
 
@@ -380,7 +380,36 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     marked.use({
       gfm: false,
       breaks: true,
+      walkTokens(token) {
+        if (token.type === "space" && token.raw.length >= 2) {
+          const blankLines = token.raw.length;
+          token.type = "emptyParagraph";
+          (token as any).count = blankLines;
+        }
+      },
       extensions: [
+        {
+          name: "heading",
+          level: "block",
+          start(src) {
+            return src.indexOf("#");
+          },
+          tokenizer(src) {
+            const match = src.match(/^(#{1,6}) ([^\n]+)\n?/);
+            if (match) {
+              return {
+                type: "heading",
+                raw: match[0],
+                depth: match[1].length,
+                text: match[2],
+                tokens: [],
+              };
+            }
+          },
+          renderer(token) {
+            return `<h${token.depth}>${token.text}</h${token.depth}>`;
+          },
+        },
         {
           name: "emptyParagraph",
           level: "block",
@@ -405,8 +434,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
-            if (isLegal) return;
-
+            if (isLegal) return "";
             return "<p><br></p>".repeat(token.count);
           },
         },
@@ -449,7 +477,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
-            if (isLegal) return;
+            if (isLegal) return "";
             return token.lines
               .map((line: string) => `<p>${line}</p>`)
               .join("\n");

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -375,6 +375,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
     CodeEditor.addFencedCodeMarkedExtension();
 
+    const isLegal = isLegalDocument(value);
+
     marked.use({
       gfm: false,
       breaks: true,
@@ -386,13 +388,17 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             return src.indexOf("\n\n");
           },
           tokenizer(src, tokens) {
+            if (isLegal) return;
+
+            const prevToken = tokens?.[tokens.length - 1];
+            if (prevToken?.type === "list") return;
+
             const isListContext = /^[ \t]*([-*+]|\d+\.)\s/m.test(src);
             if (isListContext) return;
 
             const match = src.match(/^(\n{2,})/);
             if (match) {
-              // 7 blank lines = 8 \n chars
-              const blankLines = match[0].length - 1; // 7
+              const blankLines = match[0].length - 1;
               return {
                 type: "emptyParagraph",
                 raw: match[0],
@@ -401,7 +407,6 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
-            if (token.count <= 1) return "";
             return "<p><br></p>".repeat(token.count);
           },
         },
@@ -412,6 +417,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             return src.indexOf("\n");
           },
           tokenizer(src, tokens) {
+            if (isLegal) return;
+
             const isHeading = /^#{1,6}\s/.test(src);
             if (isHeading) return;
 
@@ -2489,6 +2496,12 @@ const splitBrIntoParagraphs = (html: string): string => {
   });
 
   return container.innerHTML;
+};
+
+const isLegalDocument = (src: string) => {
+  return /^(MIT License|Apache License|GNU |BSD |ISC License|Copyright \(c\)|TERMS AND CONDITIONS|END OF TERMS)/im.test(
+    src
+  );
 };
 
 RichEditor.ToolbarButton = RichEditorToolbarButton;

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -631,6 +631,10 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
         html = value?.trim() ? await marked.parse(value) : `<p>${value}</p>`;
 
+        if (!html.trim().startsWith("<")) {
+          html = `<p>${html}</p>`;
+        }
+
         if (!isMounted || !editorRef.current) return;
 
         html = splitBrIntoParagraphs(html);

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -382,6 +382,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     marked.use({
       gfm: false,
       breaks: true,
+      // Track previous token so we can detect
+      // blank lines that appear immediately after headings.
       walkTokens(token) {
         if (
           token.type === "space" &&
@@ -389,6 +391,9 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           prevWalkToken?.type === "heading"
         ) {
           const blankLines = token.raw.length - 1;
+
+          // Convert heading-following spaces into a custom
+          // emptyParagraph token so we can preserve spacing.
           token.type = "emptyParagraph";
           (token as any).count = blankLines;
         }
@@ -396,6 +401,11 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       },
       extensions: [
         {
+          /**
+           * Custom heading tokenizer.
+           * Ensures markdown headings are parsed consistently
+           * and rendered as native h1-h6 elements.
+           */
           name: "heading",
           level: "block",
           start(src) {
@@ -418,6 +428,14 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           },
         },
         {
+          /**
+           * Preserves multiple blank lines by converting them
+           * into explicit empty paragraph elements.
+           *
+           * Skipped for:
+           * - list contexts
+           * - legal document rendering
+           */
           name: "emptyParagraph",
           level: "block",
           start(src) {
@@ -433,6 +451,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             const match = src.match(/^(\n{2,})/);
             if (match) {
               const isAfterHeading = prevToken?.type === "heading";
+              // Add an extra line when spacing follows a heading.
               const blankLines = match[0].length - 1 + (isAfterHeading ? 1 : 0);
               return {
                 type: "emptyParagraph",
@@ -448,6 +467,25 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           },
         },
         {
+          /**
+           * Converts consecutive single-line breaks into
+           * individual paragraph elements.
+           *
+           * Example:
+           *   Line A
+           *   Line B
+           *
+           * Becomes:
+           *   <p>Line A</p>
+           *   <p>Line B</p>
+           *
+           * Skipped for:
+           * - headings
+           * - code fences
+           * - lists
+           * - indented blocks
+           * - wrapped paragraphs
+           */
           name: "lineSeparated",
           level: "block",
           start(src) {
@@ -468,6 +506,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             if (match && match[0].includes("\n")) {
               const lines = match[0].split("\n");
 
+              // Treat long consecutive lines as a wrapped paragraph,
+              // not as separate paragraphs.
               const looksLikeWrappedParagraph =
                 lines.length > 1 && lines.every((l) => l.length > 20);
 

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -227,7 +227,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       filter: ["ul", "ol"],
       replacement: function (content, node) {
         const parentIsParagraph = node.parentElement?.tagName === "P";
-        return parentIsParagraph ? content : `${content}\n`;
+        return parentIsParagraph ? content : `${content}\n\n`;
       },
     });
 
@@ -297,7 +297,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           nextSibling &&
           (nextSibling.tagName === "UL" || nextSibling.tagName === "OL")
         ) {
-          return content + "\n";
+          return "\n\n" + content + "\n";
         }
 
         if (
@@ -306,7 +306,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           nextSibling &&
           (nextSibling.tagName === "UL" || nextSibling.tagName === "OL")
         ) {
-          return content.trim() ? content : "\n";
+          return content.trim() ? "\n" + content + "\n" : "\n";
         }
 
         if (hasBrOnly) {
@@ -401,12 +401,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
-            console.log(token);
-            // 1 blank line → normal separation, no extra
-            // 2 blank lines → 2 empty paragraphs
-            // 7 blank lines → 7 empty paragraphs
             if (token.count <= 1) return "";
-            return "<p><br></p>".repeat(token.count - 1);
+            return "<p><br></p>".repeat(token.count);
           },
         },
         {
@@ -415,22 +411,31 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           start(src) {
             return src.indexOf("\n");
           },
-          tokenizer(src) {
-            const isIndented = /^ {4,}/.test(src);
-            const isListContext = /^[ \t]*([-*+]|\d+\.)\s/m.test(src);
-            const isCodeFence = /^`{3,}/.test(src);
-            if (isIndented || isListContext || isCodeFence) return;
+          tokenizer(src, tokens) {
+            const isHeading = /^#{1,6}\s/.test(src);
+            if (isHeading) return;
 
-            const match = src.match(/^([^\n]+)(\n(?!\n)[^\n]+)+(?!\n)/);
-            if (match) {
-              // Also bail if any matched line starts a code fence
-              if (match[0].split("\n").some((l) => /^`{3,}/.test(l.trim())))
-                return;
+            const isCodeFence = /^`{3,}/.test(src);
+            if (isCodeFence) return;
+
+            const firstLine = src.split("\n")[0];
+            if (/^[ \t]*([-*+]|\d+\.)\s/.test(firstLine)) return;
+            if (/^[ \t]+/.test(firstLine)) return;
+
+            const match = src.match(/^([^\n]+)(\n(?!\n)[^\n]+)*(?=\n\n|\n?$)/);
+
+            if (match && match[0].includes("\n")) {
+              const lines = match[0].split("\n");
+
+              if (lines.some((l) => /^`{3,}/.test(l.trim()))) return;
+              if (lines.some((l) => /^ {4,}/.test(l))) return;
+              if (lines.some((l) => /^[ \t]+\S/.test(l))) return;
+              if (lines.some((l) => /^[ \t]*([-*+]|\d+\.)\s/.test(l))) return;
 
               return {
                 type: "lineSeparated",
                 raw: match[0],
-                lines: match[0].split("\n").filter((l) => l.trim() !== ""),
+                lines: lines.filter((l) => l.trim() !== ""),
               };
             }
           },

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -377,15 +377,22 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
     const isLegal = isLegalDocument(value);
 
+    let prevWalkToken: any = null;
+
     marked.use({
       gfm: false,
       breaks: true,
       walkTokens(token) {
-        if (token.type === "space" && token.raw.length >= 2) {
-          const blankLines = token.raw.length;
+        if (
+          token.type === "space" &&
+          token.raw.length >= 2 &&
+          prevWalkToken?.type === "heading"
+        ) {
+          const blankLines = token.raw.length - 1;
           token.type = "emptyParagraph";
           (token as any).count = blankLines;
         }
+        prevWalkToken = token;
       },
       extensions: [
         {
@@ -395,7 +402,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             return src.indexOf("#");
           },
           tokenizer(src) {
-            const match = src.match(/^(#{1,6}) ([^\n]+)\n?/);
+            const match = src.match(/^(#{1,6}) ([^\n]+)/);
             if (match) {
               return {
                 type: "heading",
@@ -425,7 +432,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
             const match = src.match(/^(\n{2,})/);
             if (match) {
-              const blankLines = match[0].length - 1;
+              const isAfterHeading = prevToken?.type === "heading";
+              const blankLines = match[0].length - 1 + (isAfterHeading ? 1 : 0);
               return {
                 type: "emptyParagraph",
                 raw: match[0],
@@ -435,6 +443,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           },
           renderer(token) {
             if (isLegal) return "";
+
             return "<p><br></p>".repeat(token.count);
           },
         },

--- a/shared.css
+++ b/shared.css
@@ -1,3 +1,10 @@
+*,
+::before,
+::after {
+  box-sizing: border-box;
+  border-width: 0;
+}
+
 html,
 :host {
   line-height: 1.5;

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -3,6 +3,7 @@ import {
   RichEditor,
   RichEditorCodeAction,
   RichEditorProps,
+  RichEditorRef,
 } from "./../../components/rich-editor";
 import { useEffect, useRef, useState } from "react";
 import { RiArrowRightSLine, RiPrinterFill } from "@remixicon/react";
@@ -35,6 +36,8 @@ describe("RichEditor", () => {
 
   context("tokenRenderers", () => {
     function ProductRichEditorWithTokenRenderers() {
+      const editorRef = useRef<RichEditorRef>(null);
+
       const [value, setValue] = useState(
         `The authentication redesign has been assigned to <{["alim"]}> . Please review the latest mockups before the standup.`
       );
@@ -51,11 +54,10 @@ describe("RichEditor", () => {
         </RichEditor.ToolbarButton>
       );
 
-      const dispatchTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
-
       return (
         <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
           <RichEditor
+            ref={editorRef}
             onChange={(e) => setValue(e)}
             onKeyDown={(e) => {
               if (e.key !== "[") return;
@@ -112,6 +114,7 @@ describe("RichEditor", () => {
                   return (
                     <Badge
                       contentEditable
+                      suppressContentEditableWarning
                       onInput={(e) => {
                         const text =
                           (e.currentTarget as HTMLElement).innerText
@@ -123,21 +126,12 @@ describe("RichEditor", () => {
                         ).closest<HTMLElement>("[data-token-start]");
 
                         if (tokenSpan) {
-                          // Update data-token-word immediately — no caret jump from this
                           tokenSpan.dataset.tokenWord = `"${text}"`;
-
-                          // Debounce the dispatchEvent after 1.5 second
-                          clearTimeout(dispatchTimerRef.current);
-                          dispatchTimerRef.current = setTimeout(() => {
-                            tokenSpan
-                              .closest<HTMLElement>(
-                                "[aria-label='rich-editor-content']"
-                              )
-                              ?.dispatchEvent(
-                                new Event("input", { bubbles: true })
-                              );
-                          }, 1500);
                         }
+                      }}
+                      onBlur={() => {
+                        // Always sync immediately on blur — no debounce needed
+                        editorRef.current?.syncTokens();
                       }}
                       onClick={(e) => {
                         e.stopPropagation();

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -4,9 +4,10 @@ import {
   RichEditorCodeAction,
   RichEditorProps,
 } from "./../../components/rich-editor";
-import { useEffect, useState } from "react";
-import { RiArrowRightSLine } from "@remixicon/react";
+import { useEffect, useRef, useState } from "react";
+import { RiArrowRightSLine, RiPrinterFill } from "@remixicon/react";
 import { generateSentence } from "./../../lib/text";
+import { Badge } from "./../../components/badge";
 
 describe("RichEditor", () => {
   function ProductRichEditor(props: RichEditorProps) {
@@ -31,6 +32,198 @@ describe("RichEditor", () => {
       />
     );
   }
+
+  context("tokenRenderers", () => {
+    function ProductRichEditorWithTokenRenderers() {
+      const [value, setValue] = useState(
+        `The authentication redesign has been assigned to <{["alim"]}> . Please review the latest mockups before the standup.`
+      );
+      const [printValue, setPrintValue] = useState("");
+
+      const TOOLBAR_RIGHT_PANEL_ACTIONS = (
+        <RichEditor.ToolbarButton
+          icon={{ image: RiPrinterFill }}
+          onClick={() => {
+            setPrintValue(value);
+          }}
+        >
+          Print
+        </RichEditor.ToolbarButton>
+      );
+
+      const dispatchTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+      return (
+        <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+          <RichEditor
+            onChange={(e) => setValue(e)}
+            onKeyDown={(e) => {
+              if (e.key !== "[") return;
+
+              const sel = window.getSelection();
+              if (!sel || !sel.rangeCount) return;
+
+              const range = sel.getRangeAt(0);
+              const node = range.startContainer;
+              if (node.nodeType !== Node.TEXT_NODE) return;
+
+              const beforeCaret = (node.textContent ?? "").slice(
+                0,
+                range.startOffset
+              );
+              if (!beforeCaret.endsWith("<{")) return;
+
+              e.preventDefault();
+
+              const delRange = document.createRange();
+              delRange.setStart(node, range.startOffset - 2);
+              delRange.setEnd(node, range.startOffset);
+              delRange.deleteContents();
+
+              const tokenSpan = document.createElement("span");
+              tokenSpan.dataset.tokenStart = "<{[";
+              tokenSpan.dataset.tokenEnd = "]}>";
+              tokenSpan.dataset.tokenWord = '"mention"';
+              tokenSpan.dataset.tokenType = "custom-token-";
+
+              const inner = document.createElement("span");
+              inner.contentEditable = "false";
+              tokenSpan.appendChild(inner);
+
+              const zws = document.createTextNode("\u200B");
+
+              const currentRange = sel.getRangeAt(0);
+              currentRange.insertNode(zws);
+              currentRange.insertNode(tokenSpan);
+
+              const afterRange = document.createRange();
+              afterRange.setStartAfter(zws);
+              afterRange.collapse(true);
+              sel.removeAllRanges();
+              sel.addRange(afterRange);
+            }}
+            value={value}
+            tokenRenderers={{
+              "<{[": {
+                endToken: "]}>",
+                render: (word) => {
+                  const parsed = JSON.parse(`[${word}]`);
+                  const [username] = parsed;
+                  return (
+                    <Badge
+                      contentEditable
+                      onInput={(e) => {
+                        const text =
+                          (e.currentTarget as HTMLElement).innerText
+                            ?.trim()
+                            .replace(/^@/, "") ?? "";
+
+                        const tokenSpan = (
+                          e.currentTarget as HTMLElement
+                        ).closest<HTMLElement>("[data-token-start]");
+
+                        if (tokenSpan) {
+                          // Update data-token-word immediately — no caret jump from this
+                          tokenSpan.dataset.tokenWord = `"${text}"`;
+
+                          // Debounce the dispatchEvent after 1.5 second
+                          clearTimeout(dispatchTimerRef.current);
+                          dispatchTimerRef.current = setTimeout(() => {
+                            tokenSpan
+                              .closest<HTMLElement>(
+                                "[aria-label='rich-editor-content']"
+                              )
+                              ?.dispatchEvent(
+                                new Event("input", { bubbles: true })
+                              );
+                          }, 1500);
+                        }
+                      }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        console.log("Mention clicked:", username);
+                      }}
+                      withCircle
+                      caption={`@${username}`}
+                    />
+                  );
+                },
+              },
+            }}
+            toolbarRightPanel={TOOLBAR_RIGHT_PANEL_ACTIONS}
+          />
+          {printValue !== "" && (
+            <pre
+              style={{
+                padding: 28,
+                background: "#D3D3D3",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+              }}
+            >
+              {printValue}
+            </pre>
+          )}
+        </div>
+      );
+    }
+
+    context("when given rule with <{[{name}]}>", () => {
+      it("should shows the component with this rule", () => {
+        cy.mount(<ProductRichEditorWithTokenRenderers />);
+        cy.findByRole("textbox")
+          .findAllByLabelText("badge")
+          .eq(0)
+          .should("have.text", "@alim");
+      });
+
+      context("when print value", () => {
+        it("renders the markdown as well", () => {
+          cy.mount(<ProductRichEditorWithTokenRenderers />);
+
+          cy.findByText("Print").click();
+
+          cy.get("pre").should(
+            "have.text",
+            'The authentication redesign has been assigned to <{["alim"]}> . Please review the latest mockups before the standup.'
+          );
+        });
+      });
+
+      context("when pressing <{[ to show <{[{name}]}>", () => {
+        it("should renders new badge", () => {
+          cy.mount(<ProductRichEditorWithTokenRenderers />);
+          cy.findByRole("textbox").realClick().realType("{enter} <{[ Test 123");
+
+          cy.findAllByLabelText("badge").eq(1).should("have.text", "@mention");
+        });
+
+        context("when print value", () => {
+          it("renders the markdown properly", () => {
+            cy.mount(<ProductRichEditorWithTokenRenderers />);
+
+            cy.findByRole("textbox")
+              .realClick()
+              .realType("{enter} <{[ Test 123");
+
+            cy.findAllByLabelText("badge")
+              .eq(1)
+              .should("have.text", "@mention");
+
+            cy.findByText("Print").click();
+
+            cy.get("pre")
+              .invoke("text")
+              .then((text) => {
+                const lines = text.split("\n");
+
+                expect(lines[1].trim()).to.eq('<{["mention"]}> Test 123');
+              });
+          });
+        });
+      });
+    });
+  });
 
   context("id", () => {
     context("code-editor mode", () => {
@@ -383,7 +576,7 @@ describe("RichEditor", () => {
         cy.findByLabelText("rich-editor-content").should(
           "have.css",
           "height",
-          "600px"
+          "576px"
         );
       });
 
@@ -396,7 +589,7 @@ describe("RichEditor", () => {
             />
           );
           cy.findByLabelText("rich-editor-content")
-            .should("have.css", "height", "600px")
+            .should("have.css", "height", "576px")
             .click()
             .type("{enter}{enter}{enter}");
 
@@ -605,7 +798,8 @@ describe("RichEditor", () => {
         it("should render exactly as the expected value", () => {
           const input = `Paragraph line 1
 
-  Paragraph line 2`;
+
+Paragraph line 2`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
             .invoke("html")
@@ -620,9 +814,9 @@ describe("RichEditor", () => {
       context("when the next line all paragraph", () => {
         it("should render exactly as the expected value", () => {
           const input = `Paragraph line 1
-  Paragraph line 2
-  Paragraph line 3
-  Paragraph line 4`;
+Paragraph line 2
+Paragraph line 3
+Paragraph line 4`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
             .invoke("html")
@@ -640,7 +834,7 @@ describe("RichEditor", () => {
         it("should render normally", () => {
           const input = `- Unordered list
 
-  Paragraph line`;
+Paragraph line`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
             .invoke("html")
@@ -655,8 +849,8 @@ describe("RichEditor", () => {
       context("when a lot of list", () => {
         it("should render list as usual", () => {
           const input = `- Unordered list 1
-  - Unordered list 2
-  - Unordered list 3`;
+- Unordered list 2
+- Unordered list 3`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
             .invoke("html")

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -163,6 +163,43 @@ describe("RichEditor", () => {
     }
 
     context("when given rule with <{[{name}]}>", () => {
+      context("when pressing backspace and control z", () => {
+        context("when print the markdown", () => {
+          it("should still renders properly markdown", () => {
+            cy.mount(<ProductRichEditorWithTokenRenderers />);
+            cy.findByRole("textbox")
+              .findAllByLabelText("badge")
+              .eq(0)
+              .should("have.text", "@alim");
+            cy.findByRole("textbox").type("{selectAll}{backspace}test");
+            cy.findByText("Print").click();
+
+            cy.get("pre").should("have.text", "test");
+            cy.wait(300);
+
+            cy.window().then((win) => {
+              const editor = win.document.querySelector('[role="textbox"]');
+              editor.dispatchEvent(
+                new win.KeyboardEvent("keydown", {
+                  key: "z",
+                  metaKey: true,
+                  bubbles: true,
+                  cancelable: true,
+                })
+              );
+              win.document.execCommand("undo");
+            });
+            cy.wait(300);
+            cy.findByText("Print").click();
+
+            cy.get("pre").should(
+              "have.text",
+              'The authentication redesign has been assigned to <{["alim"]}> . Please review the latest mockups before the standup.'
+            );
+          });
+        });
+      });
+
       it("should shows the component with this rule", () => {
         cy.mount(<ProductRichEditorWithTokenRenderers />);
         cy.findByRole("textbox")

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -5,9 +5,8 @@ import {
   RichEditorProps,
 } from "./../../components/rich-editor";
 import { useEffect, useState } from "react";
-import { generateSentence } from "./../../lib/text";
 import { RiArrowRightSLine } from "@remixicon/react";
-import { expectTextIncludesOrderedLines } from "./../../test/support/commands";
+import { generateSentence } from "./../../lib/text";
 
 describe("RichEditor", () => {
   function ProductRichEditor(props: RichEditorProps) {
@@ -72,15 +71,15 @@ describe("RichEditor", () => {
   context("mode", () => {
     context("with view-only", () => {
       const viewOnlyPlainTextValue = `                              Systatum Antrikan License
-                                        Version 1.0, 2026
-                             https://systatum.com/licenses/
+                                          Version 1.0, 2026
+                               https://systatum.com/licenses/
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+  TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-1.  Definitions.
+  1.  Definitions.
 
-    "License" shall mean the terms and conditions for use, reproduction,
-    and distribution as defined by Sections 1 through 9 of this document.`;
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.`;
       beforeEach(() => {
         cy.mount(
           <ProductRichEditor
@@ -162,11 +161,11 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
         it("should renders the value code", () => {
           const code = `import { Button } from "@systatum/coneto/button"
 
-function Content(){
-  return <Button variant="primary">Your caption</Button>
-}
+  function Content(){
+    return <Button variant="primary">Your caption</Button>
+  }
 
-export default Content`;
+  export default Content`;
           cy.mount(<ProductRichEditor mode="code-editor" value={code} />);
           cy.shouldHaveEditorFromValue("rich-editor-code", code);
         });
@@ -365,7 +364,7 @@ export default Content`;
         cy.findByLabelText("rich-editor-content").should(
           "have.css",
           "height",
-          "472px"
+          "480px"
         );
       });
 
@@ -378,14 +377,14 @@ export default Content`;
             />
           );
           cy.findByLabelText("rich-editor-content")
-            .should("have.css", "height", "472px")
+            .should("have.css", "height", "480px")
             .click()
             .type("{enter}{enter}{enter}");
 
           cy.findByLabelText("rich-editor-content").should(
             "have.css",
             "height",
-            "544px"
+            "576px"
           );
         });
       });
@@ -565,7 +564,7 @@ Paragraph line 2`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
             .invoke("text")
-            .should("eq", "Paragraph line 1\n\nParagraph line 2\n");
+            .should("eq", "Paragraph line 1\nParagraph line 2\n");
         });
       });
 
@@ -580,7 +579,7 @@ Paragraph line 4`;
             .invoke("text")
             .should(
               "eq",
-              "Paragraph line 1\nParagraph line 2\nParagraph line 3\nParagraph line 4\n"
+              "Paragraph line 1\nParagraph line 2\nParagraph line 3\nParagraph line 4"
             );
         });
       });
@@ -588,6 +587,8 @@ Paragraph line 4`;
       context("when the next line is paragraph", () => {
         it("should render exactly as the expected value", () => {
           const input = `Paragraph line 1
+
+
 Paragraph line 2`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
@@ -601,6 +602,7 @@ Paragraph line 2`;
       context("when the next line is paragraph", () => {
         it("should render normally", () => {
           const input = `- Unordered list
+
 Paragraph line`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -554,6 +554,33 @@ describe("RichEditor", () => {
   });
 
   context("preprocessed value", () => {
+    context("heading", () => {
+      context("when the next line have empty space", () => {
+        it("should add the empty space", () => {
+          const input = `### Heading line 1
+
+Paragraph line 3`;
+          cy.mount(<RichEditor value={input} />);
+          cy.findByRole("textbox")
+            .find("p")
+            .eq(0)
+            .should("contain.html", "<br>");
+        });
+      });
+
+      context("when the next line is paragraph", () => {
+        it("should not have empty space", () => {
+          const input = `### Heading line 1
+Paragraph line 2`;
+          cy.mount(<RichEditor value={input} />);
+          cy.findByRole("textbox")
+            .find("p")
+            .eq(0)
+            .should("not.contain.html", "<br>");
+        });
+      });
+    });
+
     context("paragraph", () => {
       context("when the next line have empty space", () => {
         it("should render exactly as the expected value", () => {

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -71,8 +71,8 @@ describe("RichEditor", () => {
   context("mode", () => {
     context("with view-only", () => {
       const viewOnlyPlainTextValue = `                              Systatum Antrikan License
-                                          Version 1.0, 2026
-                               https://systatum.com/licenses/
+                                            Version 1.0, 2026
+                                 https://systatum.com/licenses/
 
   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -161,11 +161,11 @@ describe("RichEditor", () => {
         it("should renders the value code", () => {
           const code = `import { Button } from "@systatum/coneto/button"
 
-  function Content(){
-    return <Button variant="primary">Your caption</Button>
-  }
+    function Content(){
+      return <Button variant="primary">Your caption</Button>
+    }
 
-  export default Content`;
+    export default Content`;
           cy.mount(<ProductRichEditor mode="code-editor" value={code} />);
           cy.shouldHaveEditorFromValue("rich-editor-code", code);
         });
@@ -590,8 +590,12 @@ Paragraph line 2`;
 Paragraph line 2`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
-            .invoke("text")
-            .should("eq", "Paragraph line 1\nParagraph line 2\n");
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should(
+              "eq",
+              "<p>Paragraph line 1</p><p><br></p><p><br></p><p>Paragraph line 2</p>"
+            );
         });
       });
 
@@ -603,24 +607,12 @@ Paragraph line 3
 Paragraph line 4`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
-            .invoke("text")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
             .should(
               "eq",
-              "Paragraph line 1\nParagraph line 2\nParagraph line 3\nParagraph line 4"
+              "<p>Paragraph line 1</p><p>Paragraph line 2</p><p>Paragraph line 3</p><p>Paragraph line 4</p>"
             );
-        });
-      });
-
-      context("when the next line is paragraph", () => {
-        it("should render exactly as the expected value", () => {
-          const input = `Paragraph line 1
-
-
-Paragraph line 2`;
-          cy.mount(<RichEditor value={input} />);
-          cy.findByRole("textbox")
-            .invoke("text")
-            .should("eq", "Paragraph line 1\nParagraph line 2\n");
         });
       });
     });
@@ -633,8 +625,12 @@ Paragraph line 2`;
 Paragraph line`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
-            .invoke("text")
-            .should("eq", "\nUnordered list\n\nParagraph line\n");
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should(
+              "eq",
+              "<ul><li>Unordered list</li></ul><p>Paragraph line</p>"
+            );
         });
       });
 
@@ -645,10 +641,11 @@ Paragraph line`;
 - Unordered list 3`;
           cy.mount(<RichEditor value={input} />);
           cy.findByRole("textbox")
-            .invoke("text")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
             .should(
               "eq",
-              "\nUnordered list 1\nUnordered list 2\nUnordered list 3\n\n"
+              "<ul><li>Unordered list 1</li><li>Unordered list 2</li><li>Unordered list 3</li></ul>"
             );
         });
       });


### PR DESCRIPTION
Description:
This PR introduces a new `tokenRenderers` prop for `RichEditor`, enabling custom inline token rendering directly from `Markdown` content.

`tokenRenderers` provides a flexible way to define custom token syntax and render it as React components while preserving normal editor behavior.

```tsx
<RichEditor
  tokenRenderers={{
    "<{[": {
      endToken: "]}>",
      render: (word) => {
        const parsed = JSON.parse(`[${word}]`);
        const [surah, ayah] = parsed;

        return <Badge caption={`${surah}:${ayah}`} />;
      },
    },
  }}
/>
```

Markdown:
This is a verse reference <{["Q", "17:32"]}> inside text.

Rendered output:
This is a verse reference [Badge: Q:17:32] inside text.

Weakness for now:
Can't render the `<div/>` element properly, if inside of paragraph.

Source:
[[Research] SYST-702: Investigate how to extend RichEditor](https://linear.app/systatum/issue/SYST-702/investigate-how-to-extend-richeditor)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself