### PR TITLE
[Feature] SYST-752: Create <Avatar.Stack>

### DIFF
--- a/components/avatar.stories.tsx
+++ b/components/avatar.stories.tsx
@@ -25,6 +25,7 @@ It automatically generates a background color and initials when no image is prov
 - 📷 Optional **image upload (changeable mode)**
 - 🖱️ Clickable interaction support
 - 🧩 Customizable size and styles
+- 👥 Built-in **Avatar Stack** support for grouped users
 
 ---
 
@@ -61,11 +62,62 @@ It automatically generates a background color and initials when no image is prov
 
 ---
 
+### 👥 Avatar Stack
+
+The **Avatar.Stack** component groups multiple avatars into a compact, overlapping layout, making it useful for displaying team members, collaborators, participants, or shared ownership.
+
+#### Features
+
+* Supports profile images and generated initials
+* Optional hover captions per avatar
+* Customizable stacking behavior
+* Action buttons for common operations such as inviting or adding users
+* Automatic overlap handling for large groups
+
+#### Example
+
+\`\`\`tsx
+const avatars = [
+  {
+    firstName: "Adam",
+    lastName: "Hakarsa",
+    profileImageUrl: "...",
+    hoverCaption: "Adam Hakarsa",
+  },
+  {
+    firstName: "Liam",
+    lastName: "Anderson",
+    profileImageUrl: "...",
+    hoverCaption: "Liam Anderson",
+  },
+];
+
+const actions = [
+  {
+    hoverCaption: "Add another person",
+    onClick: () => {},
+  },
+];
+
+<Avatar.Stack avatars={avatars} actions={actions} />
+\`\`\`
+
+#### Usage Guidelines
+
+* Use when displaying multiple users in a limited space
+* Provide \`hoverCaption\` to improve discoverability
+* Use actions for invite, add member, or management workflows
+* Prefer Avatar Stack over individual avatars when representing a group
+
+---
+
 ### 🎯 Usage Guidelines
-- Use for **user identity representation**
-- Provide \`profileImageUrl\` when available
-- Enable \`changeable\` for editable profile flows
-- Adjust \`frameSize\` and \`fontSize\` for layout consistency
+
+* Use for **user identity representation**
+* Provide \`profileImageUrl\` when available
+* Enable \`changeable\` for editable profile flows
+* Adjust \`frameSize\` and \`fontSize\` for layout consistency
+
         `,
       },
     },

--- a/components/avatar.stories.tsx
+++ b/components/avatar.stories.tsx
@@ -3,6 +3,7 @@ import { AvatarProps, AvatarStackAction, AvatarStackAvatar } from "./avatar";
 import { ChangeEvent, useState } from "react";
 import { ModalDialog, ModalDialogAction } from "./modal-dialog";
 import { Avatar } from "./avatar";
+import { Dialog } from "./dialog";
 
 const meta: Meta<typeof Avatar> = {
   title: "Content/Avatar",
@@ -409,7 +410,22 @@ export const Stacked: Story = {
       {
         hoverCaption: "Add another person",
         onClick: () => {
-          console.log("was added");
+          Dialog.show({
+            mobile: true,
+            title: "Avatar Stack Full",
+            subtitle:
+              "The maximum number of avatars has been reached. Remove an existing member before adding another.",
+            actions: [
+              {
+                id: "close",
+                caption: "Got it",
+                variant: "primary",
+              },
+            ],
+            onClick: ({ closeDialog }) => {
+              closeDialog?.();
+            },
+          });
         },
       },
     ];

--- a/components/avatar.stories.tsx
+++ b/components/avatar.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { AvatarProps } from "./avatar";
+import { AvatarProps, AvatarStackAction, AvatarStackAvatar } from "./avatar";
 import { ChangeEvent, useState } from "react";
 import { ModalDialog, ModalDialogAction } from "./modal-dialog";
 import { Avatar } from "./avatar";
@@ -316,5 +316,52 @@ export const WithImage: Story = {
         )}
       </div>
     );
+  },
+};
+
+export const Stacked: Story = {
+  render: () => {
+    const AVATARS: AvatarStackAvatar[] = [
+      {
+        firstName: "Adam",
+        lastName: "Hakarsa",
+        profileImageUrl: "https://randomuser.me/api/portraits/men/1.jpg",
+        hoverCaption: "Adam Hakarsa",
+      },
+      {
+        firstName: "Liam",
+        lastName: "Anderson",
+        profileImageUrl: "https://randomuser.me/api/portraits/men/2.jpg",
+        hoverCaption: "Liam Anderson",
+      },
+      {
+        firstName: "Sophia",
+        lastName: "Brown",
+        profileImageUrl: "https://randomuser.me/api/portraits/women/3.jpg",
+        hoverCaption: "Sophia Brown",
+      },
+      {
+        firstName: "Noah",
+        lastName: "Taylor",
+        hoverCaption: "Noah Taylor",
+      },
+      {
+        firstName: "Emma",
+        lastName: "Wilson",
+        profileImageUrl: "https://randomuser.me/api/portraits/women/4.jpg",
+        hoverCaption: "Emma Wilson",
+      },
+    ];
+
+    const ONE_ACTIONS: AvatarStackAction[] = [
+      {
+        hoverCaption: "Add another person",
+        onClick: () => {
+          console.log("was added");
+        },
+      },
+    ];
+
+    return <Avatar.Stack avatars={AVATARS} actions={ONE_ACTIONS} />;
   },
 };

--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -254,6 +254,8 @@ export interface AvatarStackProps {
   actions?: AvatarStackAction[];
   frameSize?: number;
   fontSize?: number;
+  className?: string;
+  id?: string;
 }
 
 export type AvatarStackAvatar = AvatarProps;
@@ -281,6 +283,8 @@ function AvatarStack({
   actions = [],
   fontSize = 18,
   frameSize = 50,
+  className,
+  id,
 }: AvatarStackProps) {
   const { currentTheme } = useTheme();
   const bodyTheme = currentTheme?.body;
@@ -288,7 +292,12 @@ function AvatarStack({
   const avatarLength = avatars?.length;
 
   return (
-    <ContainerAvatarStack $style={styles?.containerStyle}>
+    <ContainerAvatarStack
+      id={id}
+      className={applyClassName("avatar-stack", className)}
+      aria-label="avatar-stack"
+      $style={styles?.containerStyle}
+    >
       {avatars.map((avatar, index) => {
         const avatarProps = {
           ...avatar,
@@ -341,7 +350,13 @@ function AvatarStack({
             },
           };
 
-          const baseAction = <Button key={key} {...finalAction} />;
+          const baseAction = (
+            <Button
+              key={key}
+              aria-label="avatar-stack-action"
+              {...finalAction}
+            />
+          );
 
           if (hoverCaption) {
             return (
@@ -375,6 +390,7 @@ const ContainerAvatarStack = styled.div<{ $style?: CSSProp }>`
   position: relative;
   display: flex;
   flex-direction: row;
+  align-items: center;
 
   > *:not(:first-child) {
     margin-left: -6px;

--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -2,14 +2,16 @@
 
 import { strToColor } from "./../lib/code-color";
 import { ChangeEvent, HTMLAttributes, useRef } from "react";
-import styled, { CSSProp } from "styled-components";
+import styled, { css, CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
 import { applyClassName } from "./../constants/classname";
+import { Tooltip } from "./tooltip";
+import { BaseAction } from "./../constants/action";
+import { Button } from "./button";
+import { RiAddLine } from "@remixicon/react";
 
-export interface AvatarProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  "title" | "style" | "onChange"
-> {
+export interface AvatarProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "title" | "style" | "onChange"> {
   firstName: string;
   lastName?: string;
   profileImageUrl?: string | null | undefined;
@@ -17,8 +19,18 @@ export interface AvatarProps extends Omit<
   onChange?: (e: ChangeEvent<HTMLInputElement>, file?: File) => void;
   frameSize?: number;
   fontSize?: number;
+  hoverCaption?: string;
+  hoverCaptionPosition?: AvatarHoverCaptionPosition;
   styles?: AvatarStyles;
 }
+
+export const AvatarHoverCaptionPosition = {
+  TopCenter: "top-center",
+  BottomCenter: "bottom-center",
+} as const;
+
+export type AvatarHoverCaptionPosition =
+  (typeof AvatarHoverCaptionPosition)[keyof typeof AvatarHoverCaptionPosition];
 
 export interface AvatarStyles {
   self?: CSSProp;
@@ -55,6 +67,8 @@ function Avatar({
   onClick,
   className,
   id,
+  hoverCaption,
+  hoverCaptionPosition = AvatarHoverCaptionPosition.TopCenter,
   ...props
 }: AvatarProps) {
   const { currentTheme } = useTheme();
@@ -83,7 +97,7 @@ function Avatar({
     }
   };
 
-  return (
+  const baseAvatar = (
     <AvatarContainer
       {...props}
       onClick={changeable ? handleClick : onClick}
@@ -127,6 +141,29 @@ function Avatar({
       ) : null}
     </AvatarContainer>
   );
+
+  if (hoverCaption) {
+    return (
+      <Tooltip
+        styles={{
+          triggerStyle: css`
+            flex-shrink: 1;
+            border-radius: 9999px;
+            overflow: hidden;
+          `,
+          containerStyle: css`
+            border-radius: 9999px;
+          `,
+        }}
+        dialogPlacement={hoverCaptionPosition}
+        dialog={hoverCaption}
+      >
+        {baseAvatar}
+      </Tooltip>
+    );
+  }
+
+  return baseAvatar;
 }
 
 const AvatarContainer = styled.div<{
@@ -210,5 +247,140 @@ export function getInitials(
     ? `${firstInitial}${lastInitial}`
     : `${firstOptionInitial}`;
 }
+
+export interface AvatarStackProps {
+  avatars?: AvatarStackAvatar[];
+  styles?: AvatarStackStyles;
+  actions?: AvatarStackAction[];
+  frameSize?: number;
+  fontSize?: number;
+}
+
+export type AvatarStackAvatar = AvatarProps;
+
+export interface AvatarStackStyles {
+  containerStyle?: CSSProp;
+  actionButtonStyle?: CSSProp;
+  avatarStyle?: CSSProp;
+}
+
+export interface AvatarStackAction extends Omit<BaseAction, "caption"> {
+  styles?: AvatarStackActionStyles;
+  hoverCaption?: string;
+  hoverCaptionPosition?: AvatarHoverCaptionPosition;
+}
+
+export interface AvatarStackActionStyles {
+  self: CSSProp;
+}
+
+function AvatarStack({
+  avatars = [],
+  styles,
+  actions = [],
+  fontSize = 18,
+  frameSize = 50,
+}: AvatarStackProps) {
+  const { currentTheme } = useTheme();
+  const bodyTheme = currentTheme?.body;
+
+  const avatarLength = avatars?.length;
+
+  return (
+    <ContainerAvatarStack $style={styles?.containerStyle}>
+      {avatars.map((avatar, index) => {
+        const avatarProps = {
+          ...avatar,
+          styles: {
+            ...avatar.styles,
+            self: css`
+              border: 2px solid ${bodyTheme?.backgroundColor};
+              z-index: ${index};
+              ${styles?.avatarStyle}
+              ${avatar?.styles?.self}
+            `,
+          },
+          frameSize: avatar?.frameSize ?? frameSize,
+          fontSize: avatar?.fontSize ?? fontSize,
+        };
+
+        return <Avatar key={index} {...avatarProps} />;
+      })}
+
+      {actions
+        ?.filter((action) => !action?.hidden)
+        .map((action, index) => {
+          const key = avatarLength + index;
+          const { hoverCaption, hoverCaptionPosition, ...restAction } = action;
+
+          const finalAction = {
+            ...restAction,
+            styles: {
+              ...restAction?.styles,
+              containerStyle: css`
+                border-radius: 9999px;
+              `,
+              self: css`
+                z-index: ${key};
+
+                padding: 0px;
+                height: ${`${frameSize}px`};
+                width: ${`${frameSize}px`};
+                border-radius: 9999px;
+
+                ${styles?.actionButtonStyle}
+                ${restAction?.styles?.self}
+              `,
+            },
+            icon: {
+              ...restAction?.icon,
+              image: restAction?.icon?.image ?? RiAddLine,
+              size: restAction?.icon?.size ?? fontSize * 1.4,
+            },
+          };
+
+          const baseAction = <Button key={key} {...finalAction} />;
+
+          if (hoverCaption) {
+            return (
+              <Tooltip
+                key={index}
+                styles={{
+                  triggerStyle: css`
+                    flex-shrink: 1;
+                    border-radius: 9999px;
+                    overflow: hidden;
+                  `,
+                  containerStyle: css`
+                    border-radius: 9999px;
+                  `,
+                }}
+                dialogPlacement={hoverCaptionPosition ?? "top-center"}
+                dialog={hoverCaption}
+              >
+                {baseAction}
+              </Tooltip>
+            );
+          }
+
+          return baseAction;
+        })}
+    </ContainerAvatarStack>
+  );
+}
+
+const ContainerAvatarStack = styled.div<{ $style?: CSSProp }>`
+  position: relative;
+  display: flex;
+  flex-direction: row;
+
+  > *:not(:first-child) {
+    margin-left: -6px;
+  }
+
+  ${({ $style }) => $style}
+`;
+
+Avatar.Stack = AvatarStack;
 
 export { Avatar };

--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -123,7 +123,7 @@ function Avatar({
           src={profileImageUrl}
         />
       ) : (
-        <div>{initials}</div>
+        initials
       )}
       {changeable ? (
         <AvatarChange $overlayBg={avatarTheme.overlayBackgroundColor}>
@@ -268,6 +268,7 @@ export interface AvatarStackAction extends Omit<BaseAction, "caption"> {
   styles?: AvatarStackActionStyles;
   hoverCaption?: string;
   hoverCaptionPosition?: AvatarHoverCaptionPosition;
+  pressed?: boolean;
 }
 
 export interface AvatarStackActionStyles {
@@ -324,6 +325,7 @@ function AvatarStack({
                 z-index: ${key};
 
                 padding: 0px;
+                border: 2px solid ${bodyTheme?.backgroundColor};
                 height: ${`${frameSize}px`};
                 width: ${`${frameSize}px`};
                 border-radius: 9999px;

--- a/test/component/avatar.cy.tsx
+++ b/test/component/avatar.cy.tsx
@@ -1,4 +1,10 @@
-import { Avatar, AvatarProps } from "./../../components/avatar";
+import {
+  Avatar,
+  AvatarProps,
+  AvatarStackAction,
+  AvatarStackAvatar,
+  AvatarStackProps,
+} from "./../../components/avatar";
 
 describe("Avatar", () => {
   function AvatarComponent() {
@@ -18,6 +24,263 @@ describe("Avatar", () => {
       />
     );
   }
+
+  context("Avatar.Stack", () => {
+    const AVATARS: AvatarStackAvatar[] = [
+      {
+        firstName: "Adam",
+        lastName: "Hakarsa",
+        profileImageUrl: "https://randomuser.me/api/portraits/men/1.jpg",
+        hoverCaption: "Adam Hakarsa",
+      },
+      {
+        firstName: "Liam",
+        lastName: "Anderson",
+        profileImageUrl: "https://randomuser.me/api/portraits/men/2.jpg",
+      },
+      {
+        firstName: "Sophia",
+        lastName: "Brown",
+        hoverCaption: "Sophia Brown",
+      },
+      {
+        firstName: "Noah",
+        lastName: "Taylor",
+        hoverCaption: "Noah Taylor",
+      },
+      {
+        firstName: "Emma",
+        lastName: "Wilson",
+        profileImageUrl: "https://randomuser.me/api/portraits/women/4.jpg",
+        hoverCaption: "Emma Wilson",
+      },
+    ];
+
+    const ONE_ACTIONS: AvatarStackAction[] = [
+      {
+        hoverCaption: "Add another person",
+        onClick: () => {
+          console.log("was added");
+        },
+      },
+    ];
+
+    function ProductAvatarStack(props: AvatarStackProps) {
+      return (
+        <Avatar.Stack avatars={AVATARS} actions={ONE_ACTIONS} {...props} />
+      );
+    }
+
+    context("fontSize", () => {
+      it("renders with font-size 18px (by default)", () => {
+        cy.mount(<ProductAvatarStack />);
+
+        cy.findAllByLabelText("avatar-content")
+          .eq(2)
+          .should("have.css", "font-size", "18px");
+        cy.findAllByLabelText("avatar-content")
+          .eq(3)
+          .should("have.css", "font-size", "18px");
+      });
+
+      context("when given 20px by parent", () => {
+        it("renders all font-size with 20px", () => {
+          cy.mount(<ProductAvatarStack fontSize={20} />);
+
+          cy.findAllByLabelText("avatar-content")
+            .eq(2)
+            .should("have.css", "font-size", "20px");
+          cy.findAllByLabelText("avatar-content")
+            .eq(3)
+            .should("have.css", "font-size", "20px");
+        });
+
+        context("when given 25px for one specified avatar", () => {
+          it("renders the specified avatar font-size with 25px", () => {
+            const FINAL_AVATARS_WITH_SPECIFIED_FONT_SIZE = AVATARS.map(
+              (avatar, index) =>
+                index === 2
+                  ? {
+                      ...avatar,
+                      fontSize: 25,
+                    }
+                  : avatar
+            );
+
+            cy.mount(
+              <ProductAvatarStack
+                fontSize={20}
+                avatars={FINAL_AVATARS_WITH_SPECIFIED_FONT_SIZE}
+              />
+            );
+
+            cy.findAllByLabelText("avatar-content")
+              .eq(2)
+              .should("have.css", "font-size", "25px");
+            cy.findAllByLabelText("avatar-content")
+              .eq(3)
+              .should("have.css", "font-size", "20px");
+          });
+        });
+      });
+    });
+
+    context("frameSize", () => {
+      it("renders with size 50px (by default)", () => {
+        cy.mount(<ProductAvatarStack />);
+
+        cy.findAllByLabelText("avatar-content")
+          .should("have.css", "width", "50px")
+          .and("have.css", "height", "50px");
+      });
+
+      context("when given 70px by parent", () => {
+        it("should renders all frame-size with 70px", () => {
+          cy.mount(<ProductAvatarStack frameSize={70} />);
+
+          cy.findAllByLabelText("avatar-content")
+            .should("have.css", "width", "70px")
+            .and("have.css", "height", "70px");
+        });
+
+        context("when given 100px for one specified avatar", () => {
+          it("renders the specified avatar font-size with 100px", () => {
+            const FINAL_AVATARS_WITH_SPECIFIED_FRAME_SIZE = AVATARS.map(
+              (avatar, index) =>
+                index === 2
+                  ? {
+                      ...avatar,
+                      frameSize: 100,
+                    }
+                  : avatar
+            );
+
+            cy.mount(
+              <ProductAvatarStack
+                frameSize={70}
+                avatars={FINAL_AVATARS_WITH_SPECIFIED_FRAME_SIZE}
+              />
+            );
+
+            FINAL_AVATARS_WITH_SPECIFIED_FRAME_SIZE.map((_, index) => {
+              if (index === 2) {
+                cy.findAllByLabelText("avatar-content")
+                  .eq(2)
+                  .should("have.css", "width", "100px")
+                  .and("have.css", "height", "100px");
+              } else {
+                cy.findAllByLabelText("avatar-content")
+                  .eq(index)
+                  .should("have.css", "width", "70px")
+                  .and("have.css", "height", "70px");
+              }
+            });
+          });
+        });
+      });
+    });
+
+    context("actions", () => {
+      it("renders all the action", () => {
+        cy.mount(<ProductAvatarStack />);
+
+        cy.findByLabelText("avatar-stack-action").should("exist");
+      });
+
+      context("hoverCaption", () => {
+        it("renders the hoverCaption on hover", () => {
+          const actions: AvatarStackAction[] = [
+            {
+              hoverCaption: "Add another person",
+              onClick: cy.stub(),
+            },
+          ];
+
+          cy.mount(<ProductAvatarStack actions={actions} />);
+
+          cy.findByText("Add another person").should("not.exist");
+
+          cy.findByLabelText("avatar-stack-action").realHover();
+
+          cy.wait(200);
+
+          cy.findByText("Add another person").should("exist");
+        });
+      });
+
+      context("hidden", () => {
+        context("when given", () => {
+          it("does not render the action", () => {
+            const actions: AvatarStackAction[] = [
+              {
+                hoverCaption: "Add another person",
+                onClick: cy.stub(),
+              },
+              {
+                hidden: true,
+                hoverCaption: "Hidden Action",
+              },
+            ];
+
+            cy.mount(<ProductAvatarStack actions={actions} />);
+
+            cy.findAllByLabelText("avatar-stack-action").should(
+              "not.have.length",
+              2
+            );
+          });
+        });
+      });
+
+      context("onClick", () => {
+        context("when clicking an action", () => {
+          it("renders calls onClick", () => {
+            const onClick = cy.stub();
+
+            const actions: AvatarStackAction[] = [
+              {
+                onClick,
+              },
+            ];
+
+            cy.mount(<ProductAvatarStack actions={actions} />);
+
+            cy.findByLabelText("avatar-stack-action").click();
+
+            cy.wrap(onClick).should("have.been.calledOnce");
+          });
+        });
+      });
+    });
+
+    context("id", () => {
+      context("when given id avatar-stack-test", () => {
+        it("renders the id with avatar-stack-test", () => {
+          cy.mount(<ProductAvatarStack id="avatar-stack-test" />);
+
+          cy.get("#avatar-stack-test").should("exist");
+        });
+      });
+    });
+
+    context("className", () => {
+      it("renders coneto-avatar-stack", () => {
+        cy.mount(<ProductAvatarStack />);
+
+        cy.get(".coneto-avatar-stack").should("exist");
+      });
+
+      context("when given className test", () => {
+        it("renders the className with test", () => {
+          cy.mount(<ProductAvatarStack className="test" />);
+
+          cy.get(".coneto-avatar-stack").should("exist");
+          cy.get(".test").should("exist");
+        });
+      });
+    });
+  });
+
   context("onMouseEnter", () => {
     context("when hovering", () => {
       it("should give callback", () => {


### PR DESCRIPTION
Description:
This pull request introduces `Avatar.Stack` as part of the `Avatar` component, enabling the rendering of multiple avatars within a single stack while providing a flexible and customizable API.

The component supports a wide range of configuration options, including `avatars`, `actions`, `styles`, `frameSize`, `fontSize`, and more, allowing it to adapt to various use cases and layouts.

Additionally, this change ensures consistent prop inheritance behavior. When props are provided by the parent component, they are automatically applied to all child avatars. If a child avatar explicitly provides the same prop, the child value takes precedence, maintaining predictable and consistent behavior across the component hierarchy.

Source:
[[Feature] SYST-752: Create <Avatar.Stack>](https://linear.app/systatum/issue/SYST-752/create-avatarstack)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself