### PR TITLE
[Bug] SYST-727: Remove height: 100% from `MessageBox`

### DIFF
--- a/components/messagebox.tsx
+++ b/components/messagebox.tsx
@@ -70,6 +70,7 @@ function Messagebox({
   return (
     <Wrapper
       id={id}
+      aria-label="messagebox-container"
       className={applyClassName("messagebox", className)}
       $theme={messageboxTheme}
       $variant={variant}
@@ -88,9 +89,16 @@ function Messagebox({
         color={icon?.color ?? variantStyle.textColor}
       />
 
-      <Content $style={styles?.contentWrapperStyle}>
-        <Title $style={styles?.titleStyle}>{title}</Title>
-        <Children $style={styles?.contentStyle}>{children}</Children>
+      <Content
+        aria-label="messagebox-content-wrapper"
+        $style={styles?.contentWrapperStyle}
+      >
+        <Title aria-label="messagebox-title" $style={styles?.titleStyle}>
+          {title}
+        </Title>
+        <Children aria-label="messagebox-content" $style={styles?.contentStyle}>
+          {children}
+        </Children>
         {actionLinks && (
           <ActionList>
             {actionLinks.map((action, index) =>
@@ -177,7 +185,7 @@ const Wrapper = styled.div<{
   border-radius: 2px;
   position: relative;
   overflow: hidden;
-  height: 100%;
+  height: fit-content;
 
   background-color: ${({ $variant, $theme }) =>
     $theme[$variant].backgroundColor};

--- a/test/component/messagebox.cy.tsx
+++ b/test/component/messagebox.cy.tsx
@@ -5,7 +5,7 @@ describe("Messagebox", () => {
   function ProductMessagebox(props?: Partial<MessageboxProps>) {
     return (
       <Messagebox title="This is title" {...props}>
-        This is content
+        {props?.children ?? "This is content"}
       </Messagebox>
     );
   }
@@ -17,6 +17,23 @@ describe("Messagebox", () => {
         "height",
         "78.59375px"
       );
+    });
+
+    context("when given children", () => {
+      it("sizes itself to its content", () => {
+        cy.mount(
+          <ProductMessagebox>
+            {Array.from({ length: 12 }).map((_, i) => (
+              <p key={i}>{i}</p>
+            ))}
+          </ProductMessagebox>
+        );
+        cy.findByLabelText("messagebox-container").should(
+          "have.css",
+          "height",
+          "294.125px"
+        );
+      });
     });
 
     context("when given height 400px", () => {

--- a/test/component/messagebox.cy.tsx
+++ b/test/component/messagebox.cy.tsx
@@ -1,5 +1,6 @@
 import { css } from "styled-components";
 import { Messagebox, MessageboxProps } from "./../../components/messagebox";
+import { StatefulForm } from "./../../components/stateful-form";
 
 describe("Messagebox", () => {
   function ProductMessagebox(props?: Partial<MessageboxProps>) {
@@ -9,6 +10,7 @@ describe("Messagebox", () => {
       </Messagebox>
     );
   }
+
   context("height", () => {
     it("renders with fit-content (by default)", () => {
       cy.mount(<ProductMessagebox />);
@@ -32,6 +34,42 @@ describe("Messagebox", () => {
           "have.css",
           "height",
           "294.125px"
+        );
+      });
+    });
+
+    context("when add inside of form", () => {
+      it("sizes itself to its content", () => {
+        cy.mount(
+          <StatefulForm
+            formValues={{
+              name: "",
+              email: "",
+            }}
+            fields={[
+              {
+                name: "name",
+                type: "text",
+                title: "Name",
+              },
+              {
+                name: "email",
+                type: "email",
+                title: "Email",
+              },
+              {
+                name: "render",
+                type: "custom",
+                render: <ProductMessagebox />,
+              },
+            ]}
+          />
+        );
+
+        cy.findByLabelText("messagebox-container").should(
+          "have.css",
+          "height",
+          "78.59375px"
         );
       });
     });

--- a/test/component/messagebox.cy.tsx
+++ b/test/component/messagebox.cy.tsx
@@ -1,0 +1,41 @@
+import { css } from "styled-components";
+import { Messagebox, MessageboxProps } from "./../../components/messagebox";
+
+describe("Messagebox", () => {
+  function ProductMessagebox(props?: Partial<MessageboxProps>) {
+    return (
+      <Messagebox title="This is title" {...props}>
+        This is content
+      </Messagebox>
+    );
+  }
+  context("height", () => {
+    it("renders with fit-content (by default)", () => {
+      cy.mount(<ProductMessagebox />);
+      cy.findByLabelText("messagebox-container").should(
+        "have.css",
+        "height",
+        "78.59375px"
+      );
+    });
+
+    context("when given height 400px", () => {
+      it("renders height 400px", () => {
+        cy.mount(
+          <ProductMessagebox
+            styles={{
+              containerStyle: css`
+                height: 400px;
+              `,
+            }}
+          />
+        );
+        cy.findByLabelText("messagebox-container").should(
+          "have.css",
+          "height",
+          "400px"
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Description:
This pull request fixes an issue where `Messagebox` always inherited a height of `100%` from its parent container. As a result, if the parent had additional empty space (e.g. `200px`), the `Messagebox` would unnecessarily expand to fill it.

The `Messagebox` now uses `fit-content` by default, allowing its height to be determined by its content rather than the available space in the parent container.

Source:
[[Bug] SYST-727: Remove height: 100% from `MessageBox`](https://linear.app/systatum/issue/SYST-727/remove-height-100percent-from-messagebox)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself