### PR TITLE
[Bug] SYST-765: Make defining `id` and `className` works on `Title` rightSection and possibly other sections

### DIFF
--- a/components/context-menu.tsx
+++ b/components/context-menu.tsx
@@ -92,8 +92,9 @@ export default function ContextMenu({
         ? buttonTheme?.[variant]?.hoverBackgroundColor
         : hoverBackgroundColor;
 
-      const resolvedButtonProps = {
+      const resolvedButtonProps: ButtonProps = {
         ...buttonProps,
+        ...action,
         activeBackgroundColor: resolvedActiveBackgroundColor,
         styles: {
           self: css`

--- a/components/title.tsx
+++ b/components/title.tsx
@@ -5,7 +5,8 @@ import { TitleThemeConfig, useTheme } from "./../theme";
 import { applyClassName } from "./../constants/classname";
 import { darkenColor, lightenColor } from "./../lib/color";
 import { Capsule, CapsuleProps } from "./capsule";
-import ContextMenu, { ContextMenuAction } from "./context-menu";
+import { Button, ButtonStyles, ButtonVariant } from "./button";
+import { BaseAction } from "./../constants/action";
 
 export const TitleSize = {
   Small: "sm",
@@ -214,9 +215,17 @@ export interface TitleSection {
   styles?: TitleSectionStyles;
 }
 
-export interface TitleSectionAction extends ContextMenuAction {
-  icon: FigureProps;
+export interface TitleSectionAction extends BaseAction {
+  icon?: TitleSectionActionIcon;
+  variant?: TitleSectionActionVariant;
+  styles?: TitleSectionActionStyles;
+  id?: string;
+  className?: string;
 }
+
+export type TitleSectionActionIcon = FigureProps;
+export type TitleSectionActionVariant = ButtonVariant;
+export type TitleSectionActionStyles = ButtonStyles;
 
 export interface TitleSectionStyles {
   toggleActionStyle?: CSSProp;
@@ -271,8 +280,11 @@ function BaseTitleSection({
           }));
 
           return filteredActionsWithSize.map((action, actionIndex) => (
-            <ContextMenu
+            <Button
               key={actionIndex}
+              {...action}
+              aria-label="title-action"
+              variant={action?.variant ?? "ghost"}
               styles={{
                 self: css`
                   width: ${resolvedIconSize * 1.4}px;
@@ -286,9 +298,9 @@ function BaseTitleSection({
                 `,
                 containerStyle: action.styles?.containerStyle,
               }}
-              maxActionsBeforeCollapsing={section.actions?.length}
               hoverBackgroundColor={titleTheme?.icon?.hoverBackgroundColor}
-              actions={[action]}
+              activeBackgroundColor={titleTheme?.icon?.hoverBackgroundColor}
+              icon={action?.icon}
             />
           ));
         }

--- a/components/title.tsx
+++ b/components/title.tsx
@@ -224,7 +224,10 @@ export interface TitleSectionAction extends BaseAction {
 }
 
 export type TitleSectionActionIcon = FigureProps;
-export type TitleSectionActionVariant = ButtonVariant;
+export type TitleSectionActionVariant = Exclude<
+  ButtonVariant,
+  "outline-default" | "outline-success" | "outline-primary" | "outline-danger"
+>;
 export type TitleSectionActionStyles = ButtonStyles;
 
 export interface TitleSectionStyles {
@@ -279,30 +282,39 @@ function BaseTitleSection({
             },
           }));
 
-          return filteredActionsWithSize.map((action, actionIndex) => (
-            <Button
-              key={actionIndex}
-              {...action}
-              aria-label="title-action"
-              variant={action?.variant ?? "ghost"}
-              styles={{
-                self: css`
-                  width: ${resolvedIconSize * 1.4}px;
-                  height: ${resolvedIconSize * 1.4}px;
-                  padding: 20px;
-                  border-radius: 10px;
-                  background-color: ${titleTheme?.icon?.backgroundColor};
+          return filteredActionsWithSize.map((action, actionIndex) => {
+            const variant = action?.variant ?? "ghost";
 
-                  ${section?.styles?.toggleActionStyle}
-                  ${action.styles?.self}
-                `,
-                containerStyle: action.styles?.containerStyle,
-              }}
-              hoverBackgroundColor={titleTheme?.icon?.hoverBackgroundColor}
-              activeBackgroundColor={titleTheme?.icon?.hoverBackgroundColor}
-              icon={action?.icon}
-            />
-          ));
+            return (
+              <Button
+                key={actionIndex}
+                {...action}
+                aria-label="title-action"
+                variant={variant}
+                styles={{
+                  self: css`
+                    width: ${resolvedIconSize * 1.4}px;
+                    height: ${resolvedIconSize * 1.4}px;
+                    padding: 20px;
+                    border-radius: 10px;
+                    background-color: ${variant === "ghost" &&
+                    titleTheme?.icon?.backgroundColor};
+
+                    ${section?.styles?.toggleActionStyle}
+                    ${action.styles?.self}
+                  `,
+                  containerStyle: action.styles?.containerStyle,
+                }}
+                hoverBackgroundColor={
+                  variant === "ghost" && titleTheme?.icon?.hoverBackgroundColor
+                }
+                activeBackgroundColor={
+                  variant === "ghost" && titleTheme?.icon?.hoverBackgroundColor
+                }
+                icon={action?.icon}
+              />
+            );
+          });
         }
 
         return null;

--- a/components/title.tsx
+++ b/components/title.tsx
@@ -270,31 +270,27 @@ function BaseTitleSection({
             },
           }));
 
-          return (
-            <>
-              {filteredActionsWithSize.map((action, actionIndex) => (
-                <ContextMenu
-                  key={actionIndex}
-                  styles={{
-                    self: css`
-                      width: ${resolvedIconSize * 1.4}px;
-                      height: ${resolvedIconSize * 1.4}px;
-                      padding: 20px;
-                      border-radius: 10px;
-                      background-color: ${titleTheme?.icon?.backgroundColor};
+          return filteredActionsWithSize.map((action, actionIndex) => (
+            <ContextMenu
+              key={actionIndex}
+              styles={{
+                self: css`
+                  width: ${resolvedIconSize * 1.4}px;
+                  height: ${resolvedIconSize * 1.4}px;
+                  padding: 20px;
+                  border-radius: 10px;
+                  background-color: ${titleTheme?.icon?.backgroundColor};
 
-                      ${section?.styles?.toggleActionStyle}
-                      ${action.styles?.self}
-                    `,
-                    containerStyle: action.styles?.containerStyle,
-                  }}
-                  maxActionsBeforeCollapsing={section.actions?.length}
-                  hoverBackgroundColor={titleTheme?.icon?.hoverBackgroundColor}
-                  actions={[action]}
-                />
-              ))}
-            </>
-          );
+                  ${section?.styles?.toggleActionStyle}
+                  ${action.styles?.self}
+                `,
+                containerStyle: action.styles?.containerStyle,
+              }}
+              maxActionsBeforeCollapsing={section.actions?.length}
+              hoverBackgroundColor={titleTheme?.icon?.hoverBackgroundColor}
+              actions={[action]}
+            />
+          ));
         }
 
         return null;

--- a/test/component/title.cy.tsx
+++ b/test/component/title.cy.tsx
@@ -449,6 +449,140 @@ describe("Title", () => {
     });
 
     context("with actions", () => {
+      context("when given id", () => {
+        it("should render the id from action", () => {
+          cy.mount(
+            <Title
+              text="With Actions"
+              rightSection={[
+                {
+                  type: "actions",
+                  actions: [
+                    {
+                      id: "Test",
+                      caption: "Edit",
+                      icon: { image: RiCloseFill },
+                      onClick: cy.stub(),
+                    },
+                    {
+                      caption: "Not Editable",
+                      icon: { image: RiCloseFill },
+                      onClick: cy.stub(),
+                    },
+                  ],
+                },
+              ]}
+            />
+          );
+
+          cy.get("#Test").should("exist").and("have.length", 1);
+        });
+      });
+
+      context("when given className", () => {
+        it("should render the className", () => {
+          cy.mount(
+            <Title
+              text="With Actions"
+              rightSection={[
+                {
+                  type: "actions",
+                  actions: [
+                    {
+                      className: "test-className",
+                      caption: "Edit",
+                      icon: { image: RiCloseFill },
+                      onClick: cy.stub(),
+                    },
+                    {
+                      className: "test-another-className",
+                      caption: "Edit",
+                      icon: { image: RiCloseFill },
+                      onClick: cy.stub(),
+                    },
+                  ],
+                },
+              ]}
+            />
+          );
+
+          cy.get(".test-className").should("exist").and("have.length", 1);
+          cy.get(".test-another-className")
+            .should("exist")
+            .and("have.length", 1);
+        });
+      });
+
+      context("when given hidden", () => {
+        it("should not shows the action", () => {
+          cy.mount(
+            <Title
+              text="With Actions"
+              rightSection={[
+                {
+                  type: "actions",
+                  actions: [
+                    {
+                      className: "test-className",
+                      caption: "Edit",
+                      icon: { image: RiCloseFill },
+                      onClick: cy.stub(),
+                      hidden: true,
+                    },
+                    {
+                      className: "test-another-className",
+                      caption: "Edit",
+                      icon: { image: RiCloseFill },
+                      onClick: cy.stub(),
+                    },
+                  ],
+                },
+              ]}
+            />
+          );
+
+          cy.get(".test-className").should("not.exist");
+          cy.get(".test-another-className")
+            .should("exist")
+            .and("have.length", 1);
+        });
+      });
+
+      context("when given disabled", () => {
+        it("should disabled the action", () => {
+          cy.mount(
+            <Title
+              text="With Actions"
+              rightSection={[
+                {
+                  type: "actions",
+                  actions: [
+                    {
+                      className: "test-className",
+                      caption: "Edit",
+                      icon: { image: RiCloseFill },
+                      onClick: cy.stub(),
+                      disabled: true,
+                    },
+                    {
+                      className: "test-another-className",
+                      caption: "Edit",
+                      icon: { image: RiCloseFill },
+                      onClick: cy.stub(),
+                    },
+                  ],
+                },
+              ]}
+            />
+          );
+
+          cy.findAllByLabelText("action-button").eq(0).should("be.disabled");
+          cy.findAllByLabelText("action-button")
+            .eq(1)
+            .should("not.be.disabled");
+        });
+      });
+
       it("should render actions section", () => {
         cy.mount(
           <Title

--- a/test/component/title.cy.tsx
+++ b/test/component/title.cy.tsx
@@ -56,11 +56,11 @@ describe("Title", () => {
               />
             );
 
-            cy.findAllByLabelText("action-button")
+            cy.findAllByLabelText("title-action")
               .parent()
               .eq(0)
               .should("have.css", "border", "1px solid rgb(0, 0, 255)");
-            cy.findAllByLabelText("action-button")
+            cy.findAllByLabelText("title-action")
               .parent()
               .eq(1)
               .should("not.have.css", "border", "1px solid rgb(0, 0, 255)");
@@ -100,10 +100,10 @@ describe("Title", () => {
               />
             );
 
-            cy.findAllByLabelText("action-button")
+            cy.findAllByLabelText("title-action")
               .eq(0)
               .should("have.css", "padding", "50px");
-            cy.findAllByLabelText("action-button")
+            cy.findAllByLabelText("title-action")
               .eq(1)
               .should("have.css", "padding", "20px");
           });
@@ -576,10 +576,8 @@ describe("Title", () => {
             />
           );
 
-          cy.findAllByLabelText("action-button").eq(0).should("be.disabled");
-          cy.findAllByLabelText("action-button")
-            .eq(1)
-            .should("not.be.disabled");
+          cy.findAllByLabelText("title-action").eq(0).should("be.disabled");
+          cy.findAllByLabelText("title-action").eq(1).should("not.be.disabled");
         });
       });
 
@@ -625,10 +623,10 @@ describe("Title", () => {
             />
           );
 
-          cy.findByLabelText("action-button").realHover();
+          cy.findByLabelText("title-action").realHover();
 
           cy.wait(200);
-          cy.findByLabelText("action-button").should(
+          cy.findByLabelText("title-action").should(
             "have.css",
             "background-color",
             "rgba(255, 255, 255, 0.45)"

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1826,7 +1826,6 @@ export function createTitleTheme(
       textColor: body.textColor,
       backgroundColor: "transparent",
       hoverBackgroundColor: "rgba(255, 255, 255, 0.45)",
-      activeBackgroundColor: "",
     },
   };
 

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1826,6 +1826,7 @@ export function createTitleTheme(
       textColor: body.textColor,
       backgroundColor: "transparent",
       hoverBackgroundColor: "rgba(255, 255, 255, 0.45)",
+      activeBackgroundColor: "",
     },
   };
 


### PR DESCRIPTION
Description:
This pull request fixes an issue where the `id` and `className` props were not applied correctly to the action button.

The root cause was that the `ContextMenu` component was being used in a scenario where additional props needed to be forwarded, which it was not designed to support. To address this, the implementation has been refactored to use our `Button` component directly.

Since the current design does not require switching to a hamburger menu when there are multiple actions, using `Button` is a simpler and more appropriate solution. This refactor also preserves the existing behavior while ensuring that `id`, `className`, and other related props are forwarded and work as expected.

Source:
[[Bug] SYST-765: Make defining `id` and `className` works on `Title` rightSection and possibly other sections](https://linear.app/systatum/issue/SYST-765/make-defining-id-and-classname-works-on-title-rightsection-and)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself