### PR TITLE
[Bug] SYST-766: Can't scroll in the `Table` documentation

### DIFF
--- a/components/overlay-blocker.tsx
+++ b/components/overlay-blocker.tsx
@@ -60,6 +60,7 @@ export const OverlayBlocker = forwardRef<
       ".coneto-paper-dialog",
       ".coneto-dialog",
       ".coneto-sidebar",
+      ".sbdocs",
       ...(_exemptRegions ?? []),
     ];
 
@@ -69,6 +70,12 @@ export const OverlayBlocker = forwardRef<
       if (!visible) return;
 
       const safeRegions = exemptRegions ?? [];
+
+      // Check if the overlay is rendered inside a safe region
+      const isRenderedInsideSafeZone = isInSafeZone(
+        document.querySelector('[aria-label="overlay-blocker"]'),
+        safeRegions
+      );
 
       const scrollY = window.scrollY;
       const body = document.body;
@@ -80,10 +87,13 @@ export const OverlayBlocker = forwardRef<
         width: body.style.width,
       };
 
-      body.style.overflow = "hidden";
-      body.style.position = "fixed";
-      body.style.top = `-${scrollY}px`;
-      body.style.width = "100%";
+      // Only lock the body if NOT inside a safe zone
+      if (!isRenderedInsideSafeZone) {
+        body.style.overflow = "hidden";
+        body.style.position = "fixed";
+        body.style.top = `-${scrollY}px`;
+        body.style.width = "100%";
+      }
 
       const allow = (target: EventTarget | null) =>
         isInSafeZone(target, safeRegions);
@@ -102,15 +112,16 @@ export const OverlayBlocker = forwardRef<
       window.addEventListener("touchmove", blockTouch, { passive: false });
 
       return () => {
-        body.style.overflow = prev.overflow;
-        body.style.position = prev.position;
-        body.style.top = prev.top;
-        body.style.width = prev.width;
+        if (!isRenderedInsideSafeZone) {
+          body.style.overflow = prev.overflow;
+          body.style.position = prev.position;
+          body.style.top = prev.top;
+          body.style.width = prev.width;
+          window.scrollTo(0, scrollY);
+        }
 
         window.removeEventListener("wheel", blockWheel);
         window.removeEventListener("touchmove", blockTouch);
-
-        window.scrollTo(0, scrollY);
       };
     }, [exemptRegions, visible]);
 


### PR DESCRIPTION
Description:
This pull request fixes an issue where the Table storybook documentation page could not be scrolled properly. After investigating the problem, it was caused by the overlay-blocker class being applied incorrectly, which prevented the documentation page from scrolling whenever a story used it.

Source:
[[Bug] SYST-766: Can't scroll in the `Table` documentation](https://linear.app/systatum/issue/SYST-766/cant-scroll-in-the-table-documentation)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself