### PR TITLE
[Bug] SYST-730: Apply `Styles` Correctly to `Title` Actions

### DIFF
--- a/components/title.tsx
+++ b/components/title.tsx
@@ -282,7 +282,10 @@ function BaseTitleSection({
                   background-color: ${titleTheme?.icon?.backgroundColor};
 
                   ${section?.styles?.toggleActionStyle}
+                  ${filteredActionsWithSize?.[index]?.styles?.self}
                 `,
+                containerStyle:
+                  filteredActionsWithSize?.[index]?.styles?.containerStyle,
               }}
               maxActionsBeforeCollapsing={section.actions?.length}
               hoverBackgroundColor={titleTheme?.icon?.hoverBackgroundColor}

--- a/components/title.tsx
+++ b/components/title.tsx
@@ -271,26 +271,29 @@ function BaseTitleSection({
           }));
 
           return (
-            <ContextMenu
-              key={index}
-              styles={{
-                self: css`
-                  width: ${resolvedIconSize * 1.4}px;
-                  height: ${resolvedIconSize * 1.4}px;
-                  padding: 20px;
-                  border-radius: 10px;
-                  background-color: ${titleTheme?.icon?.backgroundColor};
+            <>
+              {filteredActionsWithSize.map((action, actionIndex) => (
+                <ContextMenu
+                  key={actionIndex}
+                  styles={{
+                    self: css`
+                      width: ${resolvedIconSize * 1.4}px;
+                      height: ${resolvedIconSize * 1.4}px;
+                      padding: 20px;
+                      border-radius: 10px;
+                      background-color: ${titleTheme?.icon?.backgroundColor};
 
-                  ${section?.styles?.toggleActionStyle}
-                  ${filteredActionsWithSize?.[index]?.styles?.self}
-                `,
-                containerStyle:
-                  filteredActionsWithSize?.[index]?.styles?.containerStyle,
-              }}
-              maxActionsBeforeCollapsing={section.actions?.length}
-              hoverBackgroundColor={titleTheme?.icon?.hoverBackgroundColor}
-              actions={filteredActionsWithSize}
-            />
+                      ${section?.styles?.toggleActionStyle}
+                      ${action.styles?.self}
+                    `,
+                    containerStyle: action.styles?.containerStyle,
+                  }}
+                  maxActionsBeforeCollapsing={section.actions?.length}
+                  hoverBackgroundColor={titleTheme?.icon?.hoverBackgroundColor}
+                  actions={[action]}
+                />
+              ))}
+            </>
           );
         }
 

--- a/test/component/title.cy.tsx
+++ b/test/component/title.cy.tsx
@@ -23,7 +23,7 @@ describe("Title", () => {
   });
 
   context("styles", () => {
-    context("title Actions (specific)", () => {
+    context("actions styles", () => {
       context("containerStyle", () => {
         context("when given border blue color", () => {
           it("renders the blue colors on the container", () => {

--- a/test/component/title.cy.tsx
+++ b/test/component/title.cy.tsx
@@ -1,4 +1,4 @@
-import { RiCloseFill } from "@remixicon/react";
+import { Ri24HoursFill, RiCloseFill, RiCloseLine } from "@remixicon/react";
 import { Title } from "./../../components/title";
 import { Button } from "./../../components/button";
 import { css } from "styled-components";
@@ -23,6 +23,94 @@ describe("Title", () => {
   });
 
   context("styles", () => {
+    context("title Actions (specific)", () => {
+      context("containerStyle", () => {
+        context("when given border blue color", () => {
+          it("renders the blue colors on the container", () => {
+            cy.mount(
+              <Title
+                rightSection={[
+                  {
+                    type: "actions",
+                    actions: [
+                      {
+                        icon: { image: RiCloseLine },
+                        onClick: () => {
+                          console.log("close was clicked");
+                        },
+                        styles: {
+                          containerStyle: css`
+                            border: 1px solid blue;
+                          `,
+                        },
+                      },
+                      {
+                        icon: { image: Ri24HoursFill },
+                        onClick: () => {
+                          console.log("close was clicked");
+                        },
+                      },
+                    ],
+                  },
+                ]}
+              />
+            );
+
+            cy.findAllByLabelText("action-button")
+              .parent()
+              .eq(0)
+              .should("have.css", "border", "1px solid rgb(0, 0, 255)");
+            cy.findAllByLabelText("action-button")
+              .parent()
+              .eq(1)
+              .should("not.have.css", "border", "1px solid rgb(0, 0, 255)");
+          });
+        });
+      });
+
+      context("self", () => {
+        context("when given padding 50px", () => {
+          it("renders specific style with 50px", () => {
+            cy.mount(
+              <Title
+                rightSection={[
+                  {
+                    type: "actions",
+                    actions: [
+                      {
+                        icon: { image: RiCloseLine },
+                        onClick: () => {
+                          console.log("close was clicked");
+                        },
+                        styles: {
+                          self: css`
+                            padding: 50px;
+                          `,
+                        },
+                      },
+                      {
+                        icon: { image: Ri24HoursFill },
+                        onClick: () => {
+                          console.log("close was clicked");
+                        },
+                      },
+                    ],
+                  },
+                ]}
+              />
+            );
+
+            cy.findAllByLabelText("action-button")
+              .eq(0)
+              .should("have.css", "padding", "50px");
+            cy.findAllByLabelText("action-button")
+              .eq(1)
+              .should("have.css", "padding", "20px");
+          });
+        });
+      });
+    });
+
     context("containerStyle", () => {
       context("when given gap: 20px", () => {
         it("should apply container gap", () => {


### PR DESCRIPTION
Description:
This pull request fixes an issue where the `styles` prop on the `Title` component was not applied correctly when defined in `containerStyle` or `self`.

The issue occurred because the `Title` component uses a different rendering mechanism from other components when used within a `ContextMenu`. While other components are automatically moved into a `TipMenu`, `Title` must remain outside the `TipMenu`, which requires additional configuration to ensure its styles are applied correctly. This change enables `Title` styles to work as expected in both `containerStyle` and `self`.

```tsx
<Title
  rightSection={[
    {
      type: "actions",
      actions: [
        {
          icon: {
            image: RiSettings5Line,
            color: TEXT_COLOR,
          },
          onClick: () => {
            onActionClicked(ContentType.Settings);
          },
          styles: {
            containerStyle: css`
              background: black;
            `,
            self: css`
              background: blue;
            `,
          },
        },
      ],
    },
  ]}
/>
```

Source:
[[Bug] SYST-730: Apply `Styles` Correctly to `Title` Actions](https://linear.app/systatum/issue/SYST-730/apply-styles-correctly-to-title-actions)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself