### PR TITLE
[Bug] SYST-756: `Toolbar.Menu` was hidden if opened inside of overflow `scroll` or `auto`

### DIFF
--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -23,6 +23,7 @@ import { Figure, FigureProps } from "./figure";
 import { useTheme } from "./../theme/provider";
 import { ToolbarThemeConfig } from "./../theme";
 import { applyClassName } from "./../constants/classname";
+import { createPortal } from "react-dom";
 
 export interface ToolbarProps {
   children: ReactNode;
@@ -358,23 +359,29 @@ function ToolbarMenu({
         )}
       </MenuWrapper>
 
-      {isOpen && subMenuList && (
-        <div
-          ref={refs.setFloating}
-          style={{ ...floatingStyles, zIndex: 9999 }}
-          onMouseEnter={() => setHovered("dropdown")}
-          onMouseLeave={() => setHovered("original")}
-        >
-          <TipMenu
-            setIsOpen={() => {
-              setIsOpen(false);
-              setHovered("original");
+      {isOpen &&
+        subMenuList &&
+        createPortal(
+          <div
+            ref={refs.setFloating}
+            style={{
+              ...floatingStyles,
+              zIndex: 9995999,
             }}
-            styles={{ self: styles?.dropdownStyle }}
-            subMenuList={filteredSubMenuList}
-          />
-        </div>
-      )}
+            onMouseEnter={() => setHovered("dropdown")}
+            onMouseLeave={() => setHovered("original")}
+          >
+            <TipMenu
+              setIsOpen={() => {
+                setIsOpen(false);
+                setHovered("original");
+              }}
+              styles={{ self: styles?.dropdownStyle }}
+              subMenuList={filteredSubMenuList}
+            />
+          </div>,
+          document.body
+        )}
     </ToolbarContainer>
   );
 }

--- a/test/component/toolbar.cy.tsx
+++ b/test/component/toolbar.cy.tsx
@@ -134,6 +134,42 @@ describe("Toolbar", () => {
   });
 
   context("tipMenu", () => {
+    context("when inside of overflow scroll/auto", () => {
+      it("doesn't hidden the tip menu", () => {
+        cy.viewport(800, 700);
+        cy.mount(
+          <div
+            style={{
+              display: "flex",
+              overflow: "scroll",
+            }}
+          >
+            <Toolbar>
+              <Toolbar.Menu
+                styles={{
+                  dropdownStyle: css`
+                    min-width: 235px;
+                  `,
+                }}
+                onClick={() => {
+                  console.log("test");
+                }}
+                caption="Default Mode"
+                icon={{ image: RiMessage2Line, color: "red" }}
+                subMenuList={TIP_MENU_ITEMS}
+              />
+            </Toolbar>
+          </div>
+        );
+
+        cy.findByLabelText("toolbar-menu-toggle").click();
+
+        TIP_MENU_ITEMS.filter((menu) => !menu.hidden).map((menu) => {
+          cy.findByText(menu.caption).should("be.visible");
+        });
+      });
+    });
+
     context("when click", () => {
       it("renders background color active by variant", () => {
         cy.viewport(800, 700);


### PR DESCRIPTION
Description:
Previously, the `Toolbar` did not render correctly when used inside `Table.subMenuList`, particularly when the parent container had `overflow: auto` or `overflow: scroll`. As a result, the `TipMenu` could be clipped or displayed improperly when opened.

This pull request fixes the issue by rendering the `TipMenu` through a React Portal and mounting it directly to `document.body`. This ensures the dropdown is displayed correctly regardless of the overflow behavior of its parent containers.

Source:
[[Bug] SYST-756: `Toolbar.Menu` was hidden if opened inside of overflow `scroll` or `auto`](https://linear.app/systatum/issue/SYST-756/toolbarmenu-was-hidden-if-opened-inside-of-overflow-scroll-or-auto)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself