### PR TITLE
[Bug] SYST-722: Fix button with just icon rendering visual bug

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -435,7 +435,7 @@ const ButtonLabel = styled.span<{
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
-  flex: 1;
+  flex: 0 1 auto;
 `;
 
 export interface ButtonTipMenuContainerStyles {
@@ -557,6 +557,9 @@ const SIZE_STYLES: Record<NonNullable<ButtonProps["size"]>, CSSProp> = {
     padding: 0 24px;
   `,
   icon: css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
     width: 36px;
     height: 36px;
     padding: 0;

--- a/test/component/button.cy.tsx
+++ b/test/component/button.cy.tsx
@@ -206,6 +206,20 @@ describe("Button", () => {
     });
   });
 
+  context("size", () => {
+    context("icon", () => {
+      it("renders icon with flex 0 1 auto (will centered)", () => {
+        cy.mount(<ButtonWithIcon maxOptions={1} size="icon" />);
+
+        cy.findByLabelText("button-label").should(
+          "have.css",
+          "flex",
+          "0 1 auto"
+        );
+      });
+    });
+  });
+
   context("icon", () => {
     it("renders buttons with icons", () => {
       cy.mount(<ButtonWithIcon />);

--- a/test/component/button.cy.tsx
+++ b/test/component/button.cy.tsx
@@ -208,14 +208,64 @@ describe("Button", () => {
 
   context("size", () => {
     context("icon", () => {
-      it("renders icon with flex 0 1 auto (will centered)", () => {
-        cy.mount(<ButtonWithIcon maxOptions={1} size="icon" />);
+      context("when given via icon props", () => {
+        it("renders in the center", () => {
+          cy.mount(
+            <Button size="icon">
+              <RiAddLine size={16} />
+            </Button>
+          );
 
-        cy.findByLabelText("button-label").should(
-          "have.css",
-          "flex",
-          "0 1 auto"
-        );
+          cy.get("button").then(($button) => {
+            const buttonRect = $button[0].getBoundingClientRect();
+
+            cy.get("svg").then(($svg) => {
+              const svgRect = $svg[0].getBoundingClientRect();
+
+              const leftSpace = svgRect.left - buttonRect.left;
+              const rightSpace = buttonRect.right - svgRect.right;
+              const topSpace = svgRect.top - buttonRect.top;
+              const bottomSpace = buttonRect.bottom - svgRect.bottom;
+
+              expect(leftSpace).to.equal(10);
+              expect(rightSpace).to.equal(10);
+              expect(topSpace).to.equal(10);
+              expect(bottomSpace).to.equal(10);
+            });
+          });
+        });
+      });
+
+      context("when given via children prop", () => {
+        it("renders in the center", () => {
+          cy.mount(
+            <Button
+              icon={{
+                image: RiAddLine,
+                size: 16,
+              }}
+              size="icon"
+            />
+          );
+
+          cy.get("button").then(($button) => {
+            const buttonRect = $button[0].getBoundingClientRect();
+
+            cy.get("svg").then(($svg) => {
+              const svgRect = $svg[0].getBoundingClientRect();
+
+              const leftSpace = svgRect.left - buttonRect.left;
+              const rightSpace = buttonRect.right - svgRect.right;
+              const topSpace = svgRect.top - buttonRect.top;
+              const bottomSpace = buttonRect.bottom - svgRect.bottom;
+
+              expect(leftSpace).to.equal(10);
+              expect(rightSpace).to.equal(10);
+              expect(topSpace).to.equal(10);
+              expect(bottomSpace).to.equal(10);
+            });
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Description:
This pull request fixes an issue where size variant `icon` not rendered properly centered in the `Button` component. It also ensures that always have `flex 0 1 auto`, which pursuing remain consistently centered.

Source:
[[Bug] SYST-722: Fix button with just icon rendering visual bug](https://linear.app/systatum/issue/SYST-722/fix-button-with-just-icon-rendering-visual-bug)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself