### PR TITLE
[Improvement] SYST-768: Improves `Radio` hover behavior

### DIFF
--- a/components/checkbox.tsx
+++ b/components/checkbox.tsx
@@ -70,7 +70,7 @@ function BaseCheckbox({
 
   return (
     <InputWrapper
-      aria-label="input-wrapper-checkbox"
+      aria-label="checkbox-label"
       htmlFor={props.disabled ? null : id}
       $hasDescription={!!description}
       $highlight={!!highlightOnChecked}

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -97,6 +97,7 @@ function BaseRadio({
           disabled={props.disabled}
         />
         <Circle
+          aria-label="radio-circle"
           $isRadio={mode === "radio"}
           $error={showError}
           $style={styles?.self}

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -69,6 +69,7 @@ function BaseRadio({
 
   return (
     <Label
+      aria-label="radio-label"
       $isRadio={mode === "radio"}
       htmlFor={props.disabled ? null : id}
       $highlight={highlightOnChecked}

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -231,11 +231,10 @@ const Label = styled.label<{
       return (
         $theme?.highlightCheckedBackgroundColor ||
         $theme?.checkedBackgroundColor ||
-        $theme?.backgroundColor ||
         "transparent"
       );
 
-    return $theme?.backgroundColor || "transparent";
+    return "transparent";
   }};
 
   ${({ $highlight, $checked, $isRadio, $theme }) =>
@@ -272,9 +271,9 @@ const Label = styled.label<{
           if ($highlight && $checked) {
             return $theme?.highlightCheckedBackgroundColor;
           } else if ($highlight) {
-            return $theme?.highlightBackgroundColor || $theme?.backgroundColor;
+            return $theme?.highlightBackgroundColor;
           }
-          return $theme?.backgroundColor;
+          return "transparent";
         })()};
       }
     `};
@@ -326,7 +325,8 @@ const Circle = styled.div<{
   height: 16px;
   border-radius: 9999px;
   border: 1px solid ${({ $theme }) => $theme?.borderColor || "#4b5563"};
-  background-color: ${({ $theme }) => $theme?.backgroundColor || "transparent"};
+  background-color: ${({ $theme }) => $theme?.backgroundColor};
+  overflow: hidden;
 
   ${({ $error }) =>
     $error &&

--- a/test/component/choice-group.cy.tsx
+++ b/test/component/choice-group.cy.tsx
@@ -52,6 +52,56 @@ describe("ChoiceGroup", () => {
       });
     });
 
+    context("when hovering", () => {
+      it("renders still consistently coloring with same background", () => {
+        cy.window().then((win) => {
+          cy.spy(win.console, "log").as("consoleLog");
+        });
+
+        cy.mount(
+          <ChoiceGroup>
+            {OPTIONS.map((props, index) => (
+              <Radio
+                key={index}
+                name="radioSelected"
+                label={props.label}
+                value={props.value}
+                onChange={(e) =>
+                  console.log(
+                    `The name is ${e.target.name} and the value is ${e.target.value}`
+                  )
+                }
+                styles={{
+                  labelStyle: css`
+                    font-size: 30px;
+                  `,
+                }}
+              />
+            ))}
+          </ChoiceGroup>
+        );
+
+        cy.findAllByLabelText("radio-label")
+          .eq(0)
+          .should("have.css", "background-color", "rgba(0, 0, 0, 0)");
+
+        cy.findAllByLabelText("radio-circle")
+          .eq(0)
+          .should("have.css", "background-color", "rgb(255, 255, 255)");
+
+        cy.findByText("Email").realHover();
+        cy.wait(200);
+
+        cy.findAllByLabelText("radio-label")
+          .eq(0)
+          .should("have.css", "background-color", "rgb(231, 242, 252)");
+
+        cy.findAllByLabelText("radio-circle")
+          .eq(0)
+          .should("have.css", "background-color", "rgb(255, 255, 255)");
+      });
+    });
+
     context("with onChange", () => {
       context("when clicking", () => {
         it("render the callback on the console", () => {
@@ -134,6 +184,50 @@ describe("ChoiceGroup", () => {
             );
           });
         });
+      });
+    });
+
+    context("when hovering", () => {
+      it("renders still consistently coloring with same background", () => {
+        cy.window().then((win) => {
+          cy.spy(win.console, "log").as("consoleLog");
+        });
+
+        cy.mount(
+          <ChoiceGroup>
+            {OPTIONS.map((option, index) => (
+              <Checkbox
+                key={index}
+                value={option.value}
+                description={option.description}
+                name={option.label}
+                label={option.label}
+                onChange={(e) =>
+                  console.log(
+                    `The name is ${e.target.name} and the value is ${e.target.value}`
+                  )
+                }
+              />
+            ))}
+          </ChoiceGroup>
+        );
+
+        cy.findAllByLabelText("checkbox-label")
+          .eq(0)
+          .should("have.css", "background-color", "rgba(0, 0, 0, 0)");
+        cy.findAllByLabelText("checkbox")
+          .eq(0)
+          .should("have.css", "background-color", "rgb(255, 255, 255)");
+        cy.findByText("Email").realHover();
+        cy.wait(200);
+
+        cy.findAllByLabelText("checkbox-label")
+          .eq(0)
+          .should("have.css", "background-color", "rgb(231, 242, 252)");
+
+        cy.findAllByLabelText("checkbox")
+          .eq(0)
+          .should("have.css", "background-color", "rgb(255, 255, 255)");
       });
     });
 

--- a/test/component/list.cy.tsx
+++ b/test/component/list.cy.tsx
@@ -279,7 +279,7 @@ describe("List", () => {
         </List>
       );
 
-      cy.findByLabelText("input-wrapper-checkbox")
+      cy.findByLabelText("checkbox-label")
         .should("have.css", "width", "14px")
         .and("have.css", "height", "14px");
     });

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -2246,13 +2246,13 @@ describe("Table", () => {
           </Table>
         );
 
-        cy.findAllByLabelText("input-wrapper-checkbox")
+        cy.findAllByLabelText("checkbox-label")
           .eq(0)
           .should("have.css", "background-color", "rgba(0, 0, 0, 0)");
-        cy.findAllByLabelText("input-wrapper-checkbox")
+        cy.findAllByLabelText("checkbox-label")
           .eq(1)
           .should("have.css", "background-color", "rgba(0, 0, 0, 0)");
-        cy.findAllByLabelText("input-wrapper-checkbox")
+        cy.findAllByLabelText("checkbox-label")
           .eq(2)
           .should("have.css", "background-color", "rgba(0, 0, 0, 0)");
       });

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1248,7 +1248,7 @@ export function createRadioTheme(
     {
       borderColor: "#6b7280",
       checkedBorderColor: "#61A9F9",
-      backgroundColor: "#ffffff",
+      backgroundColor: body?.backgroundColor ?? "#ffffff",
       checkedBackgroundColor: "#ffffff",
       checkedOutsideBorderColor: "#61A9F9",
       iconColor: "#ffffff",

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -606,7 +606,6 @@ const darkRadio = createRadioTheme(darkBody, {
   borderColor: "#374151",
   checkedBorderColor: "#1465d3bf",
   checkedOutsideBorderColor: "#374151",
-  backgroundColor: "inherit",
   checkedBackgroundColor: "white",
   textColor: "#ffffff",
   descriptionColor: "#d1d5db",


### PR DESCRIPTION
Description:
Previously, the `Radio` component had inconsistent hover styling compared to the `Checkbox`. Unlike `Checkbox`, which always uses the theme's base background color for the input element, `Radio` inherited its background color, resulting in an inconsistent and unnatural appearance.

And at the same time we need adjustment on the `StatefulForm` mobile, which really weird when hovering shows the `background` color, we need adjust the `color` for whole `label` inside of `Radio`.

This ticket addresses both issues by:

- Updating the `Radio` component to use the correct base background color instead of inheriting it.
- Adjusting the hover styling so the background is applied across the entire radio label, providing a more consistent experience in `StatefulForm.Mobile`.

All issue and result shows in source below.

Source:
[[Improvement] SYST-768: Improves `Radio` hover behavior](https://linear.app/systatum/issue/SYST-768/improves-radio-hover-behavior)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself