### PR TITLE
[Improvement] SYST-731: Allow scroll-max-ing paper dialog

### DIFF
--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -151,7 +151,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
     const resizeStartY = useRef(0);
     const resizeStartHeight = useRef(0);
 
-    // Track last pointer Y and timestamp for velocity-based minimize on mobile resize
+    // Track last pointer Y and timestamp for velocity-based snap on mobile resize
     const velocityRef = useRef(0);
 
     const dialogRef = useRef<HTMLDivElement>(null);
@@ -330,6 +330,39 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
               }
               setResizeHeight(null);
             }, 300);
+
+            // Fast flick upward → animate smoothly to max height
+          } else if (velocityRef.current < -0.5) {
+            if (!dialogRef.current || !contentRef.current) return;
+
+            // Apply smooth spring-like transition before snapping to max
+            const easing = "cubic-bezier(0.32, 0.72, 0, 1)";
+            const duration = "0.55s";
+            dialogRef.current.style.transition = `min-height ${duration} ${easing}, max-height ${duration} ${easing}`;
+            contentRef.current.style.transition = `height ${duration} ${easing}, max-height ${duration} ${easing}`;
+
+            dialogRef.current.style.minHeight = `${maxPx}px`;
+            dialogRef.current.style.maxHeight = `${maxPx}px`;
+            contentRef.current.style.height = `${maxPx}px`;
+            contentRef.current.style.maxHeight = `${maxPx}px`;
+
+            onResize?.({ height: maxPx });
+
+            // After transition ends, clear inline styles and hand off to React
+            setTimeout(() => {
+              if (dialogRef.current) {
+                dialogRef.current.style.transition = "";
+                dialogRef.current.style.minHeight = "";
+                dialogRef.current.style.maxHeight = "";
+              }
+              if (contentRef.current) {
+                contentRef.current.style.transition = "";
+                contentRef.current.style.height = "";
+                contentRef.current.style.maxHeight = "";
+              }
+              setResizeHeight(maxPx);
+              onResizeComplete?.({ height: maxPx });
+            }, 580);
           } else {
             // Read final height from DOM once, then hand back to React
             const finalHeight =

--- a/test/component/paper-dialog.cy.tsx
+++ b/test/component/paper-dialog.cy.tsx
@@ -558,6 +558,46 @@ describe("PaperDialog", () => {
     });
 
     context("drag behavior", () => {
+      context("when dragging to top", () => {
+        it("should shows to the max height", () => {
+          cy.viewport(500, 700);
+
+          cy.mount(
+            <ProductPaperDialog
+              width="100dvw"
+              height="30dvh"
+              resizable={{
+                maxHeight: "100dvh",
+              }}
+              mobile
+            />
+          );
+
+          cy.findAllByRole("button").eq(0).should("exist").click();
+
+          cy.wait(500);
+
+          cy.findByLabelText("paper-dialog-content").should(
+            "have.css",
+            "height",
+            "164px"
+          );
+
+          cy.findByLabelText("paper-dialog-drag-indicator")
+            .should("exist")
+            .realMouseDown({ position: "center" })
+            .realMouseMove(0, -350)
+            .realMouseUp();
+
+          cy.wait(1000);
+          cy.findByLabelText("paper-dialog-content").should(
+            "have.css",
+            "height",
+            "639.7578125px"
+          );
+        });
+      });
+
       context("when dragging icon drag indicator", () => {
         it("should close the dialog", () => {
           cy.viewport(500, 700);


### PR DESCRIPTION
Description:
This pull request enhances the `PaperDialog` component by improving the top-edge drag behavior. It introduces support for higher-velocity upward dragging, inspired by the existing drag-to-bottom interaction, and ensures consistent and reliable behavior across both directions.

Source:
[[Improvement] SYST-731: Allow scroll-max-ing paper dialog](https://linear.app/systatum/issue/SYST-731/allow-scroll-max-ing-paper-dialog)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself