### PR TITLE
[Bug] SYST-738: Do not make status to be `absolute`

### DIFF
--- a/components/statusbar.stories.tsx
+++ b/components/statusbar.stories.tsx
@@ -12,6 +12,7 @@ import {
   RiUserFollowLine,
   RiWindow2Fill,
 } from "@remixicon/react";
+import { generateSentence } from "./../lib/text";
 
 const meta: Meta<typeof Statusbar> = {
   title: "Stage/Statusbar",
@@ -142,84 +143,105 @@ export const Default: Story = {
       : RiFocus3Line;
 
     return (
-      <Statusbar
-        content={{
-          left: [
-            {
-              button: {
-                children: "Page 1 of 53",
-                showSubMenuOn: "self",
-                subMenu: ({ show }) =>
-                  show(<Textbox value={"@systatum/coneto 🚀"} readOnly />),
-              },
-            },
-            {
-              text: "17455 words",
-            },
-            {
-              text: "English (United States)",
-            },
-            {
-              icon: {
-                image: RiUserFollowLine,
-              },
-              text: "Accessibility: Good to go",
-            },
-          ],
-          right: [
-            {
-              button: {
-                showSubMenuOn: "self",
-                icon: {
-                  image: focusIcon,
-                },
-                subMenu: ({ list }) =>
-                  list([
-                    {
-                      caption: "Full window",
-                      icon: { image: RiFullscreenLine },
-                      onClick: () => setPressed(PRESSED_KEYS.FOCUS, true),
-                    },
-                    {
-                      caption: "Zen mode",
-                      icon: { image: RiFocus3Line },
-                      onClick: () => setPressed(PRESSED_KEYS.FOCUS, false),
-                    },
-                  ]),
-                children: "Focus",
-              },
-            },
-            {
-              button: {
-                pressed: isPressed(PRESSED_KEYS.PAGES),
-                onClick: () => togglePressed(PRESSED_KEYS.PAGES),
-                icon: { image: RiPagesLine },
-              },
-            },
-            {
-              button: {
-                pressed: isPressed(PRESSED_KEYS.WINDOW),
-                onClick: () => togglePressed(PRESSED_KEYS.WINDOW),
-                icon: { image: RiWindow2Fill },
-              },
-            },
-            {
-              button: {
-                pressed: isPressed(PRESSED_KEYS.ALIGN_ITEM_LEFT),
-                onClick: () => togglePressed(PRESSED_KEYS.ALIGN_ITEM_LEFT),
-                icon: { image: RiAlignItemLeftLine },
-              },
-            },
-            {
-              button: {
-                pressed: isPressed(PRESSED_KEYS.ALIGN_LEFT),
-                onClick: () => togglePressed(PRESSED_KEYS.ALIGN_LEFT),
-                icon: { image: RiAlignLeft },
-              },
-            },
-          ],
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          position: "relative",
+          gap: "10px",
         }}
-      />
+      >
+        {Array.from({ length: 8 }).map((_, i) => {
+          return (
+            <div key={i}>
+              {generateSentence({
+                minLen: 40,
+                maxLen: 80,
+                seed: i,
+              })}
+            </div>
+          );
+        })}
+        <Statusbar
+          content={{
+            left: [
+              {
+                button: {
+                  children: "Page 1 of 53",
+                  showSubMenuOn: "self",
+                  subMenu: ({ show }) =>
+                    show(<Textbox value={"@systatum/coneto 🚀"} readOnly />),
+                },
+              },
+              {
+                text: "17455 words",
+              },
+              {
+                text: "English (United States)",
+              },
+              {
+                icon: {
+                  image: RiUserFollowLine,
+                },
+                text: "Accessibility: Good to go",
+              },
+            ],
+            right: [
+              {
+                button: {
+                  showSubMenuOn: "self",
+                  icon: {
+                    image: focusIcon,
+                  },
+                  subMenu: ({ list }) =>
+                    list([
+                      {
+                        caption: "Full window",
+                        icon: { image: RiFullscreenLine },
+                        onClick: () => setPressed(PRESSED_KEYS.FOCUS, true),
+                      },
+                      {
+                        caption: "Zen mode",
+                        icon: { image: RiFocus3Line },
+                        onClick: () => setPressed(PRESSED_KEYS.FOCUS, false),
+                      },
+                    ]),
+                  children: "Focus",
+                },
+              },
+              {
+                button: {
+                  pressed: isPressed(PRESSED_KEYS.PAGES),
+                  onClick: () => togglePressed(PRESSED_KEYS.PAGES),
+                  icon: { image: RiPagesLine },
+                },
+              },
+              {
+                button: {
+                  pressed: isPressed(PRESSED_KEYS.WINDOW),
+                  onClick: () => togglePressed(PRESSED_KEYS.WINDOW),
+                  icon: { image: RiWindow2Fill },
+                },
+              },
+              {
+                button: {
+                  pressed: isPressed(PRESSED_KEYS.ALIGN_ITEM_LEFT),
+                  onClick: () => togglePressed(PRESSED_KEYS.ALIGN_ITEM_LEFT),
+                  icon: { image: RiAlignItemLeftLine },
+                },
+              },
+              {
+                button: {
+                  pressed: isPressed(PRESSED_KEYS.ALIGN_LEFT),
+                  onClick: () => togglePressed(PRESSED_KEYS.ALIGN_LEFT),
+                  icon: { image: RiAlignLeft },
+                },
+              },
+            ],
+          }}
+        />
+        <Statusbar.Spacer />
+      </div>
     );
   },
 };

--- a/components/statusbar.stories.tsx
+++ b/components/statusbar.stories.tsx
@@ -162,7 +162,9 @@ export const Default: Story = {
             </div>
           );
         })}
+
         <Statusbar
+          position="fixed"
           content={{
             left: [
               {

--- a/components/statusbar.stories.tsx
+++ b/components/statusbar.stories.tsx
@@ -39,6 +39,17 @@ It supports left and right sections, customizable styling, spacing, transparency
 
 ---
 
+### 📌 Positioning
+
+\`Statusbar\` supports both \`position: fixed\` and \`position: absolute\`.
+
+* \`position: fixed\` keeps the statusbar attached to the bottom of the viewport while scrolling.
+* \`position: absolute\` positions the statusbar relative to its nearest positioned ancestor and allows it to scroll with its container.
+
+\`Statusbar.Spacer\` can be used to reserve space for the statusbar and prevent content from being visually obscured, regardless of the positioning strategy being used.
+
+---
+
 ### 🛠 Usage
 
 \`\`\`tsx

--- a/components/statusbar.tsx
+++ b/components/statusbar.tsx
@@ -260,7 +260,7 @@ const StatusbarWrapper = styled.div<{
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  position: absolute;
+  position: fixed;
   overflow: hidden;
   z-index: 9991999;
   border-top: 1px solid ${({ $theme }) => $theme.borderColor};
@@ -335,6 +335,7 @@ export interface StatusbarSpacerProps {
 function StatusbarSpacer({ desktopWidth, mobileWidth }: StatusbarSpacerProps) {
   return (
     <StyledStatusbarSpacer
+      aria-label="statusbar-spacer"
       $desktopWidth={desktopWidth}
       $mobileWidth={mobileWidth}
     />

--- a/components/statusbar.tsx
+++ b/components/statusbar.tsx
@@ -13,9 +13,18 @@ export interface StatusbarProps {
   hoverBackgroundColor?: string;
   transparent?: boolean;
   size?: number;
+  position?: StatusbarPosition;
   className?: string;
   id?: string;
 }
+
+export const StatusbarPosition = {
+  Absolute: "absolute",
+  Fixed: "fixed",
+} as const;
+
+export type StatusbarPosition =
+  (typeof StatusbarPosition)[keyof typeof StatusbarPosition];
 
 export interface StatusbarContent {
   left?: StatusbarItem[];
@@ -36,6 +45,7 @@ function Statusbar({
   hoverBackgroundColor,
   transparent,
   size = 11,
+  position,
   className,
   id,
 }: StatusbarProps) {
@@ -45,6 +55,7 @@ function Statusbar({
   return (
     <StatusbarWrapper
       id={id}
+      $position={position}
       className={applyClassName("status-bar", className)}
       $theme={statusbarTheme}
       aria-label="statusbar-wrapper"
@@ -246,6 +257,7 @@ const StatusbarWrapper = styled.div<{
   $style?: CSSProp;
   $transparent?: boolean;
   $theme?: StatusbarThemeConfig;
+  $position?: StatusbarPosition;
 }>`
   *,
   ::before,
@@ -256,11 +268,12 @@ const StatusbarWrapper = styled.div<{
   color: ${({ $theme }) => $theme.textColor};
   bottom: 0;
   left: 0;
+  right: 0;
   width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  position: fixed;
+  position: ${({ $position }) => $position ?? "absolute"};
   overflow: hidden;
   z-index: 9991999;
   border-top: 1px solid ${({ $theme }) => $theme.borderColor};

--- a/test/component/statusbar.cy.tsx
+++ b/test/component/statusbar.cy.tsx
@@ -136,12 +136,49 @@ describe("Statusbar", () => {
     cy.viewport(550, 750);
   });
 
+  context("Statusbar.Spacer", () => {
+    context("when scroll to the bottom", () => {
+      it("should not cut the content", () => {
+        cy.mount(
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              position: "relative",
+              overflow: "auto",
+            }}
+            aria-label="wrapper"
+          >
+            {Array.from({ length: 50 }).map((_, i) => {
+              return <div key={i}>Test {i + 1}</div>;
+            })}
+            <ProductStatusbar />
+            <Statusbar.Spacer />
+          </div>
+        );
+        cy.findByText("Test 50").should("not.exist");
+        cy.findByLabelText("wrapper").scrollTo("bottom", {
+          ensureScrollable: false,
+        });
+
+        cy.wait(500);
+
+        cy.findByText("Test 50").should("exist");
+        cy.findByLabelText("statusbar-spacer").should(
+          "have.css",
+          "height",
+          "21px"
+        );
+      });
+    });
+  });
+
   context("styles", () => {
-    it("renders in the most bottom, justify-between, and position absolute", () => {
+    it("renders in the most bottom, justify-between, and position fixed", () => {
       cy.mount(<ProductStatusbar />);
 
       cy.findByLabelText("statusbar-wrapper")
-        .should("have.css", "position", "absolute")
+        .should("have.css", "position", "fixed")
         .and("have.css", "bottom", "0px")
         .and("have.css", "justify-content", "space-between");
     });

--- a/test/component/statusbar.cy.tsx
+++ b/test/component/statusbar.cy.tsx
@@ -173,16 +173,30 @@ describe("Statusbar", () => {
     });
   });
 
-  context("styles", () => {
-    it("renders in the most bottom, justify-between, and position fixed", () => {
-      cy.mount(<ProductStatusbar />);
+  context("position", () => {
+    context("fixed", () => {
+      it("renders in the most bottom, justify-between, and position fixed", () => {
+        cy.mount(<ProductStatusbar />);
 
-      cy.findByLabelText("statusbar-wrapper")
-        .should("have.css", "position", "fixed")
-        .and("have.css", "bottom", "0px")
-        .and("have.css", "justify-content", "space-between");
+        cy.findByLabelText("statusbar-wrapper")
+          .should("have.css", "position", "fixed")
+          .and("have.css", "bottom", "0px")
+          .and("have.css", "justify-content", "space-between");
+      });
     });
 
+    context("absolute", () => {
+      it("renders in the most bottom, justify-between, and position absolute", () => {
+        cy.mount(<ProductStatusbar />);
+
+        cy.findByLabelText("statusbar-wrapper")
+          .should("have.css", "position", "absolute")
+          .and("have.css", "bottom", "0px")
+          .and("have.css", "justify-content", "space-between");
+      });
+    });
+  });
+  context("styles", () => {
     context("self", () => {
       context("when given justify-start", () => {
         it("should render in the left side", () => {


### PR DESCRIPTION
Description:
This pull request updates the `Statusbar` component to use `position: absolute` by default, ensuring it remains consistently positioned at the bottom of the viewport while scrolling. The component continues to support both `fixed` and `absolute` positioning through the `position` prop.

If a bottom spacing/gap is required, use the `Statusbar` component itself rather than relying on external spacing, as the fixed positioning may otherwise cause content to be visually clipped at the bottom of the viewport.

Source:
[[Bug] SYST-738: Do not make status to be absolute](https://linear.app/systatum/issue/SYST-738/do-not-make-status-to-be-absolute)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself