### PR TITLE
[Bug] SYST-715: Fix hover color on title

### DIFF
--- a/components/title.tsx
+++ b/components/title.tsx
@@ -279,6 +279,7 @@ function BaseTitleSection({
                   height: ${resolvedIconSize * 1.4}px;
                   padding: 20px;
                   border-radius: 10px;
+                  background-color: ${titleTheme?.icon?.backgroundColor};
 
                   ${section?.styles?.toggleActionStyle}
                 `,

--- a/components/title.tsx
+++ b/components/title.tsx
@@ -235,6 +235,9 @@ function BaseTitleSection({
   ariaLabel,
   size,
 }: BaseTitleSectionProps) {
+  const { currentTheme } = useTheme();
+  const titleTheme = currentTheme?.title;
+
   if (!sections?.length && size === "lg") {
     return <div aria-label="title-empty-section" />;
   } else if (!sections?.length) {
@@ -281,6 +284,7 @@ function BaseTitleSection({
                 `,
               }}
               maxActionsBeforeCollapsing={section.actions?.length}
+              hoverBackgroundColor={titleTheme?.icon?.hoverBackgroundColor}
               actions={filteredActionsWithSize}
             />
           );

--- a/test/component/title.cy.tsx
+++ b/test/component/title.cy.tsx
@@ -245,11 +245,11 @@ describe("Title", () => {
 
   context("size", () => {
     context("when given sm", () => {
-      it("should render small font size (16px)", () => {
+      it("should render small font size (17px)", () => {
         cy.mount(<Title.Small text="Small Title" />);
 
         cy.findByLabelText("title-title").should(($el) => {
-          expect(getComputedStyle($el[0]).fontSize).to.eq("16px");
+          expect(getComputedStyle($el[0]).fontSize).to.eq("17px");
         });
       });
     });
@@ -381,6 +381,37 @@ describe("Title", () => {
         );
 
         cy.findAllByLabelText("title-right-section").eq(0).should("exist");
+      });
+
+      context("when hovering", () => {
+        it("should render icon with transparent background color (0.45)", () => {
+          cy.mount(
+            <Title
+              text="Icon"
+              rightSection={[
+                {
+                  type: "actions",
+                  actions: [
+                    {
+                      caption: "Edit",
+                      icon: { image: RiCloseFill },
+                      onClick: cy.stub(),
+                    },
+                  ],
+                },
+              ]}
+            />
+          );
+
+          cy.findByLabelText("action-button").realHover();
+
+          cy.wait(200);
+          cy.findByLabelText("action-button").should(
+            "have.css",
+            "background-color",
+            "rgba(255, 255, 255, 0.45)"
+          );
+        });
       });
     });
   });

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -672,6 +672,7 @@ export interface TitleThemeConfig
   };
 
   icon?: {
+    hoverBackgroundColor?: string;
     backgroundColor?: string;
     textColor?: string;
   };

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1734,6 +1734,8 @@ export function createTitleTheme(
     },
     icon: {
       textColor: body.textColor,
+      backgroundColor: "transparent",
+      hoverBackgroundColor: "rgba(255, 255, 255, 0.45)",
     },
   };
 

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -728,7 +728,8 @@ const darkTitle = createTitleTheme(darkBody, {
   },
 
   icon: {
-    backgroundColor: "#303030",
+    backgroundColor: "transparent",
+    hoverBackgroundColor: "rgba(0, 0, 0, 0.45)",
   },
 });
 


### PR DESCRIPTION
Description:
This pull request fixes the `actions` hover coloring by using a transparent background with 45% opacity instead of solid `white/black` color 

Source:
[[Bug] SYST-715: Fix hover color on title](https://linear.app/systatum/issue/SYST-715/fix-hover-color-on-title)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself