### PR TITLE
[Improvement] SYST-760: `Timebox` mobile scrolling doesn't properly prevent the entire page.

### DIFF
--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -496,7 +496,7 @@ const InputWrapper = styled.label<{ $style?: CSSProp }>`
   width: 100%;
   align-items: center;
   justify-content: flex-start;
-  height: 100%;
+  height: fit-content;
 
   ${({ $style }) => $style}
 `;

--- a/components/timebox.tsx
+++ b/components/timebox.tsx
@@ -22,10 +22,11 @@ import { TimeboxThemeConfig } from "./../theme";
 import { applyClassName } from "./../constants/classname";
 import { Wheel } from "./wheel";
 
-interface BaseTimeboxProps extends Omit<
-  InputHTMLAttributes<HTMLInputElement>,
-  "style" | "placeholder" | "value" | "name"
-> {
+interface BaseTimeboxProps
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    "style" | "placeholder" | "value" | "name"
+  > {
   withSeconds?: boolean;
   editable?: boolean;
   styles?: TimeboxStyles;
@@ -213,7 +214,7 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
 
         setNext(type, trimmedCurrent);
 
-        if (nextType) {
+        if (nextType && !mobile) {
           refMap[nextType].current?.focus();
 
           const base = nextType === "minute" ? nextMinute : nextSecond;
@@ -268,7 +269,7 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
           $disabled={disabled}
           $theme={timeboxTheme}
           onKeyDown={(e) => {
-            if (onKeyDown) {
+            if (onKeyDown && !mobile) {
               onKeyDown(e);
             }
           }}
@@ -447,11 +448,14 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
                 z-index: 9992999;
               `,
             }}
-            onChange={(value) => {
-              if (value.hour !== undefined) handleChange("hour", value.hour);
-              if (value.minute !== undefined)
+            onChange={(value, changedId) => {
+              if (changedId === "hour") {
+                handleChange("hour", value.hour);
+              }
+              if (changedId === "minute") {
                 handleChange("minute", value.minute);
-              if (withSeconds && value.second !== undefined) {
+              }
+              if (withSeconds && changedId === "second") {
                 handleChange("second", value.second);
               }
             }}
@@ -473,8 +477,7 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
 );
 
 export interface TimeboxProps
-  extends
-    Omit<BaseTimeboxProps, "styles" | "inputId">,
+  extends Omit<BaseTimeboxProps, "styles" | "inputId">,
     Omit<FieldLaneProps, "styles" | "inputId" | "type"> {
   styles?: TimeboxStyles & FieldLaneStyles;
 }

--- a/components/wheel.tsx
+++ b/components/wheel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, Fragment } from "react";
+import { useState, useRef, useCallback, Fragment, useEffect } from "react";
 import styled, { CSSProp } from "styled-components";
 import { useTheme, WheelThemeConfig } from "./../theme";
 
@@ -18,7 +18,7 @@ export type WheelValues = Record<string, string>;
 export interface WheelProps {
   parts?: WheelPart[];
   values?: WheelValues;
-  onChange?: (values: WheelValues) => void;
+  onChange?: (values: WheelValues, changedId?: string) => void;
   styles?: WheelStyles;
 }
 
@@ -44,7 +44,7 @@ function Wheel({ parts = [], values = {}, onChange, styles }: WheelProps) {
   } = styles ?? {};
 
   const handleChange = (partId: string, newValue: string) => {
-    onChange({ ...values, [partId]: newValue });
+    onChange({ ...values, [partId]: newValue }, partId);
   };
 
   return (
@@ -322,6 +322,8 @@ function WheelColumn({
       lastTime.current === null
     )
       return;
+    e.preventDefault();
+
     const y = e.clientY;
     const now = performance.now();
     const dt = now - lastTime.current;
@@ -334,6 +336,7 @@ function WheelColumn({
   const onPointerUp = useCallback(
     (_e: React.PointerEvent<HTMLDivElement>) => {
       if (startY.current === null) return;
+      _e.preventDefault();
       setDragging(false);
       startY.current = null;
 
@@ -362,27 +365,30 @@ function WheelColumn({
 
   const wheelAccumulator = useRef(0);
 
-  const onWheel = useCallback(
-    (e: React.WheelEvent<HTMLDivElement>) => {
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+
       wheelAccumulator.current += e.deltaY;
 
       const threshold = 40;
-
       if (Math.abs(wheelAccumulator.current) >= threshold) {
         const direction = wheelAccumulator.current > 0 ? 1 : -1;
-
         const next = Math.max(
           0,
           Math.min(values.length - 1, selectedIndex + direction)
         );
-
         onChange(values[next].value);
-
         wheelAccumulator.current = 0;
       }
-    },
-    [selectedIndex, values, onChange]
-  );
+    };
+
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    return () => el.removeEventListener("wheel", handleWheel);
+  }, [selectedIndex, values]);
 
   const padCount = Math.floor(VISIBLE_ITEMS / 2);
   const paddedValues: (WheelValue | null)[] = [
@@ -394,8 +400,8 @@ function WheelColumn({
   return (
     <ColumnWrapper
       ref={containerRef}
+      tabIndex={-1}
       $width={width}
-      onWheel={onWheel}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}

--- a/test/component/timebox.cy.tsx
+++ b/test/component/timebox.cy.tsx
@@ -52,6 +52,48 @@ describe("Timebox", () => {
         cy.findByLabelText("wheel-container").should("not.exist");
       });
 
+      context("when have overflow in a whole page", () => {
+        context("when scrolling", () => {
+          it("should prevents scroll only on the drawer", () => {
+            cy.viewport(500, 500);
+
+            cy.mount(
+              <div
+                aria-label="wrapper"
+                style={{
+                  height: "900px",
+                  overflow: "auto",
+                }}
+              >
+                <ProductTimebox withSeconds withOnChange mobile label="Test" />
+              </div>
+            );
+
+            cy.findByLabelText("wheel-container").should("not.exist");
+            cy.findByText("Test").eq(0).click();
+
+            cy.findByLabelText("wrapper")
+              .invoke("prop", "scrollTop")
+              .should("eq", 0);
+
+            Cypress._.times(9, () => {
+              cy.findAllByLabelText("wheel-column-container")
+                .eq(0)
+                .realMouseWheel({ deltaY: 400 });
+            });
+
+            cy.findAllByLabelText("wheel-column-item")
+              .filter('[aria-selected="true"]')
+              .eq(0)
+              .should("contain", "9");
+
+            cy.findByLabelText("wrapper")
+              .invoke("prop", "scrollTop")
+              .should("eq", 0);
+          });
+        });
+      });
+
       context("when typing", () => {
         it("not shows changes the value", () => {
           cy.mount(<ProductTimebox withSeconds withOnChange mobile />);


### PR DESCRIPTION
Description:
Previously, when scrolling reached the top or bottom of the drawer, the scroll event propagated to the page, causing the entire page to scroll.

This pull request addressed that behavior in `Timebox` mobile, especially in the drawer level. 

Source:
[[Improvement] SYST-760: `Timebox` mobile scrolling doesn't properly prevent the entire page.](https://linear.app/systatum/issue/SYST-760/timebox-mobile-scrolling-doesnt-properly-prevent-the-entire-page)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself