### PR TITLE
[Improvement] SYST-743: Register all possible screens by just using one root ScreenTransition component

### DIFF
--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -58,6 +58,8 @@ export interface PaperDialogProps {
   resizable?: boolean | PaperDialogResizable;
   onResize?: (size: { width?: number; height?: number }) => void;
   onResizeComplete?: (size: { width?: number; height?: number }) => void;
+  initialDialogState?: PaperDialogState;
+  skipInitialAnimation?: boolean;
 }
 
 export interface PaperDialogResizable {
@@ -126,6 +128,8 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
       resizable: _resizable = false,
       onResize,
       onResizeComplete,
+      initialDialogState = "closed",
+      skipInitialAnimation,
     },
     ref
   ) => {
@@ -139,7 +143,8 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
     const resizable = resolveResizable(_resizable);
 
     const [showTitlebar, setShowTitlebar] = useState(false);
-    const [dialogState, setDialogState] = useState<PaperDialogState>("closed");
+    const [dialogState, setDialogState] =
+      useState<PaperDialogState>(initialDialogState);
 
     const [resizeWidth, setResizeWidth] = useState<number | null>(null);
     const [resizeHeight, setResizeHeight] = useState<number | null>(null);
@@ -538,7 +543,13 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
               `}
               ${styles?.containerStyle}
             `}
-            initial={mobile ? { y: "100%" } : { x: isLeft ? "-100%" : "100%" }}
+            initial={
+              skipInitialAnimation
+                ? false
+                : mobile
+                  ? { y: "100%" }
+                  : { x: isLeft ? "-100%" : "100%" }
+            }
             animate={
               dialogState === "minimized"
                 ? mobile

--- a/components/screen-transition.stories.tsx
+++ b/components/screen-transition.stories.tsx
@@ -23,7 +23,15 @@ export const Default: Story = {
     const { currentTheme } = useTheme();
     const bodyTheme = currentTheme?.body;
 
-    const [activeScreens, setActiveScreens] = useState([]);
+    const screens = {
+      a: PageA,
+      b: PageB,
+      c: PageC,
+    };
+
+    type ScreenKey = keyof typeof screens;
+
+    const [activeScreens, setActiveScreens] = useState<ScreenKey[]>([]);
 
     function PageTitle({
       text,
@@ -87,7 +95,7 @@ export const Default: Story = {
       );
     }
 
-    function PageC({ goBack, goToScreen }: ScreenProps) {
+    function PageC({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
       return (
         <Wrapper>
           <PageTitle text="Page C" goBack={goBack} />
@@ -96,7 +104,7 @@ export const Default: Story = {
       );
     }
 
-    function PageB({ goBack, goToScreen }: ScreenProps) {
+    function PageB({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
       return (
         <Wrapper>
           <PageTitle text="Page B" goBack={goBack} />
@@ -105,7 +113,7 @@ export const Default: Story = {
       );
     }
 
-    function PageA({ goBack, goToScreen }: ScreenProps) {
+    function PageA({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
       return (
         <Wrapper>
           <PageTitle text="Page A" goBack={goBack} />
@@ -124,11 +132,7 @@ export const Default: Story = {
 
         {/* Imagine this generated in app.tsx */}
         <ScreenTransition
-          screens={{
-            a: PageA,
-            b: PageB,
-            c: PageC,
-          }}
+          screens={screens}
           activeScreens={activeScreens}
           onScreenChange={(screens) => setActiveScreens(screens)}
         />
@@ -142,7 +146,19 @@ export const WithInitializeScreens: Story = {
     const { currentTheme } = useTheme();
     const bodyTheme = currentTheme?.body;
 
-    const [activeScreens, setActiveScreens] = useState(["a", "b", "c"]);
+    const screens = {
+      a: PageA,
+      b: PageB,
+      c: PageC,
+    };
+
+    type ScreenKey = keyof typeof screens;
+
+    const [activeScreens, setActiveScreens] = useState<ScreenKey[]>([
+      "a",
+      "b",
+      "c",
+    ]);
 
     function PageTitle({
       text,
@@ -206,7 +222,7 @@ export const WithInitializeScreens: Story = {
       );
     }
 
-    function PageC({ goBack, goToScreen }: ScreenProps) {
+    function PageC({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
       return (
         <Wrapper>
           <PageTitle text="Page C" goBack={goBack} />
@@ -215,7 +231,7 @@ export const WithInitializeScreens: Story = {
       );
     }
 
-    function PageB({ goBack, goToScreen }: ScreenProps) {
+    function PageB({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
       return (
         <Wrapper>
           <PageTitle text="Page B" goBack={goBack} />
@@ -224,7 +240,7 @@ export const WithInitializeScreens: Story = {
       );
     }
 
-    function PageA({ goBack, goToScreen }: ScreenProps) {
+    function PageA({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
       return (
         <Wrapper>
           <PageTitle text="Page A" goBack={goBack} />
@@ -243,11 +259,7 @@ export const WithInitializeScreens: Story = {
 
         {/* Imagine this generated in app.tsx */}
         <ScreenTransition
-          screens={{
-            a: PageA,
-            b: PageB,
-            c: PageC,
-          }}
+          screens={screens}
           activeScreens={activeScreens}
           onScreenChange={(screens) => setActiveScreens(screens)}
         />

--- a/components/screen-transition.stories.tsx
+++ b/components/screen-transition.stories.tsx
@@ -137,6 +137,125 @@ export const Default: Story = {
   },
 };
 
+export const WithInitializeScreens: Story = {
+  render: () => {
+    const { currentTheme } = useTheme();
+    const bodyTheme = currentTheme?.body;
+
+    const [activeScreens, setActiveScreens] = useState(["a", "b", "c"]);
+
+    function PageTitle({
+      text,
+      goBack = null,
+    }: {
+      text?: string;
+    } & Partial<ScreenProps>) {
+      return (
+        <Title
+          size="md"
+          leftSection={
+            goBack
+              ? [
+                  {
+                    styles: {
+                      toggleActionStyle: css`
+                        padding: 4px;
+                        height: 30px;
+                        width: 30px;
+                        border-radius: 4px;
+                      `,
+                    },
+                    type: "actions",
+                    actions: [
+                      {
+                        caption: "back",
+                        icon: { image: RiArrowLeftSLine },
+                        onClick: () => {
+                          goBack();
+                        },
+                      },
+                    ],
+                  },
+                ]
+              : []
+          }
+          text={text}
+          styles={{
+            containerStyle: css`
+              border-bottom: 1px solid ${bodyTheme?.borderColor || "#ececec"};
+              height: 53px;
+              justify-content: center;
+              align-items: center;
+              padding: 0 6px;
+            `,
+            textContainerStyle: css`
+              align-items: center;
+            `,
+            titleStyle: css`
+              justify-content: center;
+              font-size: 20px;
+
+              ${goBack &&
+              css`
+                padding-right: 40px;
+              `}
+              align-items: center;
+            `,
+          }}
+        />
+      );
+    }
+
+    function PageC({ goBack, goToScreen }: ScreenProps) {
+      return (
+        <Wrapper>
+          <PageTitle text="Page C" goBack={goBack} />
+          <Button onClick={() => goToScreen("a")}>Go to Page A</Button>
+        </Wrapper>
+      );
+    }
+
+    function PageB({ goBack, goToScreen }: ScreenProps) {
+      return (
+        <Wrapper>
+          <PageTitle text="Page B" goBack={goBack} />
+          <Button onClick={() => goToScreen("c")}>Go to Page C</Button>
+        </Wrapper>
+      );
+    }
+
+    function PageA({ goBack, goToScreen }: ScreenProps) {
+      return (
+        <Wrapper>
+          <PageTitle text="Page A" goBack={goBack} />
+          <Button onClick={() => goToScreen("b")}>Go to Page B</Button>
+        </Wrapper>
+      );
+    }
+
+    return (
+      <>
+        {/* Imagine this generated in index.tsx */}
+        <Wrapper>
+          <PageTitle text="Index Screen" />
+          <Button onClick={() => setActiveScreens(["a"])}>Go to Page A</Button>
+        </Wrapper>
+
+        {/* Imagine this generated in app.tsx */}
+        <ScreenTransition
+          screens={{
+            a: PageA,
+            b: PageB,
+            c: PageC,
+          }}
+          activeScreens={activeScreens}
+          onScreenChange={(screens) => setActiveScreens(screens)}
+        />
+      </>
+    );
+  },
+};
+
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;

--- a/components/screen-transition.stories.tsx
+++ b/components/screen-transition.stories.tsx
@@ -5,6 +5,7 @@ import { RiArrowLeftSLine } from "@remixicon/react";
 import styled, { css } from "styled-components";
 import { Button } from "./button";
 import { useTheme } from "./../theme";
+import { useState } from "react";
 
 const meta: Meta<typeof ScreenTransition> = {
   title: "Mobile/ScreenTransition",
@@ -22,9 +23,11 @@ export const Default: Story = {
     const { currentTheme } = useTheme();
     const bodyTheme = currentTheme?.body;
 
+    const [activeScreens, setActiveScreens] = useState([]);
+
     function PageTitle({
       text,
-      gotoPrevScreen = null,
+      goBack = null,
     }: {
       text?: string;
     } & Partial<ScreenProps>) {
@@ -32,7 +35,7 @@ export const Default: Story = {
         <Title
           size="md"
           leftSection={
-            gotoPrevScreen
+            goBack
               ? [
                   {
                     styles: {
@@ -49,7 +52,7 @@ export const Default: Story = {
                         caption: "back",
                         icon: { image: RiArrowLeftSLine },
                         onClick: () => {
-                          gotoPrevScreen();
+                          goBack();
                         },
                       },
                     ],
@@ -73,7 +76,7 @@ export const Default: Story = {
               justify-content: center;
               font-size: 20px;
 
-              ${gotoPrevScreen &&
+              ${goBack &&
               css`
                 padding-right: 40px;
               `}
@@ -84,49 +87,53 @@ export const Default: Story = {
       );
     }
 
-    function PageC() {
+    function PageC({ goBack, goToScreen }: ScreenProps) {
       return (
-        <ScreenTransition>
-          {({ gotoPrevScreen }) => (
-            <Wrapper>
-              <PageTitle text="Page C" gotoPrevScreen={gotoPrevScreen} />
-            </Wrapper>
-          )}
-        </ScreenTransition>
+        <Wrapper>
+          <PageTitle text="Page C" goBack={goBack} />
+          <Button onClick={() => goToScreen("a")}>Go to Page A</Button>
+        </Wrapper>
       );
     }
 
-    function PageB() {
+    function PageB({ goBack, goToScreen }: ScreenProps) {
       return (
-        <ScreenTransition nextScreen={PageC}>
-          {({ gotoPrevScreen, gotoNextScreen }) => (
-            <Wrapper>
-              <PageTitle text="Page B" gotoPrevScreen={gotoPrevScreen} />
-              <Button onClick={gotoNextScreen ?? undefined}>
-                Go to Page C
-              </Button>
-            </Wrapper>
-          )}
-        </ScreenTransition>
+        <Wrapper>
+          <PageTitle text="Page B" goBack={goBack} />
+          <Button onClick={() => goToScreen("c")}>Go to Page C</Button>
+        </Wrapper>
       );
     }
 
-    function PageA() {
+    function PageA({ goBack, goToScreen }: ScreenProps) {
       return (
-        <ScreenTransition nextScreen={PageB}>
-          {({ gotoNextScreen }) => (
-            <Wrapper>
-              <PageTitle text="Page A" gotoPrevScreen={null} />
-              <Button onClick={gotoNextScreen ?? undefined}>
-                Go to Page B
-              </Button>
-            </Wrapper>
-          )}
-        </ScreenTransition>
+        <Wrapper>
+          <PageTitle text="Page A" goBack={goBack} />
+          <Button onClick={() => goToScreen("b")}>Go to Page B</Button>
+        </Wrapper>
       );
     }
 
-    return <PageA />;
+    return (
+      <>
+        {/* Imagine this generated in index.tsx */}
+        <Wrapper>
+          <PageTitle text="Index Screen" />
+          <Button onClick={() => setActiveScreens(["a"])}>Go to Page A</Button>
+        </Wrapper>
+
+        {/* Imagine this generated in app.tsx */}
+        <ScreenTransition
+          screens={{
+            a: PageA,
+            b: PageB,
+            c: PageC,
+          }}
+          activeScreens={activeScreens}
+          onScreenChange={(screens) => setActiveScreens(screens)}
+        />
+      </>
+    );
   },
 };
 

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -1,74 +1,147 @@
 import React, {
-  cloneElement,
-  createContext,
-  isValidElement,
+  ComponentType,
   ReactNode,
-  useContext,
+  useCallback,
+  useEffect,
   useRef,
 } from "react";
 import { PaperDialog, PaperDialogRef } from "./paper-dialog";
 import { css } from "styled-components";
 
 export interface ScreenProps {
-  gotoNextScreen: (() => void) | null;
-  gotoPrevScreen: (() => void) | null;
+  goToScreen: ((key: string) => void) | null;
+  goBack: (() => void) | null;
 }
+
+type ScreensMap = Record<string, ComponentType<Partial<ScreenProps>>>;
 
 export interface ScreenTransitionProps {
-  children: ReactNode | ((props: ScreenProps) => ReactNode);
-  nextScreen?: React.ComponentType | null;
+  /** Registry of every screen this transition can render, keyed by id */
+  screens: ScreensMap;
+  /** Ordered stack of active screen keys. First = base, rest = nested dialogs */
+  activeScreens: string[];
+  /** Called with the next stack whenever navigation happens */
+  onScreenChange: (screens: string[]) => void;
 }
 
-const ParentDialogContext =
-  createContext<React.RefObject<PaperDialogRef | null> | null>(null);
-
 function ScreenTransition({
-  children,
-  nextScreen: NextScreen,
+  screens,
+  activeScreens,
+  onScreenChange,
 }: ScreenTransitionProps) {
-  const parentDialogRef = useContext(ParentDialogContext);
+  const dialogRefsRef = useRef<
+    Map<number, React.RefObject<PaperDialogRef | null>>
+  >(new Map());
 
-  const dialogRef = useRef<PaperDialogRef>(null);
+  const mountedIndicesRef = useRef<Set<number> | null>(null);
+  if (mountedIndicesRef.current === null) {
+    const seeded = new Set<number>();
+    // Seed all initial screens — including index 0 — so none animate on mount
+    for (let i = 0; i < activeScreens.length; i++) {
+      seeded.add(i);
+    }
+    mountedIndicesRef.current = seeded;
+  }
 
-  const injectedProps: ScreenProps = {
-    gotoNextScreen: NextScreen
-      ? () => {
-          dialogRef?.current?.openDialog();
-        }
-      : null,
-    gotoPrevScreen: parentDialogRef
-      ? () => {
-          parentDialogRef?.current?.minimizeDialog();
-
-          setTimeout(() => {
-            parentDialogRef?.current?.closeDialog();
-          }, 400);
-        }
-      : null,
+  const getDialogRef = (index: number) => {
+    if (!dialogRefsRef.current.has(index)) {
+      dialogRefsRef.current.set(index, React.createRef<PaperDialogRef>());
+    }
+    return dialogRefsRef.current.get(index)!;
   };
 
-  return (
-    <ParentDialogContext.Provider value={dialogRef}>
-      {typeof children === "function"
-        ? children(injectedProps)
-        : isValidElement(children)
-          ? cloneElement(children, injectedProps)
-          : children}
-      <PaperDialog
-        styles={{
-          contentStyle: css`
-            gap: 0px;
-          `,
-        }}
-        ref={dialogRef}
-        closable={false}
-        controls={[]}
-        width={"100dvw"}
-        height={"100dvh"}
+  const goToScreen = useCallback(
+    (key: string) => {
+      if (!screens[key]) {
+        console.warn(`ScreenTransition: screen "${key}" is not registered`);
+        return;
+      }
+      onScreenChange([...activeScreens, key]);
+    },
+    [screens, activeScreens, onScreenChange]
+  );
+
+  const goBack = useCallback(() => {
+    if (activeScreens.length === 0) return;
+
+    const topIndex = activeScreens.length - 1; // the dialog wrapping the top screen
+    const ref = dialogRefsRef.current.get(topIndex);
+
+    ref?.current?.minimizeDialog();
+    setTimeout(() => {
+      ref?.current?.closeDialog();
+      onScreenChange(activeScreens.slice(0, -1));
+      mountedIndicesRef.current!.delete(topIndex);
+    }, 300);
+  }, [activeScreens, onScreenChange]);
+
+  const renderStack = (index: number): ReactNode => {
+    const key = activeScreens[index];
+    if (!key) return null;
+
+    const ScreenComponent = screens[key] as ComponentType<Partial<ScreenProps>>;
+    if (!ScreenComponent) {
+      console.warn(`ScreenTransition: screen "${key}" is not registered`);
+      return null;
+    }
+
+    const screenProps: ScreenProps = {
+      goToScreen,
+      goBack,
+    };
+
+    const skipInitialAnimation = mountedIndicesRef.current!.has(index);
+    if (!skipInitialAnimation) mountedIndicesRef.current!.add(index);
+
+    return (
+      <DialogLevel
+        dialogRef={getDialogRef(index)}
+        skipInitialAnimation={skipInitialAnimation}
       >
-        {NextScreen && <NextScreen />}
-      </PaperDialog>
-    </ParentDialogContext.Provider>
+        <ScreenComponent {...screenProps} />
+        {index < activeScreens.length - 1 && renderStack(index + 1)}
+      </DialogLevel>
+    );
+  };
+
+  if (activeScreens.length === 0) return null;
+
+  return renderStack(0);
+}
+
+function DialogLevel({
+  dialogRef,
+  children,
+  skipInitialAnimation,
+}: {
+  dialogRef: React.RefObject<PaperDialogRef | null>;
+  children: ReactNode;
+  skipInitialAnimation?: boolean;
+}) {
+  useEffect(() => {
+    // Only animate-open if this dialog wasn't pre-existing/already mounted.
+    if (!skipInitialAnimation) {
+      dialogRef?.current?.openDialog();
+    }
+  }, [dialogRef, skipInitialAnimation]);
+
+  return (
+    <PaperDialog
+      styles={{
+        contentStyle: css`
+          gap: 0px;
+        `,
+      }}
+      ref={dialogRef}
+      closable={false}
+      controls={[]}
+      width={"100dvw"}
+      height={"100dvh"}
+      initialDialogState={skipInitialAnimation ? "restored" : "closed"}
+      skipInitialAnimation={skipInitialAnimation}
+    >
+      {children}
+    </PaperDialog>
   );
 }
 

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -4,34 +4,37 @@ import React, {
   useCallback,
   useEffect,
   useRef,
+  useState,
 } from "react";
 import { PaperDialog, PaperDialogRef } from "./paper-dialog";
 import { css } from "styled-components";
 
-export interface ScreenProps {
-  goToScreen: ((key: string) => void) | null;
+export interface ScreenProps<TScreenKey extends string = string> {
+  goToScreen: ((key: TScreenKey) => void) | null;
   goBack: (() => void) | null;
 }
 
 type ScreensMap = Record<string, ComponentType<Partial<ScreenProps>>>;
 
-export interface ScreenTransitionProps {
+export interface ScreenTransitionProps<TScreens extends ScreensMap> {
   /** Registry of every screen this transition can render, keyed by id */
-  screens: ScreensMap;
+  screens: TScreens;
   /** Ordered stack of active screen keys. First = base, rest = nested dialogs */
-  activeScreens: string[];
+  activeScreens: (keyof TScreens)[] | string[];
   /** Called with the next stack whenever navigation happens */
-  onScreenChange: (screens: string[]) => void;
+  onScreenChange: (screens: (keyof TScreens)[]) => void;
 }
 
-function ScreenTransition({
+function ScreenTransition<TScreens extends ScreensMap>({
   screens,
   activeScreens,
   onScreenChange,
-}: ScreenTransitionProps) {
+}: ScreenTransitionProps<TScreens>) {
   const dialogRefsRef = useRef<
     Map<number, React.RefObject<PaperDialogRef | null>>
   >(new Map());
+
+  type ScreenKey = keyof TScreens;
 
   const mountedIndicesRef = useRef<Set<number> | null>(null);
   if (mountedIndicesRef.current === null) {
@@ -51,9 +54,11 @@ function ScreenTransition({
   };
 
   const goToScreen = useCallback(
-    (key: string) => {
+    (key: ScreenKey) => {
       if (!screens[key]) {
-        console.warn(`ScreenTransition: screen "${key}" is not registered`);
+        console.warn(
+          `ScreenTransition: screen "${String(key)}" is not registered`
+        );
         return;
       }
       onScreenChange([...activeScreens, key]);
@@ -81,7 +86,9 @@ function ScreenTransition({
 
     const ScreenComponent = screens[key] as ComponentType<Partial<ScreenProps>>;
     if (!ScreenComponent) {
-      console.warn(`ScreenTransition: screen "${key}" is not registered`);
+      console.warn(
+        `ScreenTransition: screen "${String(key)}" is not registered`
+      );
       return null;
     }
 

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -4,7 +4,6 @@ import React, {
   useCallback,
   useEffect,
   useRef,
-  useState,
 } from "react";
 import { PaperDialog, PaperDialogRef } from "./paper-dialog";
 import { css } from "styled-components";
@@ -27,24 +26,26 @@ export interface ScreenTransitionProps<TScreens extends ScreensMap> {
 
 function ScreenTransition<TScreens extends ScreensMap>({
   screens,
-  activeScreens,
+  activeScreens = [],
   onScreenChange,
 }: ScreenTransitionProps<TScreens>) {
   const dialogRefsRef = useRef<
     Map<number, React.RefObject<PaperDialogRef | null>>
   >(new Map());
+  const mountedIndicesRef = useRef<Set<number>>(
+    new Set(activeScreens.map((_, i) => i))
+  );
 
   type ScreenKey = keyof TScreens;
 
-  const mountedIndicesRef = useRef<Set<number> | null>(null);
-  if (mountedIndicesRef.current === null) {
-    const seeded = new Set<number>();
-    // Seed all initial screens — including index 0 — so none animate on mount
-    for (let i = 0; i < activeScreens.length; i++) {
-      seeded.add(i);
-    }
-    mountedIndicesRef.current = seeded;
-  }
+  const getSkipInitialAnimation = (index: number) =>
+    mountedIndicesRef.current.has(index);
+
+  useEffect(() => {
+    activeScreens.forEach((_, index) => {
+      mountedIndicesRef.current.add(index);
+    });
+  }, [activeScreens.length]);
 
   const getDialogRef = (index: number) => {
     if (!dialogRefsRef.current.has(index)) {
@@ -97,8 +98,7 @@ function ScreenTransition<TScreens extends ScreensMap>({
       goBack,
     };
 
-    const skipInitialAnimation = mountedIndicesRef.current!.has(index);
-    if (!skipInitialAnimation) mountedIndicesRef.current!.add(index);
+    const skipInitialAnimation = getSkipInitialAnimation(index);
 
     return (
       <DialogLevel

--- a/test/component/screen-transition.cy.tsx
+++ b/test/component/screen-transition.cy.tsx
@@ -7,16 +7,32 @@ import styled, { css } from "styled-components";
 import { RiArrowLeftSLine } from "@remixicon/react";
 import { Title } from "./../../components/title";
 import { Button } from "./../../components/button";
+import { useState } from "react";
 
 describe("Screen Transition", () => {
-  //   with function children
-  function ProductTransition() {
+  function ProductTransition({
+    initializeScreen = [],
+    onScreenChange,
+  }: {
+    initializeScreen?: ("a" | "b" | "c")[];
+    onScreenChange?: (screens: ("a" | "b" | "c")[]) => void;
+  }) {
     const { currentTheme } = useTheme();
+    const screens = {
+      a: PageA,
+      b: PageB,
+      c: PageC,
+    };
+
+    type ScreenKey = keyof typeof screens;
     const bodyTheme = currentTheme?.body;
+
+    const [activeScreens, setActiveScreens] =
+      useState<ScreenKey[]>(initializeScreen);
 
     function PageTitle({
       text,
-      gotoPrevScreen = null,
+      goBack = null,
     }: {
       text?: string;
     } & Partial<ScreenProps>) {
@@ -24,7 +40,7 @@ describe("Screen Transition", () => {
         <Title
           size="md"
           leftSection={
-            gotoPrevScreen
+            goBack
               ? [
                   {
                     styles: {
@@ -41,7 +57,7 @@ describe("Screen Transition", () => {
                         caption: "back",
                         icon: { image: RiArrowLeftSLine },
                         onClick: () => {
-                          gotoPrevScreen();
+                          goBack();
                         },
                       },
                     ],
@@ -65,7 +81,7 @@ describe("Screen Transition", () => {
               justify-content: center;
               font-size: 20px;
 
-              ${gotoPrevScreen &&
+              ${goBack &&
               css`
                 padding-right: 40px;
               `}
@@ -76,292 +92,178 @@ describe("Screen Transition", () => {
       );
     }
 
-    function PageC() {
+    function PageC({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
       return (
-        <ScreenTransition>
-          {({ gotoPrevScreen }) => (
-            <Wrapper aria-label="wrapper">
-              <PageTitle text="Page C" gotoPrevScreen={gotoPrevScreen} />
-            </Wrapper>
-          )}
-        </ScreenTransition>
+        <Wrapper>
+          <PageTitle text="Page C" goBack={goBack} />
+          <Button onClick={() => goToScreen("a")}>Go to Page A</Button>
+        </Wrapper>
       );
     }
 
-    function PageB() {
+    function PageB({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
       return (
-        <ScreenTransition nextScreen={PageC}>
-          {({ gotoPrevScreen, gotoNextScreen }) => (
-            <Wrapper aria-label="wrapper">
-              <PageTitle text="Page B" gotoPrevScreen={gotoPrevScreen} />
-              <Button onClick={gotoNextScreen ?? undefined}>
-                Go to Page C
-              </Button>
-            </Wrapper>
-          )}
-        </ScreenTransition>
+        <Wrapper>
+          <PageTitle text="Page B" goBack={goBack} />
+          <Button onClick={() => goToScreen("c")}>Go to Page C</Button>
+        </Wrapper>
       );
     }
 
-    function PageA() {
+    function PageA({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
       return (
-        <ScreenTransition nextScreen={PageB}>
-          {({ gotoNextScreen }) => (
-            <Wrapper aria-label="wrapper">
-              <PageTitle text="Page A" gotoPrevScreen={null} />
-              <Button onClick={gotoNextScreen ?? undefined}>
-                Go to Page B
-              </Button>
-            </Wrapper>
-          )}
-        </ScreenTransition>
+        <Wrapper>
+          <PageTitle text="Page A" goBack={goBack} />
+          <Button onClick={() => goToScreen("b")}>Go to Page B</Button>
+        </Wrapper>
       );
     }
 
-    return <PageA />;
-  }
+    return (
+      <>
+        {/* Imagine this generated in index.tsx */}
+        <Wrapper>
+          <PageTitle text="Index Screen" />
+          <Button onClick={() => setActiveScreens(["a"])}>Go to Page A</Button>
+        </Wrapper>
 
-  //   with separate children
-  function ProductWithSeparateChildren() {
-    const { currentTheme } = useTheme();
-    const bodyTheme = currentTheme?.body;
-
-    function PageTitle({
-      text,
-      gotoPrevScreen = null,
-    }: {
-      text?: string;
-    } & Partial<ScreenProps>) {
-      return (
-        <Title
-          size="md"
-          leftSection={
-            gotoPrevScreen
-              ? [
-                  {
-                    styles: {
-                      toggleActionStyle: css`
-                        padding: 4px;
-                        height: 30px;
-                        width: 30px;
-                        border-radius: 4px;
-                      `,
-                    },
-                    type: "actions",
-                    actions: [
-                      {
-                        caption: "back",
-                        icon: { image: RiArrowLeftSLine },
-                        onClick: () => {
-                          gotoPrevScreen();
-                        },
-                      },
-                    ],
-                  },
-                ]
-              : []
-          }
-          text={text}
-          styles={{
-            containerStyle: css`
-              border-bottom: 1px solid ${bodyTheme?.borderColor || "#ececec"};
-              height: 53px;
-              justify-content: center;
-              align-items: center;
-              padding: 0 6px;
-            `,
-            textContainerStyle: css`
-              align-items: center;
-            `,
-            titleStyle: css`
-              justify-content: center;
-              font-size: 20px;
-
-              ${gotoPrevScreen &&
-              css`
-                padding-right: 40px;
-              `}
-              align-items: center;
-            `,
+        {/* Imagine this generated in app.tsx */}
+        <ScreenTransition
+          screens={screens}
+          activeScreens={activeScreens}
+          onScreenChange={(screens) => {
+            setActiveScreens(screens);
+            onScreenChange?.(screens as ("a" | "b" | "c")[]);
           }}
         />
-      );
-    }
-
-    function PageCScreen({ gotoPrevScreen }: Partial<ScreenProps>) {
-      return (
-        <Wrapper aria-label="wrapper">
-          <PageTitle text="Page C" gotoPrevScreen={gotoPrevScreen} />
-        </Wrapper>
-      );
-    }
-
-    function PageC() {
-      return (
-        <ScreenTransition>
-          <PageCScreen />
-        </ScreenTransition>
-      );
-    }
-
-    function PageBScreen({
-      gotoPrevScreen,
-      gotoNextScreen,
-    }: Partial<ScreenProps>) {
-      return (
-        <Wrapper aria-label="wrapper">
-          <PageTitle text="Page B" gotoPrevScreen={gotoPrevScreen} />
-
-          <Button onClick={gotoNextScreen ?? undefined}>Go to Page C</Button>
-        </Wrapper>
-      );
-    }
-
-    function PageB() {
-      return (
-        <ScreenTransition nextScreen={PageC}>
-          <PageBScreen />
-        </ScreenTransition>
-      );
-    }
-
-    function PageAScreen({ gotoNextScreen }: Partial<ScreenProps>) {
-      return (
-        <Wrapper aria-label="wrapper">
-          <PageTitle text="Page A" gotoPrevScreen={null} />
-
-          <Button onClick={gotoNextScreen ?? undefined}>Go to Page B</Button>
-        </Wrapper>
-      );
-    }
-
-    function PageA() {
-      return (
-        <ScreenTransition nextScreen={PageB}>
-          <PageAScreen />
-        </ScreenTransition>
-      );
-    }
-
-    return <PageA />;
+      </>
+    );
   }
 
-  context("when clicking next button", () => {
-    it("should move to the page B", () => {
-      cy.mount(<ProductTransition />);
-      cy.findByLabelText("title-title").should("not.have.text", "Page B");
-      cy.findAllByLabelText("wrapper")
-        .eq(0)
-        .then(() => {
-          cy.findByText("Go to Page B").should("be.visible").click();
-        });
-
-      cy.wait(700);
-      cy.findAllByLabelText("title-title").eq(1).should("have.text", "Page B");
-      cy.findAllByLabelText("wrapper")
-        .eq(1)
-        .then(() => {
-          cy.findByText("Go to Page C").should("be.visible");
-        });
-    });
-
+  context("screens", () => {
     context("when clicking next button", () => {
-      it("should move to the page C", () => {
-        cy.mount(<ProductTransition />);
-        cy.findByLabelText("title-title").should("not.have.text", "Page B");
-        cy.findAllByLabelText("wrapper")
-          .eq(0)
-          .then(() => {
-            cy.findByText("Go to Page B").should("be.visible").click();
-          });
-
-        cy.wait(700);
-        cy.findAllByLabelText("title-title")
-          .eq(1)
-          .should("have.text", "Page B");
-        cy.findAllByLabelText("wrapper")
-          .eq(1)
-          .then(() => {
-            cy.findByText("Go to Page C").should("be.visible").click();
-          });
-
-        cy.wait(700);
-        cy.findAllByLabelText("title-title")
-          .eq(2)
-          .should("have.text", "Page C");
-        cy.findAllByLabelText("wrapper").eq(2).should("exist");
-      });
-    });
-
-    context("when clicking chevron icon", () => {
       it("should move to the page A", () => {
         cy.mount(<ProductTransition />);
-        cy.findByLabelText("title-title").should("not.have.text", "Page B");
-        cy.findAllByLabelText("wrapper")
-          .eq(0)
-          .then(() => {
-            cy.findByText("Go to Page B").should("be.visible").click();
-          });
+        cy.findByLabelText("title-title").should("have.text", "Index Screen");
+
+        cy.findByText("Go to Page A").should("be.visible").click();
 
         cy.wait(700);
         cy.findAllByLabelText("title-title")
           .eq(1)
-          .should("have.text", "Page B");
-        cy.findAllByLabelText("wrapper")
-          .eq(1)
-          .then(() => {
-            cy.findByLabelText("action-button").click();
-          });
+          .should("have.text", "Page A");
+      });
 
-        cy.wait(700);
-        cy.findAllByLabelText("wrapper").eq(1).should("not.exist");
-        cy.findAllByLabelText("title-title").eq(1).should("not.exist");
+      context("when clicking next button", () => {
+        it("should move to the page C", () => {
+          cy.mount(<ProductTransition />);
+          cy.findByLabelText("title-title").should("have.text", "Index Screen");
+
+          cy.findByText("Go to Page A").should("be.visible").click();
+          cy.wait(700);
+
+          cy.findAllByLabelText("title-title")
+            .eq(1)
+            .should("have.text", "Page A");
+
+          cy.findByText("Go to Page B").should("be.visible").click();
+          cy.wait(700);
+
+          cy.findAllByLabelText("title-title")
+            .eq(2)
+            .should("have.text", "Page B");
+        });
+      });
+
+      context("when clicking chevron icon", () => {
+        it("should move to the initial screen", () => {
+          cy.mount(<ProductTransition />);
+          cy.findByLabelText("title-title").should("have.text", "Index Screen");
+
+          cy.findByText("Go to Page A").should("be.visible").click();
+
+          cy.wait(700);
+          cy.findAllByLabelText("title-title")
+            .eq(1)
+            .should("have.text", "Page A");
+
+          cy.findAllByLabelText("action-button").eq(0).click();
+        });
       });
     });
   });
 
-  context("children", () => {
-    context("when using function", () => {
-      it("still can use next and previous function", () => {
-        cy.mount(<ProductTransition />);
-        cy.findByLabelText("title-title").should("not.have.text", "Page B");
-        cy.findAllByLabelText("wrapper")
-          .eq(0)
-          .then(() => {
-            cy.findByText("Go to Page B").should("be.visible").click();
-          });
+  context("activeScreens", () => {
+    context("when initialize 3 screen", () => {
+      it("should render 3 screen", () => {
+        cy.mount(<ProductTransition initializeScreen={["b", "c", "a"]} />);
+        cy.findAllByLabelText("paper-dialog-wrapper").should("have.length", 3);
+      });
 
-        cy.wait(700);
-        cy.findAllByLabelText("title-title")
-          .eq(1)
-          .should("have.text", "Page B");
-        cy.findAllByLabelText("wrapper")
-          .eq(1)
-          .then(() => {
-            cy.findByText("Go to Page C").should("be.visible");
-          });
+      context("when move to back", () => {
+        it("closes screens in reverse order", () => {
+          cy.mount(<ProductTransition initializeScreen={["b", "c", "a"]} />);
+          cy.findAllByLabelText("title-title")
+            .eq(3)
+            .should("have.text", "Page A");
+          cy.findAllByLabelText("title-title")
+            .eq(2)
+            .should("have.text", "Page C");
+          cy.findAllByLabelText("title-title")
+            .eq(1)
+            .should("have.text", "Page B");
+
+          cy.findAllByLabelText("action-button").eq(2).click();
+
+          cy.findAllByLabelText("title-title").eq(3).should("not.exist");
+
+          cy.findAllByLabelText("action-button").eq(1).click();
+          cy.findAllByLabelText("title-title").eq(2).should("not.exist");
+
+          cy.findAllByLabelText("action-button").eq(0).click();
+          cy.findAllByLabelText("title-title").eq(1).should("not.exist");
+        });
       });
     });
+  });
 
-    context("when using separate children", () => {
-      it("still can use next and previous function", () => {
-        cy.mount(<ProductWithSeparateChildren />);
-        cy.findByLabelText("title-title").should("not.have.text", "Page B");
-        cy.findAllByLabelText("wrapper")
-          .eq(0)
-          .then(() => {
-            cy.findByText("Go to Page B").should("be.visible").click();
-          });
+  context("onScreenChange", () => {
+    context("when pressing goToScreen('b')", () => {
+      it("should give callback when with last value ['a', 'b']", () => {
+        const onScreenChangeSpy = cy.stub().as("onScreenChange");
 
-        cy.wait(700);
-        cy.findAllByLabelText("title-title")
-          .eq(1)
-          .should("have.text", "Page B");
-        cy.findAllByLabelText("wrapper")
-          .eq(1)
-          .then(() => {
-            cy.findByText("Go to Page C").should("be.visible");
-          });
+        cy.mount(
+          <ProductTransition
+            initializeScreen={["a"]}
+            onScreenChange={onScreenChangeSpy}
+          />
+        );
+
+        cy.findByText("Go to Page B").should("be.visible").click();
+
+        cy.get("@onScreenChange").should("have.been.calledWith", ["a", "b"]);
+      });
+
+      context("when pressing goBack", () => {
+        it("give callback in onScreenPage with with last value ['a']", () => {
+          const onScreenChangeSpy = cy.stub().as("onScreenChange");
+
+          cy.mount(
+            <ProductTransition
+              initializeScreen={["a"]}
+              onScreenChange={onScreenChangeSpy}
+            />
+          );
+
+          cy.findByText("Go to Page B").should("be.visible").click();
+
+          cy.get("@onScreenChange").should("have.been.calledWith", ["a", "b"]);
+
+          cy.findAllByLabelText("action-button").eq(1).click();
+          cy.wait(400);
+
+          cy.get("@onScreenChange").should("have.been.calledWith", ["a"]);
+        });
       });
     });
   });


### PR DESCRIPTION
Description:
This pull request simplifies `ScreenTransition` to use a single root component. Users now only need to initialize it with `screens`, while screen content can be managed through `onScreenChange`. The `activeScreens` state is used to render multiple screen layers during transitions.

It also ensures that all existing functionality continues to work properly and remains compatible with current implementations.

Source:
[[Improvement] SYST-743: Register all possible screens by just using one root ScreenTransition component](https://linear.app/systatum/issue/SYST-743/register-all-possible-screens-by-just-using-one-root-screentransition)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself