### PR TITLE
[Feature] SYST-728: Add a `Progressbar` control

### DIFF
--- a/components/progressbar.stories.tsx
+++ b/components/progressbar.stories.tsx
@@ -253,4 +253,5 @@ const Section = styled.div`
 
 const Title = styled.h2`
   margin: 0;
+  font-weight: 500;
 `;

--- a/components/progressbar.stories.tsx
+++ b/components/progressbar.stories.tsx
@@ -1,0 +1,256 @@
+import { Meta, StoryObj } from "@storybook/react/*";
+import { Progressbar, ProgressbarVariant } from "./progressbar";
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+
+const meta: Meta<typeof Progressbar> = {
+  title: "Controls/Progressbar",
+  component: Progressbar,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+The **Progressbar** component visually represents the progress of a task or process.
+
+It supports determinate and indeterminate states, multiple color variants, bidirectional progress, optional percentage labels, and custom styling hooks.
+
+---
+
+### ✨ Features
+
+* 📊 Determinate progress with configurable values
+* 🔄 Indeterminate loading animation
+* 🎨 Multiple predefined variants (primary, success, danger, warning)
+* ↔️ Support for left-to-right and right-to-left progress
+* 🏷️ Optional percentage labeling
+* 🎛️ Custom styling through style overrides
+* ♿ Accessible with ARIA progressbar attributes
+
+---
+
+### 🧱 Component Structure
+
+\`\`\`tsx
+<Progressbar
+  value={60}
+  variant="primary"
+  labeling="right"
+/>
+\`\`\`
+
+---
+
+### ⚙️ Core Behaviors
+
+#### Determinate Mode
+
+Use the \`value\` prop to display a specific completion percentage.
+
+\`\`\`tsx
+<Progressbar value={75} />
+\`\`\`
+
+* Values are automatically clamped between \`0\` and \`100\`
+* Smooth width transitions are applied when the value changes
+
+---
+
+#### Indeterminate Mode
+
+Use \`indeterminate\` when the progress amount is unknown.
+
+\`\`\`tsx
+<Progressbar indeterminate />
+\`\`\`
+
+* Displays a continuous loading animation
+* Hides percentage labels automatically
+
+---
+
+#### Variants
+
+Use \`variant\` to apply predefined semantic styles.
+
+\`\`\`tsx
+<Progressbar variant="success" />
+\`\`\`
+
+Available variants:
+
+* \`primary\`
+* \`success\`
+* \`danger\`
+* \`warning\`
+
+---
+
+#### Direction
+
+Use \`directionTo\` to control the progress direction.
+
+\`\`\`tsx
+<Progressbar
+  value={60}
+  directionTo="left"
+/>
+\`\`\`
+
+Available directions:
+
+* \`right\` — fills from left to right
+* \`left\` — fills from right to left
+
+Works for both determinate and indeterminate modes.
+
+---
+
+#### Labeling
+
+Display the progress percentage beside the progress bar.
+
+\`\`\`tsx
+<Progressbar
+  value={60}
+  labeling="right"
+/>
+\`\`\`
+
+Available options:
+
+* \`none\`
+* \`right\`
+* \`left\`
+
+Labels are automatically hidden when \`indeterminate\` is enabled.
+
+---
+
+#### Custom Styles
+
+Customize individual parts of the component using the \`styles\` prop.
+
+\`\`\`tsx
+<Progressbar
+  value={60}
+  styles={{
+    containerStyle: css\`
+      margin: 8px 0;
+    \`,
+    valueBarStyle: css\`
+      border-radius: 9999px;
+    \`,
+    labelStyle: css\`
+      font-weight: 700;
+    \`,
+  }}
+/>
+\`\`\`
+
+Available style targets:
+
+* \`containerStyle\`
+* \`valueBarStyle\`
+* \`labelStyle\`
+
+---
+
+### 🎯 Usage Guidelines
+
+* Use **determinate mode** when completion progress is known
+* Use **indeterminate mode** while waiting for unknown-duration operations
+* Use semantic variants to communicate status and intent
+* Prefer concise percentage labels for user-facing progress updates
+* Use \`directionTo="left"\` for RTL interfaces or reverse progress flows
+* Avoid displaying labels when progress information is not meaningful
+`,
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Progressbar>;
+
+export const Labelling: Story = {
+  render: () => {
+    const [value, setValue] = useState(0);
+
+    useEffect(() => {
+      const interval = setInterval(() => {
+        setValue((prev) => (prev >= 100 ? 0 : prev + 10));
+      }, 600);
+
+      return () => clearInterval(interval);
+    }, []);
+
+    return (
+      <Container>
+        <Section>
+          <Title>Labeling in right</Title>
+          <Progressbar value={value} labeling="right" directionTo="right" />
+        </Section>
+
+        <Section>
+          <Title>Labeling in left</Title>
+          <Progressbar value={value} labeling="left" directionTo="left" />
+        </Section>
+      </Container>
+    );
+  },
+};
+
+export const Indeterminate: Story = {
+  render: () => {
+    return (
+      <Container>
+        <Section>
+          <Title>Indeterminate direction to right</Title>
+          <Progressbar indeterminate directionTo="right" />
+        </Section>
+
+        <Section>
+          <Title>Indeterminate direction to left</Title>
+          <Progressbar indeterminate directionTo="left" />
+        </Section>
+      </Container>
+    );
+  },
+};
+
+export const Variants: Story = {
+  render: () => {
+    return (
+      <Container>
+        {Object.values(ProgressbarVariant).map((variant, index) => (
+          <Section key={index}>
+            <Title>Variant {variant}</Title>
+            <Progressbar
+              variant={variant}
+              indeterminate
+              directionTo={index % 2 === 0 ? "right" : "left"}
+            />
+          </Section>
+        ))}
+      </Container>
+    );
+  },
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+`;
+
+const Section = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const Title = styled.h2`
+  margin: 0;
+`;

--- a/components/progressbar.tsx
+++ b/components/progressbar.tsx
@@ -64,12 +64,17 @@ function Progressbar({
       aria-valuenow={indeterminate ? undefined : clampedValue}
       aria-valuemin={0}
       aria-valuemax={100}
-      aria-label="Progress"
+      aria-label="progressbar"
       $labeling={labeling}
       $style={styles?.containerStyle}
     >
-      <Track $theme={progressBarTheme} $variant={variant}>
+      <Track
+        aria-label="progressbar-track"
+        $theme={progressBarTheme}
+        $variant={variant}
+      >
         <Fill
+          aria-label="progressbar-fill"
           $value={clampedValue}
           $theme={progressBarTheme}
           $variant={variant}
@@ -81,6 +86,7 @@ function Progressbar({
 
       {showLabel && (
         <Label
+          aria-label="progressbar-label"
           $theme={progressBarTheme}
           $variant={variant}
           $style={styles?.labelStyle}

--- a/components/progressbar.tsx
+++ b/components/progressbar.tsx
@@ -1,0 +1,202 @@
+import styled, { css, CSSProp, keyframes } from "styled-components";
+import { ProgressbarThemeConfig, useTheme } from "./../theme";
+
+export interface ProgressbarProps {
+  variant?: ProgressbarVariant;
+  indeterminate?: boolean;
+  labeling?: ProgressbarLabelling;
+  directionTo?: ProgressbarDirectionTo;
+  styles?: ProgressbarStyles;
+  value?: number;
+}
+
+export interface ProgressbarStyles {
+  containerStyle?: CSSProp;
+  valueBarStyle?: CSSProp;
+  labelStyle?: CSSProp;
+}
+
+export const ProgressbarVariant = {
+  Primary: "primary",
+  Success: "success",
+  Danger: "danger",
+  Warning: "warning",
+} as const;
+
+export type ProgressbarVariant =
+  (typeof ProgressbarVariant)[keyof typeof ProgressbarVariant];
+
+export const ProgressbarLabelling = {
+  None: "none",
+  Right: "right",
+  Left: "left",
+} as const;
+
+export type ProgressbarLabelling =
+  (typeof ProgressbarLabelling)[keyof typeof ProgressbarLabelling];
+
+export const ProgressbarDirectionTo = {
+  Right: "right",
+  Left: "left",
+} as const;
+
+export type ProgressbarDirectionTo =
+  (typeof ProgressbarDirectionTo)[keyof typeof ProgressbarDirectionTo];
+
+function Progressbar({
+  value = 0,
+  indeterminate = false,
+  labeling = "none",
+  directionTo = ProgressbarDirectionTo.Right,
+  variant = ProgressbarVariant.Primary,
+  styles,
+}: ProgressbarProps) {
+  const { currentTheme } = useTheme();
+  const progressBarTheme = currentTheme?.progressbar;
+
+  const clampedValue = Math.min(100, Math.max(0, value));
+  const showLabel = labeling !== "none" && !indeterminate;
+
+  return (
+    <Wrapper
+      role="progressbar"
+      aria-valuenow={indeterminate ? undefined : clampedValue}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label="Progress"
+      $labeling={labeling}
+      $style={styles?.containerStyle}
+    >
+      <Track $theme={progressBarTheme} $variant={variant}>
+        <Fill
+          $value={clampedValue}
+          $theme={progressBarTheme}
+          $variant={variant}
+          $indeterminate={indeterminate}
+          $directionTo={directionTo}
+          $style={styles?.valueBarStyle}
+        />
+      </Track>
+
+      {showLabel && (
+        <Label
+          $theme={progressBarTheme}
+          $variant={variant}
+          $style={styles?.labelStyle}
+        >
+          {clampedValue}%
+        </Label>
+      )}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div<{
+  $labeling: ProgressbarProps["labeling"];
+  $style?: ProgressbarStyles["containerStyle"];
+}>`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  flex-direction: ${({ $labeling }) =>
+    $labeling === "left" ? "row-reverse" : "row"};
+
+  ${({ $style }) => $style}
+`;
+
+const Track = styled.div<{
+  $theme?: ProgressbarThemeConfig;
+  $variant?: ProgressbarVariant;
+}>`
+  position: relative;
+  flex: 1;
+  height: 8px;
+  border-radius: 9999px;
+  background-color: ${({ $theme, $variant }) => $theme?.[$variant]?.trackColor};
+  overflow: hidden;
+`;
+
+const Fill = styled.div<{
+  $value: number;
+  $theme?: ProgressbarThemeConfig;
+  $variant?: ProgressbarVariant;
+  $indeterminate: boolean;
+  $directionTo: ProgressbarDirectionTo;
+  $style?: CSSProp;
+}>`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  height: 100%;
+  border-radius: 9999px;
+  background-color: ${({ $theme, $variant }) => $theme?.[$variant]?.barColor};
+
+  transition: width 0.3s ease;
+
+  ${({ $indeterminate, $directionTo, $value }) => {
+    if ($indeterminate) {
+      if ($directionTo === ProgressbarDirectionTo.Left) {
+        return css`
+          right: 0;
+          left: auto;
+          width: 30%;
+          animation: ${indeterminateSlideRTL} 2.1s ease-in-out infinite;
+          transform-origin: right center;
+        `;
+      } else {
+        return css`
+          left: 0;
+          right: auto;
+          width: 30%;
+          animation: ${indeterminateSlide} 2.1s ease-in-out infinite;
+          transform-origin: left center;
+        `;
+      }
+    } else {
+      if ($directionTo === ProgressbarDirectionTo.Left) {
+        return css`
+          right: 0;
+          left: auto;
+          width: ${$value}%;
+        `;
+      } else {
+        return css`
+          left: 0;
+          right: auto;
+          width: ${$value}%;
+        `;
+      }
+    }
+  }}
+
+  ${({ $style }) => $style}
+`;
+
+const Label = styled.span<{
+  $theme?: ProgressbarThemeConfig;
+  $variant?: ProgressbarVariant;
+  $style?: CSSProp;
+}>`
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: ${({ $theme, $variant }) => $theme?.[$variant]?.textColor};
+  line-height: 1;
+  min-width: 2.8ch;
+  text-align: center;
+
+  ${({ $style }) => $style}
+`;
+
+const indeterminateSlide = keyframes`
+  0%   { transform: translateX(-400%) scaleX(0.9); }
+  100% { transform: translateX(400%)  scaleX(0.9); }
+`;
+
+const indeterminateSlideRTL = keyframes`
+  0%   { transform: translateX(400%)  scaleX(0.9); }
+  100% { transform: translateX(-400%) scaleX(0.9); }
+`;
+
+export { Progressbar };

--- a/components/progressbar.tsx
+++ b/components/progressbar.tsx
@@ -145,17 +145,15 @@ const Fill = styled.div<{
         return css`
           right: 0;
           left: auto;
-          width: 40%;
-          animation: ${indeterminateSlideRTL} 2.1s ease-in-out infinite;
-          transform-origin: right center;
+          animation: ${indeterminateSlideRTL} 2.1s
+            cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
         `;
       } else {
         return css`
           left: 0;
           right: auto;
-          width: 40%;
-          animation: ${indeterminateSlide} 2.1s ease-in-out infinite;
-          transform-origin: left center;
+          animation: ${indeterminateSlide} 2.1s
+            cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
         `;
       }
     } else {
@@ -193,15 +191,16 @@ const Label = styled.span<{
 
   ${({ $style }) => $style}
 `;
-
 const indeterminateSlide = keyframes`
-  0%   { transform: translateX(-400%) scaleX(0.9); }
-  100% { transform: translateX(400%)  scaleX(0.9); }
+  0%   { left: -35%; right: 100%; }
+  60%  { left: 100%; right: -90%; }
+  100% { left: 100%; right: -90%; }
 `;
 
 const indeterminateSlideRTL = keyframes`
-  0%   { transform: translateX(400%)  scaleX(0.9); }
-  100% { transform: translateX(-400%) scaleX(0.9); }
+  0%   { right: -35%; left: 100%; }
+  60%  { right: 100%; left: -90%; }
+  100% { right: 100%; left: -90%; }
 `;
 
 export { Progressbar };

--- a/components/progressbar.tsx
+++ b/components/progressbar.tsx
@@ -17,6 +17,7 @@ export interface ProgressbarStyles {
 }
 
 export const ProgressbarVariant = {
+  Neutral: "neutral",
   Primary: "primary",
   Success: "success",
   Danger: "danger",
@@ -48,7 +49,7 @@ function Progressbar({
   indeterminate = false,
   labeling = "none",
   directionTo = ProgressbarDirectionTo.Right,
-  variant = ProgressbarVariant.Primary,
+  variant = ProgressbarVariant.Neutral,
   styles,
 }: ProgressbarProps) {
   const { currentTheme } = useTheme();
@@ -130,7 +131,7 @@ const Fill = styled.div<{
   height: 100%;
   background-color: ${({ $theme, $variant }) => $theme?.[$variant]?.barColor};
 
-  transition: width 0.3s ease;
+  transition: width 0.1s linear;
 
   ${({ $indeterminate, $directionTo, $value }) => {
     if ($indeterminate) {

--- a/components/progressbar.tsx
+++ b/components/progressbar.tsx
@@ -1,5 +1,6 @@
 import styled, { css, CSSProp, keyframes } from "styled-components";
 import { ProgressbarThemeConfig, useTheme } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 
 export interface ProgressbarProps {
   variant?: ProgressbarVariant;
@@ -8,6 +9,8 @@ export interface ProgressbarProps {
   directionTo?: ProgressbarDirectionTo;
   styles?: ProgressbarStyles;
   value?: number;
+  className?: string;
+  id?: string;
 }
 
 export interface ProgressbarStyles {
@@ -47,10 +50,12 @@ export type ProgressbarDirectionTo =
 function Progressbar({
   value = 0,
   indeterminate = false,
-  labeling = "none",
+  labeling = ProgressbarLabelling.None,
   directionTo = ProgressbarDirectionTo.Right,
   variant = ProgressbarVariant.Neutral,
   styles,
+  className,
+  id,
 }: ProgressbarProps) {
   const { currentTheme } = useTheme();
   const progressBarTheme = currentTheme?.progressbar;
@@ -60,6 +65,8 @@ function Progressbar({
 
   return (
     <Wrapper
+      id={id}
+      className={applyClassName("progressbar", className)}
       role="progressbar"
       aria-valuenow={indeterminate ? undefined : clampedValue}
       aria-valuemin={0}

--- a/components/progressbar.tsx
+++ b/components/progressbar.tsx
@@ -111,8 +111,7 @@ const Track = styled.div<{
 }>`
   position: relative;
   flex: 1;
-  height: 8px;
-  border-radius: 9999px;
+  height: 6px;
   background-color: ${({ $theme, $variant }) => $theme?.[$variant]?.trackColor};
   overflow: hidden;
 `;
@@ -129,7 +128,6 @@ const Fill = styled.div<{
   top: 0;
   bottom: 0;
   height: 100%;
-  border-radius: 9999px;
   background-color: ${({ $theme, $variant }) => $theme?.[$variant]?.barColor};
 
   transition: width 0.3s ease;
@@ -140,7 +138,7 @@ const Fill = styled.div<{
         return css`
           right: 0;
           left: auto;
-          width: 30%;
+          width: 40%;
           animation: ${indeterminateSlideRTL} 2.1s ease-in-out infinite;
           transform-origin: right center;
         `;
@@ -148,7 +146,7 @@ const Fill = styled.div<{
         return css`
           left: 0;
           right: auto;
-          width: 30%;
+          width: 40%;
           animation: ${indeterminateSlide} 2.1s ease-in-out infinite;
           transform-origin: left center;
         `;

--- a/components/toast.tsx
+++ b/components/toast.tsx
@@ -23,6 +23,7 @@ import { Button } from "./button";
 import { AnimatePresence, motion } from "framer-motion";
 import { applyClassName } from "./../constants/classname";
 import { BaseAction } from "./../constants/action";
+import { Progressbar } from "./progressbar";
 
 export const ToastVariant = {
   Primary: "primary",
@@ -97,14 +98,6 @@ export interface ToastProps {
 
 type ToastWithoutVariant = Omit<ToastProps, "variant">;
 
-interface ToastCardProps extends Omit<HTMLAttributes<HTMLDivElement>, "style"> {
-  children?: ReactNode;
-  variant?: ToastVariant;
-  styles?: {
-    self?: CSSProp;
-  };
-}
-
 export interface ToastAPI {
   alert(options: ToastProps): string;
 
@@ -147,6 +140,20 @@ function ToastItem({ item, onClose }: ToastItemProps) {
     position = "top-right",
     className,
   } = item;
+
+  const [progress, setProgress] = useState(100);
+
+  useEffect(() => {
+    const start = Date.now();
+
+    const interval = setInterval(() => {
+      const elapsed = Date.now() - start;
+
+      setProgress(Math.max(0, 100 - (elapsed / disappearAfterMs) * 100));
+    }, 16);
+
+    return () => clearInterval(interval);
+  }, [disappearAfterMs]);
 
   const {
     position: iconPosition = ToastIconPosition.LeftTop,
@@ -264,10 +271,17 @@ function ToastItem({ item, onClose }: ToastItemProps) {
         </AnimatePresence>
 
         {withLoadingBar && disappearAfterMs > 0 && (
-          <ProgressBar
-            aria-label="toast-progress-bar"
-            $theme={toastTheme}
-            $ms={disappearAfterMs}
+          <Progressbar
+            styles={{
+              containerStyle: css`
+                height: 2px;
+                position: absolute;
+                bottom: 0;
+                left: 0;
+              `,
+            }}
+            variant={variant}
+            value={progress}
           />
         )}
       </Card>
@@ -606,18 +620,6 @@ const slideOut = keyframes`
 const shrinkProgress = keyframes`
   from { width: 100%; }
   to   { width: 0%; }
-`;
-
-const ProgressBar = styled.div<{ $theme?: ToastThemeConfig; $ms: number }>`
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  height: 3px;
-  background: ${({ $theme }) => $theme?.progressColor};
-  border-radius: 0 0 0 12px;
-  animation: ${({ $ms }) => css`
-    ${shrinkProgress} ${$ms}ms linear forwards
-  `};
 `;
 
 // Per-position root renderer

--- a/test/component/progressbar.cy.tsx
+++ b/test/component/progressbar.cy.tsx
@@ -1,0 +1,258 @@
+import { css } from "styled-components";
+import {
+  Progressbar,
+  ProgressbarProps,
+  ProgressbarVariant,
+} from "./../../components/progressbar";
+
+describe("Progressbar", () => {
+  function ProductProgressbar(props: Partial<ProgressbarProps>) {
+    return <Progressbar {...props} />;
+  }
+
+  context("variant", () => {
+    const variantCases: Array<{
+      variant: ProgressbarVariant;
+      barColor: string;
+      trackColor: string;
+    }> = [
+      {
+        variant: "neutral",
+        barColor: "rgb(100, 116, 139)",
+        trackColor: "rgb(203, 213, 225)",
+      },
+      {
+        variant: "primary",
+        barColor: "rgb(91, 99, 246)",
+        trackColor: "rgb(199, 204, 255)",
+      },
+      {
+        variant: "success",
+        barColor: "rgb(34, 197, 94)",
+        trackColor: "rgb(187, 247, 208)",
+      },
+      {
+        variant: "danger",
+        barColor: "rgb(244, 63, 94)",
+        trackColor: "rgb(254, 205, 211)",
+      },
+      {
+        variant: "warning",
+        barColor: "rgb(245, 158, 11)",
+        trackColor: "rgb(253, 230, 138)",
+      },
+    ];
+
+    variantCases.forEach(({ variant, barColor, trackColor }) => {
+      context(`when given variant ${variant}`, () => {
+        beforeEach(() => {
+          cy.mount(<ProductProgressbar variant={variant} value={50} />);
+        });
+
+        it(`should render the fill with the correct bar color`, () => {
+          cy.findByLabelText("progressbar-fill").should(
+            "have.css",
+            "background-color",
+            barColor
+          );
+        });
+
+        it(`should render the track with the correct track color`, () => {
+          cy.findByLabelText("progressbar-track").should(
+            "have.css",
+            "background-color",
+            trackColor
+          );
+        });
+      });
+    });
+  });
+
+  context("indeterminate", () => {
+    context("when given true", () => {
+      it("should not expose aria-valuenow", () => {
+        cy.mount(<ProductProgressbar indeterminate={true} />);
+        cy.findByRole("progressbar").should("not.have.attr", "aria-valuenow");
+      });
+
+      it("should not render the label even when labeling is right", () => {
+        cy.mount(
+          <ProductProgressbar
+            indeterminate={true}
+            labeling="right"
+            value={50}
+          />
+        );
+        cy.findByRole("progressbar").should("not.contain.text", "%");
+      });
+    });
+
+    context("when given false", () => {
+      it("should expose aria-valuenow", () => {
+        cy.mount(<ProductProgressbar indeterminate={false} value={60} />);
+        cy.findByRole("progressbar").should("have.attr", "aria-valuenow", "60");
+      });
+    });
+  });
+
+  context("labelling", () => {
+    context("when given none (by default)", () => {
+      it("should not render the label", () => {
+        cy.mount(<ProductProgressbar labeling="none" value={40} />);
+        cy.findByRole("progressbar").should("not.contain.text", "%");
+      });
+    });
+
+    context("when given right", () => {
+      it("should render the label in the right side", () => {
+        cy.mount(<ProductProgressbar labeling="right" value={40} />);
+        cy.findByRole("progressbar").should(
+          "have.css",
+          "flex-direction",
+          "row"
+        );
+        cy.findByRole("progressbar").should("contain.text", "40%");
+      });
+    });
+
+    context("when given left", () => {
+      it("should render the label", () => {
+        cy.mount(<ProductProgressbar labeling="left" value={75} />);
+        cy.findByRole("progressbar").should(
+          "have.css",
+          "flex-direction",
+          "row-reverse"
+        );
+        cy.findByRole("progressbar").should("contain.text", "75%");
+      });
+    });
+  });
+
+  context("directionTo", () => {
+    context("when given right", () => {
+      it("should render the progressbar", () => {
+        cy.mount(<ProductProgressbar directionTo="right" value={50} />);
+        cy.findByRole("progressbar").should("exist");
+      });
+    });
+
+    context("when given left", () => {
+      it("should render the progressbar", () => {
+        cy.mount(<ProductProgressbar directionTo="left" value={50} />);
+        cy.findByRole("progressbar").should("exist");
+      });
+    });
+  });
+
+  context("value", () => {
+    context("when given 50", () => {
+      it("should set aria-valuenow to 50", () => {
+        cy.mount(<ProductProgressbar value={50} />);
+        cy.findByRole("progressbar").should("have.attr", "aria-valuenow", "50");
+      });
+    });
+
+    context("when given 0", () => {
+      it("should set aria-valuenow to 0", () => {
+        cy.mount(<ProductProgressbar value={0} />);
+        cy.findByRole("progressbar").should("have.attr", "aria-valuenow", "0");
+      });
+    });
+
+    context("when given 100", () => {
+      it("should set aria-valuenow to 100", () => {
+        cy.mount(<ProductProgressbar value={100} />);
+        cy.findByRole("progressbar").should(
+          "have.attr",
+          "aria-valuenow",
+          "100"
+        );
+      });
+    });
+
+    context("when given value above 100", () => {
+      it("should clamp aria-valuenow to 100", () => {
+        cy.mount(<ProductProgressbar value={150} />);
+        cy.findByRole("progressbar").should(
+          "have.attr",
+          "aria-valuenow",
+          "100"
+        );
+      });
+    });
+
+    context("when given value below 0", () => {
+      it("should clamp aria-valuenow to 0", () => {
+        cy.mount(<ProductProgressbar value={-20} />);
+        cy.findByRole("progressbar").should("have.attr", "aria-valuenow", "0");
+      });
+    });
+  });
+
+  context("styles", () => {
+    context("containerStyle", () => {
+      context("when given background-color red", () => {
+        it("should render background color with rgb(255, 0, 0)", () => {
+          cy.mount(
+            <ProductProgressbar
+              value={50}
+              styles={{
+                containerStyle: css`
+                  background-color: red;
+                `,
+              }}
+            />
+          );
+          cy.findByRole("progressbar").should(
+            "have.css",
+            "background-color",
+            "rgb(255, 0, 0)"
+          );
+        });
+      });
+    });
+
+    context("valueBarStyle", () => {
+      context("when given background-color blue", () => {
+        it("should render the fill with rgb(0, 0, 255)", () => {
+          cy.mount(
+            <ProductProgressbar
+              value={50}
+              styles={{
+                valueBarStyle: css`
+                  background-color: blue;
+                `,
+              }}
+            />
+          );
+          cy.findByLabelText("progressbar-fill")
+
+            .should("have.css", "background-color", "rgb(0, 0, 255)");
+        });
+      });
+    });
+
+    context("labelStyle", () => {
+      context("when given color green", () => {
+        it("should render the label with rgb(0, 128, 0)", () => {
+          cy.mount(
+            <ProductProgressbar
+              value={50}
+              labeling="right"
+              styles={{
+                labelStyle: css`
+                  color: green;
+                `,
+              }}
+            />
+          );
+          cy.findByLabelText("progressbar-label").should(
+            "have.css",
+            "color",
+            "rgb(0, 128, 0)"
+          );
+        });
+      });
+    });
+  });
+});

--- a/test/component/progressbar.cy.tsx
+++ b/test/component/progressbar.cy.tsx
@@ -10,6 +10,32 @@ describe("Progressbar", () => {
     return <Progressbar {...props} />;
   }
 
+  context("id", () => {
+    context("when given id", () => {
+      it("renders id in the progressbar", () => {
+        cy.mount(
+          <ProductProgressbar id="progressbar-coneto" indeterminate={true} />
+        );
+        cy.get("#progressbar-coneto").should("exist");
+      });
+    });
+  });
+
+  context("className", () => {
+    it("renders the default className", () => {
+      cy.mount(<ProductProgressbar indeterminate={true} />);
+      cy.get(".coneto-progressbar").should("exist");
+    });
+
+    context("when given class test", () => {
+      it("renders another class in the element", () => {
+        cy.mount(<ProductProgressbar className="test" indeterminate={true} />);
+        cy.get(".coneto-progressbar").should("exist");
+        cy.get(".test").should("exist");
+      });
+    });
+  });
+
   context("variant", () => {
     const variantCases: Array<{
       variant: ProgressbarVariant;

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -4,6 +4,7 @@ import { ToolbarVariant } from "./../components/toolbar";
 import { BaseSteplineItem } from "./../constants/step-component-util";
 import { TipMenuVariant } from "./../components/tip-menu";
 import { ToastVariant } from "./../components/toast";
+import { ProgressbarVariant } from "./../components/progressbar";
 
 // body
 export interface BodyThemeConfig {
@@ -474,6 +475,17 @@ export interface PhoneboxThemeConfig extends BodyThemeConfig {
   optionHighlightedBackground?: string;
 }
 
+// progressbar.tsx
+export interface ProgressbarVariantTheme
+  extends Omit<BodyThemeConfig, "borderColor"> {
+  barColor: string;
+  trackColor: string;
+}
+
+export type ProgressbarThemeConfig = {
+  [K in ProgressbarVariant]: ProgressbarVariantTheme;
+};
+
 // radio.tsx
 export interface RadioThemeConfig extends BodyThemeConfig {
   checkedBorderColor?: string;
@@ -823,6 +835,7 @@ export interface AppTheme {
   pagination: PaginationThemeConfig;
   pinbox: PinboxThemeConfig;
   phonebox: PhoneboxThemeConfig;
+  progressbar: ProgressbarThemeConfig;
   radio: RadioThemeConfig;
   rating: RatingThemeConfig;
   richEditor: RichEditorThemeConfig;

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1155,27 +1155,37 @@ export function createProgressbarTheme(
   const defaultTheme: ProgressbarThemeConfig = {
     primary: {
       backgroundColor: "#e7f2fc",
-      textColor: "#2a63b4",
-      barColor: "#2a63b4",
-      trackColor: "#bdd9f5",
+      textColor: "#5B63F6",
+      barColor: "#5B63F6",
+      trackColor: "#C7CCFF",
     },
+
     success: {
       backgroundColor: "#e9f3e8",
-      textColor: "#43843d",
-      barColor: "#43843d",
-      trackColor: "#b5d9b2",
+      textColor: "#22C55E",
+      barColor: "#22C55E",
+      trackColor: "#BBF7D0",
     },
+
     danger: {
       backgroundColor: "#f6e7e7",
-      textColor: "#b92c25",
-      barColor: "#b92c25",
-      trackColor: "#f0b8b6",
+      textColor: "#F43F5E",
+      barColor: "#F43F5E",
+      trackColor: "#FECDD3",
     },
+
     warning: {
       backgroundColor: "#fbf0e4",
-      textColor: "#9e5b20",
-      barColor: "#9e5b20",
-      trackColor: "#f5ceaa",
+      textColor: "#F59E0B",
+      barColor: "#F59E0B",
+      trackColor: "#FDE68A",
+    },
+
+    neutral: {
+      backgroundColor: "#f8fafc",
+      textColor: "#64748B",
+      barColor: "#64748B",
+      trackColor: "#CBD5E1",
     },
   };
 
@@ -1195,6 +1205,10 @@ export function createProgressbarTheme(
     warning: mergeTheme(
       defaultTheme.warning,
       ...themeConfigurations.map((o) => o.warning ?? {})
+    ),
+    neutral: mergeTheme(
+      defaultTheme.neutral,
+      ...themeConfigurations.map((o) => o.neutral ?? {})
     ),
   };
 }

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -43,6 +43,7 @@ import {
   PaperDialogThemeConfig,
   PhoneboxThemeConfig,
   PinboxThemeConfig,
+  ProgressbarThemeConfig,
   RadioThemeConfig,
   RatingThemeConfig,
   RichEditorThemeConfig,
@@ -1146,6 +1147,56 @@ export function createPhoneboxTheme(
     },
     ...themeConfigurations
   );
+}
+
+export function createProgressbarTheme(
+  ...themeConfigurations: Array<Partial<ProgressbarThemeConfig>>
+): ProgressbarThemeConfig {
+  const defaultTheme: ProgressbarThemeConfig = {
+    primary: {
+      backgroundColor: "#e7f2fc",
+      textColor: "#2a63b4",
+      barColor: "#2a63b4",
+      trackColor: "#bdd9f5",
+    },
+    success: {
+      backgroundColor: "#e9f3e8",
+      textColor: "#43843d",
+      barColor: "#43843d",
+      trackColor: "#b5d9b2",
+    },
+    danger: {
+      backgroundColor: "#f6e7e7",
+      textColor: "#b92c25",
+      barColor: "#b92c25",
+      trackColor: "#f0b8b6",
+    },
+    warning: {
+      backgroundColor: "#fbf0e4",
+      textColor: "#9e5b20",
+      barColor: "#9e5b20",
+      trackColor: "#f5ceaa",
+    },
+  };
+
+  return {
+    primary: mergeTheme(
+      defaultTheme.primary,
+      ...themeConfigurations.map((o) => o.primary ?? {})
+    ),
+    success: mergeTheme(
+      defaultTheme.success,
+      ...themeConfigurations.map((o) => o.success ?? {})
+    ),
+    danger: mergeTheme(
+      defaultTheme.danger,
+      ...themeConfigurations.map((o) => o.danger ?? {})
+    ),
+    warning: mergeTheme(
+      defaultTheme.warning,
+      ...themeConfigurations.map((o) => o.warning ?? {})
+    ),
+  };
 }
 
 // radio.tsx

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -69,6 +69,7 @@ import {
   createWheelTheme,
   createLaunchpadTheme,
   createToastTheme,
+  createProgressbarTheme,
 } from "./creator";
 
 // Dark
@@ -551,6 +552,33 @@ const darkPinbox = createPinboxTheme(darkBody, darkFieldLane);
 
 const darkPhonebox = createPhoneboxTheme(darkBody, darkFieldLane);
 
+const darkProgressbar = createProgressbarTheme({
+  primary: {
+    backgroundColor: "#1e293b",
+    textColor: "#93c5fd",
+    barColor: "#60a5fa",
+    trackColor: "#334155",
+  },
+  success: {
+    backgroundColor: "#1f2d1f",
+    textColor: "#86efac",
+    barColor: "#4ade80",
+    trackColor: "#2f4a33",
+  },
+  danger: {
+    backgroundColor: "#2d1f1f",
+    textColor: "#fca5a5",
+    barColor: "#f87171",
+    trackColor: "#4a2f2f",
+  },
+  warning: {
+    backgroundColor: "#2d241f",
+    textColor: "#fdba74",
+    barColor: "#fb923c",
+    trackColor: "#4a392f",
+  },
+});
+
 const darkRadio = createRadioTheme(darkBody, {
   borderColor: "#374151",
   checkedBorderColor: "#1465d3bf",
@@ -887,6 +915,7 @@ export const darkTheme: AppTheme = {
   pagination: darkPagination,
   pinbox: darkPinbox,
   phonebox: darkPhonebox,
+  progressbar: darkProgressbar,
   radio: darkRadio,
   rating: darkRating,
   richEditor: darkRichEditor,
@@ -959,6 +988,7 @@ export {
   darkPagination,
   darkPinbox,
   darkPhonebox,
+  darkProgressbar,
   darkRadio,
   darkRating,
   darkRichEditor,

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -556,26 +556,36 @@ const darkProgressbar = createProgressbarTheme({
   primary: {
     backgroundColor: "#1e293b",
     textColor: "#93c5fd",
-    barColor: "#60a5fa",
+    barColor: "#6C77FF",
     trackColor: "#334155",
   },
+
   success: {
     backgroundColor: "#1f2d1f",
     textColor: "#86efac",
-    barColor: "#4ade80",
+    barColor: "#3DDC84",
     trackColor: "#2f4a33",
   },
+
   danger: {
     backgroundColor: "#2d1f1f",
     textColor: "#fca5a5",
-    barColor: "#f87171",
+    barColor: "#F06B82",
     trackColor: "#4a2f2f",
   },
+
   warning: {
     backgroundColor: "#2d241f",
     textColor: "#fdba74",
-    barColor: "#fb923c",
+    barColor: "#E6B84F",
     trackColor: "#4a392f",
+  },
+
+  neutral: {
+    backgroundColor: "#1f2937",
+    textColor: "#cbd5e1",
+    barColor: "#94A3B8",
+    trackColor: "#334155",
   },
 });
 

--- a/theme/mode/light.ts
+++ b/theme/mode/light.ts
@@ -68,6 +68,7 @@ import {
   createWheelTheme,
   createTitleTheme,
   createToastTheme,
+  createProgressbarTheme,
 } from "./creator";
 
 // Light
@@ -164,6 +165,8 @@ const lightPagination = createPaginationTheme(lightBody, lightFieldLane);
 const lightPinbox = createPinboxTheme(lightBody, lightFieldLane);
 
 const lightPhonebox = createPhoneboxTheme(lightBody, lightFieldLane);
+
+const lightProgressbar = createProgressbarTheme();
 
 const lightRadio = createRadioTheme(lightBody);
 
@@ -278,6 +281,7 @@ export const lightTheme: AppTheme = {
   pagination: lightPagination,
   pinbox: lightPinbox,
   phonebox: lightPhonebox,
+  progressbar: lightProgressbar,
   radio: lightRadio,
   rating: lightRating,
   richEditor: lightRichEditor,
@@ -350,6 +354,7 @@ export {
   lightPagination,
   lightPinbox,
   lightPhonebox,
+  lightProgressbar,
   lightRadio,
   lightRating,
   lightRichEditor,


### PR DESCRIPTION
Description:
This pull request introduces a `Progressbar` component in `controls` category to provide visual feedback for task and process progress. It support `determinate` and `indeterminates` states, multiple `variants`, configurable progress direction, optional percentage labelling, and custom styling.

The following props are available to configure the progress value, appearance, animation, labeling, and direction:

* `value` — Progress value between `0` and `100`.
* `variant` — Color variant of the progress bar.
* `indeterminate` — Shows a loading animation when progress is unknown.
* `labeling` — Displays the percentage label on the left, right, or hides it.
* `directionTo` — Sets the progress direction.
* `styles` — Applies custom styles to the component.

The following style targets are available to customize the appearance of the component:

* `containerStyle` — Styles the container.
* `valueBarStyle` — Styles the filled bar.
* `labelStyle` — Styles the percentage label.


Source:
[[Feature] SYST-728: Add a `Progressbar` control](https://linear.app/systatum/issue/SYST-728/add-a-progressbar-control)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[] I have created/updated any relevant test code
[x] I have tested it myself