### PR TITLE
[Improvment] SYST-758: Enrich `styles` in `Colorbox`

### DIFF
--- a/components/colorbox.tsx
+++ b/components/colorbox.tsx
@@ -30,6 +30,8 @@ interface BaseColorboxProps
 }
 
 export interface BaseColorboxStyles {
+  textInputGroupStyle?: CSSProp;
+  textInputStyle?: CSSProp;
   self?: CSSProp;
 }
 
@@ -115,17 +117,21 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
           $hovered={hovered}
           $theme={colorboxTheme}
           $showError={!!showError}
+          aria-label="colorbox-input-group"
+          $style={styles?.textInputGroupStyle}
         >
           <Prefix $theme={colorboxTheme} $showError={!!showError}>
             #
           </Prefix>
           <TextInput
             {...props}
+            aria-label="colorbox-input"
             $theme={colorboxTheme}
             $disabled={disabled}
             type="text"
             ref={ref}
             disabled={disabled}
+            $style={styles?.textInputStyle}
             value={value?.replace(/^#/, "")}
             onChange={(e) => {
               const cleanValue = e.target.value.replace(/#/g, "");
@@ -189,6 +195,9 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
       id: props.id,
     });
 
+    const { self, textInputGroupStyle, textInputStyle, ...fieldLaneInput } =
+      styles ?? {};
+
     return (
       <FieldLane
         id={inputId}
@@ -205,10 +214,7 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
         disabled={disabled}
         required={rest.required}
         className={applyClassName("colorbox", className)}
-        styles={{
-          containerStyle: styles?.containerStyle,
-          labelStyle: styles?.labelStyle,
-        }}
+        styles={fieldLaneInput}
       >
         <BaseColorbox
           {...rest}
@@ -216,13 +222,15 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
           showError={showError}
           disabled={disabled}
           styles={{
+            textInputGroupStyle,
+            textInputStyle,
             self: css`
               ${dropdowns &&
               css`
                 border-top-left-radius: 0px;
                 border-bottom-left-radius: 0px;
               `}
-              ${styles?.self}
+              ${self}
             `,
           }}
           ref={ref}
@@ -312,6 +320,7 @@ const TextInputGroup = styled.span<{
   $showError: boolean;
   $disabled?: boolean;
   $theme: ColorboxThemeConfig;
+  $style?: CSSProp;
 }>`
   display: flex;
   align-items: center;
@@ -333,6 +342,8 @@ const TextInputGroup = styled.span<{
             : $theme.borderColor};
 
   width: 100%;
+
+  ${({ $style }) => $style}
 `;
 
 const Prefix = styled.span<{
@@ -347,6 +358,7 @@ const TextInput = styled.input<{
   $showError: boolean;
   $disabled?: boolean;
   $theme: ColorboxThemeConfig;
+  $style?: CSSProp;
 }>`
   flex: 1;
   width: 100%;
@@ -369,6 +381,8 @@ const TextInput = styled.input<{
       : $showError
         ? $theme.errorTextColor
         : $theme.textColor};
+
+  ${({ $style }) => $style}
 `;
 
 export { Colorbox };

--- a/components/colorbox.tsx
+++ b/components/colorbox.tsx
@@ -84,6 +84,7 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
         $theme={colorboxTheme}
         $disabled={disabled}
         $style={styles?.self}
+        aria-label="colorbox"
         $hovered={hovered}
         $showError={!!showError}
         onBlur={() => {

--- a/components/colorbox.tsx
+++ b/components/colorbox.tsx
@@ -32,6 +32,7 @@ interface BaseColorboxProps
 export interface BaseColorboxStyles {
   textInputGroupStyle?: CSSProp;
   textInputStyle?: CSSProp;
+  boxStyle?: CSSProp;
   self?: CSSProp;
 }
 
@@ -92,6 +93,7 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
         }}
       >
         <ColorBox
+          $style={styles?.boxStyle}
           $theme={colorboxTheme}
           $disabled={disabled}
           onClick={() => {
@@ -101,6 +103,7 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
           }}
           tabIndex={0}
           $bgColor={value}
+          aria-label={"colorbox-box"}
           $showError={!!showError}
         />
 
@@ -196,8 +199,13 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
       id: props.id,
     });
 
-    const { self, textInputGroupStyle, textInputStyle, ...fieldLaneInput } =
-      styles ?? {};
+    const {
+      self,
+      textInputGroupStyle,
+      textInputStyle,
+      boxStyle,
+      ...fieldLaneInput
+    } = styles ?? {};
 
     return (
       <FieldLane
@@ -225,6 +233,7 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
           styles={{
             textInputGroupStyle,
             textInputStyle,
+            boxStyle,
             self: css`
               ${dropdowns &&
               css`
@@ -283,6 +292,7 @@ const ColorBox = styled.div<{
   $showError?: boolean;
   $disabled?: boolean;
   $theme: ColorboxThemeConfig;
+  $style?: CSSProp;
 }>`
   min-width: 24px;
   min-height: 24px;
@@ -305,6 +315,8 @@ const ColorBox = styled.div<{
       user-select: none;
       cursor: not-allowed;
     `};
+
+  ${({ $style }) => $style}
 `;
 
 const HiddenColorInput = styled.input`

--- a/test/component/colorbox.cy.tsx
+++ b/test/component/colorbox.cy.tsx
@@ -7,6 +7,7 @@ import {
   RiUser2Line,
 } from "@remixicon/react";
 import { useState } from "react";
+import { css } from "styled-components";
 
 describe("Colorbox", () => {
   function ProductColorbox(
@@ -26,6 +27,77 @@ describe("Colorbox", () => {
       />
     );
   }
+
+  context("styles", () => {
+    context("self", () => {
+      context("when given border-radius 12px", () => {
+        it("should render with border-radius 12px", () => {
+          cy.mount(
+            <ProductColorbox
+              withOnChange
+              styles={{
+                self: css`
+                  border-radius: 12px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("colorbox").should(
+            "have.css",
+            "border-radius",
+            "12px"
+          );
+        });
+      });
+    });
+
+    context("textInputGroupStyle", () => {
+      context("when given padding 30px", () => {
+        it("should render with padding 30px", () => {
+          cy.mount(
+            <ProductColorbox
+              withOnChange
+              styles={{
+                textInputGroupStyle: css`
+                  padding: 30px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("colorbox-input-group")
+            .should("have.css", "padding-top", "30px")
+            .and("have.css", "padding-right", "30px")
+            .and("have.css", "padding-bottom", "30px")
+            .and("have.css", "padding-left", "30px");
+        });
+      });
+    });
+
+    context("textInputStyle", () => {
+      context("when given font-size 20px", () => {
+        it("should render with font-size 20px", () => {
+          cy.mount(
+            <ProductColorbox
+              withOnChange
+              styles={{
+                textInputStyle: css`
+                  font-size: 20px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("colorbox-input").should(
+            "have.css",
+            "font-size",
+            "20px"
+          );
+        });
+      });
+    });
+  });
 
   context("onChange", () => {
     context("when given", () => {

--- a/test/component/colorbox.cy.tsx
+++ b/test/component/colorbox.cy.tsx
@@ -75,6 +75,29 @@ describe("Colorbox", () => {
       });
     });
 
+    context("boxStyle", () => {
+      context("when given background red", () => {
+        it("should render box with rgb(255, 0, 0)", () => {
+          cy.mount(
+            <ProductColorbox
+              withOnChange
+              styles={{
+                boxStyle: css`
+                  background-color: red;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("colorbox-box").should(
+            "have.css",
+            "background-color",
+            "rgb(255, 0, 0)"
+          );
+        });
+      });
+    });
+
     context("textInputStyle", () => {
       context("when given font-size 20px", () => {
         it("should render with font-size 20px", () => {


### PR DESCRIPTION
Description:
Previously, it wasn't possible to customize the input group or input text styles in the Colorbox, which limited its styling flexibility.

This ticket introduces `textInputStyle` and `textInputGroupStyle` to `BaseColorboxStyles` through the `styles` prop, providing greater flexibility for customizing the Colorbox's appearance.

Source:
[[Improvment] SYST-758: Enrich `styles` in `Colorbox`](https://linear.app/systatum/issue/SYST-758/enrich-styles-on-the-colorbox)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself