### PR TITLE
[Bug] SYST-753: Fix invisible paper dialog button shadowing

### DIFF
--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -590,24 +590,19 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 $mobile={mobile}
                 $top={4}
                 $isLeft={isLeft}
+                $theme={paperDialogTheme}
+                onClick={() => {
+                  closeDialog();
+                }}
+                $style={styles?.closeButtonStyle}
+                aria-label="paper-dialog-toggle-close"
               >
-                <IconButton
-                  $mobile={mobile}
-                  $theme={paperDialogTheme}
-                  $isLeft={isLeft}
-                  $style={styles?.closeButtonStyle}
-                  aria-label="paper-dialog-toggle-close"
-                  onClick={() => {
-                    closeDialog();
-                  }}
-                >
-                  <Figure
-                    {...icons?.closeIcon}
-                    aria-label="paper-dialog-close-icon"
-                    image={icons?.closeIcon?.image ?? RiCloseLine}
-                    size={icons?.closeIcon?.size ?? 18}
-                  />
-                </IconButton>
+                <Figure
+                  {...icons?.closeIcon}
+                  aria-label="paper-dialog-close-icon"
+                  image={icons?.closeIcon?.image ?? RiCloseLine}
+                  size={icons?.closeIcon?.size ?? 18}
+                />
               </ActionButtonWrapper>
             )}
 
@@ -617,45 +612,40 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 $mobile={mobile}
                 $top={44}
                 $isLeft={isLeft}
+                aria-label="paper-dialog-toggle-restore"
+                $style={styles?.minimizeButtonStyle}
+                onClick={() => {
+                  setDialogState(
+                    dialogState === "minimized" ? "restored" : "minimized"
+                  );
+                  setShowTitlebar(true);
+                }}
+                $theme={paperDialogTheme}
               >
-                <IconButton
-                  $mobile={mobile}
-                  $theme={paperDialogTheme}
-                  $style={styles?.minimizeButtonStyle}
-                  $isLeft={isLeft}
-                  aria-label="paper-dialog-toggle-restore"
-                  onClick={() => {
-                    setDialogState(
-                      dialogState === "minimized" ? "restored" : "minimized"
-                    );
-                    setShowTitlebar(true);
+                <Figure
+                  {...icons?.restoreIcon}
+                  image={
+                    icons?.restoreIcon?.image ??
+                    (mobile
+                      ? RiSubtractLine
+                      : isLeft
+                        ? RiArrowRightSLine
+                        : RiArrowLeftSLine)
+                  }
+                  aria-label="paper-dialog-restore-icon"
+                  size={icons?.restoreIcon?.size ?? 18}
+                  styles={{
+                    self: css`
+                      display: flex;
+                      transition: transform 0.5s ease-in-out;
+                      transform: ${mobile
+                        ? "rotate(0deg)"
+                        : dialogState === "restored"
+                          ? "rotate(180deg)"
+                          : "rotate(0deg)"};
+                    `,
                   }}
-                >
-                  <Figure
-                    {...icons?.restoreIcon}
-                    image={
-                      icons?.restoreIcon?.image ??
-                      (mobile
-                        ? RiSubtractLine
-                        : isLeft
-                          ? RiArrowRightSLine
-                          : RiArrowLeftSLine)
-                    }
-                    aria-label="paper-dialog-restore-icon"
-                    size={icons?.restoreIcon?.size ?? 18}
-                    styles={{
-                      self: css`
-                        display: flex;
-                        transition: transform 0.5s ease-in-out;
-                        transform: ${mobile
-                          ? "rotate(0deg)"
-                          : dialogState === "restored"
-                            ? "rotate(180deg)"
-                            : "rotate(0deg)"};
-                      `,
-                    }}
-                  />
-                </IconButton>
+                />
               </ActionButtonWrapper>
             )}
 
@@ -851,16 +841,36 @@ const ActionButtonWrapper = styled.div<{
   $style?: CSSProp;
   $mobile?: boolean;
   $indexAction?: number;
+  $theme?: PaperDialogThemeConfig;
 }>`
   position: absolute;
   z-index: 50;
   display: flex;
   flex-direction: column;
   height: fit-content;
+  width: fit-content;
+  cursor: pointer;
+  padding: 8px;
+  background-color: ${({ $theme }) => $theme?.backgroundColor};
 
-  ${({ $isLeft, $mobile, $top, $indexAction }) =>
+  ${({ $mobile, $theme }) =>
+    !$mobile &&
+    css`
+      &:hover {
+        background-color: ${$theme?.actionHoverBackgroundColor};
+      }
+    `}
+
+  ${({ $isLeft, $mobile, $theme, $indexAction, $top }) =>
     $mobile
       ? css`
+          border: 1px solid ${$theme?.borderColor};
+          border-top-width: 1px;
+          border-right-width: 1px;
+          border-left-width: 1px;
+          border-bottom-width: 0px;
+          border-radius: 0.75rem 0.75rem 0 0;
+          padding: 6px;
           top: -30.5px;
           user-select: none;
 
@@ -875,60 +885,21 @@ const ActionButtonWrapper = styled.div<{
       : css`
           top: ${`${$top}px`};
 
-          ${$isLeft
-            ? css`
-                left: 100%;
-                translate: -4px;
-              `
-            : css`
-                right: 100%;
-                translate: 4px;
-              `}
-        `}
-`;
-
-const IconButton = styled.button<{
-  $isLeft: boolean;
-  $theme?: PaperDialogThemeConfig;
-  $style?: CSSProp;
-  $mobile?: boolean;
-}>`
-  position: relative;
-  cursor: pointer;
-  padding: 8px;
-  background-color: ${({ $theme }) => $theme?.backgroundColor};
-
-  ${({ $mobile, $theme }) =>
-    !$mobile &&
-    css`
-      &:hover {
-        background-color: ${$theme?.actionHoverBackgroundColor};
-      }
-    `}
-
-  ${({ $isLeft, $mobile, $theme }) =>
-    $mobile
-      ? css`
-          border: 1px solid ${$theme?.borderColor};
-          border-top-width: 1px;
-          border-right-width: 1px;
-          border-left-width: 1px;
-          border-bottom-width: 0px;
-          border-radius: 0.75rem 0.75rem 0 0;
-          padding: 6px;
-        `
-      : css`
           border: 1px solid ${$theme?.borderColor};
           box-shadow: ${$theme?.boxShadow};
 
           ${$isLeft
             ? css`
+                right: 0;
+                transform: translateX(30px);
                 border-right-width: 1px;
                 border-top-width: 1px;
                 border-bottom-width: 1px;
                 border-radius: 0 0.75rem 0.75rem 0;
               `
             : css`
+                left: 0;
+                transform: translateX(-30px);
                 border-left-width: 1px;
                 border-top-width: 1px;
                 border-bottom-width: 1px;


### PR DESCRIPTION
Description:
This pull request simplifies the `PaperDialog` controls by consolidating two separate elements into a single control mechanism. This reduces the number of rendered elements, making the component easier to maintain, style, and validate while improving the overall architecture.

It also ensures that the `closeButtonStyle` and `minimizeButtonStyle` props are applied correctly and consistently.

Source:
[[Bug] SYST-753: Fix invisible paper dialog button shadowing](https://linear.app/systatum/issue/SYST-753/fix-invisible-paper-dialog-button-shadowing)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[] I have created/updated any relevant test code
[x] I have tested it myself