### PR TITLE
[Improvement] SYST-630: Add disabled to `ChoiceGroup`

### DIFF
--- a/components/checkbox.tsx
+++ b/components/checkbox.tsx
@@ -258,18 +258,21 @@ const InputWrapper = styled.label<{
       : "transparent"};
 
   transition: background-color 0.2s;
-
-  &:hover {
-    background-color: ${({ $highlight, $theme, $checked }) => {
-      if ($highlight && $checked) {
-        return $theme?.highlightCheckedBackgroundColor ?? "#E7F2FC";
-      } else if ($highlight) {
-        return $theme?.highlightHoverBackgroundColor;
-      } else {
-        return "transparent";
+  ${({ $disabled, $highlight, $theme, $checked }) =>
+    !$disabled &&
+    css`
+      &:hover {
+        background-color: ${() => {
+          if ($highlight && $checked) {
+            return $theme?.highlightCheckedBackgroundColor ?? "#E7F2FC";
+          } else if ($highlight) {
+            return $theme?.highlightHoverBackgroundColor;
+          } else {
+            return "transparent";
+          }
+        }};
       }
-    }};
-  }
+    `}
 
   ${({ $disabled }) =>
     $disabled &&

--- a/components/choice-group.tsx
+++ b/components/choice-group.tsx
@@ -30,7 +30,7 @@ function ChoiceGroup({
   styles,
   className,
   id,
-  disabled = true,
+  disabled,
 }: ChoiceGroupProps) {
   const { currentTheme } = useTheme();
   const choiceGroupTheme = currentTheme.choiceGroup;
@@ -45,6 +45,7 @@ function ChoiceGroup({
   return (
     <ChoiceGroupWrapper
       id={id}
+      aria-label="choice-group"
       className={applyClassName("choice-group", className)}
       $disabled={disabled}
       $isRowDirection={isRadioButton}

--- a/components/choice-group.tsx
+++ b/components/choice-group.tsx
@@ -17,6 +17,7 @@ export interface ChoiceGroupProps {
   styles?: ChoiceGroupStyles;
   id?: string;
   className?: string;
+  disabled?: boolean;
 }
 
 export interface ChoiceGroupStyles {
@@ -24,7 +25,13 @@ export interface ChoiceGroupStyles {
   dividerStyle?: CSSProp;
 }
 
-function ChoiceGroup({ children, styles, className, id }: ChoiceGroupProps) {
+function ChoiceGroup({
+  children,
+  styles,
+  className,
+  id,
+  disabled = true,
+}: ChoiceGroupProps) {
   const { currentTheme } = useTheme();
   const choiceGroupTheme = currentTheme.choiceGroup;
 
@@ -39,6 +46,7 @@ function ChoiceGroup({ children, styles, className, id }: ChoiceGroupProps) {
     <ChoiceGroupWrapper
       id={id}
       className={applyClassName("choice-group", className)}
+      $disabled={disabled}
       $isRowDirection={isRadioButton}
       $style={styles?.containerStyle}
       $borderColor={choiceGroupTheme.borderColor}
@@ -65,6 +73,7 @@ function ChoiceGroup({ children, styles, className, id }: ChoiceGroupProps) {
 
         const modifiedChild = cloneElement(componentChild, {
           highlightOnChecked: true,
+          disabled: componentChild?.props?.disabled ?? disabled,
           ...(isRadioButton && {
             styles: {
               ...radioProps?.styles,
@@ -138,6 +147,7 @@ function ChoiceGroup({ children, styles, className, id }: ChoiceGroupProps) {
 const ChoiceGroupWrapper = styled.div<{
   $style?: CSSProp;
   $isRowDirection?: boolean;
+  $disabled?: boolean;
   $borderColor: string;
 }>`
   display: flex;
@@ -146,6 +156,14 @@ const ChoiceGroupWrapper = styled.div<{
   border-radius: 4px;
   overflow: hidden;
   width: 100%;
+
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+      opacity: 0.9;
+      user-select: none;
+    `}
 
   ${({ $isRowDirection }) =>
     $isRowDirection

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -257,24 +257,27 @@ const Label = styled.label<{
   width: 100%;
   transition: background-color 0.2s;
 
-  &:hover {
-    border: 0.5px solid
-      ${({ $highlight, $checked, $isRadio, $theme }) =>
-        $highlight && $checked && !$isRadio
-          ? $theme?.highlightCheckedBorderColor
-          : $highlight && !$isRadio
+  ${({ $disabled, $highlight, $checked, $isRadio, $theme }) =>
+    !$disabled &&
+    css`
+      &:hover {
+        border: 0.5px solid
+          ${$highlight && $checked && !$isRadio
             ? $theme?.highlightCheckedBorderColor
-            : "transparent"};
+            : $highlight && !$isRadio
+              ? $theme?.highlightCheckedBorderColor
+              : "transparent"};
 
-    background-color: ${({ $highlight, $checked, $theme }) => {
-      if ($highlight && $checked) {
-        return $theme?.highlightCheckedBackgroundColor;
-      } else if ($highlight) {
-        return $theme?.highlightBackgroundColor || $theme?.backgroundColor;
+        background-color: ${(() => {
+          if ($highlight && $checked) {
+            return $theme?.highlightCheckedBackgroundColor;
+          } else if ($highlight) {
+            return $theme?.highlightBackgroundColor || $theme?.backgroundColor;
+          }
+          return $theme?.backgroundColor;
+        })()};
       }
-      return $theme?.backgroundColor;
-    }};
-  }
+    `};
 
   ${({ $disabled }) =>
     $disabled &&

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -301,6 +301,9 @@ const HiddenRadio = styled.input<{ $disabled?: boolean; $style?: CSSProp }>`
   position: absolute;
   opacity: 0;
   pointer-events: none;
+  background: none;
+  appearance: none;
+  -webkit-appearance: none;
 
   ${({ $disabled }) =>
     $disabled &&

--- a/test/component/choice-group.cy.tsx
+++ b/test/component/choice-group.cy.tsx
@@ -5,6 +5,53 @@ import { css } from "styled-components";
 
 describe("ChoiceGroup", () => {
   context("Radio", () => {
+    context("when given disabled", () => {
+      beforeEach(() => {
+        cy.window().then((win) => {
+          cy.spy(win.console, "log").as("consoleLog");
+        });
+
+        cy.mount(
+          <ChoiceGroup disabled>
+            {OPTIONS.map((props, index) => (
+              <Radio
+                key={index}
+                name="radioSelected"
+                label={props.label}
+                value={props.value}
+                onChange={(e) =>
+                  console.log(
+                    `The name is ${e.target.name} and the value is ${e.target.value}`
+                  )
+                }
+                styles={{
+                  labelStyle: css`
+                    font-size: 30px;
+                  `,
+                }}
+              />
+            ))}
+          </ChoiceGroup>
+        );
+      });
+
+      it("renders with transparent background", () => {
+        cy.findByLabelText("choice-group").should("have.css", "opacity", "0.9");
+      });
+
+      context("when clicking", () => {
+        it("not render the callback on the console", () => {
+          OPTIONS.map((props) => {
+            cy.findByText(props.label).click();
+            cy.get("@consoleLog").should(
+              "not.have.been.calledWith",
+              `The name is radioSelected and the value is ${props.value}`
+            );
+          });
+        });
+      });
+    });
+
     context("with onChange", () => {
       context("when clicking", () => {
         it("render the callback on the console", () => {
@@ -47,6 +94,49 @@ describe("ChoiceGroup", () => {
   });
 
   context("Checkbox", () => {
+    context("when given disabled", () => {
+      beforeEach(() => {
+        cy.window().then((win) => {
+          cy.spy(win.console, "log").as("consoleLog");
+        });
+
+        cy.mount(
+          <ChoiceGroup disabled>
+            {OPTIONS.map((option, index) => (
+              <Checkbox
+                key={index}
+                value={option.value}
+                description={option.description}
+                name={option.label}
+                label={option.label}
+                onChange={(e) =>
+                  console.log(
+                    `The name is ${e.target.name} and the value is ${e.target.value}`
+                  )
+                }
+              />
+            ))}
+          </ChoiceGroup>
+        );
+      });
+
+      it("renders with transparent background", () => {
+        cy.findByLabelText("choice-group").should("have.css", "opacity", "0.9");
+      });
+
+      context("when clicking", () => {
+        it("not render the callback with args onChange", () => {
+          OPTIONS.map((props) => {
+            cy.findByText(props.label).click();
+            cy.get("@consoleLog").should(
+              "not.have.been.calledWith",
+              `The name is ${props.label} and the value is ${props.value}`
+            );
+          });
+        });
+      });
+    });
+
     context("with onChange", () => {
       context("when clicking", () => {
         it("render the callback with args onChange", () => {


### PR DESCRIPTION
Description:
This pull request introduces a `disabled` prop to the `ChoiceGroup` component to prevent interaction with `radio` and `checkbox` inputs. 

It ensures that `disabled` items cannot be clicked and do not trigger any fallback behavior. The implementation also ensures the prop behaves correctly across all related states.

Source:
[[Improvement] SYST-630: Add disabled to `ChoiceGroup`](https://linear.app/systatum/issue/SYST-630/add-disabled-to-choicegroup)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself