### PR TITLE
[Bug] SYST-750: Fix `z-index` on Toast

### DIFF
--- a/components/toast.tsx
+++ b/components/toast.tsx
@@ -744,11 +744,12 @@ const TOAST_POSITION_STYLE: Record<ToastPosition, CSSProp> = {
 
 const Container = styled.div<{ $position: ToastPosition }>`
   position: fixed;
-  z-index: 9999;
+  z-index: 99949999;
   display: flex;
   flex-direction: column;
   gap: 0;
   pointer-events: none;
+
   ${({ $position }) => TOAST_POSITION_STYLE[$position]}
 `;
 

--- a/components/toast.tsx
+++ b/components/toast.tsx
@@ -744,7 +744,7 @@ const TOAST_POSITION_STYLE: Record<ToastPosition, CSSProp> = {
 
 const Container = styled.div<{ $position: ToastPosition }>`
   position: fixed;
-  z-index: 99949999;
+  z-index: 9995999;
   display: flex;
   flex-direction: column;
   gap: 0;

--- a/components/toast.tsx
+++ b/components/toast.tsx
@@ -92,6 +92,7 @@ export interface ToastProps {
   position?: ToastPosition;
   detailSlot?: ReactNode;
   withLoadingBar?: boolean;
+  zIndex?: number;
   className?: string;
   id?: string;
 }
@@ -627,20 +628,29 @@ interface PositionStore {
   el: HTMLDivElement;
   root: ReturnType<typeof createRoot>;
   items: ToastItemState[];
+  zIndex?: number;
   setItems?: (items: ToastItemState[]) => void;
+  setZIndex?: (z: number | undefined) => void;
 }
 
 const stores = new Map<ToastPosition, PositionStore>();
 
-function getStore(position: ToastPosition): PositionStore {
-  if (stores.has(position)) return stores.get(position)!;
+function getStore(position: ToastPosition, zIndex?: number): PositionStore {
+  if (stores.has(position)) {
+    const store = stores.get(position)!;
+    if (zIndex !== undefined) {
+      store.zIndex = zIndex;
+      store.setZIndex?.(zIndex);
+    }
+    return store;
+  }
 
   const el = document.createElement("div");
   el.setAttribute("toast-portal", position);
   document.body.appendChild(el);
 
   const root = createRoot(el);
-  const store: PositionStore = { el, root, items: [] };
+  const store: PositionStore = { el, root, items: [], zIndex };
   stores.set(position, store);
   return store;
 }
@@ -663,20 +673,29 @@ function ToastBridge({ position }: { position: ToastPosition }) {
 
 function ToastContainer({ position }: { position: ToastPosition }) {
   const [items, setItems] = useState<ToastItemState[]>([]);
+  const [zIndex, setZIndex] = useState<number | undefined>(
+    stores.get(position)?.zIndex
+  );
 
   // Register the setter so the imperative API can push updates in
   useEffect(() => {
     const store = getStore(position);
     store.setItems = setItems;
+    store.setZIndex = setZIndex;
     // Flush any items that arrived before this component mounted
     setItems([...store.items]);
+    setZIndex(store.zIndex);
     return () => {
       store.setItems = undefined;
     };
   }, [position]);
 
   return (
-    <Container $position={position}>
+    <Container
+      aria-label="toast-root-container"
+      $position={position}
+      $zIndex={zIndex}
+    >
       {items.map((item) => (
         <ToastItem
           key={item.id}
@@ -742,9 +761,9 @@ const TOAST_POSITION_STYLE: Record<ToastPosition, CSSProp> = {
   `,
 };
 
-const Container = styled.div<{ $position: ToastPosition }>`
+const Container = styled.div<{ $position: ToastPosition; $zIndex?: number }>`
   position: fixed;
-  z-index: 9995999;
+  z-index: ${({ $zIndex }) => $zIndex ?? 9995999};
   display: flex;
   flex-direction: column;
   gap: 0;
@@ -795,7 +814,7 @@ function show(options: ToastProps): string {
   const position = options.position ?? "top-right";
   const item: ToastItemState = { ...options, id, exiting: false };
 
-  const store = getStore(position);
+  const store = getStore(position, options?.zIndex);
   store.items = [...store.items, item];
   renderStore(store, position);
 

--- a/test/component/toast.cy.tsx
+++ b/test/component/toast.cy.tsx
@@ -160,7 +160,7 @@ describe("Toast", () => {
         disappearAfterMs: 3000,
         withLoadingBar: true,
       });
-      cy.findByLabelText("toast-progress-bar").should(
+      cy.findByLabelText("progressbar-fill").should(
         "have.css",
         "background-color",
         THEME.success.progressColor
@@ -175,10 +175,10 @@ describe("Toast", () => {
           disappearAfterMs: 3000,
           withLoadingBar: true,
         });
-        cy.findByLabelText("toast-progress-bar")
+        cy.findByLabelText("progressbar-fill")
           .should("have.css", "position", "absolute")
           .and("have.css", "bottom", "0px")
-          .and("have.css", "height", "3px");
+          .and("have.css", "height", "6px");
       });
     });
 

--- a/test/component/toast.cy.tsx
+++ b/test/component/toast.cy.tsx
@@ -1,3 +1,4 @@
+import { PaperDialog, PaperDialogRef } from "./../../components/paper-dialog";
 import { Button } from "./../../components/button";
 import {
   Toast,
@@ -6,6 +7,7 @@ import {
   ToastIconPosition,
   ToastVariant,
 } from "./../../components/toast";
+import { useRef } from "react";
 
 const THEME = {
   primary: {
@@ -48,6 +50,48 @@ function openToast(props: ToastProps) {
 describe("Toast", () => {
   afterEach(() => {
     Toast.closeAll();
+  });
+
+  // bug
+  context("when open the paper dialog", () => {
+    context("when clicking the toast", () => {
+      it("still shows the Toast", () => {
+        function ProductPaperDialogAndToast() {
+          const dialogRef = useRef<PaperDialogRef>(null);
+          return (
+            <>
+              <PaperDialog width="100dvw" ref={dialogRef}>
+                <Button
+                  onClick={() => {
+                    Toast.success({
+                      content: "This is Toast component",
+                    });
+                  }}
+                >
+                  Open Toast
+                </Button>
+              </PaperDialog>
+
+              <Button onClick={() => dialogRef?.current?.openDialog()}>
+                Open Paper
+              </Button>
+            </>
+          );
+        }
+        cy.mount(<ProductPaperDialogAndToast />);
+
+        cy.findByText("Open Toast").should("not.exist");
+
+        cy.findByText("Open Paper").click();
+        cy.wait(300);
+
+        cy.findByText("This is Toast component").should("not.exist");
+
+        cy.findByText("Open Toast").should("exist").click();
+
+        cy.findByText("This is Toast component").should("exist");
+      });
+    });
   });
 
   context("variants", () => {

--- a/test/component/toast.cy.tsx
+++ b/test/component/toast.cy.tsx
@@ -94,6 +94,25 @@ describe("Toast", () => {
     });
   });
 
+  context("zIndex", () => {
+    context("when given 99999999", () => {
+      it("renders zIndex with 99999999", () => {
+        openToast({
+          variant: "success",
+          content: "Bar colour",
+          disappearAfterMs: 3000,
+          withLoadingBar: true,
+          zIndex: 99999999,
+        });
+
+        cy.findByLabelText("toast-root-container").should(
+          "have.css",
+          "z-index",
+          "99999999"
+        );
+      });
+    });
+  });
   context("variants", () => {
     const variants: ToastVariant[] = [
       "primary",


### PR DESCRIPTION
Description:
This pull request fixes a toast `z-index` issue where the toast is not visible when rendered inside components such as `<PaperDialog />` or other elements with a higher `z-index` than the toast itself.

It also ensures that the `Toast` is correctly displayed when used inside `<PaperDialog />` and introduces a new `z-index` prop to enrich flexibility index for the `Toast` component.

Source:
[[Bug] SYST-750: Fix `z-index` on Toast](https://linear.app/systatum/issue/SYST-750/fix-z-index-on-toast)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself