### PR TITLE
[Improvement] SYST-726: Allow styling column and make column span has 100% width

### DIFF
--- a/components/table.tsx
+++ b/components/table.tsx
@@ -36,9 +36,16 @@ import { Figure } from "./figure";
 export interface TableColumn {
   caption: string;
   sortable?: boolean;
-  styles?: { self?: CSSProp };
+  styles?: TableColumnStyle;
   width?: string;
   id: string;
+}
+
+export interface TableColumnStyle {
+  labelStyle?: CSSProp;
+  containerStyle?: CSSProp;
+  toggleSortableStyle?: CSSProp;
+  dropdownSortableStyle?: CSSProp;
 }
 
 export const TableActionType = {
@@ -473,18 +480,16 @@ function Table({
                         : css`
                             flex: 1;
                           `}
+
+                      ${col?.styles?.containerStyle}
                     `}
                   >
-                    <span
-                      style={{
-                        display: "block",
-                        whiteSpace: "nowrap",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                      }}
+                    <Label
+                      aria-label="table-column-label"
+                      $style={col?.styles?.labelStyle}
                     >
                       {col.caption}
-                    </span>
+                    </Label>
                     {col.sortable && (
                       <Toolbar
                         styles={{
@@ -502,8 +507,11 @@ function Table({
                           closedIcon={RiArrowUpDownLine}
                           openedIcon={RiArrowUpDownLine}
                           styles={{
+                            triggerStyle: col?.styles?.toggleSortableStyle,
                             dropdownStyle: css`
                               min-width: 235px;
+
+                              ${col?.styles?.dropdownSortableStyle}
                             `,
                           }}
                           subMenuList={
@@ -680,6 +688,16 @@ const Wrapper = styled.div<{
   width: 100%;
 
   color: ${({ $theme }) => $theme?.textColor};
+
+  ${({ $style }) => $style}
+`;
+
+const Label = styled.span<{ $style?: CSSProp }>`
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
 
   ${({ $style }) => $style}
 `;
@@ -1614,6 +1632,7 @@ function TableRowCell({
     <CellContent
       id={id}
       className={applyClassName("table-row-cell", className)}
+      aria-label="table-row-cell"
       onClick={() => {
         if (onClick) {
           onClick();

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -6,6 +6,7 @@ import {
   RiDeleteBin2Line,
   RiForbid2Line,
   RiReactjsLine,
+  RiRefreshLine,
   RiSpam2Line,
 } from "@remixicon/react";
 import {
@@ -132,7 +133,7 @@ describe("Table", () => {
   }));
 
   function BasicTable(
-    props: Omit<TableProps, "children" | "columns"> & { hasRowGroup?: boolean }
+    props: Partial<Omit<TableProps, "children">> & { hasRowGroup?: boolean }
   ) {
     const [selectedItems, setSelectedItems] = useState([]);
 
@@ -185,6 +186,170 @@ describe("Table", () => {
       </Table>
     );
   }
+
+  context("columns prop", () => {
+    context("styles", () => {
+      context("containerStyle", () => {
+        context("when given background with red color", () => {
+          it("renders background color with rgb(255, 0, 0)", () => {
+            cy.mount(
+              <BasicTable
+                columns={[
+                  {
+                    id: "name",
+                    caption: "Name",
+                    sortable: true,
+                    styles: {
+                      containerStyle: css`
+                        background-color: red;
+                      `,
+                    },
+                  },
+                  {
+                    id: "type",
+                    caption: "Type",
+                    sortable: true,
+                  },
+                ]}
+              />
+            );
+
+            cy.findAllByLabelText("table-row-cell")
+              .eq(0)
+              .should("have.css", "background-color", "rgb(255, 0, 0)");
+          });
+        });
+      });
+
+      context("labelStyle", () => {
+        context("when given blue color", () => {
+          it("renders the text column header with rgb(0, 0, 255)", () => {
+            cy.mount(
+              <BasicTable
+                columns={[
+                  {
+                    id: "name",
+                    caption: "Name",
+                    sortable: true,
+                    styles: {
+                      labelStyle: css`
+                        color: blue;
+                      `,
+                    },
+                  },
+                  {
+                    id: "type",
+                    caption: "Type",
+                    sortable: true,
+                  },
+                ]}
+              />
+            );
+
+            cy.findAllByLabelText("table-column-label")
+              .eq(0)
+              .should("have.css", "color", "rgb(0, 0, 255)");
+            cy.findAllByLabelText("table-column-label")
+              .eq(1)
+              .should("have.css", "color", "rgb(0, 0, 0)");
+          });
+        });
+      });
+
+      const TIP_MENU_ACTION = (
+        columnCaption: "from" | "content"
+      ): TableSubMenuList[] => {
+        return [
+          {
+            caption: "Sort Ascending",
+            icon: {
+              image: RiArrowUpSLine,
+            },
+            onClick: () => {},
+          },
+          {
+            caption: "Reset Sorting",
+            icon: {
+              image: RiRefreshLine,
+            },
+            onClick: () => {},
+          },
+        ];
+      };
+
+      context("dropdownSortableStyle", () => {
+        context("when given width 400px", () => {
+          it("renders the dropdown with 400px", () => {
+            cy.mount(
+              <BasicTable
+                subMenuList={TIP_MENU_ACTION}
+                columns={[
+                  {
+                    id: "name",
+                    caption: "Name",
+                    sortable: true,
+                    styles: {
+                      dropdownSortableStyle: css`
+                        width: 400px;
+                      `,
+                    },
+                  },
+                  {
+                    id: "type",
+                    caption: "Type",
+                    sortable: true,
+                  },
+                ]}
+              />
+            );
+
+            cy.get("button").eq(0).click();
+            cy.findAllByLabelText("tip-menu")
+              .eq(0)
+              .should("have.css", "width", "400px");
+
+            // check also on default width
+            cy.get("button").eq(1).click();
+            cy.findAllByLabelText("tip-menu")
+              .eq(1)
+              .should("have.css", "width", "235px");
+          });
+        });
+      });
+      context("toggleSortableStyle", () => {
+        context("when given background red", () => {
+          it("renders the trigger style with rgb(255, 0, 0)", () => {
+            cy.mount(
+              <BasicTable
+                subMenuList={TIP_MENU_ACTION}
+                columns={[
+                  {
+                    id: "name",
+                    caption: "Name",
+                    sortable: true,
+                    styles: {
+                      toggleSortableStyle: css`
+                        background-color: red;
+                      `,
+                    },
+                  },
+                  {
+                    id: "type",
+                    caption: "Type",
+                    sortable: true,
+                  },
+                ]}
+              />
+            );
+
+            cy.get("button")
+              .eq(0)
+              .should("have.css", "background-color", "rgb(255, 0, 0)");
+          });
+        });
+      });
+    });
+  });
 
   context("when children with function", () => {
     type SeparateMode = "row" | "group" | "group-separate-row";


### PR DESCRIPTION
Description:
This pull request improves the `styles` on the columns level to reach flexibilty style per column, such as `containerStyle`, `labelStyle`, `toggleSortableStyle`, and `dropdownSortableStyle`.

Source:
[[Improvement] SYST-726: Allow styling column and make column span has 100% width](https://linear.app/systatum/issue/SYST-726/allow-styling-column-and-make-column-span-has-100percent-width)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself