### PR TITLE
[Improvement] SYST-716: Changes `OverlayBlocker` Documentation and Rename `scrollSafeAriaLabels` to `exemptRegions`

### DIFF
--- a/components/overlay-blocker.stories.tsx
+++ b/components/overlay-blocker.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof OverlayBlocker> = {
   - **Function**: Custom behavior
 - 🎨 Fully styleable via \`styles.self\` (CSSProp compatible)
 - 🔧 Supports imperative \`open\` and \`close\` via \`ref\`
-- ♿ Accessibility support via \`scrollSafeAriaLabels\` (featuring prop for improved scroll-safe screen reader labels)
+- ♿ Accessibility support via \`exemptRegions\` to keep specific regions (by ID or class name) scrollable and interactive while the overlay is active
 
 
 ### 🛠 Usage
@@ -42,16 +42,17 @@ const meta: Meta<typeof OverlayBlocker> = {
 \`\`\`
 
 
-## 🧠 Using scrollSafeAriaLabels
+## 🧠 Using \`exemptRegions\`
 
-You can pass an array of aria label strings to improve accessibility when scroll is blocked.
+Pass an array of ID or class locators where scroll-blocking will not take effect.
 
 <OverlayBlocker
   show={isOpen}
   zIndex={9999}
-  scrollSafeAriaLabels={[
-    "dialog-wrapper",
-    "messagebox-wrapper",
+  exemptRegions={[
+    "coneto-paper-dialog",
+    "coneto-dialog",
+    "coneto-sidebar",
   ]}
   onClick={({ close }) => {
     close();
@@ -63,6 +64,11 @@ You can pass an array of aria label strings to improve accessibility when scroll
 ### 📝 Notes
 - Overlay automatically disappears when \`show={false}\`.
 - Use \`ref\` to programmatically open or close the overlay.
+- While active, the overlay prevents page scrolling by locking the document body.
+- Regions specified in \`exemptRegions\` remain scrollable and interactive.
+- Values passed to \`exemptRegions\` can be either element IDs or class names (without \`#\` or \`.\` prefixes).
+- Default exempt regions include \`coneto-paper-dialog\`, \`coneto-dialog\`, and \`coneto-sidebar\`.
+- Clicking the overlay triggers the behavior configured via \`onClick\`.
       `,
       },
     },

--- a/components/overlay-blocker.stories.tsx
+++ b/components/overlay-blocker.stories.tsx
@@ -50,9 +50,9 @@ Pass an array of ID or class locators where scroll-blocking will not take effect
   show={isOpen}
   zIndex={9999}
   exemptRegions={[
-    "coneto-paper-dialog",
-    "coneto-dialog",
-    "coneto-sidebar",
+    ".coneto-paper-dialog",
+    ".coneto-dialog",
+    ".coneto-sidebar",
   ]}
   onClick={({ close }) => {
     close();
@@ -66,7 +66,7 @@ Pass an array of ID or class locators where scroll-blocking will not take effect
 - Use \`ref\` to programmatically open or close the overlay.
 - While active, the overlay prevents page scrolling by locking the document body.
 - Regions specified in \`exemptRegions\` remain scrollable and interactive.
-- Values passed to \`exemptRegions\` can be either element IDs or class names (without \`#\` or \`.\` prefixes).
+- Values passed to \`exemptRegions\` can be either element IDs (\`#\`) or class names (\`.\`) .
 - Default exempt regions include \`coneto-paper-dialog\`, \`coneto-dialog\`, and \`coneto-sidebar\`.
 - Clicking the overlay triggers the behavior configured via \`onClick\`.
       `,
@@ -127,7 +127,11 @@ export const Default: Story = {
     return (
       <>
         <Button onClick={() => ref?.current?.open()}>Open Overlay</Button>
-        <OverlayBlocker ref={ref} onClick="close" />
+        <OverlayBlocker
+          exemptRegions={["#aria-test"]}
+          ref={ref}
+          onClick="close"
+        />
       </>
     );
   },

--- a/components/overlay-blocker.stories.tsx
+++ b/components/overlay-blocker.stories.tsx
@@ -50,9 +50,8 @@ You can pass an array of aria label strings to improve accessibility when scroll
   show={isOpen}
   zIndex={9999}
   scrollSafeAriaLabels={[
-    "Overlay is active",
-    "Background content is disabled",
-    "Press Escape to close"
+    "dialog-wrapper",
+    "messagebox-wrapper",
   ]}
   onClick={({ close }) => {
     close();

--- a/components/overlay-blocker.stories.tsx
+++ b/components/overlay-blocker.stories.tsx
@@ -23,6 +23,8 @@ const meta: Meta<typeof OverlayBlocker> = {
   - **Function**: Custom behavior
 - 🎨 Fully styleable via \`styles.self\` (CSSProp compatible)
 - 🔧 Supports imperative \`open\` and \`close\` via \`ref\`
+- ♿ Accessibility support via \`scrollSafeAriaLabels\` (featuring prop for improved scroll-safe screen reader labels)
+
 
 ### 🛠 Usage
 \`\`\`tsx
@@ -38,6 +40,26 @@ const meta: Meta<typeof OverlayBlocker> = {
   <p>Your content here</p>
 </OverlayBlocker>
 \`\`\`
+
+
+## 🧠 Using scrollSafeAriaLabels
+
+You can pass an array of aria label strings to improve accessibility when scroll is blocked.
+
+<OverlayBlocker
+  show={isOpen}
+  zIndex={9999}
+  scrollSafeAriaLabels={[
+    "Overlay is active",
+    "Background content is disabled",
+    "Press Escape to close"
+  ]}
+  onClick={({ close }) => {
+    close();
+  }}
+>
+  <p>Your content here</p>
+</OverlayBlocker>
 
 ### 📝 Notes
 - Overlay automatically disappears when \`show={false}\`.

--- a/components/overlay-blocker.tsx
+++ b/components/overlay-blocker.tsx
@@ -29,7 +29,7 @@ export interface OverlayBlockerProps {
   children?: ReactNode;
   className?: string;
   id?: string;
-  scrollSafeAriaLabels?: string[];
+  exemptRegions?: string[];
 }
 
 export interface OverlayBlockerStyles {
@@ -49,26 +49,26 @@ export const OverlayBlocker = forwardRef<
       children,
       className,
       id,
-      scrollSafeAriaLabels: _scrollSafeAriaLabels,
+      exemptRegions: _exemptRegions,
     },
     ref
   ) => {
     const { currentTheme } = useTheme();
     const overlayBlockerTheme = currentTheme.overlayBlocker;
 
-    const scrollSafeAriaLabels = [
-      "paper-dialog-wrapper",
-      "dialog-wrapper",
-      "sidebar-desktop",
-      "sidebar-mobile",
-      ...(_scrollSafeAriaLabels ?? []),
+    const exemptRegions = [
+      "coneto-paper-dialog",
+      "coneto-dialog",
+      "coneto-sidebar",
+      ...(_exemptRegions ?? []),
     ];
 
     const [visible, setVisible] = useState(show);
 
     useEffect(() => {
       if (!show) return;
-      const safeLabels = scrollSafeAriaLabels ?? [];
+
+      const safeRegions = exemptRegions ?? [];
 
       const scrollY = window.scrollY;
       const body = document.body;
@@ -86,7 +86,7 @@ export const OverlayBlocker = forwardRef<
       body.style.width = "100%";
 
       const allow = (target: EventTarget | null) =>
-        isInSafeZone(target, safeLabels);
+        isInSafeZone(target, safeRegions);
 
       const blockWheel = (e: WheelEvent) => {
         if (allow(e.target)) return;
@@ -112,16 +112,21 @@ export const OverlayBlocker = forwardRef<
 
         window.scrollTo(0, scrollY);
       };
-    }, [scrollSafeAriaLabels, show]);
+    }, [exemptRegions, show]);
 
-    const isInSafeZone = (target: EventTarget | null, safeLabels: string[]) => {
+    const isInSafeZone = (target: EventTarget | null, regions: string[]) => {
       if (!(target instanceof Element)) return false;
 
       let el: Element | null = target;
 
       while (el) {
-        const label = el.getAttribute?.("aria-label");
-        if (label && safeLabels.includes(label)) return true;
+        if (
+          regions.some(
+            (region) => el.id === region || el.classList.contains(region)
+          )
+        ) {
+          return true;
+        }
 
         el = el.parentElement;
       }

--- a/components/overlay-blocker.tsx
+++ b/components/overlay-blocker.tsx
@@ -66,7 +66,7 @@ export const OverlayBlocker = forwardRef<
     const [visible, setVisible] = useState(show);
 
     useEffect(() => {
-      if (!show) return;
+      if (!visible) return;
 
       const safeRegions = exemptRegions ?? [];
 
@@ -112,7 +112,7 @@ export const OverlayBlocker = forwardRef<
 
         window.scrollTo(0, scrollY);
       };
-    }, [exemptRegions, show]);
+    }, [exemptRegions, visible]);
 
     const isInSafeZone = (target: EventTarget | null, regions: string[]) => {
       if (!(target instanceof Element)) return false;

--- a/components/overlay-blocker.tsx
+++ b/components/overlay-blocker.tsx
@@ -57,9 +57,9 @@ export const OverlayBlocker = forwardRef<
     const overlayBlockerTheme = currentTheme.overlayBlocker;
 
     const exemptRegions = [
-      "coneto-paper-dialog",
-      "coneto-dialog",
-      "coneto-sidebar",
+      ".coneto-paper-dialog",
+      ".coneto-dialog",
+      ".coneto-sidebar",
       ...(_exemptRegions ?? []),
     ];
 
@@ -115,16 +115,26 @@ export const OverlayBlocker = forwardRef<
     }, [exemptRegions, visible]);
 
     const isInSafeZone = (target: EventTarget | null, regions: string[]) => {
-      if (!(target instanceof Element)) return false;
+      if (!(target instanceof Element)) {
+        return false;
+      }
 
       let el: Element | null = target;
 
       while (el) {
-        if (
-          regions.some(
-            (region) => el.id === region || el.classList.contains(region)
-          )
-        ) {
+        const matched = regions.some((region) => {
+          if (region.startsWith("#")) {
+            return el.id === region.slice(1);
+          }
+
+          if (region.startsWith(".")) {
+            return el.classList.contains(region.slice(1));
+          }
+
+          return false;
+        });
+
+        if (matched) {
           return true;
         }
 

--- a/components/overlay-blocker.tsx
+++ b/components/overlay-blocker.tsx
@@ -67,6 +67,7 @@ export const OverlayBlocker = forwardRef<
     const [visible, setVisible] = useState(show);
 
     useEffect(() => {
+      if (!show) return;
       const safeLabels = scrollSafeAriaLabels ?? [];
 
       const scrollY = window.scrollY;
@@ -111,7 +112,7 @@ export const OverlayBlocker = forwardRef<
 
         window.scrollTo(0, scrollY);
       };
-    }, [scrollSafeAriaLabels]);
+    }, [scrollSafeAriaLabels, show]);
 
     const isInSafeZone = (target: EventTarget | null, safeLabels: string[]) => {
       if (!(target instanceof Element)) return false;

--- a/components/paper-dialog.stories.tsx
+++ b/components/paper-dialog.stories.tsx
@@ -35,6 +35,7 @@ const meta: Meta<typeof PaperDialog> = {
 - ❌ Optional close button and minimize toggle
 - 🛡 Overlay blocker when restored to prevent outside interactions
 - 🎛 Trigger opening/closing externally
+- ♿ Accessibility support via \`scrollSafeAriaLabels\` (featuring prop for improved scroll-safe screen reader labels)
 - 🎨 Fully styleable via \`styles\` props
 - ⌨️ Handles "Escape" key to close the dialog
 
@@ -51,6 +52,25 @@ const meta: Meta<typeof PaperDialog> = {
 </>
 \`\`\`
 
+## 🧠 Using scrollSafeAriaLabels
+
+You can pass an array of aria label strings to improve accessibility when scroll is blocked.
+
+<OverlayBlocker
+  show={isOpen}
+  zIndex={9999}
+  scrollSafeAriaLabels={[
+    "Overlay is active",
+    "Background content is disabled",
+    "Press Escape to close"
+  ]}
+  onClick={({ close }) => {
+    close();
+  }}
+>
+  <p>Your content here</p>
+</OverlayBlocker>
+
 ### 🎨 Custom Icons
 You can override the default control icons (e.g. close and restore) by passing custom icon components:
 
@@ -62,8 +82,6 @@ You can override the default control icons (e.g. close and restore) by passing c
   }}
 />
 \`\`\`
-
-
 
 ### 📏 Resizable
 

--- a/components/paper-dialog.stories.tsx
+++ b/components/paper-dialog.stories.tsx
@@ -35,7 +35,6 @@ const meta: Meta<typeof PaperDialog> = {
 - ❌ Optional close button and minimize toggle
 - 🛡 Overlay blocker when restored to prevent outside interactions
 - 🎛 Trigger opening/closing externally
-- ♿ Accessibility support via \`scrollSafeAriaLabels\` (featuring prop for improved scroll-safe screen reader labels)
 - 🎨 Fully styleable via \`styles\` props
 - ⌨️ Handles "Escape" key to close the dialog
 
@@ -51,25 +50,6 @@ const meta: Meta<typeof PaperDialog> = {
   </PaperDialog>
 </>
 \`\`\`
-
-## 🧠 Using scrollSafeAriaLabels
-
-You can pass an array of aria label strings to improve accessibility when scroll is blocked.
-
-<OverlayBlocker
-  show={isOpen}
-  zIndex={9999}
-  scrollSafeAriaLabels={[
-    "Overlay is active",
-    "Background content is disabled",
-    "Press Escape to close"
-  ]}
-  onClick={({ close }) => {
-    close();
-  }}
->
-  <p>Your content here</p>
-</OverlayBlocker>
 
 ### 🎨 Custom Icons
 You can override the default control icons (e.g. close and restore) by passing custom icon components:

--- a/test/component/overlay-blocker.cy.tsx
+++ b/test/component/overlay-blocker.cy.tsx
@@ -10,6 +10,7 @@ import { PaperDialog, PaperDialogRef } from "./../../components/paper-dialog";
 import { Dialog, DialogProps } from "./../../components/dialog";
 import { RiInboxArchiveFill } from "@remixicon/react";
 import { generateSentence } from "./../../lib/text";
+import { Combobox, ComboboxOption } from "./../../components/combobox";
 
 describe("Overlay Blocker", () => {
   function ProductOverlayBlocker(props: OverlayBlockerProps) {
@@ -24,6 +25,87 @@ describe("Overlay Blocker", () => {
   }
 
   context("scroll in overlay", () => {
+    context("Custom Combobox", () => {
+      function ProductCombobox(overlayProps?: OverlayBlockerProps) {
+        const [isOpen, setIsOpen] = useState(false);
+
+        const RANDOM_OPTIONS: ComboboxOption[] = Array.from({ length: 20 }).map(
+          (_, index) => ({ text: String(index), value: index })
+        );
+
+        return (
+          <>
+            <Button
+              onClick={() => {
+                setIsOpen(true);
+              }}
+            >
+              Test
+            </Button>
+            {isOpen && (
+              <Combobox
+                styles={{
+                  containerStyle: css`
+                    position: absolute;
+                    top: 0px;
+                    z-index: 99999999999;
+                  `,
+                }}
+                options={RANDOM_OPTIONS}
+                mobile
+              />
+            )}
+            <OverlayBlocker show={isOpen} {...overlayProps} />
+          </>
+        );
+      }
+
+      it("should not scroll to the bottom", () => {
+        cy.mount(<ProductCombobox />);
+
+        cy.contains("Test").click();
+
+        cy.wait(500);
+        cy.findByPlaceholderText("Search your item...").click();
+
+        cy.get("#combo-list").realMouseWheel({ deltaY: 1000 });
+
+        cy.findByText(19).should("not.be.visible");
+      });
+
+      context("when given exemptRegions", () => {
+        context("when given accurate id or className", () => {
+          it("should scroll to the bottom", () => {
+            cy.mount(<ProductCombobox exemptRegions={["#combo-list"]} />);
+
+            cy.contains("Test").click();
+
+            cy.wait(500);
+            cy.findByPlaceholderText("Search your item...").click();
+
+            cy.get("#combo-list").realMouseWheel({ deltaY: 1000 });
+
+            cy.findByText(19).should("be.visible");
+          });
+        });
+
+        context("when given not accurate id or className", () => {
+          it("should not scroll to the bottom", () => {
+            cy.mount(<ProductCombobox exemptRegions={[".combo-list"]} />);
+
+            cy.contains("Test").click();
+
+            cy.wait(500);
+            cy.findByPlaceholderText("Search your item...").click();
+
+            cy.get("#combo-list").realMouseWheel({ deltaY: 1000 });
+
+            cy.findByText(19).should("not.be.visible");
+          });
+        });
+      });
+    });
+
     context("PaperDialog", () => {
       function ProductPaperDialog() {
         const paperRef = useRef<PaperDialogRef>(null);


### PR DESCRIPTION
Description:
This ticket improves the documentation for how to use `scrollSafeArialabels` prop on the `OverlayBlocker` component. It also add `show` prop dependencies to the `useEffect` hook to properly handle it's availability.

```tsx
<OverlayBlocker
  show={isOpen}
  zIndex={9999}
  exemptRegions={[
    "coneto-paper-dialog",
    "coneto-dialog",
    "coneto-sidebar"
  ]}
  onClick={({ close }) => {
    close();
  }}
>
  <p>Your content here</p>
</OverlayBlocker>
```

It also updates the `scrollSafeAriaLabels` prop to `exemptRegions` . The detection mechanism now relies on element id and className instead of using aria-label attributes.

Source:
[[Improvement] SYST-716: Add properly documentation for `scrollSafeAriaLabels` in `OverlayBlocker`](https://linear.app/systatum/issue/SYST-716/add-properly-documentation-for-scrollsafearialabels-in-overlayblocker)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself