### PR TITLE
[Bug] SYST-719: Make resizable mobile paper dialog less jittery

### DIFF
--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -240,7 +240,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
           }
 
           lastPointerY.current = ev.clientY;
-          lastPointerTime.current = performance.now();
+          lastPointerTime.current = now;
         };
 
         const onUp = (ev: PointerEvent) => {

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -157,6 +157,9 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
 
     const isLeft = position === "left";
 
+    const widthRef = useRef<number | null>(null);
+    const heightRef = useRef<number | null>(null);
+
     const handleDesktopResizePointerDown = useCallback(
       (e: React.PointerEvent) => {
         if (!resizable || mobile) return;
@@ -166,7 +169,6 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         resizeStartX.current = e.clientX;
         resizeStartWidth.current =
           dialogRef.current?.getBoundingClientRect().width ??
-          resizeWidth ??
           window.innerWidth * 0.92;
 
         const minPx = parsePx(resizable.minWidth);
@@ -181,31 +183,38 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             maxPx,
             Math.max(minPx, resizeStartWidth.current + delta)
           );
-          setResizeWidth(next);
-          onResize?.({ width: next });
+
+          // Write to ref, batch via rAF
+          widthRef.current = next;
         };
+
+        let rafId: number;
+        const loop = () => {
+          if (widthRef.current !== null) {
+            setResizeWidth(widthRef.current);
+            onResize?.({ width: widthRef.current });
+            widthRef.current = null;
+          }
+          if (isResizingDesktop.current) rafId = requestAnimationFrame(loop);
+        };
+        rafId = requestAnimationFrame(loop);
 
         const onUp = () => {
           isResizingDesktop.current = false;
+          cancelAnimationFrame(rafId);
           window.removeEventListener("pointermove", onMove);
           window.removeEventListener("pointerup", onUp);
-          const finalWidth = resizeWidth ?? resizeStartWidth.current;
+
+          const finalWidth =
+            dialogRef.current?.getBoundingClientRect().width ??
+            resizeStartWidth.current;
           onResizeComplete?.({ width: finalWidth });
         };
 
         window.addEventListener("pointermove", onMove);
         window.addEventListener("pointerup", onUp);
       },
-      [
-        resizable,
-        mobile,
-        isLeft,
-        resizable,
-        resizeWidth,
-        setResizeWidth,
-        onResize,
-        onResizeComplete,
-      ]
+      [resizable, mobile, isLeft, onResize, onResizeComplete]
     );
 
     const handleMobileResizePointerDown = useCallback(
@@ -215,10 +224,13 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         e.stopPropagation();
         isResizingMobile.current = true;
         resizeStartY.current = e.clientY;
-        resizeStartHeight.current =
+
+        // Read from DOM once, store in ref — not state
+        const initialHeight =
           dialogRef.current?.getBoundingClientRect().height ??
           resizeHeight ??
           window.innerHeight * 0.88;
+        resizeStartHeight.current = initialHeight;
 
         lastPointerY.current = e.clientY;
         lastPointerTime.current = performance.now();
@@ -229,49 +241,49 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         const onMove = (ev: PointerEvent) => {
           if (!isResizingMobile.current) return;
           const delta = resizeStartY.current - ev.clientY;
-          const DAMPING = 0.72;
 
           const next = Math.min(
             maxPx,
-            Math.max(minPx, resizeStartHeight.current + delta * DAMPING)
+            Math.max(minPx, resizeStartHeight.current + delta)
           );
 
-          setResizeHeight(next);
-          onResize?.({ height: next });
+          //  Write to ref first, batch the state update via rAF
+          heightRef.current = next;
 
           const now = performance.now();
-
-          const dy = ev.clientY - lastPointerY.current;
           const dt = now - lastPointerTime.current;
-
           if (dt > 0) {
-            velocityRef.current = dy / dt;
+            velocityRef.current = (ev.clientY - lastPointerY.current) / dt;
           }
-
           lastPointerY.current = ev.clientY;
-          lastPointerTime.current = performance.now();
+          lastPointerTime.current = now;
         };
 
-        const onUp = (ev: PointerEvent) => {
+        // rAF loop drives state updates — decoupled from pointermove frequency
+        let rafId: number;
+        const loop = () => {
+          if (heightRef.current !== null) {
+            setResizeHeight(heightRef.current);
+            onResize?.({ height: heightRef.current });
+            heightRef.current = null;
+          }
+          if (isResizingMobile.current) rafId = requestAnimationFrame(loop);
+        };
+        rafId = requestAnimationFrame(loop);
+
+        const onUp = () => {
           isResizingMobile.current = false;
+          cancelAnimationFrame(rafId);
           window.removeEventListener("pointermove", onMove);
           window.removeEventListener("pointerup", onUp);
-
-          // Compute instantaneous velocity (px/ms, positive = downward)
-          const dt = performance.now() - lastPointerTime.current;
-          const velocity =
-            dt > 0 ? (ev.clientY - lastPointerY.current) / dt : 0;
 
           if (velocityRef.current > 0.5) {
             setDialogState("minimized");
             setShowTitlebar(true);
-            setTimeout(() => {
-              setResizeHeight(null);
-            }, 300);
+            setTimeout(() => setResizeHeight(null), 300);
           } else {
             const finalHeight =
               dialogRef.current?.getBoundingClientRect().height ??
-              resizeHeight ??
               resizeStartHeight.current;
             onResizeComplete?.({ height: finalHeight });
           }
@@ -280,18 +292,8 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         window.addEventListener("pointermove", onMove);
         window.addEventListener("pointerup", onUp);
       },
-      [
-        resizable,
-        mobile,
-        resizable,
-        resizeHeight,
-        setResizeHeight,
-        onResize,
-        onResizeComplete,
-        lastPointerTime,
-        lastPointerY,
-        velocityRef,
-      ]
+      // `resizeHeight` from deps — read from DOM/ref instead
+      [resizable, mobile, onResize, onResizeComplete]
     );
 
     const resolvedWidth = resizeWidth != null ? `${resizeWidth}px` : width;

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -131,6 +131,9 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
   ) => {
     const { currentTheme } = useTheme();
     const paperDialogTheme = currentTheme.paperDialog;
+
+    const contentRef = useRef<HTMLDivElement>(null);
+
     const dragControls = useDragControls();
 
     const resizable = resolveResizable(_resizable);
@@ -195,7 +198,6 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
               maxPx,
               Math.max(minPx, resizeStartWidth.current + delta)
             );
-            setResizeWidth(next);
 
             // Write directly to DOM — bypasses React, styled-components, and
             // Framer Motion entirely. Zero re-renders during the drag.
@@ -290,11 +292,14 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
               Math.max(minPx, resizeStartHeight.current + delta * DAMPING)
             );
 
-            // Write directly to DOM — bypasses React, styled-components, and
-            // Framer Motion entirely. Zero re-renders during the drag.
+            // Target both the dialog wrapper and the content element
+
             dialogRef.current.style.minHeight = `${next}px`;
             dialogRef.current.style.maxHeight = `${next}px`;
-            setResizeHeight(next);
+
+            contentRef.current.style.height = `${next}px`;
+            contentRef.current.style.maxHeight = `${next}px`;
+
             onResize?.({ height: next });
           });
         };
@@ -318,6 +323,11 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
               if (dialogRef.current) {
                 dialogRef.current.style.minHeight = "";
                 dialogRef.current.style.maxHeight = "";
+              }
+
+              if (contentRef.current) {
+                contentRef.current.style.height = "";
+                contentRef.current.style.maxHeight = "";
               }
               setResizeHeight(null);
             }, 300);
@@ -626,6 +636,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             )}
 
             <PaperDialogContent
+              ref={contentRef}
               $height={resolvedHeight}
               $theme={paperDialogTheme}
               aria-label="paper-dialog-content"

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -254,7 +254,6 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
 
         const maxPx = parsePx(resizable.maxHeight);
         const minPx = parsePx(resizable.minHeight);
-        const DAMPING = 0.72;
 
         let pendingY = e.clientY;
         let rafId: number | null = null;
@@ -289,7 +288,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             const delta = resizeStartY.current - pendingY;
             const next = Math.min(
               maxPx,
-              Math.max(minPx, resizeStartHeight.current + delta * DAMPING)
+              Math.max(minPx, resizeStartHeight.current + delta)
             );
 
             // Target both the dialog wrapper and the content element

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -149,8 +149,6 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
     const resizeStartHeight = useRef(0);
 
     // Track last pointer Y and timestamp for velocity-based minimize on mobile resize
-    const lastPointerY = useRef(0);
-    const lastPointerTime = useRef(0);
     const velocityRef = useRef(0);
 
     const dialogRef = useRef<HTMLDivElement>(null);
@@ -162,8 +160,10 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         if (!resizable || mobile) return;
         e.preventDefault();
         e.stopPropagation();
+
         isResizingDesktop.current = true;
         resizeStartX.current = e.clientX;
+        // Read width once at drag start — never read DOM again during move
         resizeStartWidth.current =
           dialogRef.current?.getBoundingClientRect().width ??
           window.innerWidth * 0.92;
@@ -171,26 +171,63 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         const minPx = parsePx(resizable.minWidth);
         const maxPx = parsePx(resizable.maxWidth);
 
+        let pendingX = e.clientX;
+        let rafId: number | null = null;
+
         const onMove = (ev: PointerEvent) => {
           if (!isResizingDesktop.current) return;
-          const delta = isLeft
-            ? ev.clientX - resizeStartX.current
-            : resizeStartX.current - ev.clientX;
-          const next = Math.min(
-            maxPx,
-            Math.max(minPx, resizeStartWidth.current + delta)
-          );
-          setResizeWidth(next);
-          onResize?.({ width: next });
+
+          // Store latest pointer position — no DOM work here
+          pendingX = ev.clientX;
+
+          // Multiple pointermove events between frames collapse into one write
+          if (rafId !== null) return;
+
+          rafId = requestAnimationFrame(() => {
+            rafId = null;
+            if (!isResizingDesktop.current || !dialogRef.current) return;
+
+            const delta = isLeft
+              ? pendingX - resizeStartX.current
+              : resizeStartX.current - pendingX;
+
+            const next = Math.min(
+              maxPx,
+              Math.max(minPx, resizeStartWidth.current + delta)
+            );
+            setResizeWidth(next);
+
+            // Write directly to DOM — bypasses React, styled-components, and
+            // Framer Motion entirely. Zero re-renders during the drag.
+            dialogRef.current.style.minWidth = `${next}px`;
+            dialogRef.current.style.maxWidth = `${next}px`;
+            onResize?.({ width: next });
+          });
         };
 
         const onUp = () => {
           isResizingDesktop.current = false;
+
+          if (rafId !== null) {
+            cancelAnimationFrame(rafId);
+            rafId = null;
+          }
+
           window.removeEventListener("pointermove", onMove);
           window.removeEventListener("pointerup", onUp);
+
+          // Read final width from DOM once, then hand back to React
           const finalWidth =
             dialogRef.current?.getBoundingClientRect().width ??
             resizeStartWidth.current;
+
+          // Clear inline styles first so styled-components doesn't conflict
+          if (dialogRef.current) {
+            dialogRef.current.style.minWidth = "";
+            dialogRef.current.style.maxWidth = "";
+          }
+
+          setResizeWidth(finalWidth);
           onResizeComplete?.({ width: finalWidth });
         };
 
@@ -205,61 +242,98 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         if (!resizable || !mobile) return;
         e.preventDefault();
         e.stopPropagation();
+
         isResizingMobile.current = true;
         resizeStartY.current = e.clientY;
+        // Read height once at drag start — never read it again during move
         resizeStartHeight.current =
           dialogRef.current?.getBoundingClientRect().height ??
           window.innerHeight * 0.88;
 
-        lastPointerY.current = e.clientY;
-        lastPointerTime.current = performance.now();
-
         const maxPx = parsePx(resizable.maxHeight);
         const minPx = parsePx(resizable.minHeight);
+        const DAMPING = 0.72;
+
+        let pendingY = e.clientY;
+        let rafId: number | null = null;
+
+        // Velocity tracking runs on every event — not inside rAF
+        // so fast flicks are not missed between frames
+        let lastVelocityY = e.clientY;
+        let lastVelocityTime = performance.now();
+        velocityRef.current = 0;
 
         const onMove = (ev: PointerEvent) => {
           if (!isResizingMobile.current) return;
-          const delta = resizeStartY.current - ev.clientY;
-          const DAMPING = 0.72;
 
-          const next = Math.min(
-            maxPx,
-            Math.max(minPx, resizeStartHeight.current + delta * DAMPING)
-          );
-
-          setResizeHeight(next);
-          onResize?.({ height: next });
-
+          // Track velocity on every event for accuracy
           const now = performance.now();
+          const dy = ev.clientY - lastVelocityY;
+          const dt = now - lastVelocityTime;
+          if (dt > 0) velocityRef.current = dy / dt;
+          lastVelocityY = ev.clientY;
+          lastVelocityTime = now;
 
-          const dy = ev.clientY - lastPointerY.current;
-          const dt = now - lastPointerTime.current;
+          // Store latest Y — actual DOM work happens in rAF
+          pendingY = ev.clientY;
 
-          if (dt > 0) {
-            velocityRef.current = dy / dt;
-          }
+          // Multiple pointermove events between frames collapse into one write
+          if (rafId !== null) return;
 
-          lastPointerY.current = ev.clientY;
-          lastPointerTime.current = now;
+          rafId = requestAnimationFrame(() => {
+            rafId = null;
+            if (!isResizingMobile.current || !dialogRef.current) return;
+
+            const delta = resizeStartY.current - pendingY;
+            const next = Math.min(
+              maxPx,
+              Math.max(minPx, resizeStartHeight.current + delta * DAMPING)
+            );
+
+            // Write directly to DOM — bypasses React, styled-components, and
+            // Framer Motion entirely. Zero re-renders during the drag.
+            dialogRef.current.style.minHeight = `${next}px`;
+            dialogRef.current.style.maxHeight = `${next}px`;
+            setResizeHeight(next);
+            onResize?.({ height: next });
+          });
         };
 
-        const onUp = (ev: PointerEvent) => {
+        const onUp = () => {
           isResizingMobile.current = false;
+
+          if (rafId !== null) {
+            cancelAnimationFrame(rafId);
+            rafId = null;
+          }
+
           window.removeEventListener("pointermove", onMove);
           window.removeEventListener("pointerup", onUp);
-
-          // Compute instantaneous velocity (px/ms, positive = downward)
 
           if (velocityRef.current > 0.5) {
             setDialogState("minimized");
             setShowTitlebar(true);
             setTimeout(() => {
+              // Clear inline styles so Framer Motion takes back control
+              if (dialogRef.current) {
+                dialogRef.current.style.minHeight = "";
+                dialogRef.current.style.maxHeight = "";
+              }
               setResizeHeight(null);
             }, 300);
           } else {
+            // Read final height from DOM once, then hand back to React
             const finalHeight =
               dialogRef.current?.getBoundingClientRect().height ??
               resizeStartHeight.current;
+
+            // Clear inline styles first so styled-components doesn't conflict
+            if (dialogRef.current) {
+              dialogRef.current.style.minHeight = "";
+              dialogRef.current.style.maxHeight = "";
+            }
+
+            setResizeHeight(finalHeight);
             onResizeComplete?.({ height: finalHeight });
           }
         };

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -157,9 +157,6 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
 
     const isLeft = position === "left";
 
-    const widthRef = useRef<number | null>(null);
-    const heightRef = useRef<number | null>(null);
-
     const handleDesktopResizePointerDown = useCallback(
       (e: React.PointerEvent) => {
         if (!resizable || mobile) return;
@@ -183,28 +180,14 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             maxPx,
             Math.max(minPx, resizeStartWidth.current + delta)
           );
-
-          // Write to ref, batch via rAF
-          widthRef.current = next;
+          setResizeWidth(next);
+          onResize?.({ width: next });
         };
-
-        let rafId: number;
-        const loop = () => {
-          if (widthRef.current !== null) {
-            setResizeWidth(widthRef.current);
-            onResize?.({ width: widthRef.current });
-            widthRef.current = null;
-          }
-          if (isResizingDesktop.current) rafId = requestAnimationFrame(loop);
-        };
-        rafId = requestAnimationFrame(loop);
 
         const onUp = () => {
           isResizingDesktop.current = false;
-          cancelAnimationFrame(rafId);
           window.removeEventListener("pointermove", onMove);
           window.removeEventListener("pointerup", onUp);
-
           const finalWidth =
             dialogRef.current?.getBoundingClientRect().width ??
             resizeStartWidth.current;
@@ -214,7 +197,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         window.addEventListener("pointermove", onMove);
         window.addEventListener("pointerup", onUp);
       },
-      [resizable, mobile, isLeft, onResize, onResizeComplete]
+      [resizable, mobile, onResize, onResizeComplete, isLeft]
     );
 
     const handleMobileResizePointerDown = useCallback(
@@ -224,13 +207,9 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         e.stopPropagation();
         isResizingMobile.current = true;
         resizeStartY.current = e.clientY;
-
-        // Read from DOM once, store in ref — not state
-        const initialHeight =
+        resizeStartHeight.current =
           dialogRef.current?.getBoundingClientRect().height ??
-          resizeHeight ??
           window.innerHeight * 0.88;
-        resizeStartHeight.current = initialHeight;
 
         lastPointerY.current = e.clientY;
         lastPointerTime.current = performance.now();
@@ -241,46 +220,42 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         const onMove = (ev: PointerEvent) => {
           if (!isResizingMobile.current) return;
           const delta = resizeStartY.current - ev.clientY;
+          const DAMPING = 0.72;
 
           const next = Math.min(
             maxPx,
-            Math.max(minPx, resizeStartHeight.current + delta)
+            Math.max(minPx, resizeStartHeight.current + delta * DAMPING)
           );
 
-          //  Write to ref first, batch the state update via rAF
-          heightRef.current = next;
+          setResizeHeight(next);
+          onResize?.({ height: next });
 
           const now = performance.now();
+
+          const dy = ev.clientY - lastPointerY.current;
           const dt = now - lastPointerTime.current;
+
           if (dt > 0) {
-            velocityRef.current = (ev.clientY - lastPointerY.current) / dt;
+            velocityRef.current = dy / dt;
           }
+
           lastPointerY.current = ev.clientY;
-          lastPointerTime.current = now;
+          lastPointerTime.current = performance.now();
         };
 
-        // rAF loop drives state updates — decoupled from pointermove frequency
-        let rafId: number;
-        const loop = () => {
-          if (heightRef.current !== null) {
-            setResizeHeight(heightRef.current);
-            onResize?.({ height: heightRef.current });
-            heightRef.current = null;
-          }
-          if (isResizingMobile.current) rafId = requestAnimationFrame(loop);
-        };
-        rafId = requestAnimationFrame(loop);
-
-        const onUp = () => {
+        const onUp = (ev: PointerEvent) => {
           isResizingMobile.current = false;
-          cancelAnimationFrame(rafId);
           window.removeEventListener("pointermove", onMove);
           window.removeEventListener("pointerup", onUp);
+
+          // Compute instantaneous velocity (px/ms, positive = downward)
 
           if (velocityRef.current > 0.5) {
             setDialogState("minimized");
             setShowTitlebar(true);
-            setTimeout(() => setResizeHeight(null), 300);
+            setTimeout(() => {
+              setResizeHeight(null);
+            }, 300);
           } else {
             const finalHeight =
               dialogRef.current?.getBoundingClientRect().height ??
@@ -292,7 +267,6 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         window.addEventListener("pointermove", onMove);
         window.addEventListener("pointerup", onUp);
       },
-      // `resizeHeight` from deps — read from DOM/ref instead
       [resizable, mobile, onResize, onResizeComplete]
     );
 


### PR DESCRIPTION
Description:
This pull request fixes a jitter issue in `resizable` mode on the `PaperDialog` component, especially on `mobile` devices. The implementation reduces unnecessary dependencies and callbak re-creations, preventing excessive function executions that could cause laggy or jittery during resizing behavior.

Source:
[[Bug] SYST-719: Make resizable mobile paper dialog less jittery](https://linear.app/systatum/issue/SYST-719/make-resizable-mobile-paper-dialog-less-jittery)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[ ] I have tested it myself