### PR TITLE
[Bug] SYST-725: Fix autogrow not working

### DIFF
--- a/components/textarea.tsx
+++ b/components/textarea.tsx
@@ -3,6 +3,8 @@ import {
   MutableRefObject,
   TextareaHTMLAttributes,
   forwardRef,
+  useEffect,
+  useRef,
 } from "react";
 import styled, { css, CSSProp } from "styled-components";
 import {
@@ -40,6 +42,16 @@ const BaseTextarea = forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
     const { currentTheme } = useTheme();
     const textareaTheme = currentTheme?.textarea;
 
+    const innerRef = useRef<HTMLTextAreaElement | null>(null);
+
+    // runs once on mount
+    useEffect(() => {
+      if (autogrow && innerRef.current) {
+        innerRef.current.style.height = "auto";
+        innerRef.current.style.height = `${innerRef.current.scrollHeight}px`;
+      }
+    }, []);
+
     return (
       <TextareaInput
         $width={width}
@@ -48,6 +60,7 @@ const BaseTextarea = forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
         $autogrow={autogrow}
         id={id}
         ref={(el) => {
+          innerRef.current = el;
           if (typeof ref === "function") {
             ref(el);
           } else if (ref) {
@@ -55,6 +68,11 @@ const BaseTextarea = forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
           }
         }}
         onChange={(e) => {
+          if (autogrow) {
+            e.target.style.height = "auto";
+            e.target.style.height = `${e.target.scrollHeight}px`;
+          }
+
           if (onChange) {
             onChange(e);
           }

--- a/test/component/textarea.cy.tsx
+++ b/test/component/textarea.cy.tsx
@@ -15,6 +15,7 @@ describe("Textarea", () => {
     }
   ) {
     const [value, setValue] = useState("");
+
     return (
       <Textarea
         value={value}
@@ -25,6 +26,48 @@ describe("Textarea", () => {
       />
     );
   }
+
+  context("autogrow", () => {
+    it("renders with the default height of 68px", () => {
+      cy.mount(<ProductTextarea autogrow />);
+
+      cy.get("#textarea").should("have.css", "height", "68px");
+    });
+
+    context("when typing", () => {
+      it("increases the height as content grows", () => {
+        cy.mount(<ProductTextarea withOnChange autogrow />);
+
+        cy.get("#textarea")
+          .should("have.css", "height", "68px")
+          .type("halo{enter}my name{enter}is{enter}john{enter}doe");
+        cy.get("#textarea").should("have.css", "height", "104px");
+      });
+    });
+
+    context("when provides initial value", () => {
+      it("renders with a height larger than the default", () => {
+        cy.mount(
+          <ProductTextarea
+            value={`
+            Line 1
+Line 2
+Line 3
+Line 4
+Line 5
+Line 6
+Line 7
+Line 8
+Line 9
+          `}
+            autogrow
+          />
+        );
+
+        cy.get("#textarea").should("have.css", "height", "212px");
+      });
+    });
+  });
 
   context("width", () => {
     context("when given 250px", () => {


### PR DESCRIPTION
Description:
This pull request fixes an issue where the `autogrow` prop in `Textarea` component did not correctly adjust its height while the user was typing. It also ensures that the component grows appropriately based on both the `initialize` value or subsequent user input.

Source:
[[Bug] SYST-725: Fix autogrow not working](https://linear.app/systatum/issue/SYST-725/fix-autogrow-not-working)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself