### PR TITLE
[Improvement] SYST-755: Extract `drawerHeight` out of `mobile`

### DIFF
--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -56,10 +56,7 @@ interface BaseComboboxProps {
   navigableOptions?: SelectboxOption[];
   isLoading?: boolean;
   labels?: ComboboxLabelsProps;
-  mobile?: boolean | ComboboxMobile;
-}
-
-export interface ComboboxMobile {
+  mobile?: boolean;
   drawerHeight?: string;
 }
 
@@ -160,6 +157,7 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       labels,
       className,
       mobile,
+      drawerHeight,
     },
     ref
   ) => {
@@ -356,6 +354,7 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
               actions={actions}
               onClick={onClick}
               options={filteredForDrawer}
+              drawerHeight={drawerHeight}
               maxSelectableItems={maxSelectableItems}
               multiple={multiple}
               openedCategoryGroup={openedCategoryGroup}
@@ -399,6 +398,7 @@ function ComboboxDrawer({
   styles,
   navigableOptions,
   mobile,
+  drawerHeight,
 }: ComboboxDrawerProps) {
   const { mode, currentTheme } = useTheme();
   const comboboxTheme = currentTheme?.combobox;
@@ -842,6 +842,7 @@ function ComboboxDrawer({
       $hasNestedOptions={hasNestedOptions}
       style={mobile ? {} : { ...floatingStyles }}
       $theme={comboboxTheme}
+      $drawerHeight={drawerHeight}
       id="combo-list"
       aria-label="combobox-drawer"
       role="listbox"
@@ -1117,7 +1118,7 @@ function ComboboxDrawer({
 
 const DrawerContainer = styled.div<{
   $theme?: ComboboxThemeConfig;
-  $mobile?: boolean | ComboboxMobile;
+  $mobile?: boolean;
 }>`
   *,
   ::before,
@@ -1140,9 +1141,10 @@ const DrawerWrapper = styled.ul<{
   $width?: number;
   $theme: ComboboxThemeConfig;
   $style?: CSSProp;
-  $mobile?: boolean | ComboboxMobile;
+  $mobile?: boolean;
   $multiple?: boolean;
   $hasNestedOptions?: boolean;
+  $drawerHeight?: string;
 }>`
   *,
   ::before,
@@ -1181,26 +1183,21 @@ const DrawerWrapper = styled.ul<{
     border-radius: 4px;
   }
 
-  ${({ $mobile, $theme, $multiple, $hasNestedOptions }) =>
-    $mobile &&
+  ${({ $mobile, $theme, $multiple, $hasNestedOptions, $drawerHeight }) => css`
+    min-height: ${$drawerHeight};
+    max-height: ${$drawerHeight};
+
+    ${$mobile &&
     css`
       width: 100%;
       z-index: 9992999;
       border-radius: 14px;
-      min-height: ${typeof $mobile === "object"
-        ? $mobile?.drawerHeight
-        : "220px"};
-      max-height: ${typeof $mobile === "object"
-        ? $mobile?.drawerHeight
-        : "220px"};
+      min-height: ${$drawerHeight ? $drawerHeight : "220px"};
+      max-height: ${$drawerHeight ? $drawerHeight : "220px"};
       border-width: 0.5;
       ${!$multiple &&
       css`
-        padding: calc(
-            ${typeof $mobile === "object" ? $mobile.drawerHeight : "220px"} *
-              0.4545
-          )
-          0;
+        padding: calc(${$mobile ? $drawerHeight : "220px"} * 0.4545) 0;
       `}
 
       background-color: ${$mobile && $hasNestedOptions
@@ -1209,6 +1206,7 @@ const DrawerWrapper = styled.ul<{
           ? $theme.mobileBackgroundColor
           : $theme.backgroundColor};
     `}
+  `}
 
   ${({ $style }) => $style}
 `;

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -389,7 +389,6 @@ function ComboboxDrawer({
   inputRef,
   handleKeyDown,
   maxSelectableItems,
-  name,
   interactionMode,
   setInteractionMode,
   setConfirmedValue,

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -1183,30 +1183,34 @@ const DrawerWrapper = styled.ul<{
     border-radius: 4px;
   }
 
-  ${({ $mobile, $theme, $multiple, $hasNestedOptions, $drawerHeight }) => css`
-    min-height: ${$drawerHeight};
-    max-height: ${$drawerHeight};
+  ${({ $mobile, $theme, $multiple, $hasNestedOptions, $drawerHeight }) => {
+    const $mobileHeight = $drawerHeight ?? "220px";
 
-    ${$mobile &&
-    css`
-      width: 100%;
-      z-index: 9992999;
-      border-radius: 14px;
-      min-height: ${$drawerHeight ? $drawerHeight : "220px"};
-      max-height: ${$drawerHeight ? $drawerHeight : "220px"};
-      border-width: 0.5;
-      ${!$multiple &&
+    return css`
+      min-height: ${$drawerHeight};
+      max-height: ${$drawerHeight};
+
+      ${$mobile &&
       css`
-        padding: calc(${$mobile ? $drawerHeight : "220px"} * 0.4545) 0;
-      `}
+        width: 100%;
+        z-index: 9992999;
+        border-radius: 14px;
+        min-height: ${$mobileHeight};
+        max-height: ${$mobileHeight};
+        border-width: 0.5;
+        ${!$multiple &&
+        css`
+          padding: calc(${$mobileHeight} * 0.4545) 0;
+        `}
 
-      background-color: ${$mobile && $hasNestedOptions
-        ? $theme.mobileGroupBackgroundColor
-        : $mobile
-          ? $theme.mobileBackgroundColor
-          : $theme.backgroundColor};
-    `}
-  `}
+        background-color: ${$mobile && $hasNestedOptions
+          ? $theme.mobileGroupBackgroundColor
+          : $mobile
+            ? $theme.mobileBackgroundColor
+            : $theme.backgroundColor};
+      `}
+    `;
+  }}
 
   ${({ $style }) => $style}
 `;

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -143,6 +143,58 @@ describe("Combobox", () => {
     );
   }
 
+  context("drawerHeight", () => {
+    context("when given 60dvh", () => {
+      it("should render with 420px", () => {
+        cy.viewport(500, 700);
+
+        cy.mount(
+          <ProductCombobox options={FRUIT_OPTIONS} drawerHeight={"60dvh"} />
+        );
+
+        cy.findByRole("textbox").click();
+
+        cy.window().then((win) => {
+          const expectedHeight = `${win.innerHeight * 0.6}px`;
+
+          cy.findByLabelText("combobox-drawer").should(
+            "have.css",
+            "height",
+            expectedHeight
+          );
+        });
+      });
+    });
+
+    context("when given mobile", () => {
+      context("when given 60dvh", () => {
+        it("should render with 420px", () => {
+          cy.viewport(500, 700);
+
+          cy.mount(
+            <ProductCombobox
+              mobile
+              options={FRUIT_OPTIONS}
+              drawerHeight={"60dvh"}
+            />
+          );
+
+          cy.findByRole("textbox").click();
+
+          cy.window().then((win) => {
+            const expectedHeight = `${win.innerHeight * 0.6}px`;
+
+            cy.findByLabelText("combobox-drawer-mobile").should(
+              "have.css",
+              "height",
+              expectedHeight
+            );
+          });
+        });
+      });
+    });
+  });
+
   context("dynamic options", () => {
     context("when fetch after move", () => {
       function ProductDynamicCombobox({ timeDelay }: { timeDelay?: number }) {
@@ -480,37 +532,6 @@ describe("Combobox", () => {
           "height",
           "220px"
         );
-      });
-    });
-
-    context("object", () => {
-      context("drawerHeight", () => {
-        context("when given 60dvh", () => {
-          it("should render with px", () => {
-            cy.viewport(500, 700);
-
-            cy.mount(
-              <ProductCombobox
-                options={FRUIT_OPTIONS}
-                mobile={{
-                  drawerHeight: "60dvh",
-                }}
-              />
-            );
-
-            cy.findByRole("textbox").click();
-
-            cy.window().then((win) => {
-              const expectedHeight = `${win.innerHeight * 0.6}px`;
-
-              cy.findByLabelText("combobox-drawer-mobile").should(
-                "have.css",
-                "height",
-                expectedHeight
-              );
-            });
-          });
-        });
       });
     });
 


### PR DESCRIPTION
Description:
This pull request simplifies and clarifies the API by making `drawerHeight` prop available for both desktop and mobile layouts, rather than limiting it to the `mobile` configuration. As a result, the `mobile` prop is now a simple boolean instead of an object.

It also ensures that `drawerHeight` is applied correctly and consistently across all supported layouts.

Source:
[[Improvement] SYST-755: Extract `drawerHeight` out of `mobile`](https://linear.app/systatum/issue/SYST-755/extract-drawerheight-out-of-mobile)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself