### PR TITLE
[Improvement] SYST-767: Change API of defining column-level action for `Table`

### DIFF
--- a/components/action-button.tsx
+++ b/components/action-button.tsx
@@ -8,6 +8,7 @@ import {
 import { ReactNode } from "react";
 import { useTheme } from "./../theme/provider";
 import { BaseAction } from "../constants/action";
+import { TipMenuSize } from "./tip-menu";
 
 export type ActionButtonSubMenu = ButtonSubMenu;
 export type ActionButtonShowSubMenuPosition = ButtonShowSubMenuPosition;
@@ -19,6 +20,7 @@ export interface ActionButtonProps extends BaseAction {
   variant?: ButtonVariants["variant"];
   className?: string;
   pressed?: boolean;
+  tipMenuSize?: TipMenuSize;
 }
 
 export interface ActionButtonStyles {
@@ -42,6 +44,7 @@ export function ActionButton({
   pressed,
   hidden,
   id,
+  tipMenuSize = "sm",
 }: ActionButtonProps & { forTable?: boolean }) {
   const { currentTheme } = useTheme();
   const actionButtonTheme = currentTheme.actionButton;
@@ -63,7 +66,7 @@ export function ActionButton({
       disabled={disabled}
       showSubMenuOn={showSubMenuOn}
       size="sm"
-      tipMenuSize="sm"
+      tipMenuSize={tipMenuSize}
       variant={variant}
       className={className}
       pressed={pressed}

--- a/components/card.stories.tsx
+++ b/components/card.stories.tsx
@@ -808,7 +808,7 @@ export const WithFullWidthContent: Story = {
     });
 
     const columnActions = (id?: DepartmentKeys): TableColumnAction => ({
-      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      subMenu: ({ list }) => list(COLUMN_ACTIONS(id)),
       title: "Column Action",
     });
 
@@ -931,29 +931,27 @@ export const WithFullWidthContent: Story = {
       console.log("Selected rows:", data);
     };
 
-    const TIP_MENU_ACTION = (
-      columnCaption: DepartmentKeys
-    ): TableSubMenuList[] => {
+    const COLUMN_ACTIONS = (columnId: DepartmentKeys): TableSubMenuList[] => {
       return [
         {
           caption: "Sort Ascending",
           icon: { image: RiArrowUpSLine, color: "gray" },
           onClick: () => {
-            handleSortingRequested({ mode: "asc", column: columnCaption });
+            handleSortingRequested({ mode: "asc", column: columnId });
           },
         },
         {
           caption: "Sort Descending",
           icon: { image: RiArrowDownSLine, color: "gray" },
           onClick: () => {
-            handleSortingRequested({ mode: "desc", column: columnCaption });
+            handleSortingRequested({ mode: "desc", column: columnId });
           },
         },
         {
           caption: "Reset Sorting",
           icon: { image: RiRefreshLine, color: "gray" },
           onClick: () => {
-            handleSortingRequested({ mode: "original", column: columnCaption });
+            handleSortingRequested({ mode: "original", column: columnId });
           },
         },
       ];

--- a/components/card.stories.tsx
+++ b/components/card.stories.tsx
@@ -14,6 +14,9 @@ import {
   RiArrowDownSLine,
   RiRefreshLine,
   RiAddBoxLine,
+  RiArrowUpDownLine,
+  RiArrowDownLine,
+  RiArrowUpLine,
 } from "@remixicon/react";
 import { Toolbar, ToolbarSubMenuList } from "./toolbar";
 import { Searchbox } from "./searchbox";
@@ -22,7 +25,12 @@ import { Checkbox } from "./checkbox";
 import { Button } from "./button";
 import { List, ListGroupContent, ListItemProps } from "./list";
 import { css } from "styled-components";
-import { TableColumn, TableSubMenuList, Table } from "./table";
+import {
+  TableColumn,
+  TableSubMenuList,
+  Table,
+  TableColumnAction,
+} from "./table";
 import { DormantText } from "./dormant-text";
 import { Textbox } from "./textbox";
 import { useTheme } from "./../theme/provider";
@@ -799,26 +807,31 @@ export const WithFullWidthContent: Story = {
       subtitle: value.subtitle,
     });
 
+    const columnActions = (id?: DepartmentKeys): TableColumnAction => ({
+      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      title: "Column Action",
+    });
+
     const columns: TableColumn[] = [
       {
         id: "name",
         caption: "Name",
-        sortable: true,
+        actions: columnActions,
       },
       {
         id: "code",
         caption: "Code",
-        sortable: true,
+        actions: columnActions,
       },
       {
         id: "lead",
         caption: "Lead",
-        sortable: true,
+        actions: columnActions,
       },
       {
         id: "members",
         caption: "Members",
-        sortable: true,
+        actions: columnActions,
       },
     ];
 
@@ -1031,7 +1044,6 @@ export const WithFullWidthContent: Story = {
           }}
           columns={columns}
           onItemsSelected={handleItemsSelected}
-          subMenuList={TIP_MENU_ACTION}
           labels={{ totalSelectedItemText: (n) => `${n} Department selected` }}
         >
           {rows.map((rowValue, rowIndex) => (
@@ -1110,23 +1122,43 @@ export const Toggleable: Story = {
         setRows(sorted);
       };
 
-      const tipMenu = (column: keyof T): TableSubMenuList[] => [
-        {
-          caption: "Sort Ascending",
-          icon: { image: RiArrowUpSLine, color: "gray" },
-          onClick: () => handleSorting({ mode: "asc", column }),
+      const sortableColumns: TableColumn[] = columns.map((column) => ({
+        ...column,
+        actions: {
+          title: "Sort",
+          icon: { image: RiArrowUpDownLine },
+          subMenu: ({ list }) =>
+            list([
+              {
+                caption: "Sort Ascending",
+                icon: { image: RiArrowUpLine },
+                onClick: () =>
+                  handleSorting({
+                    mode: "asc",
+                    column: column.id as keyof T,
+                  }),
+              },
+              {
+                caption: "Sort Descending",
+                icon: { image: RiArrowDownLine },
+                onClick: () =>
+                  handleSorting({
+                    mode: "desc",
+                    column: column.id as keyof T,
+                  }),
+              },
+              {
+                caption: "Reset Sorting",
+                icon: { image: RiArrowUpDownLine },
+                onClick: () =>
+                  handleSorting({
+                    mode: "original",
+                    column: column.id as keyof T,
+                  }),
+              },
+            ]),
         },
-        {
-          caption: "Sort Descending",
-          icon: { image: RiArrowDownSLine, color: "gray" },
-          onClick: () => handleSorting({ mode: "desc", column }),
-        },
-        {
-          caption: "Reset Sorting",
-          icon: { image: RiRefreshLine, color: "gray" },
-          onClick: () => handleSorting({ mode: "original", column }),
-        },
-      ];
+      }));
 
       return (
         <Table
@@ -1136,8 +1168,7 @@ export const Toggleable: Story = {
             `,
           }}
           selectable
-          columns={columns}
-          subMenuList={tipMenu}
+          columns={sortableColumns}
         >
           {rows.map((row, index) => (
             <Table.Row
@@ -1184,10 +1215,10 @@ export const Toggleable: Story = {
     ];
 
     const departmentColumns: TableColumn[] = [
-      { id: "departmentName", caption: "Department", sortable: true },
-      { id: "head", caption: "Department Head", sortable: true },
-      { id: "employeeCount", caption: "Employees", sortable: true },
-      { id: "budget", caption: "Annual Budget", sortable: true },
+      { id: "departmentName", caption: "Department" },
+      { id: "head", caption: "Department Head" },
+      { id: "employeeCount", caption: "Employees" },
+      { id: "budget", caption: "Annual Budget" },
     ];
 
     const [departmentRows, setDepartmentRows] = useState(DEPARTMENTS);
@@ -1226,10 +1257,10 @@ export const Toggleable: Story = {
     ];
 
     const assetColumns: TableColumn[] = [
-      { id: "assetName", caption: "Asset Name", sortable: true },
-      { id: "category", caption: "Category", sortable: true },
-      { id: "assignedTo", caption: "Assigned To", sortable: true },
-      { id: "condition", caption: "Condition", sortable: true },
+      { id: "assetName", caption: "Asset Name" },
+      { id: "category", caption: "Category" },
+      { id: "assignedTo", caption: "Assigned To" },
+      { id: "condition", caption: "Condition" },
     ];
 
     const [assetRows, setAssetRows] = useState(ASSETS);

--- a/components/flippable.stories.tsx
+++ b/components/flippable.stories.tsx
@@ -299,12 +299,10 @@ export const OnTable: Story = {
       {
         id: "name",
         caption: "Name",
-        sortable: false,
       },
       {
         id: "role",
         caption: "Role",
-        sortable: false,
       },
     ];
 

--- a/components/nav-tab.stories.tsx
+++ b/components/nav-tab.stories.tsx
@@ -557,12 +557,10 @@ export const WithSubItems: Story = {
       {
         id: "name",
         caption: "Name",
-        sortable: false,
       },
       {
         id: "type",
         caption: "Type",
-        sortable: false,
       },
     ];
 

--- a/components/paper-dialog.stories.tsx
+++ b/components/paper-dialog.stories.tsx
@@ -966,7 +966,7 @@ export const Nested: Story = {
               <Table.Row
                 key={rowIndex}
                 rowId={`${rowValue.name}-${rowValue.status}-${rowValue.gender}-${rowValue.birthday}`}
-                actions={(columnCaption) => ROW_ACTIONS(columnCaption, true)}
+                actions={(columnId) => ROW_ACTIONS(columnId, true)}
                 content={[
                   rowValue.name,
                   rowValue.status,

--- a/components/split-pane.stories.tsx
+++ b/components/split-pane.stories.tsx
@@ -292,12 +292,10 @@ export const WithCellRef: Story = {
       {
         id: "name",
         caption: "Name",
-        sortable: false,
       },
       {
         id: "type",
         caption: "Type",
-        sortable: false,
       },
     ];
 

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -10,7 +10,10 @@ import {
 } from "./table";
 import { useEffect, useMemo, useState } from "react";
 import {
+  RiArrowDownLine,
   RiArrowDownSLine,
+  RiArrowUpDownLine,
+  RiArrowUpLine,
   RiArrowUpSLine,
   RiBookMarkedLine,
   RiCheckboxMultipleLine,
@@ -21,13 +24,14 @@ import {
   RiDownload2Fill,
   RiEditLine,
   RiFileCopy2Line,
+  RiInformationLine,
   RiReactjsLine,
   RiRefreshLine,
   RiSettings3Line,
 } from "@remixicon/react";
 import { EmptySlate } from "./empty-slate";
 import { Button } from "./button";
-import { css } from "styled-components";
+import styled, { css } from "styled-components";
 import { CapsuleTab } from "./capsule";
 import { List } from "./list";
 import { Card } from "./card";
@@ -537,11 +541,122 @@ export const Default: Story = {
 
 export const Loose: Story = {
   render: () => {
+    const { currentTheme } = useTheme();
+    const tableTheme = currentTheme?.table;
+
+    interface LoadBalancerRow {
+      id: string;
+      name: string;
+      type: string;
+      region: string;
+      status: string;
+      version: string;
+      uptime: string;
+
+      requests: number;
+      latency: number;
+      errorRate: number;
+      cpu: number;
+      memory: number;
+      connections: number;
+      bandwidth: number;
+
+      zone: string;
+      provider: string;
+    }
+
+    const TYPES_DATA = [
+      {
+        name: "HTTP",
+        description: "Standard protocol for transferring web pages.",
+      },
+      {
+        name: "HTTPS",
+        description: "Secure version of HTTP using TLS encryption.",
+      },
+      {
+        name: "TCP",
+        description: "Reliable, connection-oriented transport protocol.",
+      },
+      {
+        name: "UDP",
+        description:
+          "Fast, connectionless protocol for low-latency communication.",
+      },
+      {
+        name: "QUIC",
+        description:
+          "Modern transport protocol providing faster and more secure connections.",
+      },
+    ];
+    const REGIONS = ["SG", "ID", "US-W", "EU", "JP"];
+    const STATUS = ["active", "idle", "degraded"];
+    const PROVIDERS = [
+      "AWS",
+      "Google Cloud",
+      "Microsoft Azure",
+      "Cloudflare",
+      "DigitalOcean",
+      "Oracle Cloud",
+      "Alibaba Cloud",
+      "IBM Cloud",
+      "Linode",
+      "Vultr",
+      "Hetzner",
+      "Akamai",
+    ];
+
+    const initialRows = useMemo<LoadBalancerRow[]>(
+      () =>
+        Array.from({ length: 15 }, (_, i) => {
+          const type = TYPES_DATA[i % TYPES_DATA.length].name;
+          const region = REGIONS[i % REGIONS.length];
+          const status = STATUS[i % STATUS.length];
+
+          const seed = (i + 1) * 17;
+          const req = 200 + (seed % 200);
+          const lat = 50 + (seed % 50);
+          const errRate = (seed % 500) / 100;
+          const cpu = 80 + (seed % 80);
+          const mem = 70 + (seed % 70);
+          const conn = 1000 + (seed % 1000);
+          const bw = 100 + (seed % 100);
+          const provider = PROVIDERS[i % PROVIDERS.length];
+
+          return {
+            id: `lb-${i}`,
+            name: `lb-${region}-${i + 1}`,
+            type,
+            region,
+            status,
+            version: `v${1 + (i % 3)}.${i % 10}`,
+            uptime: `${10 + i}d`,
+
+            requests: req,
+            latency: lat,
+            errorRate: errRate,
+            cpu,
+            memory: mem,
+            connections: conn,
+            bandwidth: bw,
+
+            zone: `zone-${(i % 3) + 1}`,
+            provider,
+          };
+        }),
+      []
+    );
+
+    const [rows, setRows] = useState(initialRows);
     const [activeTab, setActiveTab] = useState({
       withCheckbox: false,
       withActions: false,
       withSummary: false,
+      withSorter: false,
     });
+    const [status, setStatus] = useState<"desc" | "asc" | "original">(
+      "original"
+    );
 
     const TOP_ACTIONS: TableAction[] = [
       {
@@ -571,6 +686,14 @@ export const Loose: Story = {
         onClick: () =>
           setActiveTab((prev) => ({ ...prev, withSummary: !prev.withSummary })),
       },
+      {
+        type: "button",
+        caption: "With Sorter",
+        pressed: activeTab.withSorter,
+        icon: { image: RiArrowUpDownLine },
+        onClick: () =>
+          setActiveTab((prev) => ({ ...prev, withSorter: !prev.withSorter })),
+      },
     ];
 
     const ROW_ACTION = (rowId: string): TableSubMenuList[] => [
@@ -587,102 +710,201 @@ export const Loose: Story = {
       },
     ];
 
-    const TYPES_DATA = ["HTTP", "HTTPS", "TCP", "UDP", "QUIC"];
-    const REGIONS = ["SG", "ID", "US-W", "EU", "JP"];
-    const STATUS = ["active", "idle", "degraded"];
+    const handleSortingRequested = ({
+      mode,
+      column,
+    }: {
+      mode: "asc" | "desc" | "original";
+      column: keyof (typeof initialRows)[number];
+    }) => {
+      setStatus(mode);
+
+      if (mode === "original") {
+        setRows(initialRows);
+        return;
+      }
+
+      const sorted = [...rows].sort((a, b) => {
+        const aVal = a[column];
+        const bVal = b[column];
+
+        if (typeof aVal === "string" && typeof bVal === "string") {
+          return mode === "asc"
+            ? aVal.localeCompare(bVal)
+            : bVal.localeCompare(aVal);
+        }
+
+        if (typeof aVal === "number" && typeof bVal === "number") {
+          return mode === "asc" ? aVal - bVal : bVal - aVal;
+        }
+
+        return 0;
+      });
+
+      setRows(sorted);
+    };
+
+    const TIP_MENU_ACTION = (
+      columnCaption: keyof (typeof initialRows)[number]
+    ): TableSubMenuList[] => {
+      return [
+        {
+          caption: "Sort Ascending",
+          icon: {
+            image: RiArrowUpLine,
+          },
+          onClick: () => {
+            handleSortingRequested({ mode: "asc", column: columnCaption });
+          },
+        },
+        {
+          caption: "Sort Descending",
+          icon: {
+            image: RiArrowDownLine,
+          },
+          onClick: () => {
+            handleSortingRequested({ mode: "desc", column: columnCaption });
+          },
+        },
+        {
+          caption: "Reset Sorting",
+          icon: {
+            image: RiArrowUpDownLine,
+          },
+          onClick: () => {
+            handleSortingRequested({ mode: "original", column: columnCaption });
+          },
+        },
+      ];
+    };
+
+    const imageStatus =
+      status === "asc"
+        ? RiArrowUpLine
+        : status === "desc"
+          ? RiArrowDownLine
+          : RiArrowUpDownLine;
+
+    const columnActions = (
+      id?: keyof (typeof initialRows)[number]
+    ): TableColumnAction => ({
+      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      title: "Sorter Action",
+      icon: {
+        image: imageStatus,
+      },
+    });
+
+    const columnProtocol = (): TableColumnAction => ({
+      subMenu: ({ show }) =>
+        show(
+          <ProtocolList>
+            {TYPES_DATA.map((protocol, index) => (
+              <ProtocolItem key={index}>
+                <ProtocolName>{protocol.name}</ProtocolName>
+                <ProtocolDescription>
+                  {protocol.description}
+                </ProtocolDescription>
+              </ProtocolItem>
+            ))}
+          </ProtocolList>
+        ),
+      title: "Info Action",
+      icon: {
+        image: RiInformationLine,
+      },
+    });
+
+    const withSorter = activeTab.withSorter ? columnActions : null;
+
+    const ProtocolItem = styled.div`
+      padding: 10px 12px;
+      border-radius: 6px;
+      background: ${tableTheme.backgroundColor};
+    `;
+
+    const ProtocolName = styled.div`
+      font-weight: 600;
+      font-size: 13px;
+      color: ${tableTheme?.textColor};
+    `;
+
+    const ProtocolDescription = styled.div`
+      margin-top: 2px;
+      font-size: 12px;
+      color: ${tableTheme?.rowGroupSubtitleTextColor};
+    `;
+
+    const ProtocolList = styled.div`
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 6px;
+    `;
 
     const columns: TableColumn[] = [
-      { id: "name", caption: "Name" },
-      { id: "type", caption: "Protocol" },
-      { id: "region", caption: "Region" },
-      { id: "status", caption: "Status" },
-      { id: "version", caption: "Version" },
-      { id: "uptime", caption: "Uptime" },
-      { id: "requests", caption: "Requests/s" },
-      { id: "latency", caption: "Latency (ms)" },
-      { id: "errorRate", caption: "Error Rate" },
-      { id: "cpu", caption: "CPU %" },
-      { id: "memory", caption: "Memory %" },
-      { id: "connections", caption: "Connections" },
-      { id: "bandwidth", caption: "Bandwidth" },
-      { id: "zone", caption: "Zone" },
-      { id: "provider", caption: "Provider" },
+      { id: "name", caption: "Name", actions: withSorter },
+      {
+        id: "type",
+        caption: "Protocol",
+        actions: activeTab?.withSorter ? columnProtocol : null,
+      },
+      { id: "region", caption: "Region", actions: withSorter },
+      { id: "status", caption: "Status", actions: withSorter },
+      { id: "version", caption: "Version", actions: withSorter },
+      { id: "uptime", caption: "Uptime", actions: withSorter },
+      { id: "requests", caption: "Requests/s", actions: withSorter },
+      { id: "latency", caption: "Latency (ms)", actions: withSorter },
+      { id: "errorRate", caption: "Error Rate", actions: withSorter },
+      { id: "cpu", caption: "CPU %", actions: withSorter },
+      { id: "memory", caption: "Memory %", actions: withSorter },
+      { id: "connections", caption: "Connections", actions: withSorter },
+      { id: "bandwidth", caption: "Bandwidth", actions: withSorter },
+      { id: "zone", caption: "Zone", actions: withSorter },
+      { id: "provider", caption: "Provider", actions: withSorter },
     ];
-
-    const rowData = useMemo(
-      () =>
-        Array.from({ length: 15 }, (_, i) => {
-          const type = TYPES_DATA[i % TYPES_DATA.length];
-          const region = REGIONS[i % REGIONS.length];
-          const status = STATUS[i % STATUS.length];
-
-          const seed = (i + 1) * 17;
-          const req = 200 + (seed % 200);
-          const lat = 50 + (seed % 50);
-          const errRate = ((seed % 500) / 100).toFixed(2);
-          const cpu = 80 + (seed % 80);
-          const mem = 70 + (seed % 70);
-          const conn = 1000 + (seed % 1000);
-          const bw = 100 + (seed % 100);
-
-          return {
-            id: `lb-${i}`,
-            content: [
-              `lb-${region}-${i + 1}`,
-              type,
-              region,
-              status,
-              `v${1 + (i % 3)}.${i % 10}`,
-              `${10 + i}d`,
-              req,
-              lat,
-              `${errRate}%`,
-              cpu,
-              mem,
-              conn,
-              `${bw}Mbps`,
-              `zone-${(i % 3) + 1}`,
-              "aws",
-            ] as TableRowContent,
-            req,
-            lat,
-            errRate: parseFloat(errRate),
-            cpu,
-            mem,
-            conn,
-            bw,
-          };
-        }),
-      []
-    );
 
     const totals = useMemo(
       () => ({
-        req: rowData.reduce((s, r) => s + r.req, 0),
-        lat: Math.round(
-          rowData.reduce((s, r) => s + r.lat, 0) / rowData.length
+        requests: rows.reduce((s, r) => s + r.requests, 0),
+        latency: Math.round(
+          rows.reduce((s, r) => s + r.latency, 0) / rows.length
         ),
-        errRate: (
-          rowData.reduce((s, r) => s + r.errRate, 0) / rowData.length
+        errorRate: (
+          rows.reduce((s, r) => s + r.errorRate, 0) / rows.length
         ).toFixed(2),
-        cpu: Math.round(
-          rowData.reduce((s, r) => s + r.cpu, 0) / rowData.length
+        cpu: Math.round(rows.reduce((s, r) => s + r.cpu, 0) / rows.length),
+        memory: Math.round(
+          rows.reduce((s, r) => s + r.memory, 0) / rows.length
         ),
-        mem: Math.round(
-          rowData.reduce((s, r) => s + r.mem, 0) / rowData.length
-        ),
-        conn: rowData.reduce((s, r) => s + r.conn, 0),
-        bw: rowData.reduce((s, r) => s + r.bw, 0),
+        connections: rows.reduce((s, r) => s + r.connections, 0),
+        bandwidth: rows.reduce((s, r) => s + r.bandwidth, 0),
       }),
-      [rowData]
+      [rows]
     );
 
-    const sampleRows = rowData.map((row, i) => (
+    const sampleRows = rows.map((row) => (
       <Table.Row
         key={row.id}
         rowId={row.id}
         actions={activeTab.withActions ? ROW_ACTION : null}
-        content={row.content}
+        content={[
+          row.name,
+          row.type,
+          row.region,
+          row.status,
+          row.version,
+          row.uptime,
+          row.requests,
+          row.latency,
+          row.errorRate,
+          row.cpu,
+          row.memory,
+          row.connections,
+          row.bandwidth,
+          row.zone,
+          row.provider,
+        ]}
       />
     ));
 
@@ -693,13 +915,13 @@ export const Loose: Story = {
       { content: "" },
       { content: "" },
       { content: "" },
-      { content: totals.req, bold: true },
-      { content: `${totals.lat} ms`, bold: true },
-      { content: `${totals.errRate}%`, bold: true },
+      { content: totals.requests, bold: true },
+      { content: `${totals.latency} ms`, bold: true },
+      { content: `${totals.errorRate}%`, bold: true },
       { content: `${totals.cpu}%`, bold: true },
-      { content: `${totals.mem}%`, bold: true },
-      { content: totals.conn, bold: true },
-      { content: `${totals.bw}Mbps`, bold: true },
+      { content: `${totals.memory}%`, bold: true },
+      { content: totals.connections, bold: true },
+      { content: `${totals.bandwidth}Mbps`, bold: true },
       { content: "" },
       { content: "" },
     ];

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -5,7 +5,6 @@ import {
   Table,
   TableAction,
   TableSummaryRowColumn,
-  TableRowContent,
   TableColumnAction,
 } from "./table";
 import { useEffect, useMemo, useState } from "react";
@@ -86,13 +85,35 @@ The **Table** component is a powerful and flexible data display component design
 {
   id: string;
   caption: string;
-  sortable?: boolean;
   width?: string;
-  styles?: {
-    self?: CSSProp;
-  };
+  action?: TableColumnAction;
+  styles?: TableColumnStyles;
 }
 \`\`\`
+
+#### Column Actions
+
+Columns can expose an action button (typically rendered in the header) that opens a contextual menu.
+
+\`\`\`tsx
+{
+  action: {
+    title: "Protocol",
+    icon: {
+      image: RiFilterLine,
+    },
+    subMenu: ({ show }) =>
+      show(<ProtocolMenu />),
+  },
+}
+\`\`\`
+
+This is useful for features such as:
+
+- Filtering
+- Sorting
+- Column-specific settings
+- Custom contextual actions
 
 ---
 
@@ -294,12 +315,34 @@ Displays a loading overlay on top of the table.
       description: `
 Defines the table columns.
 
-Each column includes:
-- \`id\`: unique identifier
-- \`caption\`: header label
-- \`sortable\`: enable sorting menu
-- \`width\`: optional fixed width
-    `,
+Each column supports:
+
+- \`id\`: Unique identifier for the column.
+- \`caption\`: Header label displayed at the top of the column.
+- \`width\`: Optional fixed width (e.g. \`"120px"\`).
+- \`styles\`: Custom styles for the column.
+- \`actions\`: Optional header action or contextual menu. Can be provided as a \`TableColumnAction\` object or a callback that returns one.
+
+Example:
+
+\`\`\`tsx
+const columns: TableColumn[] = [
+  {
+    id: "protocol",
+    caption: "Protocol",
+    width: "160px",
+    actions: {
+      title: "Protocol",
+      icon: {
+        image: RiFilterLine,
+      },
+      subMenu: ({ show }) =>
+        show(<ProtocolMenu />),
+    },
+  },
+];
+\`\`\`
+  `,
       control: false,
       table: {
         type: { summary: "TableColumn[]" },
@@ -745,8 +788,8 @@ export const Loose: Story = {
       setRows(sorted);
     };
 
-    const TIP_MENU_ACTION = (
-      columnCaption: keyof (typeof initialRows)[number]
+    const COLUMN_ACTIONS = (
+      columnId: keyof (typeof initialRows)[number]
     ): TableSubMenuList[] => {
       return [
         {
@@ -755,7 +798,7 @@ export const Loose: Story = {
             image: RiArrowUpLine,
           },
           onClick: () => {
-            handleSortingRequested({ mode: "asc", column: columnCaption });
+            handleSortingRequested({ mode: "asc", column: columnId });
           },
         },
         {
@@ -764,7 +807,7 @@ export const Loose: Story = {
             image: RiArrowDownLine,
           },
           onClick: () => {
-            handleSortingRequested({ mode: "desc", column: columnCaption });
+            handleSortingRequested({ mode: "desc", column: columnId });
           },
         },
         {
@@ -773,7 +816,7 @@ export const Loose: Story = {
             image: RiArrowUpDownLine,
           },
           onClick: () => {
-            handleSortingRequested({ mode: "original", column: columnCaption });
+            handleSortingRequested({ mode: "original", column: columnId });
           },
         },
       ];
@@ -828,26 +871,26 @@ export const Loose: Story = {
         icon: {
           image: imageStatus,
         },
-        subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+        subMenu: ({ list }) => list(COLUMN_ACTIONS(id)),
       };
     };
 
     const columns: TableColumn[] = [
       { id: "name", caption: "Name", actions: columnActions },
       { id: "type", caption: "Protocol", actions: columnActions },
-      { id: "region", caption: "Region", actions: columnActions },
-      { id: "status", caption: "Status", actions: columnActions },
-      { id: "version", caption: "Version", actions: columnActions },
-      { id: "uptime", caption: "Uptime", actions: columnActions },
-      { id: "requests", caption: "Requests/s", actions: columnActions },
-      { id: "latency", caption: "Latency (ms)", actions: columnActions },
-      { id: "errorRate", caption: "Error Rate", actions: columnActions },
-      { id: "cpu", caption: "CPU %", actions: columnActions },
-      { id: "memory", caption: "Memory %", actions: columnActions },
-      { id: "connections", caption: "Connections", actions: columnActions },
-      { id: "bandwidth", caption: "Bandwidth", actions: columnActions },
-      { id: "zone", caption: "Zone", actions: columnActions },
-      { id: "provider", caption: "Provider", actions: columnActions },
+      { id: "region", caption: "Region" },
+      { id: "status", caption: "Status" },
+      { id: "version", caption: "Version" },
+      { id: "uptime", caption: "Uptime" },
+      { id: "requests", caption: "Requests/s" },
+      { id: "latency", caption: "Latency (ms)" },
+      { id: "errorRate", caption: "Error Rate" },
+      { id: "cpu", caption: "CPU %" },
+      { id: "memory", caption: "Memory %" },
+      { id: "connections", caption: "Connections" },
+      { id: "bandwidth", caption: "Bandwidth" },
+      { id: "zone", caption: "Zone" },
+      { id: "provider", caption: "Provider" },
     ];
 
     const totals = useMemo(
@@ -1067,8 +1110,8 @@ export const Appendable: Story = {
       console.log("Selected rows:", ids);
     };
 
-    const TIP_MENU_ACTION = (
-      columnCaption: "from" | "content"
+    const COLUMN_ACTIONS = (
+      columnId: "from" | "content"
     ): TableSubMenuList[] => {
       return [
         {
@@ -1077,7 +1120,7 @@ export const Appendable: Story = {
             image: RiArrowUpSLine,
           },
           onClick: () => {
-            handleSortingRequested({ mode: "asc", column: columnCaption });
+            handleSortingRequested({ mode: "asc", column: columnId });
           },
         },
         {
@@ -1086,7 +1129,7 @@ export const Appendable: Story = {
             image: RiArrowDownSLine,
           },
           onClick: () => {
-            handleSortingRequested({ mode: "desc", column: columnCaption });
+            handleSortingRequested({ mode: "desc", column: columnId });
           },
         },
         {
@@ -1095,7 +1138,7 @@ export const Appendable: Story = {
             image: RiRefreshLine,
           },
           onClick: () => {
-            handleSortingRequested({ mode: "original", column: columnCaption });
+            handleSortingRequested({ mode: "original", column: columnId });
           },
         },
       ];
@@ -1135,7 +1178,7 @@ export const Appendable: Story = {
     };
 
     const columnActions = (id?: "from" | "content"): TableColumnAction => ({
-      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      subMenu: ({ list }) => list(COLUMN_ACTIONS(id)),
       title: "Column Action",
     });
 
@@ -1312,8 +1355,8 @@ export const WithOneAction: Story = {
       console.log("Selected rows:", ids);
     };
 
-    const TIP_MENU_ACTION = (
-      columnCaption: "from" | "content"
+    const COLUMN_ACTIONS = (
+      columnId: "from" | "content"
     ): TableSubMenuList[] => {
       return [
         {
@@ -1322,7 +1365,7 @@ export const WithOneAction: Story = {
             image: RiArrowUpSLine,
           },
           onClick: () => {
-            handleSortingRequested({ mode: "asc", column: columnCaption });
+            handleSortingRequested({ mode: "asc", column: columnId });
           },
         },
         {
@@ -1331,7 +1374,7 @@ export const WithOneAction: Story = {
             image: RiArrowDownSLine,
           },
           onClick: () => {
-            handleSortingRequested({ mode: "desc", column: columnCaption });
+            handleSortingRequested({ mode: "desc", column: columnId });
           },
         },
         {
@@ -1340,14 +1383,14 @@ export const WithOneAction: Story = {
             image: RiRefreshLine,
           },
           onClick: () => {
-            handleSortingRequested({ mode: "original", column: columnCaption });
+            handleSortingRequested({ mode: "original", column: columnId });
           },
         },
       ];
     };
 
     const columnActions = (id?: "from" | "content"): TableColumnAction => ({
-      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      subMenu: ({ list }) => list(COLUMN_ACTIONS(id)),
       title: "Column Action",
     });
 
@@ -1515,7 +1558,7 @@ export const SortableWithPagination: Story = {
     };
 
     const columnActions = (id?: "from" | "content"): TableColumnAction => ({
-      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      subMenu: ({ list }) => list(COLUMN_ACTIONS(id)),
       title: "Column Action",
     });
 
@@ -1532,8 +1575,8 @@ export const SortableWithPagination: Story = {
       },
     ];
 
-    const TIP_MENU_ACTION = (columnCaption: string): TableSubMenuList[] => {
-      const column = columnCaption.toLowerCase() as keyof (typeof rawRows)[0];
+    const COLUMN_ACTIONS = (columnId: string): TableSubMenuList[] => {
+      const column = columnId.toLowerCase() as keyof (typeof rawRows)[0];
 
       return [
         {
@@ -1789,7 +1832,7 @@ export const WithSummary: Story = {
     const columnActions = (
       id?: keyof (typeof TABLE_ITEMS)[0]["items"][0]
     ): TableColumnAction => ({
-      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      subMenu: ({ list }) => list(COLUMN_ACTIONS(id)),
       title: "Column Action",
     });
 
@@ -1850,8 +1893,8 @@ export const WithSummary: Story = {
       setRows(sortedRows);
     };
 
-    const TIP_MENU_ACTION = (columnCaption: string): TableSubMenuList[] => {
-      const column = columnCaption as keyof (typeof TABLE_ITEMS)[0]["items"][0];
+    const COLUMN_ACTIONS = (columnId: string): TableSubMenuList[] => {
+      const column = columnId as keyof (typeof TABLE_ITEMS)[0]["items"][0];
 
       return [
         {
@@ -2165,7 +2208,7 @@ export const WithRowGroup: Story = {
     const columnActions = (
       id?: keyof (typeof TABLE_ITEMS)[0]["items"][0]
     ): TableColumnAction => ({
-      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      subMenu: ({ list }) => list(COLUMN_ACTIONS(id)),
       title: "Column Action",
     });
 
@@ -2331,9 +2374,9 @@ export const WithRowGroup: Story = {
       },
     ];
 
-    const TIP_MENU_ACTION = (columnCaption: string): TableSubMenuList[] => {
+    const COLUMN_ACTIONS = (columnId: string): TableSubMenuList[] => {
       const column =
-        columnCaption.toLowerCase() as keyof (typeof TABLE_ITEMS)[0]["items"][0];
+        columnId.toLowerCase() as keyof (typeof TABLE_ITEMS)[0]["items"][0];
 
       return [
         {
@@ -2640,7 +2683,7 @@ export const WithRowAppendix: Story = {
     const columnActions = (
       id?: keyof (typeof TABLE_ITEMS)[0]["items"][0]
     ): TableColumnAction => ({
-      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      subMenu: ({ list }) => list(COLUMN_ACTIONS(id)),
       title: "Column Action",
     });
 
@@ -2701,8 +2744,8 @@ export const WithRowAppendix: Story = {
       setRows(sortedRows);
     };
 
-    const TIP_MENU_ACTION = (columnCaption: string): TableSubMenuList[] => {
-      const column = columnCaption as keyof (typeof TABLE_ITEMS)[0]["items"][0];
+    const COLUMN_ACTIONS = (columnId: string): TableSubMenuList[] => {
+      const column = columnId as keyof (typeof TABLE_ITEMS)[0]["items"][0];
 
       return [
         {
@@ -2992,7 +3035,7 @@ export const Draggable: Story = {
       rowNumber?: number,
       category?: TableCategoryState
     ): TableColumnAction => ({
-      subMenu: ({ list }) => list(TIP_MENU_ACTION(id, rowNumber, category)),
+      subMenu: ({ list }) => list(COLUMN_ACTIONS(id, rowNumber, category)),
       title: "Column Action",
     });
 
@@ -3271,13 +3314,13 @@ export const Draggable: Story = {
       },
     ];
 
-    const TIP_MENU_ACTION = (
-      columnCaption: string,
+    const COLUMN_ACTIONS = (
+      columnId: string,
       rowNumber?: number,
       category?: TableCategoryState
     ): TableSubMenuList[] => {
       const column =
-        columnCaption.toLowerCase() as keyof (typeof TABLE_ITEMS_GROUPS)[0]["items"][0];
+        columnId.toLowerCase() as keyof (typeof TABLE_ITEMS_GROUPS)[0]["items"][0];
 
       return [
         {

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -654,6 +654,7 @@ export const Loose: Story = {
       withSummary: false,
       withSorter: false,
     });
+
     const [status, setStatus] = useState<"desc" | "asc" | "original">(
       "original"
     );
@@ -786,63 +787,67 @@ export const Loose: Story = {
           : RiArrowUpDownLine;
 
     const columnActions = (
-      id?: keyof (typeof initialRows)[number]
-    ): TableColumnAction => ({
-      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
-      title: "Sorter Action",
-      icon: {
-        image: imageStatus,
-      },
-    });
+      id: keyof (typeof initialRows)[number]
+    ): TableColumnAction | null => {
+      if (!activeTab.withSorter) {
+        return null;
+      }
 
-    const columnProtocol = (): TableColumnAction => ({
-      subMenu: ({ show }) =>
-        show(
-          TYPES_DATA.map((protocol, index) => (
-            <ProtocolItem $theme={tableTheme} key={index}>
-              <ProtocolName $theme={tableTheme}>{protocol.name}</ProtocolName>
-              <ProtocolDescription $theme={tableTheme}>
-                {protocol.description}
-              </ProtocolDescription>
-            </ProtocolItem>
-          )),
-          {
-            drawerStyle: css`
-              padding: 6px;
-              gap: 6px;
-              display: flex;
-              flex-direction: column;
-            `,
-          }
-        ),
-      title: "Info Action",
-      icon: {
-        image: RiInformationLine,
-      },
-    });
+      if (id === "type") {
+        return {
+          title: "Info Action",
+          icon: {
+            image: RiInformationLine,
+          },
+          subMenu: ({ show }) =>
+            show(
+              TYPES_DATA.map((protocol, index) => (
+                <ProtocolItem $theme={tableTheme} key={index}>
+                  <ProtocolName $theme={tableTheme}>
+                    {protocol.name}
+                  </ProtocolName>
+                  <ProtocolDescription $theme={tableTheme}>
+                    {protocol.description}
+                  </ProtocolDescription>
+                </ProtocolItem>
+              )),
+              {
+                drawerStyle: css`
+                  display: flex;
+                  flex-direction: column;
+                  gap: 6px;
+                  padding: 6px;
+                `,
+              }
+            ),
+        };
+      }
 
-    const withSorter = activeTab.withSorter ? columnActions : null;
+      return {
+        title: "Sorter Action",
+        icon: {
+          image: imageStatus,
+        },
+        subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      };
+    };
 
     const columns: TableColumn[] = [
-      { id: "name", caption: "Name", actions: withSorter },
-      {
-        id: "type",
-        caption: "Protocol",
-        actions: activeTab?.withSorter ? columnProtocol : null,
-      },
-      { id: "region", caption: "Region", actions: withSorter },
-      { id: "status", caption: "Status", actions: withSorter },
-      { id: "version", caption: "Version", actions: withSorter },
-      { id: "uptime", caption: "Uptime", actions: withSorter },
-      { id: "requests", caption: "Requests/s", actions: withSorter },
-      { id: "latency", caption: "Latency (ms)", actions: withSorter },
-      { id: "errorRate", caption: "Error Rate", actions: withSorter },
-      { id: "cpu", caption: "CPU %", actions: withSorter },
-      { id: "memory", caption: "Memory %", actions: withSorter },
-      { id: "connections", caption: "Connections", actions: withSorter },
-      { id: "bandwidth", caption: "Bandwidth", actions: withSorter },
-      { id: "zone", caption: "Zone", actions: withSorter },
-      { id: "provider", caption: "Provider", actions: withSorter },
+      { id: "name", caption: "Name", actions: columnActions },
+      { id: "type", caption: "Protocol", actions: columnActions },
+      { id: "region", caption: "Region", actions: columnActions },
+      { id: "status", caption: "Status", actions: columnActions },
+      { id: "version", caption: "Version", actions: columnActions },
+      { id: "uptime", caption: "Uptime", actions: columnActions },
+      { id: "requests", caption: "Requests/s", actions: columnActions },
+      { id: "latency", caption: "Latency (ms)", actions: columnActions },
+      { id: "errorRate", caption: "Error Rate", actions: columnActions },
+      { id: "cpu", caption: "CPU %", actions: columnActions },
+      { id: "memory", caption: "Memory %", actions: columnActions },
+      { id: "connections", caption: "Connections", actions: columnActions },
+      { id: "bandwidth", caption: "Bandwidth", actions: columnActions },
+      { id: "zone", caption: "Zone", actions: columnActions },
+      { id: "provider", caption: "Provider", actions: columnActions },
     ];
 
     const totals = useMemo(

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -36,7 +36,7 @@ import { CapsuleTab } from "./capsule";
 import { List } from "./list";
 import { Card } from "./card";
 import { generateSentence } from "./../lib/text";
-import { useTheme } from "./../theme";
+import { TableThemeConfig, useTheme } from "./../theme";
 
 const meta: Meta<typeof Table> = {
   title: "Content/Table",
@@ -798,16 +798,22 @@ export const Loose: Story = {
     const columnProtocol = (): TableColumnAction => ({
       subMenu: ({ show }) =>
         show(
-          <ProtocolList>
-            {TYPES_DATA.map((protocol, index) => (
-              <ProtocolItem key={index}>
-                <ProtocolName>{protocol.name}</ProtocolName>
-                <ProtocolDescription>
-                  {protocol.description}
-                </ProtocolDescription>
-              </ProtocolItem>
-            ))}
-          </ProtocolList>
+          TYPES_DATA.map((protocol, index) => (
+            <ProtocolItem $theme={tableTheme} key={index}>
+              <ProtocolName $theme={tableTheme}>{protocol.name}</ProtocolName>
+              <ProtocolDescription $theme={tableTheme}>
+                {protocol.description}
+              </ProtocolDescription>
+            </ProtocolItem>
+          )),
+          {
+            drawerStyle: css`
+              padding: 6px;
+              gap: 6px;
+              display: flex;
+              flex-direction: column;
+            `,
+          }
         ),
       title: "Info Action",
       icon: {
@@ -816,31 +822,6 @@ export const Loose: Story = {
     });
 
     const withSorter = activeTab.withSorter ? columnActions : null;
-
-    const ProtocolItem = styled.div`
-      padding: 10px 12px;
-      border-radius: 6px;
-      background: ${tableTheme.backgroundColor};
-    `;
-
-    const ProtocolName = styled.div`
-      font-weight: 600;
-      font-size: 13px;
-      color: ${tableTheme?.textColor};
-    `;
-
-    const ProtocolDescription = styled.div`
-      margin-top: 2px;
-      font-size: 12px;
-      color: ${tableTheme?.rowGroupSubtitleTextColor};
-    `;
-
-    const ProtocolList = styled.div`
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-      padding: 6px;
-    `;
 
     const columns: TableColumn[] = [
       { id: "name", caption: "Name", actions: withSorter },
@@ -944,6 +925,24 @@ export const Loose: Story = {
     );
   },
 };
+
+const ProtocolItem = styled.div<{ $theme?: TableThemeConfig }>`
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: ${({ $theme }) => $theme?.backgroundColor};
+`;
+
+const ProtocolName = styled.div<{ $theme?: TableThemeConfig }>`
+  font-weight: 600;
+  font-size: 13px;
+  color: ${({ $theme }) => $theme?.textColor};
+`;
+
+const ProtocolDescription = styled.div<{ $theme?: TableThemeConfig }>`
+  margin-top: 2px;
+  font-size: 12px;
+  color: ${({ $theme }) => $theme?.rowGroupSubtitleTextColor};
+`;
 
 export const Appendable: Story = {
   render: () => {

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -695,7 +695,6 @@ export const Loose: Story = {
       withCheckbox: false,
       withActions: false,
       withSummary: false,
-      withSorter: false,
     });
 
     const [status, setStatus] = useState<"desc" | "asc" | "original">(
@@ -729,14 +728,6 @@ export const Loose: Story = {
         icon: { image: RiBookMarkedLine },
         onClick: () =>
           setActiveTab((prev) => ({ ...prev, withSummary: !prev.withSummary })),
-      },
-      {
-        type: "button",
-        caption: "With Sorter",
-        pressed: activeTab.withSorter,
-        icon: { image: RiArrowUpDownLine },
-        onClick: () =>
-          setActiveTab((prev) => ({ ...prev, withSorter: !prev.withSorter })),
       },
     ];
 
@@ -832,10 +823,6 @@ export const Loose: Story = {
     const columnActions = (
       id: keyof (typeof initialRows)[number]
     ): TableColumnAction | null => {
-      if (!activeTab.withSorter) {
-        return null;
-      }
-
       if (id === "type") {
         return {
           title: "Info Action",

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -6,6 +6,7 @@ import {
   TableAction,
   TableSummaryRowColumn,
   TableRowContent,
+  TableColumnAction,
 } from "./table";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -347,26 +348,6 @@ Used to define rows and grouping structure.
         type: { summary: "ReactNode" },
       },
     },
-
-    subMenuList: {
-      description: `
-Generates sorting menu for each column.
-
-\`\`\`ts
-(columnId: string) => TableSubMenuList[]
-\`\`\`
-
-- Used when \`sortable: true\` in column
-- Allows custom sorting options (ASC, DESC, etc.)
-    `,
-      control: false,
-      table: {
-        type: {
-          summary: "(columnId: string) => TableSubMenuList[]",
-        },
-      },
-    },
-
     emptySlate: {
       description: `
 Content displayed when there are no rows.
@@ -532,12 +513,10 @@ export const Default: Story = {
       {
         id: "name",
         caption: "Name",
-        sortable: false,
       },
       {
         id: "type",
         caption: "Type",
-        sortable: false,
       },
     ];
 
@@ -613,21 +592,21 @@ export const Loose: Story = {
     const STATUS = ["active", "idle", "degraded"];
 
     const columns: TableColumn[] = [
-      { id: "name", caption: "Name", sortable: false },
-      { id: "type", caption: "Protocol", sortable: false },
-      { id: "region", caption: "Region", sortable: false },
-      { id: "status", caption: "Status", sortable: false },
-      { id: "version", caption: "Version", sortable: false },
-      { id: "uptime", caption: "Uptime", sortable: false },
-      { id: "requests", caption: "Requests/s", sortable: false },
-      { id: "latency", caption: "Latency (ms)", sortable: false },
-      { id: "errorRate", caption: "Error Rate", sortable: false },
-      { id: "cpu", caption: "CPU %", sortable: false },
-      { id: "memory", caption: "Memory %", sortable: false },
-      { id: "connections", caption: "Connections", sortable: false },
-      { id: "bandwidth", caption: "Bandwidth", sortable: false },
-      { id: "zone", caption: "Zone", sortable: false },
-      { id: "provider", caption: "Provider", sortable: false },
+      { id: "name", caption: "Name" },
+      { id: "type", caption: "Protocol" },
+      { id: "region", caption: "Region" },
+      { id: "status", caption: "Status" },
+      { id: "version", caption: "Version" },
+      { id: "uptime", caption: "Uptime" },
+      { id: "requests", caption: "Requests/s" },
+      { id: "latency", caption: "Latency (ms)" },
+      { id: "errorRate", caption: "Error Rate" },
+      { id: "cpu", caption: "CPU %" },
+      { id: "memory", caption: "Memory %" },
+      { id: "connections", caption: "Connections" },
+      { id: "bandwidth", caption: "Bandwidth" },
+      { id: "zone", caption: "Zone" },
+      { id: "provider", caption: "Provider" },
     ];
 
     const rowData = useMemo(
@@ -746,21 +725,6 @@ export const Loose: Story = {
 
 export const Appendable: Story = {
   render: () => {
-    const columns: TableColumn[] = [
-      {
-        id: "from",
-        caption: "From",
-        sortable: true,
-        width: "40%",
-      },
-      {
-        id: "content",
-        caption: "Content",
-        sortable: true,
-        width: "60%",
-      },
-    ];
-
     const generate20RandomSender = () => {
       const names = [
         "adam.h",
@@ -944,6 +908,26 @@ export const Appendable: Story = {
       setRows((prev) => [...prev, ...moreEmails]);
     };
 
+    const columnActions = (id?: "from" | "content"): TableColumnAction => ({
+      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      title: "Column Action",
+    });
+
+    const columns: TableColumn[] = [
+      {
+        id: "from",
+        caption: "From",
+        width: "40%",
+        actions: columnActions,
+      },
+      {
+        id: "content",
+        caption: "Content",
+        width: "60%",
+        actions: columnActions,
+      },
+    ];
+
     return (
       <Table
         selectable
@@ -955,7 +939,6 @@ export const Appendable: Story = {
         labels={{ totalSelectedItemText: null }}
         columns={columns}
         onItemsSelected={handleItemsSelected}
-        subMenuList={TIP_MENU_ACTION}
         onLastRowReached={handleFetchData}
       >
         {rows.map((rowValue, rowIndex) => (
@@ -987,21 +970,6 @@ export const Appendable: Story = {
 
 export const WithOneAction: Story = {
   render: () => {
-    const columns: TableColumn[] = [
-      {
-        id: "from",
-        caption: "From",
-        sortable: true,
-        width: "40%",
-      },
-      {
-        id: "content",
-        caption: "Content",
-        sortable: true,
-        width: "60%",
-      },
-    ];
-
     const generate20RandomSender = () => {
       const names = [
         "adam.h",
@@ -1152,6 +1120,11 @@ export const WithOneAction: Story = {
       ];
     };
 
+    const columnActions = (id?: "from" | "content"): TableColumnAction => ({
+      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      title: "Column Action",
+    });
+
     const ROW_ACTION = (rowId: string): TableSubMenuList[] => {
       return [
         {
@@ -1175,6 +1148,21 @@ export const WithOneAction: Story = {
       setRows((prev) => [...prev, ...moreEmails]);
     };
 
+    const columns: TableColumn[] = [
+      {
+        id: "from",
+        caption: "From",
+        width: "40%",
+        actions: columnActions,
+      },
+      {
+        id: "content",
+        caption: "Content",
+        width: "60%",
+        actions: columnActions,
+      },
+    ];
+
     return (
       <Table
         selectable
@@ -1185,7 +1173,6 @@ export const WithOneAction: Story = {
         }}
         columns={columns}
         onItemsSelected={handleItemsSelected}
-        subMenuList={TIP_MENU_ACTION}
         onLastRowReached={handleFetchData}
         labels={{ totalSelectedItemText: (n) => `${n} emails selected` }}
       >
@@ -1301,16 +1288,21 @@ export const SortableWithPagination: Story = {
       setPagedRows(sorted);
     };
 
+    const columnActions = (id?: "from" | "content"): TableColumnAction => ({
+      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      title: "Column Action",
+    });
+
     const columns: TableColumn[] = [
       {
         id: "name",
         caption: "Name",
-        sortable: true,
+        actions: columnActions,
       },
       {
         id: "type",
         caption: "Type",
-        sortable: true,
+        actions: columnActions,
       },
     ];
 
@@ -1370,7 +1362,6 @@ export const SortableWithPagination: Story = {
           showPagination
           columns={columns}
           onItemsSelected={handleItemsSelected}
-          subMenuList={TIP_MENU_ACTION}
           labels={{ pageNumberText: page }}
           onPreviousPageRequested={handlePrevious}
           onNextPageRequested={handleNext}
@@ -1418,16 +1409,15 @@ export const WithLoading: Story = {
         />
       );
     });
+
     const columns: TableColumn[] = [
       {
         id: "name",
         caption: "Name",
-        sortable: false,
       },
       {
         id: "type",
         caption: "Type",
-        sortable: false,
       },
     ];
 
@@ -1570,28 +1560,35 @@ export const WithSummary: Story = {
     const [rows, setRows] = useState(TABLE_ITEMS);
     const [search, setSearch] = useState("");
 
+    const columnActions = (
+      id?: keyof (typeof TABLE_ITEMS)[0]["items"][0]
+    ): TableColumnAction => ({
+      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      title: "Column Action",
+    });
+
     const columns: TableColumn[] = [
       {
         id: "itemId",
         caption: "Item ID",
-        sortable: true,
+        actions: columnActions,
       },
       {
         id: "name",
         caption: "Name",
-        sortable: true,
         width: "40%",
+        actions: columnActions,
       },
       {
         id: "cost",
         caption: "Cost",
-        sortable: true,
+        actions: columnActions,
       },
       {
         id: "quantity",
         caption: "Quantity",
-        sortable: true,
         width: "20%",
+        actions: columnActions,
       },
     ];
 
@@ -1741,7 +1738,6 @@ export const WithSummary: Story = {
             `,
           }}
           columns={columns}
-          subMenuList={TIP_MENU_ACTION}
           searchbox={{ onChange: (e) => setSearch(e.target.value) }}
           sumRow={[
             {
@@ -1940,23 +1936,30 @@ export const WithRowGroup: Story = {
     });
     const [isFocus, setIsFocus] = useState(false);
 
+    const columnActions = (
+      id?: keyof (typeof TABLE_ITEMS)[0]["items"][0]
+    ): TableColumnAction => ({
+      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      title: "Column Action",
+    });
+
     const columns: TableColumn[] = [
       {
         id: "title",
         caption: "Title",
-        sortable: true,
         width: "45%",
+        actions: columnActions,
       },
       {
         id: "category",
         caption: "Category",
-        sortable: true,
         width: "30%",
+        actions: columnActions,
       },
       {
         id: "author",
         caption: "Author",
-        sortable: true,
+        actions: columnActions,
         width: "25%",
       },
     ];
@@ -2302,7 +2305,6 @@ export const WithRowGroup: Story = {
           }}
           columns={columns}
           onItemsSelected={handleItemsSelected}
-          subMenuList={TIP_MENU_ACTION}
           actions={TOP_ACTIONS}
           searchable
           searchbox={{
@@ -2409,28 +2411,35 @@ export const WithRowAppendix: Story = {
     const [rows, setRows] = useState(TABLE_ITEMS);
     const [search, setSearch] = useState("");
 
+    const columnActions = (
+      id?: keyof (typeof TABLE_ITEMS)[0]["items"][0]
+    ): TableColumnAction => ({
+      subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+      title: "Column Action",
+    });
+
     const columns: TableColumn[] = [
       {
         id: "itemId",
         caption: "Item ID",
-        sortable: true,
+        actions: columnActions,
       },
       {
         id: "name",
         caption: "Name",
-        sortable: true,
         width: "40%",
+        actions: columnActions,
       },
       {
         id: "cost",
         caption: "Cost",
-        sortable: true,
+        actions: columnActions,
       },
       {
         id: "quantity",
         caption: "Quantity",
-        sortable: true,
         width: "20%",
+        actions: columnActions,
       },
     ];
 
@@ -2657,7 +2666,6 @@ export const WithRowAppendix: Story = {
             `,
           }}
           columns={columns}
-          subMenuList={TIP_MENU_ACTION}
           searchbox={{ onChange: (e) => setSearch(e.target.value) }}
           selectable
           sumRow={[
@@ -2753,18 +2761,33 @@ export const Draggable: Story = {
 
     const TYPES_DATA = ["HTTP", "HTTPS", "TCP", "UDP", "QUIC"];
 
-    const columnsDefault = (sortable?: boolean): TableColumn[] => {
-      let sortableValue = sortable;
+    const columnActions = (
+      id?: string,
+      rowNumber?: number,
+      category?: TableCategoryState
+    ): TableColumnAction => ({
+      subMenu: ({ list }) => list(TIP_MENU_ACTION(id, rowNumber, category)),
+      title: "Column Action",
+    });
+
+    const columnsDefault = (
+      sortable?: boolean,
+      rowNumber?: number,
+      category?: TableCategoryState
+    ): TableColumn[] => {
+      const withActions = (id?: string) =>
+        sortable ? columnActions(id, rowNumber, category) : undefined;
+
       return [
         {
           id: "name",
           caption: "Name",
-          sortable: sortableValue,
+          actions: withActions,
         },
         {
           id: "type",
           caption: "Type",
-          sortable: sortableValue,
+          actions: withActions,
         },
       ];
     };
@@ -2853,24 +2876,27 @@ export const Draggable: Story = {
 
     const [selected, setSelected] = useState([]);
 
+    // groupColumn
+    const groupColumnActions = (id: string) => columnActions(id, 3, "group");
+
     const columnsGroup: TableColumn[] = [
       {
         id: "title",
         caption: "Title",
-        sortable: true,
         width: "45%",
+        actions: groupColumnActions,
       },
       {
         id: "category",
         caption: "Category",
-        sortable: true,
         width: "30%",
+        actions: groupColumnActions,
       },
       {
         id: "author",
         caption: "Author",
-        sortable: true,
         width: "25%",
+        actions: groupColumnActions,
       },
     ];
 
@@ -3244,8 +3270,7 @@ export const Draggable: Story = {
                 max-height: 400px;
               `,
             }}
-            columns={columnsDefault(false)}
-            subMenuList={(props) => TIP_MENU_ACTION(props, 1, "simple")}
+            columns={columnsDefault(false, 1, "simple")}
             onItemsSelected={handleItemsSelected}
             searchbox={{
               onChange: (e) => {
@@ -3291,9 +3316,8 @@ export const Draggable: Story = {
                 max-height: 400px;
               `,
             }}
-            columns={columnsDefault(true)}
+            columns={columnsDefault(true, 2, "simple")}
             onItemsSelected={handleItemsSelected}
-            subMenuList={(props) => TIP_MENU_ACTION(props, 2, "simple")}
             actions={TOP_ACTIONS}
             searchbox={{
               onChange: (e) => {
@@ -3342,7 +3366,6 @@ export const Draggable: Story = {
             }}
             columns={columnsGroup}
             onItemsSelected={handleItemsSelected}
-            subMenuList={(props) => TIP_MENU_ACTION(props, 1, "group")}
             actions={TOP_ACTIONS}
             searchbox={{
               onChange: (e) => {

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -43,9 +43,18 @@ export interface TableColumn {
 }
 
 export interface TableColumnAction
-  extends Omit<ActionButtonProps, "showSubMenuOn" | "caption" | "onClick"> {
+  extends Omit<
+    ActionButtonProps,
+    "showSubMenuOn" | "caption" | "onClick" | "variant"
+  > {
   title?: string;
+  variant?: TableColumnVariant;
 }
+
+export type TableColumnVariant = Exclude<
+  ButtonProps["variant"],
+  `outline-${string}`
+>;
 
 export type TableSubMenuList = TipMenuItemProps;
 
@@ -571,17 +580,27 @@ function Table({
                         ? col.actions(col.id)
                         : col.actions;
 
-                    const finalColumnAction: ButtonProps = columnAction
-                      ? {
-                          ...columnAction,
-                          icon: {
-                            ...columnAction?.icon,
-                            image:
-                              columnAction?.icon?.image ?? RiArrowUpDownLine,
-                          },
-                          showSubMenuOn: "self",
-                        }
-                      : {};
+                    const finalColumnAction: ButtonProps = columnAction && {
+                      ...columnAction,
+                      icon: {
+                        ...columnAction?.icon,
+                        image: columnAction?.icon?.image ?? RiArrowUpDownLine,
+                        size: columnAction?.icon?.size ?? 20,
+                      },
+                      showSubMenuOn: "self",
+                      tipMenuSize: columnAction?.tipMenuSize ?? "md",
+                      styles: {
+                        ...columnAction?.styles,
+                        self: css`
+                          padding: 0px;
+                          height: 40px;
+                          width: 40px;
+                          border-radius: 6px;
+                          ${columnAction?.styles?.self};
+                        `,
+                      },
+                      variant: columnAction?.variant ?? "ghost",
+                    };
 
                     return (
                       <TableRowCell
@@ -617,9 +636,7 @@ function Table({
                         >
                           {col.caption}
                         </Label>
-                        {finalColumnAction && (
-                          <ActionButton {...finalColumnAction} />
-                        )}
+                        {finalColumnAction && <Button {...finalColumnAction} />}
                       </TableRowCell>
                     );
                   })}

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -590,8 +590,8 @@ function Table({
                           ...columnAction?.styles,
                           self: css`
                             padding: 0px;
-                            height: 40px;
-                            width: 40px;
+                            height: 34px;
+                            width: 34px;
                             border-radius: 6px;
                             &:not(:focus-visible):not(:active):not(:hover):not(
                                 :focus
@@ -632,6 +632,11 @@ function Table({
                               : css`
                                   flex: 1;
                                 `}
+
+                          ${finalColumnAction &&
+                          css`
+                            padding: 4px 19.2px;
+                          `}
 
                           ${col?.styles?.containerStyle}
                         `}
@@ -1047,7 +1052,6 @@ const TableHeader = styled.div<{
     $theme?.boxShadow || "0 1px 2px 0 rgba(0, 0, 0, 0.05)"};
   align-items: stretch;
   background-color: ${({ $theme }) => $theme?.headerBackgroundColor};
-  min-height: 64px;
 
   ${({ $loose }) =>
     $loose &&

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -580,27 +580,29 @@ function Table({
                         ? col.actions(col.id)
                         : col.actions;
 
-                    const finalColumnAction: ButtonProps = columnAction && {
-                      ...columnAction,
-                      icon: {
-                        ...columnAction?.icon,
-                        image: columnAction?.icon?.image ?? RiArrowUpDownLine,
-                        size: columnAction?.icon?.size ?? 20,
-                      },
-                      showSubMenuOn: "self",
-                      tipMenuSize: columnAction?.tipMenuSize ?? "md",
-                      styles: {
-                        ...columnAction?.styles,
-                        self: css`
-                          padding: 0px;
-                          height: 40px;
-                          width: 40px;
-                          border-radius: 6px;
-                          ${columnAction?.styles?.self};
-                        `,
-                      },
-                      variant: columnAction?.variant ?? "ghost",
-                    };
+                    const finalColumnAction: ButtonProps = columnAction &&
+                      !columnAction.hidden && {
+                        ...columnAction,
+                        icon: {
+                          ...columnAction?.icon,
+                          image: columnAction?.icon?.image ?? RiArrowUpDownLine,
+                          size: columnAction?.icon?.size ?? 20,
+                        },
+                        showSubMenuOn: "self",
+                        tipMenuSize: columnAction?.tipMenuSize ?? "md",
+                        styles: {
+                          ...columnAction?.styles,
+                          self: css`
+                            padding: 0px;
+                            height: 40px;
+                            width: 40px;
+                            border-radius: 6px;
+                            ${columnAction?.styles?.self};
+                          `,
+                        },
+                        variant: columnAction?.variant ?? "ghost",
+                        "aria-label": "table-column-action",
+                      };
 
                     return (
                       <TableRowCell
@@ -1040,6 +1042,7 @@ const TableHeader = styled.div<{
   box-shadow: ${({ $theme }) =>
     $theme?.boxShadow || "0 1px 2px 0 rgba(0, 0, 0, 0.05)"};
   align-items: stretch;
+  background-color: ${({ $theme }) => $theme?.headerBackgroundColor};
 
   ${({ $loose }) =>
     $loose &&

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -465,9 +465,9 @@ function Table({
                     )}
                     {hasActions &&
                       filteredActions.map((action, index) => {
-                        const { capsuleProps, ...rest } = action;
+                        const { capsuleProps, type, ...rest } = action;
 
-                        if (action.type === "capsule") {
+                        if (type === "capsule") {
                           return (
                             <ActionCapsule key={index} {...capsuleProps} />
                           );

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -12,7 +12,6 @@ import React, {
 } from "react";
 import { Checkbox } from "./checkbox";
 import { LoadingSpinner } from "./loading-spinner";
-import { Toolbar } from "./toolbar";
 import { TipMenuItemProps } from "./tip-menu";
 import {
   RiArrowDownSLine,
@@ -33,20 +32,26 @@ import { TableThemeConfig } from "./../theme";
 import { applyClassName } from "./../constants/classname";
 import { Figure } from "./figure";
 import { Scrollbar, ScrollbarRef } from "./scrollbar";
+import { Button, ButtonProps } from "./button";
 
 export interface TableColumn {
   caption: string;
-  sortable?: boolean;
   styles?: TableColumnStyle;
   width?: string;
   id: string;
+  actions?: ((id?: string) => TableColumnAction) | TableColumnAction;
 }
+
+export interface TableColumnAction
+  extends Omit<ActionButtonProps, "showSubMenuOn" | "caption" | "onClick"> {
+  title?: string;
+}
+
+export type TableSubMenuList = TipMenuItemProps;
 
 export interface TableColumnStyle {
   labelStyle?: CSSProp;
   containerStyle?: CSSProp;
-  toggleSortableStyle?: CSSProp;
-  dropdownSortableStyle?: CSSProp;
 }
 
 export const TableActionType = {
@@ -79,7 +84,6 @@ export interface TableProps {
   onItemsSelected?: (items: string[]) => void;
   children: ReactNode;
   isLoading?: boolean;
-  subMenuList?: (columnCaption: string) => TableSubMenuList[];
   emptySlate?: ReactNode;
   onLastRowReached?: () => void;
   showPagination?: boolean;
@@ -97,8 +101,6 @@ export interface TableProps {
 }
 
 type TableSearchbox = SearchboxProps;
-
-export type TableSubMenuList = TipMenuItemProps;
 
 export interface TableStyles {
   containerStyle?: CSSProp;
@@ -178,7 +180,6 @@ function Table({
   selectedItems = [],
   children,
   isLoading,
-  subMenuList,
   emptySlate,
   actions,
   onLastRowReached,
@@ -565,6 +566,23 @@ function Table({
                     const isLast =
                       rowActions?.length > 0 && columns.length - 1 === i;
 
+                    const columnAction =
+                      typeof col.actions === "function"
+                        ? col.actions(col.id)
+                        : col.actions;
+
+                    const finalColumnAction: ButtonProps = columnAction
+                      ? {
+                          ...columnAction,
+                          icon: {
+                            ...columnAction?.icon,
+                            image:
+                              columnAction?.icon?.image ?? RiArrowUpDownLine,
+                          },
+                          showSubMenuOn: "self",
+                        }
+                      : {};
+
                     return (
                       <TableRowCell
                         key={i}
@@ -599,37 +617,8 @@ function Table({
                         >
                           {col.caption}
                         </Label>
-                        {col.sortable && (
-                          <Toolbar
-                            styles={{
-                              self: css`
-                                width: fit-content;
-                                z-index: 50;
-
-                                ${isLast &&
-                                css`
-                                  padding-right: 14px;
-                                `}
-                              `,
-                            }}
-                          >
-                            <Toolbar.Menu
-                              closedIcon={RiArrowUpDownLine}
-                              openedIcon={RiArrowUpDownLine}
-                              styles={{
-                                triggerStyle: col?.styles?.toggleSortableStyle,
-                                dropdownStyle: css`
-                                  min-width: 235px;
-
-                                  ${col?.styles?.dropdownSortableStyle}
-                                `,
-                              }}
-                              subMenuList={
-                                subMenuList ? subMenuList(col.id) : undefined
-                              }
-                              variant="ghost"
-                            />
-                          </Toolbar>
+                        {finalColumnAction && (
+                          <ActionButton {...finalColumnAction} />
                         )}
                       </TableRowCell>
                     );

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -1408,7 +1408,7 @@ export interface TableRowProps {
   handleSelect?: (data: string) => void;
   rowId?: string;
   children?: ReactNode;
-  actions?: (columnCaption: string) => TableRowAction[];
+  actions?: (columnId: string) => TableRowAction[];
   onClick?: (args?: {
     toggleCheckbox: () => void;
     isFirstClick?: boolean;

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -575,6 +575,7 @@ function Table({
                     const columnAction =
                       typeof col.actions === "function" && col.actions(col.id);
 
+                    const variant = columnAction?.variant ?? "ghost";
                     const finalColumnAction: ButtonProps = columnAction &&
                       !columnAction.hidden && {
                         ...columnAction,
@@ -592,10 +593,18 @@ function Table({
                             height: 40px;
                             width: 40px;
                             border-radius: 6px;
+                            &:not(:focus-visible):not(:active):not(:hover):not(
+                                :focus
+                              ) {
+                              background-color: transparent;
+                            }
                             ${columnAction?.styles?.self};
                           `,
                         },
-                        variant: columnAction?.variant ?? "ghost",
+                        hoverBackgroundColor:
+                          variant === "ghost" &&
+                          tableTheme?.headerActionHoverBackgroundColor,
+                        variant,
                         "aria-label": "table-column-action",
                       };
 

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -39,7 +39,7 @@ export interface TableColumn {
   styles?: TableColumnStyle;
   width?: string;
   id: string;
-  actions?: ((id?: string) => TableColumnAction) | TableColumnAction;
+  actions?: (id?: string) => TableColumnAction;
 }
 
 export interface TableColumnAction
@@ -572,13 +572,8 @@ function Table({
                     </CheckboxWrapper>
                   )}
                   {columns.map((col, i) => {
-                    const isLast =
-                      rowActions?.length > 0 && columns.length - 1 === i;
-
                     const columnAction =
-                      typeof col.actions === "function"
-                        ? col.actions(col.id)
-                        : col.actions;
+                      typeof col.actions === "function" && col.actions(col.id);
 
                     const finalColumnAction: ButtonProps = columnAction &&
                       !columnAction.hidden && {
@@ -1043,6 +1038,7 @@ const TableHeader = styled.div<{
     $theme?.boxShadow || "0 1px 2px 0 rgba(0, 0, 0, 0.05)"};
   align-items: stretch;
   background-color: ${({ $theme }) => $theme?.headerBackgroundColor};
+  min-height: 64px;
 
   ${({ $loose }) =>
     $loose &&

--- a/test/component/action-button.cy.tsx
+++ b/test/component/action-button.cy.tsx
@@ -865,12 +865,10 @@ describe("ActionButton", () => {
           {
             id: "name",
             caption: "Name",
-            sortable: false,
           },
           {
             id: "type",
             caption: "Type",
-            sortable: false,
           },
         ];
 
@@ -939,12 +937,10 @@ describe("ActionButton", () => {
             {
               id: "name",
               caption: "Name",
-              sortable: false,
             },
             {
               id: "type",
               caption: "Type",
-              sortable: false,
             },
           ];
 
@@ -992,12 +988,10 @@ describe("ActionButton", () => {
             {
               id: "name",
               caption: "Name",
-              sortable: false,
             },
             {
               id: "type",
               caption: "Type",
-              sortable: false,
             },
           ];
 
@@ -1045,12 +1039,10 @@ describe("ActionButton", () => {
               {
                 id: "name",
                 caption: "Name",
-                sortable: false,
               },
               {
                 id: "type",
                 caption: "Type",
-                sortable: false,
               },
             ];
 
@@ -1098,12 +1090,10 @@ describe("ActionButton", () => {
               {
                 id: "name",
                 caption: "Name",
-                sortable: false,
               },
               {
                 id: "type",
                 caption: "Type",
-                sortable: false,
               },
             ];
 
@@ -1167,12 +1157,10 @@ describe("ActionButton", () => {
               {
                 id: "name",
                 caption: "Name",
-                sortable: false,
               },
               {
                 id: "type",
                 caption: "Type",
-                sortable: false,
               },
             ];
 

--- a/test/component/context-menu.cy.tsx
+++ b/test/component/context-menu.cy.tsx
@@ -796,12 +796,10 @@ describe("context-menu", () => {
       {
         id: "name",
         caption: "Name",
-        sortable: false,
       },
       {
         id: "type",
         caption: "Type",
-        sortable: false,
       },
     ];
 

--- a/test/component/flippable.cy.tsx
+++ b/test/component/flippable.cy.tsx
@@ -178,12 +178,10 @@ describe("Flippable", () => {
         {
           id: "name",
           caption: "Name",
-          sortable: false,
         },
         {
           id: "role",
           caption: "Role",
-          sortable: false,
         },
       ];
 

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -615,22 +615,22 @@ describe("Table", () => {
       });
 
       context("height in table header", () => {
-        it("renders height with 65px", () => {
+        it("renders height with 49px", () => {
           cy.mount(<ProductTableLoose loose />);
           cy.findByLabelText("table-header").should(
             "have.css",
             "height",
-            "65px"
+            "49px"
           );
         });
 
         context("when given actions in table column", () => {
-          it("should consistently with height 65px", () => {
+          it("should consistently with height 49px", () => {
             cy.mount(<ProductTableLoose loose />);
             cy.findByLabelText("table-header").should(
               "have.css",
               "height",
-              "65px"
+              "49px"
             );
             cy.findAllByLabelText("column-action").should("not.exist");
 
@@ -639,7 +639,7 @@ describe("Table", () => {
             cy.findByLabelText("table-header").should(
               "have.css",
               "height",
-              "65px"
+              "49px"
             );
             cy.findAllByLabelText("table-column-action")
               .should("exist")
@@ -938,10 +938,10 @@ describe("Table", () => {
     });
 
     context("actions", () => {
-      it("renders with height and width 40px", () => {
+      it("renders with height and width 34px", () => {
         cy.findByLabelText("table-column-action")
-          .should("have.css", "height", "40px")
-          .and("have.css", "width", "40px");
+          .should("have.css", "height", "34px")
+          .and("have.css", "width", "34px");
       });
 
       const ICON_DEFAULT =
@@ -3028,12 +3028,12 @@ describe("Table", () => {
         cy.findByLabelText("textbox-search-wrapper").should(
           "have.css",
           "margin-left",
-          "40px"
+          "34px"
         );
         cy.findByLabelText("textbox-search-wrapper").should(
           "have.css",
           "margin-right",
-          "40px"
+          "34px"
         );
         cy.findByLabelText("textbox-search-wrapper").should(
           "have.css",
@@ -3081,12 +3081,12 @@ describe("Table", () => {
         cy.findByLabelText("textbox-search-wrapper").should(
           "have.css",
           "margin-right",
-          "40px"
+          "34px"
         );
         cy.findByLabelText("textbox-search-wrapper").should(
           "not.have.css",
           "margin-left",
-          "40px"
+          "34px"
         );
         cy.findByLabelText("textbox-search-wrapper").should(
           "have.css",
@@ -3135,12 +3135,12 @@ describe("Table", () => {
         cy.findByLabelText("textbox-search-wrapper").should(
           "have.css",
           "margin-left",
-          "40px"
+          "34px"
         );
         cy.findByLabelText("textbox-search-wrapper").should(
           "not.have.css",
           "margin-right",
-          "40px"
+          "34px"
         );
         cy.findByLabelText("textbox-search-wrapper").should(
           "have.css",
@@ -3188,12 +3188,12 @@ describe("Table", () => {
         cy.findByLabelText("textbox-search-wrapper").should(
           "not.have.css",
           "margin-left",
-          "40px"
+          "34px"
         );
         cy.findByLabelText("textbox-search-wrapper").should(
           "not.have.css",
           "margin-right",
-          "40px"
+          "34px"
         );
         cy.findByLabelText("textbox-search-wrapper").should(
           "have.css",

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -311,6 +311,7 @@ describe("Table", () => {
         withSummary: false,
         withSorter: false,
       });
+
       const [status, setStatus] = useState<"desc" | "asc" | "original">(
         "original"
       );
@@ -435,10 +436,7 @@ describe("Table", () => {
               image: RiArrowUpDownLine,
             },
             onClick: () => {
-              handleSortingRequested({
-                mode: "original",
-                column: columnId,
-              });
+              handleSortingRequested({ mode: "original", column: columnId });
             },
           },
         ];
@@ -452,63 +450,67 @@ describe("Table", () => {
             : RiArrowUpDownLine;
 
       const columnActions = (
-        id?: keyof (typeof initialRows)[number]
-      ): TableColumnAction => ({
-        subMenu: ({ list }) => list(COLUMN_ACTIONS(id)),
-        title: "Sorter Action",
-        icon: {
-          image: imageStatus,
-        },
-      });
+        id: keyof (typeof initialRows)[number]
+      ): TableColumnAction | null => {
+        if (!activeTab.withSorter) {
+          return null;
+        }
 
-      const columnProtocol = (): TableColumnAction => ({
-        subMenu: ({ show }) =>
-          show(
-            TYPES_DATA.map((protocol, index) => (
-              <ProtocolItem $theme={tableTheme} key={index}>
-                <ProtocolName $theme={tableTheme}>{protocol.name}</ProtocolName>
-                <ProtocolDescription $theme={tableTheme}>
-                  {protocol.description}
-                </ProtocolDescription>
-              </ProtocolItem>
-            )),
-            {
-              drawerStyle: css`
-                padding: 6px;
-                gap: 6px;
-                display: flex;
-                flex-direction: column;
-              `,
-            }
-          ),
-        title: "Info Action",
-        icon: {
-          image: RiInformationLine,
-        },
-      });
+        if (id === "type") {
+          return {
+            title: "Info Action",
+            icon: {
+              image: RiInformationLine,
+            },
+            subMenu: ({ show }) =>
+              show(
+                TYPES_DATA.map((protocol, index) => (
+                  <ProtocolItem $theme={tableTheme} key={index}>
+                    <ProtocolName $theme={tableTheme}>
+                      {protocol.name}
+                    </ProtocolName>
+                    <ProtocolDescription $theme={tableTheme}>
+                      {protocol.description}
+                    </ProtocolDescription>
+                  </ProtocolItem>
+                )),
+                {
+                  drawerStyle: css`
+                    display: flex;
+                    flex-direction: column;
+                    gap: 6px;
+                    padding: 6px;
+                  `,
+                }
+              ),
+          };
+        }
 
-      const withSorter = activeTab.withSorter ? columnActions : null;
+        return {
+          title: "Sorter Action",
+          icon: {
+            image: imageStatus,
+          },
+          subMenu: ({ list }) => list(COLUMN_ACTIONS(id)),
+        };
+      };
 
       const columns: TableColumn[] = [
-        { id: "name", caption: "Name", actions: withSorter },
-        {
-          id: "type",
-          caption: "Protocol",
-          actions: activeTab?.withSorter ? columnProtocol : null,
-        },
-        { id: "region", caption: "Region", actions: withSorter },
-        { id: "status", caption: "Status", actions: withSorter },
-        { id: "version", caption: "Version", actions: withSorter },
-        { id: "uptime", caption: "Uptime", actions: withSorter },
-        { id: "requests", caption: "Requests/s", actions: withSorter },
-        { id: "latency", caption: "Latency (ms)", actions: withSorter },
-        { id: "errorRate", caption: "Error Rate", actions: withSorter },
-        { id: "cpu", caption: "CPU %", actions: withSorter },
-        { id: "memory", caption: "Memory %", actions: withSorter },
-        { id: "connections", caption: "Connections", actions: withSorter },
-        { id: "bandwidth", caption: "Bandwidth", actions: withSorter },
-        { id: "zone", caption: "Zone", actions: withSorter },
-        { id: "provider", caption: "Provider", actions: withSorter },
+        { id: "name", caption: "Name", actions: columnActions },
+        { id: "type", caption: "Protocol", actions: columnActions },
+        { id: "region", caption: "Region" },
+        { id: "status", caption: "Status" },
+        { id: "version", caption: "Version" },
+        { id: "uptime", caption: "Uptime" },
+        { id: "requests", caption: "Requests/s" },
+        { id: "latency", caption: "Latency (ms)" },
+        { id: "errorRate", caption: "Error Rate" },
+        { id: "cpu", caption: "CPU %" },
+        { id: "memory", caption: "Memory %" },
+        { id: "connections", caption: "Connections" },
+        { id: "bandwidth", caption: "Bandwidth" },
+        { id: "zone", caption: "Zone" },
+        { id: "provider", caption: "Provider" },
       ];
 
       const totals = useMemo(
@@ -590,6 +592,7 @@ describe("Table", () => {
         </Table>
       );
     }
+
     context("when given false", () => {
       it("should render the body element with overflow x hidden", () => {
         cy.mount(<ProductTableLoose loose={false} />);
@@ -609,6 +612,40 @@ describe("Table", () => {
           .parent()
           .should("have.css", "overflow-x", "scroll")
           .and("have.css", "overflow-y", "scroll");
+      });
+
+      context("height in table header", () => {
+        it("renders height with 65px", () => {
+          cy.mount(<ProductTableLoose loose />);
+          cy.findByLabelText("table-header").should(
+            "have.css",
+            "height",
+            "65px"
+          );
+        });
+
+        context("when given actions in table column", () => {
+          it("should consistently with height 65px", () => {
+            cy.mount(<ProductTableLoose loose />);
+            cy.findByLabelText("table-header").should(
+              "have.css",
+              "height",
+              "65px"
+            );
+            cy.findAllByLabelText("column-action").should("not.exist");
+
+            cy.findAllByRole("button").eq(3).click();
+
+            cy.findByLabelText("table-header").should(
+              "have.css",
+              "height",
+              "65px"
+            );
+            cy.findAllByLabelText("table-column-action")
+              .should("exist")
+              .and("have.length", 2);
+          });
+        });
       });
 
       context("loose effect", () => {

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -1,5 +1,8 @@
 import {
   RiArchive2Fill,
+  RiArrowDownLine,
+  RiArrowUpDownLine,
+  RiArrowUpLine,
   RiArrowUpSLine,
   RiBookMarkedLine,
   RiCheckboxMultipleLine,
@@ -7,6 +10,7 @@ import {
   RiDeleteBin2Fill,
   RiDeleteBin2Line,
   RiForbid2Line,
+  RiInformationLine,
   RiReactjsLine,
   RiRefreshLine,
   RiSettings3Line,
@@ -21,15 +25,17 @@ import {
   TableRowProps,
   TableRowGroupProps,
   TableSummaryRowColumn,
-  TableRowContent,
+  TableColumnAction,
 } from "./../../components/table";
 import { TipMenuItemProps } from "./../../components/tip-menu";
-import { css } from "styled-components";
+import styled, { css } from "styled-components";
 import { CapsuleTab } from "./../../components/capsule";
 import { Button } from "./../../components/button";
 import { Card } from "./../../components/card";
 import { ReactNode, useMemo, useState } from "react";
 import { generateSentence } from "./../../lib/text";
+import { TableThemeConfig, useTheme } from "./../../theme";
+
 interface TableSummaryProps {
   id?: string;
   title: string;
@@ -190,484 +196,906 @@ describe("Table", () => {
     );
   }
 
-  context("loose", () => {
-    function ProductTableLoose({ loose = true }: { loose?: boolean }) {
-      const [activeTab, setActiveTab] = useState({
-        withCheckbox: false,
-        withActions: false,
-        withSummary: false,
-      });
-
-      const TOP_ACTIONS: TableAction[] = [
-        {
-          type: "button",
-          caption: "With Checkbox",
-          pressed: activeTab.withCheckbox,
-          icon: { image: RiCheckboxMultipleLine },
-          onClick: () =>
-            setActiveTab((prev) => ({
-              ...prev,
-              withCheckbox: !prev.withCheckbox,
-            })),
-        },
-        {
-          type: "button",
-          caption: "With Row Actions",
-          pressed: activeTab.withActions,
-          icon: { image: RiSettings3Line },
-          onClick: () =>
-            setActiveTab((prev) => ({
-              ...prev,
-              withActions: !prev.withActions,
-            })),
-        },
-        {
-          type: "button",
-          caption: "With Summary",
-          pressed: activeTab.withSummary,
-          icon: { image: RiBookMarkedLine },
-          onClick: () =>
-            setActiveTab((prev) => ({
-              ...prev,
-              withSummary: !prev.withSummary,
-            })),
-        },
-      ];
-
-      const ROW_ACTION = (rowId: string): TableSubMenuList[] => [
-        {
-          caption: "Edit",
-          icon: { image: RiArrowUpSLine },
-          onClick: () => console.log(`${rowId} was edited`),
-        },
-        {
-          caption: "Delete",
-          icon: { image: RiDeleteBin2Fill },
-          variant: "danger",
-          onClick: () => console.log(`${rowId} was deleted`),
-        },
-      ];
-
-      const TYPES_DATA = ["HTTP", "HTTPS", "TCP", "UDP", "QUIC"];
-      const REGIONS = ["SG", "ID", "US-W", "EU", "JP"];
-      const STATUS = ["active", "idle", "degraded"];
-
-      const columns: TableColumn[] = [
-        { id: "name", caption: "Name" },
-        { id: "type", caption: "Protocol" },
-        { id: "region", caption: "Region" },
-        { id: "status", caption: "Status" },
-        { id: "version", caption: "Version" },
-        { id: "uptime", caption: "Uptime" },
-        { id: "requests", caption: "Requests/s" },
-        { id: "latency", caption: "Latency (ms)" },
-        { id: "errorRate", caption: "Error Rate" },
-        { id: "cpu", caption: "CPU %" },
-        { id: "memory", caption: "Memory %" },
-        { id: "connections", caption: "Connections" },
-        { id: "bandwidth", caption: "Bandwidth" },
-        { id: "zone", caption: "Zone" },
-        { id: "provider", caption: "Provider" },
-      ];
-
-      const rowData = useMemo(
-        () =>
-          Array.from({ length: 15 }, (_, i) => {
-            const type = TYPES_DATA[i % TYPES_DATA.length];
-            const region = REGIONS[i % REGIONS.length];
-            const status = STATUS[i % STATUS.length];
-
-            const seed = (i + 1) * 17;
-            const req = 200 + (seed % 200);
-            const lat = 50 + (seed % 50);
-            const errRate = ((seed % 500) / 100).toFixed(2);
-            const cpu = 80 + (seed % 80);
-            const mem = 70 + (seed % 70);
-            const conn = 1000 + (seed % 1000);
-            const bw = 100 + (seed % 100);
-
-            return {
-              id: `lb-${i}`,
-              content: [
-                `lb-${region}-${i + 1}`,
-                type,
-                region,
-                status,
-                `v${1 + (i % 3)}.${i % 10}`,
-                `${10 + i}d`,
-                req,
-                lat,
-                `${errRate}%`,
-                cpu,
-                mem,
-                conn,
-                `${bw}Mbps`,
-                `zone-${(i % 3) + 1}`,
-                "aws",
-              ] as TableRowContent,
-              req,
-              lat,
-              errRate: parseFloat(errRate),
-              cpu,
-              mem,
-              conn,
-              bw,
-            };
-          }),
-        []
-      );
-
-      const totals = useMemo(
-        () => ({
-          req: rowData.reduce((s, r) => s + r.req, 0),
-          lat: Math.round(
-            rowData.reduce((s, r) => s + r.lat, 0) / rowData.length
-          ),
-          errRate: (
-            rowData.reduce((s, r) => s + r.errRate, 0) / rowData.length
-          ).toFixed(2),
-          cpu: Math.round(
-            rowData.reduce((s, r) => s + r.cpu, 0) / rowData.length
-          ),
-          mem: Math.round(
-            rowData.reduce((s, r) => s + r.mem, 0) / rowData.length
-          ),
-          conn: rowData.reduce((s, r) => s + r.conn, 0),
-          bw: rowData.reduce((s, r) => s + r.bw, 0),
-        }),
-        [rowData]
-      );
-
-      const sampleRows = rowData.map((row, i) => (
-        <Table.Row
-          key={row.id}
-          rowId={row.id}
-          actions={activeTab.withActions ? ROW_ACTION : null}
-          content={row.content}
-        />
-      ));
-
-      const sumRow: TableSummaryRowColumn[] = [
-        { content: "Totals / Avg", bold: true },
-        { content: "" },
-        { content: "" },
-        { content: "" },
-        { content: "" },
-        { content: "" },
-        { content: totals.req, bold: true },
-        { content: `${totals.lat} ms`, bold: true },
-        { content: `${totals.errRate}%`, bold: true },
-        { content: `${totals.cpu}%`, bold: true },
-        { content: `${totals.mem}%`, bold: true },
-        { content: totals.conn, bold: true },
-        { content: `${totals.bw}Mbps`, bold: true },
-        { content: "" },
-        { content: "" },
-      ];
-
-      return (
-        <Table
-          styles={{
-            tableBodyStyle: css`
-              max-height: 250px;
-            `,
-          }}
-          loose={loose}
-          actions={TOP_ACTIONS}
-          columns={columns}
-          selectable={activeTab.withCheckbox}
-          sumRow={activeTab.withSummary && sumRow}
-        >
-          {sampleRows}
-        </Table>
-      );
-    }
-    context("when given false", () => {
-      it("should render the body element with overflow x hidden", () => {
-        cy.mount(<ProductTableLoose loose={false} />);
-
-        cy.findByLabelText("table-body")
-          .parent()
-          .should("have.css", "overflow-x", "hidden")
-          .and("have.css", "overflow-y", "scroll");
-      });
-    });
-
-    context("when given true", () => {
-      it("should render the by overflow auto in body element", () => {
-        cy.mount(<ProductTableLoose loose />);
-
-        cy.findByLabelText("table-body")
-          .parent()
-          .should("have.css", "overflow-x", "scroll")
-          .and("have.css", "overflow-y", "scroll");
-      });
-
-      context("loose effect", () => {
-        context("first column", () => {
-          it("shouldn't render loose effect on the first column", () => {
-            cy.mount(<ProductTableLoose loose />);
-
-            cy.findAllByLabelText("table-row-cell")
-              .first()
-              .then(($el) => {
-                const after = window.getComputedStyle($el[0], "::after");
-
-                expect(after.backgroundImage).to.not.equal(
-                  "linear-gradient(to right, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
-                );
-              });
-          });
-
-          context("when scrolling to the right", () => {
-            it("should render loose effect on the first column", () => {
-              cy.mount(<ProductTableLoose loose />);
-
-              cy.findByLabelText("table-body")
-                .parent()
-                .then(($el) => {
-                  const el = $el[0];
-
-                  const scrollToEnd = () => {
-                    const maxScroll = el.scrollWidth - el.clientWidth;
-                    el.scrollLeft = maxScroll;
-                    el.dispatchEvent(new Event("scroll", { bubbles: true }));
-
-                    if (el.scrollLeft < maxScroll) {
-                      scrollToEnd();
-                    }
-                  };
-
-                  scrollToEnd();
-                });
-              cy.wait(300);
-
-              cy.findAllByLabelText("table-row-cell")
-                .first()
-                .then(($el) => {
-                  const after = window.getComputedStyle($el[0], "::after");
-
-                  expect(after.backgroundImage).to.equal(
-                    "linear-gradient(to right, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
-                  );
-                });
-            });
-          });
-        });
-
-        context("last column", () => {
-          context("with actions", () => {
-            it("should render loose effect on the last column", () => {
-              cy.mount(<ProductTableLoose loose />);
-
-              cy.findAllByLabelText("action-button").eq(1).click();
-              cy.findAllByLabelText("action-button").eq(2).click();
-
-              cy.wait(300);
-
-              cy.get(".coneto-button")
-                .eq(3)
-                .then(($el) => {
-                  const after = window.getComputedStyle($el[0], "::before");
-
-                  expect(after.backgroundImage).to.equal(
-                    "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
-                  );
-                });
-            });
-
-            it("renders header loose actions with width 48px", () => {
-              cy.mount(<ProductTableLoose loose />);
-
-              cy.findAllByLabelText("action-button").eq(1).click();
-              cy.findAllByLabelText("action-button").eq(2).click();
-
-              cy.wait(300);
-
-              cy.findByLabelText("header-row-loose-action")
-                .should("have.css", "width", "48px")
-                .then(($el) => {
-                  const after = window.getComputedStyle($el[0], "::before");
-
-                  expect(after.backgroundImage).to.equal(
-                    "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
-                  );
-                });
-            });
-
-            it("renders summary row loose actions with width 48px", () => {
-              cy.mount(<ProductTableLoose loose />);
-
-              cy.findAllByLabelText("action-button").eq(1).click();
-              cy.findAllByLabelText("action-button").eq(2).click();
-
-              cy.wait(300);
-
-              cy.findByLabelText("summary-row-loose-action")
-                .should("have.css", "width", "48px")
-                .then(($el) => {
-                  const after = window.getComputedStyle($el[0], "::before");
-
-                  expect(after.backgroundImage).to.equal(
-                    "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
-                  );
-                });
-            });
-
-            context("when scrolling to the right", () => {
-              it("shouldn't render loose effect on the last column", () => {
-                cy.mount(<ProductTableLoose loose />);
-
-                cy.findAllByLabelText("action-button").eq(1).click();
-                cy.findAllByLabelText("action-button").eq(2).click();
-
-                cy.findByLabelText("table-body")
-                  .parent()
-                  .then(($el) => {
-                    const el = $el[0];
-
-                    const scrollToEnd = () => {
-                      const maxScroll = el.scrollWidth - el.clientWidth;
-                      el.scrollLeft = maxScroll;
-                      el.dispatchEvent(new Event("scroll", { bubbles: true }));
-
-                      if (el.scrollLeft < maxScroll) {
-                        scrollToEnd();
-                      }
-                    };
-
-                    scrollToEnd();
-                  });
-
-                cy.wait(300);
-
-                cy.get(".coneto-button")
-                  .eq(3)
-                  .then(($el) => {
-                    const after = window.getComputedStyle($el[0], "::before");
-
-                    expect(after.backgroundImage).to.not.equal(
-                      "linear-gradient(to right, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
-                    );
-                  });
-              });
-            });
-          });
-
-          context("when activate summary", () => {
-            it("renders the summary row loose action", () => {
-              cy.mount(<ProductTableLoose loose />);
-
-              cy.findAllByLabelText("action-button").eq(1).click();
-              cy.findAllByLabelText("action-button").eq(2).click();
-              cy.wait(300);
-
-              cy.findByLabelText("summary-row-loose-action")
-                .should("exist")
-                .and("have.css", "width", "48px");
-            });
-          });
-        });
-      });
-
-      context("with checkbox", () => {
-        it("renders checkbox stick in the left side", () => {
-          cy.mount(<ProductTableLoose loose />);
-
-          cy.findAllByLabelText("action-button").eq(0).click();
-
-          cy.get(".coneto-checkbox")
-            .eq(0)
-            .parent()
-            .should("be.visible")
-            .and("have.css", "position", "sticky")
-            .and("have.css", "left", "0px");
-
-          cy.findAllByText("aws").eq(0).should("not.be.visible");
-
-          cy.findAllByText("aws").eq(0).scrollIntoView().should("be.visible");
-
-          cy.get(".coneto-checkbox").eq(0).parent().should("be.visible");
-        });
-
-        it("renders height same with table-row-cell", () => {
-          cy.mount(<ProductTableLoose loose />);
-
-          cy.findAllByLabelText("action-button").eq(0).click();
-
-          ["field-lane-control", "table-row-cell"].forEach((label) => {
-            cy.findAllByLabelText(label)
-              .eq(0)
-              .should("have.css", "height", "48px");
-          });
-        });
-      });
-
-      context("with actions", () => {
-        it("renders the row actions sticky in the right side", () => {
-          cy.mount(<ProductTableLoose loose />);
-
-          cy.findAllByLabelText("action-button").eq(1).click();
-          cy.wait(300);
-
-          cy.get(".coneto-button")
-            .eq(4)
-            .should("have.css", "position", "sticky")
-            .and("have.css", "right", "0px");
-        });
-      });
-
-      context("with summary", () => {
-        it("renders the first column summary stick in the left side", () => {
-          cy.mount(<ProductTableLoose loose />);
-
-          cy.findAllByLabelText("action-button").eq(2).click();
-          cy.wait(300);
-
-          cy.findByText("Totals / Avg").should("be.visible");
-
-          cy.findAllByText("aws").eq(0).should("not.be.visible");
-
-          cy.findAllByText("aws").eq(0).scrollIntoView().should("be.visible");
-
-          cy.findByText("Totals / Avg").should("be.visible");
-        });
-      });
-
-      context("when scrolling to the right", () => {
-        it("shows the most right content", () => {
-          cy.mount(<ProductTableLoose loose />);
-
-          cy.findByLabelText("table-body")
-            .parent()
-            .should("have.css", "overflow-x", "scroll")
-            .and("have.css", "overflow-y", "scroll");
-
-          cy.findAllByText("aws").eq(0).should("not.be.visible");
-
-          cy.findAllByText("aws").eq(0).scrollIntoView().should("be.visible");
-        });
-
-        it("the first column still visible", () => {
-          cy.mount(<ProductTableLoose loose />);
-
-          cy.findByText("Name").should("be.visible");
-          cy.findByText("lb-SG-1").should("be.visible");
-          cy.findByText("lb-ID-2").should("be.visible");
-
-          cy.findAllByText("aws").eq(0).should("not.be.visible");
-
-          cy.findAllByText("aws").eq(0).scrollIntoView().should("be.visible");
-
-          cy.findByText("Name").should("be.visible");
-          cy.findByText("lb-SG-1").should("be.visible");
-          cy.findByText("lb-ID-2").should("be.visible");
-        });
-      });
-    });
-  });
+  // context("loose", () => {
+  //   function ProductTableLoose({ loose = true }: { loose?: boolean }) {
+  //     const { currentTheme } = useTheme();
+  //     const tableTheme = currentTheme?.table;
+
+  //     interface LoadBalancerRow {
+  //       id: string;
+  //       name: string;
+  //       type: string;
+  //       region: string;
+  //       status: string;
+  //       version: string;
+  //       uptime: string;
+
+  //       requests: number;
+  //       latency: number;
+  //       errorRate: number;
+  //       cpu: number;
+  //       memory: number;
+  //       connections: number;
+  //       bandwidth: number;
+
+  //       zone: string;
+  //       provider: string;
+  //     }
+
+  //     const TYPES_DATA = [
+  //       {
+  //         name: "HTTP",
+  //         description: "Standard protocol for transferring web pages.",
+  //       },
+  //       {
+  //         name: "HTTPS",
+  //         description: "Secure version of HTTP using TLS encryption.",
+  //       },
+  //       {
+  //         name: "TCP",
+  //         description: "Reliable, connection-oriented transport protocol.",
+  //       },
+  //       {
+  //         name: "UDP",
+  //         description:
+  //           "Fast, connectionless protocol for low-latency communication.",
+  //       },
+  //       {
+  //         name: "QUIC",
+  //         description:
+  //           "Modern transport protocol providing faster and more secure connections.",
+  //       },
+  //     ];
+  //     const REGIONS = ["SG", "ID", "US-W", "EU", "JP"];
+  //     const STATUS = ["active", "idle", "degraded"];
+  //     const PROVIDERS = [
+  //       "AWS",
+  //       "Google Cloud",
+  //       "Microsoft Azure",
+  //       "Cloudflare",
+  //       "DigitalOcean",
+  //       "Oracle Cloud",
+  //       "Alibaba Cloud",
+  //       "IBM Cloud",
+  //       "Linode",
+  //       "Vultr",
+  //       "Hetzner",
+  //       "Akamai",
+  //     ];
+
+  //     const initialRows = useMemo<LoadBalancerRow[]>(
+  //       () =>
+  //         Array.from({ length: 15 }, (_, i) => {
+  //           const type = TYPES_DATA[i % TYPES_DATA.length].name;
+  //           const region = REGIONS[i % REGIONS.length];
+  //           const status = STATUS[i % STATUS.length];
+
+  //           const seed = (i + 1) * 17;
+  //           const req = 200 + (seed % 200);
+  //           const lat = 50 + (seed % 50);
+  //           const errRate = (seed % 500) / 100;
+  //           const cpu = 80 + (seed % 80);
+  //           const mem = 70 + (seed % 70);
+  //           const conn = 1000 + (seed % 1000);
+  //           const bw = 100 + (seed % 100);
+  //           const provider = PROVIDERS[i % PROVIDERS.length];
+
+  //           return {
+  //             id: `lb-${i}`,
+  //             name: `lb-${region}-${i + 1}`,
+  //             type,
+  //             region,
+  //             status,
+  //             version: `v${1 + (i % 3)}.${i % 10}`,
+  //             uptime: `${10 + i}d`,
+
+  //             requests: req,
+  //             latency: lat,
+  //             errorRate: errRate,
+  //             cpu,
+  //             memory: mem,
+  //             connections: conn,
+  //             bandwidth: bw,
+
+  //             zone: `zone-${(i % 3) + 1}`,
+  //             provider,
+  //           };
+  //         }),
+  //       []
+  //     );
+
+  //     const [rows, setRows] = useState(initialRows);
+  //     const [activeTab, setActiveTab] = useState({
+  //       withCheckbox: false,
+  //       withActions: false,
+  //       withSummary: false,
+  //       withSorter: false,
+  //     });
+  //     const [status, setStatus] = useState<"desc" | "asc" | "original">(
+  //       "original"
+  //     );
+
+  //     const TOP_ACTIONS: TableAction[] = [
+  //       {
+  //         type: "button",
+  //         caption: "With Checkbox",
+  //         pressed: activeTab.withCheckbox,
+  //         icon: { image: RiCheckboxMultipleLine },
+  //         onClick: () =>
+  //           setActiveTab((prev) => ({
+  //             ...prev,
+  //             withCheckbox: !prev.withCheckbox,
+  //           })),
+  //       },
+  //       {
+  //         type: "button",
+  //         caption: "With Row Actions",
+  //         pressed: activeTab.withActions,
+  //         icon: { image: RiSettings3Line },
+  //         onClick: () =>
+  //           setActiveTab((prev) => ({
+  //             ...prev,
+  //             withActions: !prev.withActions,
+  //           })),
+  //       },
+  //       {
+  //         type: "button",
+  //         caption: "With Summary",
+  //         pressed: activeTab.withSummary,
+  //         icon: { image: RiBookMarkedLine },
+  //         onClick: () =>
+  //           setActiveTab((prev) => ({
+  //             ...prev,
+  //             withSummary: !prev.withSummary,
+  //           })),
+  //       },
+  //       {
+  //         type: "button",
+  //         caption: "With Sorter",
+  //         pressed: activeTab.withSorter,
+  //         icon: { image: RiArrowUpDownLine },
+  //         onClick: () =>
+  //           setActiveTab((prev) => ({ ...prev, withSorter: !prev.withSorter })),
+  //       },
+  //     ];
+
+  //     const ROW_ACTION = (rowId: string): TableSubMenuList[] => [
+  //       {
+  //         caption: "Edit",
+  //         icon: { image: RiArrowUpSLine },
+  //         onClick: () => console.log(`${rowId} was edited`),
+  //       },
+  //       {
+  //         caption: "Delete",
+  //         icon: { image: RiDeleteBin2Fill },
+  //         variant: "danger",
+  //         onClick: () => console.log(`${rowId} was deleted`),
+  //       },
+  //     ];
+
+  //     const handleSortingRequested = ({
+  //       mode,
+  //       column,
+  //     }: {
+  //       mode: "asc" | "desc" | "original";
+  //       column: keyof (typeof initialRows)[number];
+  //     }) => {
+  //       setStatus(mode);
+
+  //       if (mode === "original") {
+  //         setRows(initialRows);
+  //         return;
+  //       }
+
+  //       const sorted = [...rows].sort((a, b) => {
+  //         const aVal = a[column];
+  //         const bVal = b[column];
+
+  //         if (typeof aVal === "string" && typeof bVal === "string") {
+  //           return mode === "asc"
+  //             ? aVal.localeCompare(bVal)
+  //             : bVal.localeCompare(aVal);
+  //         }
+
+  //         if (typeof aVal === "number" && typeof bVal === "number") {
+  //           return mode === "asc" ? aVal - bVal : bVal - aVal;
+  //         }
+
+  //         return 0;
+  //       });
+
+  //       setRows(sorted);
+  //     };
+
+  //     const TIP_MENU_ACTION = (
+  //       columnCaption: keyof (typeof initialRows)[number]
+  //     ): TableSubMenuList[] => {
+  //       return [
+  //         {
+  //           caption: "Sort Ascending",
+  //           icon: {
+  //             image: RiArrowUpLine,
+  //           },
+  //           onClick: () => {
+  //             handleSortingRequested({ mode: "asc", column: columnCaption });
+  //           },
+  //         },
+  //         {
+  //           caption: "Sort Descending",
+  //           icon: {
+  //             image: RiArrowDownLine,
+  //           },
+  //           onClick: () => {
+  //             handleSortingRequested({ mode: "desc", column: columnCaption });
+  //           },
+  //         },
+  //         {
+  //           caption: "Reset Sorting",
+  //           icon: {
+  //             image: RiArrowUpDownLine,
+  //           },
+  //           onClick: () => {
+  //             handleSortingRequested({
+  //               mode: "original",
+  //               column: columnCaption,
+  //             });
+  //           },
+  //         },
+  //       ];
+  //     };
+
+  //     const imageStatus =
+  //       status === "asc"
+  //         ? RiArrowUpLine
+  //         : status === "desc"
+  //           ? RiArrowDownLine
+  //           : RiArrowUpDownLine;
+
+  //     const columnActions = (
+  //       id?: keyof (typeof initialRows)[number]
+  //     ): TableColumnAction => ({
+  //       subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
+  //       title: "Sorter Action",
+  //       icon: {
+  //         image: imageStatus,
+  //       },
+  //     });
+
+  //     const columnProtocol = (): TableColumnAction => ({
+  //       subMenu: ({ show }) =>
+  //         show(
+  //           TYPES_DATA.map((protocol, index) => (
+  //             <ProtocolItem $theme={tableTheme} key={index}>
+  //               <ProtocolName $theme={tableTheme}>{protocol.name}</ProtocolName>
+  //               <ProtocolDescription $theme={tableTheme}>
+  //                 {protocol.description}
+  //               </ProtocolDescription>
+  //             </ProtocolItem>
+  //           )),
+  //           {
+  //             drawerStyle: css`
+  //               padding: 6px;
+  //               gap: 6px;
+  //               display: flex;
+  //               flex-direction: column;
+  //             `,
+  //           }
+  //         ),
+  //       title: "Info Action",
+  //       icon: {
+  //         image: RiInformationLine,
+  //       },
+  //     });
+
+  //     const withSorter = activeTab.withSorter ? columnActions : null;
+
+  //     const columns: TableColumn[] = [
+  //       { id: "name", caption: "Name", actions: withSorter },
+  //       {
+  //         id: "type",
+  //         caption: "Protocol",
+  //         actions: activeTab?.withSorter ? columnProtocol : null,
+  //       },
+  //       { id: "region", caption: "Region", actions: withSorter },
+  //       { id: "status", caption: "Status", actions: withSorter },
+  //       { id: "version", caption: "Version", actions: withSorter },
+  //       { id: "uptime", caption: "Uptime", actions: withSorter },
+  //       { id: "requests", caption: "Requests/s", actions: withSorter },
+  //       { id: "latency", caption: "Latency (ms)", actions: withSorter },
+  //       { id: "errorRate", caption: "Error Rate", actions: withSorter },
+  //       { id: "cpu", caption: "CPU %", actions: withSorter },
+  //       { id: "memory", caption: "Memory %", actions: withSorter },
+  //       { id: "connections", caption: "Connections", actions: withSorter },
+  //       { id: "bandwidth", caption: "Bandwidth", actions: withSorter },
+  //       { id: "zone", caption: "Zone", actions: withSorter },
+  //       { id: "provider", caption: "Provider", actions: withSorter },
+  //     ];
+
+  //     const totals = useMemo(
+  //       () => ({
+  //         requests: rows.reduce((s, r) => s + r.requests, 0),
+  //         latency: Math.round(
+  //           rows.reduce((s, r) => s + r.latency, 0) / rows.length
+  //         ),
+  //         errorRate: (
+  //           rows.reduce((s, r) => s + r.errorRate, 0) / rows.length
+  //         ).toFixed(2),
+  //         cpu: Math.round(rows.reduce((s, r) => s + r.cpu, 0) / rows.length),
+  //         memory: Math.round(
+  //           rows.reduce((s, r) => s + r.memory, 0) / rows.length
+  //         ),
+  //         connections: rows.reduce((s, r) => s + r.connections, 0),
+  //         bandwidth: rows.reduce((s, r) => s + r.bandwidth, 0),
+  //       }),
+  //       [rows]
+  //     );
+
+  //     const sampleRows = rows.map((row) => (
+  //       <Table.Row
+  //         key={row.id}
+  //         rowId={row.id}
+  //         actions={activeTab.withActions ? ROW_ACTION : null}
+  //         content={[
+  //           row.name,
+  //           row.type,
+  //           row.region,
+  //           row.status,
+  //           row.version,
+  //           row.uptime,
+  //           row.requests,
+  //           row.latency,
+  //           row.errorRate,
+  //           row.cpu,
+  //           row.memory,
+  //           row.connections,
+  //           row.bandwidth,
+  //           row.zone,
+  //           row.provider,
+  //         ]}
+  //       />
+  //     ));
+
+  //     const sumRow: TableSummaryRowColumn[] = [
+  //       { content: "Totals / Avg", bold: true },
+  //       { content: "" },
+  //       { content: "" },
+  //       { content: "" },
+  //       { content: "" },
+  //       { content: "" },
+  //       { content: totals.requests, bold: true },
+  //       { content: `${totals.latency} ms`, bold: true },
+  //       { content: `${totals.errorRate}%`, bold: true },
+  //       { content: `${totals.cpu}%`, bold: true },
+  //       { content: `${totals.memory}%`, bold: true },
+  //       { content: totals.connections, bold: true },
+  //       { content: `${totals.bandwidth}Mbps`, bold: true },
+  //       { content: "" },
+  //       { content: "" },
+  //     ];
+
+  //     return (
+  //       <Table
+  //         styles={{
+  //           tableBodyStyle: css`
+  //             max-height: 250px;
+  //           `,
+  //         }}
+  //         loose={loose}
+  //         actions={TOP_ACTIONS}
+  //         columns={columns}
+  //         selectable={activeTab.withCheckbox}
+  //         sumRow={activeTab.withSummary && sumRow}
+  //       >
+  //         {sampleRows}
+  //       </Table>
+  //     );
+  //   }
+  //   context("when given false", () => {
+  //     it("should render the body element with overflow x hidden", () => {
+  //       cy.mount(<ProductTableLoose loose={false} />);
+
+  //       cy.findByLabelText("table-body")
+  //         .parent()
+  //         .should("have.css", "overflow-x", "hidden")
+  //         .and("have.css", "overflow-y", "scroll");
+  //     });
+  //   });
+
+  //   context("when given true", () => {
+  //     it("should render the by overflow auto in body element", () => {
+  //       cy.mount(<ProductTableLoose loose />);
+
+  //       cy.findByLabelText("table-body")
+  //         .parent()
+  //         .should("have.css", "overflow-x", "scroll")
+  //         .and("have.css", "overflow-y", "scroll");
+  //     });
+
+  //     context("loose effect", () => {
+  //       context("first column", () => {
+  //         it("shouldn't render loose effect on the first column", () => {
+  //           cy.mount(<ProductTableLoose loose />);
+
+  //           cy.findAllByLabelText("table-row-cell")
+  //             .first()
+  //             .then(($el) => {
+  //               const after = window.getComputedStyle($el[0], "::after");
+
+  //               expect(after.backgroundImage).to.not.equal(
+  //                 "linear-gradient(to right, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+  //               );
+  //             });
+  //         });
+
+  //         context("when scrolling to the right", () => {
+  //           it("should render loose effect on the first column", () => {
+  //             cy.mount(<ProductTableLoose loose />);
+
+  //             cy.findByLabelText("table-body")
+  //               .parent()
+  //               .then(($el) => {
+  //                 const el = $el[0];
+
+  //                 const scrollToEnd = () => {
+  //                   const maxScroll = el.scrollWidth - el.clientWidth;
+  //                   el.scrollLeft = maxScroll;
+  //                   el.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+  //                   if (el.scrollLeft < maxScroll) {
+  //                     scrollToEnd();
+  //                   }
+  //                 };
+
+  //                 scrollToEnd();
+  //               });
+  //             cy.wait(300);
+
+  //             cy.findAllByLabelText("table-row-cell")
+  //               .first()
+  //               .then(($el) => {
+  //                 const after = window.getComputedStyle($el[0], "::after");
+
+  //                 expect(after.backgroundImage).to.equal(
+  //                   "linear-gradient(to right, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+  //                 );
+  //               });
+  //           });
+  //         });
+  //       });
+
+  //       context("last column", () => {
+  //         context("with actions", () => {
+  //           it("should render loose effect on the last column", () => {
+  //             cy.mount(<ProductTableLoose loose />);
+
+  //             cy.findAllByLabelText("action-button").eq(1).click();
+  //             cy.findAllByLabelText("action-button").eq(2).click();
+
+  //             cy.wait(300);
+
+  //             cy.get(".coneto-button")
+  //               .eq(4)
+  //               .then(($el) => {
+  //                 const after = window.getComputedStyle($el[0], "::before");
+
+  //                 expect(after.backgroundImage).to.equal(
+  //                   "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+  //                 );
+  //               });
+  //           });
+
+  //           it("renders header loose actions with width 48px", () => {
+  //             cy.mount(<ProductTableLoose loose />);
+
+  //             cy.findAllByLabelText("action-button").eq(1).click();
+  //             cy.findAllByLabelText("action-button").eq(2).click();
+
+  //             cy.wait(300);
+
+  //             cy.findByLabelText("header-row-loose-action")
+  //               .should("have.css", "width", "48px")
+  //               .then(($el) => {
+  //                 const after = window.getComputedStyle($el[0], "::before");
+
+  //                 expect(after.backgroundImage).to.equal(
+  //                   "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+  //                 );
+  //               });
+  //           });
+
+  //           it("renders summary row loose actions with width 48px", () => {
+  //             cy.mount(<ProductTableLoose loose />);
+
+  //             cy.findAllByLabelText("action-button").eq(1).click();
+  //             cy.findAllByLabelText("action-button").eq(2).click();
+
+  //             cy.wait(300);
+
+  //             cy.findByLabelText("summary-row-loose-action")
+  //               .should("have.css", "width", "48px")
+  //               .then(($el) => {
+  //                 const after = window.getComputedStyle($el[0], "::before");
+
+  //                 expect(after.backgroundImage).to.equal(
+  //                   "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+  //                 );
+  //               });
+  //           });
+
+  //           context("when scrolling to the right", () => {
+  //             it("shouldn't render loose effect on the last column", () => {
+  //               cy.mount(<ProductTableLoose loose />);
+
+  //               cy.findAllByLabelText("action-button").eq(1).click();
+  //               cy.findAllByLabelText("action-button").eq(2).click();
+
+  //               cy.findByLabelText("table-body")
+  //                 .parent()
+  //                 .then(($el) => {
+  //                   const el = $el[0];
+
+  //                   const scrollToEnd = () => {
+  //                     const maxScroll = el.scrollWidth - el.clientWidth;
+  //                     el.scrollLeft = maxScroll;
+  //                     el.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+  //                     if (el.scrollLeft < maxScroll) {
+  //                       scrollToEnd();
+  //                     }
+  //                   };
+
+  //                   scrollToEnd();
+  //                 });
+
+  //               cy.wait(300);
+
+  //               cy.get(".coneto-button")
+  //                 .eq(4)
+  //                 .then(($el) => {
+  //                   const after = window.getComputedStyle($el[0], "::before");
+
+  //                   expect(after.backgroundImage).to.not.equal(
+  //                     "linear-gradient(to right, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+  //                   );
+  //                 });
+  //             });
+  //           });
+  //         });
+
+  //         context("when activate summary", () => {
+  //           it("renders the summary row loose action", () => {
+  //             cy.mount(<ProductTableLoose loose />);
+
+  //             cy.findAllByLabelText("action-button").eq(1).click();
+  //             cy.findAllByLabelText("action-button").eq(2).click();
+  //             cy.wait(300);
+
+  //             cy.findByLabelText("summary-row-loose-action")
+  //               .should("exist")
+  //               .and("have.css", "width", "48px");
+  //           });
+  //         });
+  //       });
+  //     });
+
+  //     context("with checkbox", () => {
+  //       it("renders checkbox stick in the left side", () => {
+  //         cy.mount(<ProductTableLoose loose />);
+
+  //         cy.findAllByLabelText("action-button").eq(0).click();
+
+  //         cy.get(".coneto-checkbox")
+  //           .eq(0)
+  //           .parent()
+  //           .should("be.visible")
+  //           .and("have.css", "position", "sticky")
+  //           .and("have.css", "left", "0px");
+
+  //         cy.findAllByText("AWS").eq(0).should("not.be.visible");
+
+  //         cy.findAllByText("AWS").eq(0).scrollIntoView().should("be.visible");
+
+  //         cy.get(".coneto-checkbox").eq(0).parent().should("be.visible");
+  //       });
+
+  //       it("renders height same with table-row-cell", () => {
+  //         cy.mount(<ProductTableLoose loose />);
+
+  //         cy.findAllByLabelText("action-button").eq(0).click();
+
+  //         ["field-lane-control", "table-row-cell"].forEach((label) => {
+  //           cy.findAllByLabelText(label)
+  //             .eq(0)
+  //             .should("have.css", "height", "48px");
+  //         });
+  //       });
+  //     });
+
+  //     context("with actions", () => {
+  //       it("renders the row actions sticky in the right side", () => {
+  //         cy.mount(<ProductTableLoose loose />);
+
+  //         cy.findAllByLabelText("action-button").eq(1).click();
+  //         cy.wait(300);
+
+  //         cy.get(".coneto-button")
+  //           .eq(4)
+  //           .should("have.css", "position", "sticky")
+  //           .and("have.css", "right", "0px");
+  //       });
+  //     });
+
+  //     context("with summary", () => {
+  //       it("renders the first column summary stick in the left side", () => {
+  //         cy.mount(<ProductTableLoose loose />);
+
+  //         cy.findAllByLabelText("action-button").eq(2).click();
+  //         cy.wait(300);
+
+  //         cy.findByText("Totals / Avg").should("be.visible");
+
+  //         cy.findAllByText("AWS").eq(0).should("not.be.visible");
+
+  //         cy.findAllByText("AWS").eq(0).scrollIntoView().should("be.visible");
+
+  //         cy.findByText("Totals / Avg").should("be.visible");
+  //       });
+  //     });
+
+  //     context("when scrolling to the right", () => {
+  //       it("shows the most right content", () => {
+  //         cy.mount(<ProductTableLoose loose />);
+
+  //         cy.findByLabelText("table-body")
+  //           .parent()
+  //           .should("have.css", "overflow-x", "scroll")
+  //           .and("have.css", "overflow-y", "scroll");
+
+  //         cy.findAllByText("AWS").eq(0).should("not.be.visible");
+
+  //         cy.findAllByText("AWS").eq(0).scrollIntoView().should("be.visible");
+  //       });
+
+  //       it("the first column still visible", () => {
+  //         cy.mount(<ProductTableLoose loose />);
+
+  //         cy.findByText("Name").should("be.visible");
+  //         cy.findByText("lb-SG-1").should("be.visible");
+  //         cy.findByText("lb-ID-2").should("be.visible");
+
+  //         cy.findAllByText("AWS").eq(0).should("not.be.visible");
+
+  //         cy.findAllByText("AWS").eq(0).scrollIntoView().should("be.visible");
+
+  //         cy.findByText("Name").should("be.visible");
+  //         cy.findByText("lb-SG-1").should("be.visible");
+  //         cy.findByText("lb-ID-2").should("be.visible");
+  //       });
+  //     });
+  //   });
+  // });
 
   context("columns prop", () => {
+    beforeEach(() => {
+      const columnsWithShow: TableColumn[] = [
+        {
+          id: "name",
+          caption: "Name",
+          actions: () => ({
+            subMenu: ({ show }) => show(<div aria-label="test">test</div>),
+            className: "test",
+            id: "test",
+          }),
+        },
+        {
+          id: "type",
+          caption: "Type",
+          actions: () => ({
+            subMenu: ({ show }) => show(<div aria-label="test">test</div>),
+            className: "test",
+            hidden: true,
+          }),
+        },
+      ];
+      cy.mount(<BasicTable columns={columnsWithShow} />);
+    });
+
+    context("actions", () => {
+      it("renders with height and width 40px", () => {
+        cy.findByLabelText("table-column-action")
+          .should("have.css", "height", "40px")
+          .and("have.css", "width", "40px");
+      });
+
+      const ICON_DEFAULT =
+        "M11.9498 7.94975L10.5356 9.36396L8.00079 6.828L8.00004 20H6.00004L6.00079 6.828L3.46451 9.36396L2.05029 7.94975L7.00004 3L11.9498 7.94975ZM21.9498 16.0503L17 21L12.0503 16.0503L13.4645 14.636L16.0008 17.172L16 4H18L18.0008 17.172L20.5356 14.636L21.9498 16.0503Z";
+
+      context("icon", () => {
+        it("renders with up and down arrow (by default)", () => {
+          cy.get("svg path")
+            .eq(0)
+            .invoke("attr", "d")
+            .should("equal", ICON_DEFAULT);
+        });
+        context("when given another icon", () => {
+          it("should not equal value on icon default", () => {
+            const columnsWithShow: TableColumn[] = [
+              {
+                id: "name",
+                caption: "Name",
+                actions: () => ({
+                  subMenu: ({ show }) =>
+                    show(<div aria-label="test">test</div>),
+                  className: "test",
+                  id: "test",
+                  icon: {
+                    image: RiArchive2Fill,
+                  },
+                }),
+              },
+              {
+                id: "type",
+                caption: "Type",
+                actions: () => ({
+                  subMenu: ({ show }) =>
+                    show(<div aria-label="test">test</div>),
+                  className: "test",
+                  hidden: true,
+                }),
+              },
+            ];
+            cy.mount(<BasicTable columns={columnsWithShow} />);
+            cy.get("svg path")
+              .eq(0)
+              .invoke("attr", "d")
+              .should("not.equal", ICON_DEFAULT);
+          });
+        });
+      });
+
+      context("hidden", () => {
+        context("when given true in another action", () => {
+          it("should renders only with hidden false", () => {
+            cy.findByLabelText("table-column-action").should(
+              "not.have.length",
+              2
+            );
+          });
+        });
+      });
+
+      context("id", () => {
+        context("when given with test", () => {
+          it("should render id with test", () => {
+            cy.get("#test").should("exist");
+          });
+        });
+      });
+
+      context("className", () => {
+        it("should render coneto-button by default", () => {
+          cy.get(".coneto-button").should("exist");
+        });
+
+        context("when given test", () => {
+          it("should render test", () => {
+            cy.get(".test").should("exist");
+          });
+        });
+      });
+
+      context("subMenu", () => {
+        context("list()", () => {
+          beforeEach(() => {
+            const onAscending = cy.stub().as("onAscending");
+            const onDescending = cy.stub().as("onDescending");
+            const onReset = cy.stub().as("onReset");
+
+            const TIP_MENU_ACTION = (): TableSubMenuList[] => [
+              {
+                caption: "Sort Ascending",
+                icon: { image: RiArrowUpLine },
+                onClick: onAscending,
+              },
+              {
+                caption: "Sort Descending",
+                icon: { image: RiArrowDownLine },
+                onClick: onDescending,
+              },
+              {
+                caption: "Reset Sorting",
+                icon: { image: RiArrowUpDownLine },
+                onClick: onReset,
+              },
+            ];
+
+            const columnsWithList: TableColumn[] = [
+              {
+                id: "name",
+                caption: "Name",
+                actions: () => ({
+                  subMenu: ({ list }) => list(TIP_MENU_ACTION()),
+                }),
+              },
+              {
+                id: "type",
+                caption: "Type",
+              },
+            ];
+            cy.mount(<BasicTable columns={columnsWithList} />);
+          });
+
+          context("when clicking action", () => {
+            it("shows the tip-menu", () => {
+              cy.findByLabelText("table-column-action").click();
+              cy.findByLabelText("tip-menu").should("exist");
+            });
+
+            context("when clicking the tip menu item", () => {
+              it("should render the console", () => {
+                cy.findByLabelText("table-column-action").click();
+                cy.findByLabelText("tip-menu").should("exist");
+                cy.findByText("Sort Ascending").click();
+                cy.get("@onAscending").should("have.been.calledOnce");
+              });
+            });
+          });
+        });
+
+        context("show()", () => {
+          context("when given show", () => {
+            const columnsWithShow: TableColumn[] = [
+              {
+                id: "name",
+                caption: "Name",
+                actions: () => ({
+                  subMenu: ({ show }) =>
+                    show(<div aria-label="test">test</div>),
+                }),
+              },
+              {
+                id: "type",
+                caption: "Type",
+              },
+            ];
+            it("renders with tooltip container", () => {
+              cy.mount(<BasicTable columns={columnsWithShow} />);
+              cy.findByLabelText("table-column-action").click();
+
+              cy.findByLabelText("tooltip-drawer").should("exist");
+              cy.findByLabelText("test").should("exist");
+            });
+          });
+        });
+
+        context("render()", () => {
+          context("when given render", () => {
+            const columnWithRender: TableColumn[] = [
+              {
+                id: "name",
+                caption: "Name",
+                actions: () => ({
+                  subMenu: ({ render }) =>
+                    render(<div aria-label="render">render content</div>),
+                }),
+              },
+              {
+                id: "type",
+                caption: "Type",
+              },
+            ];
+            it("renders just drawer", () => {
+              cy.mount(<BasicTable columns={columnWithRender} />);
+              cy.findByLabelText("table-column-action").click();
+
+              cy.findByLabelText("tooltip-drawer").should("not.exist");
+              cy.findByLabelText("render").should("exist");
+            });
+          });
+        });
+      });
+    });
+
     context("styles", () => {
       context("containerStyle", () => {
         context("when given background with red color", () => {
@@ -733,25 +1161,6 @@ describe("Table", () => {
           });
         });
       });
-
-      const TIP_MENU_ACTION = (columnCaption: string): TableSubMenuList[] => {
-        return [
-          {
-            caption: "Sort Ascending",
-            icon: {
-              image: RiArrowUpSLine,
-            },
-            onClick: () => {},
-          },
-          {
-            caption: "Reset Sorting",
-            icon: {
-              image: RiRefreshLine,
-            },
-            onClick: () => {},
-          },
-        ];
-      };
     });
   });
 
@@ -2221,7 +2630,7 @@ describe("Table", () => {
         cy.get('input[type="checkbox"]').eq(0).should("not.be.checked");
         cy.get('input[type="checkbox"]').eq(1).should("be.checked");
         cy.get('input[type="checkbox"]').eq(2).should("not.be.checked");
-        cy.get('input[type="checkbox"]').eq(3).should("be.checked");
+        cy.get('input[type="checkbox"]').eq(4).should("be.checked");
         cy.get('input[type="checkbox"]').eq(4).should("be.checked");
       });
     });
@@ -2957,3 +3366,21 @@ describe("Table", () => {
     });
   });
 });
+
+const ProtocolItem = styled.div<{ $theme?: TableThemeConfig }>`
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: ${({ $theme }) => $theme?.backgroundColor};
+`;
+
+const ProtocolName = styled.div<{ $theme?: TableThemeConfig }>`
+  font-weight: 600;
+  font-size: 13px;
+  color: ${({ $theme }) => $theme?.textColor};
+`;
+
+const ProtocolDescription = styled.div<{ $theme?: TableThemeConfig }>`
+  margin-top: 2px;
+  font-size: 12px;
+  color: ${({ $theme }) => $theme?.rowGroupSubtitleTextColor};
+`;

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -110,12 +110,10 @@ describe("Table", () => {
     {
       id: "name",
       caption: "Name",
-      sortable: true,
     },
     {
       id: "type",
       caption: "Type",
-      sortable: true,
     },
   ];
 
@@ -255,21 +253,21 @@ describe("Table", () => {
       const STATUS = ["active", "idle", "degraded"];
 
       const columns: TableColumn[] = [
-        { id: "name", caption: "Name", sortable: false },
-        { id: "type", caption: "Protocol", sortable: false },
-        { id: "region", caption: "Region", sortable: false },
-        { id: "status", caption: "Status", sortable: false },
-        { id: "version", caption: "Version", sortable: false },
-        { id: "uptime", caption: "Uptime", sortable: false },
-        { id: "requests", caption: "Requests/s", sortable: false },
-        { id: "latency", caption: "Latency (ms)", sortable: false },
-        { id: "errorRate", caption: "Error Rate", sortable: false },
-        { id: "cpu", caption: "CPU %", sortable: false },
-        { id: "memory", caption: "Memory %", sortable: false },
-        { id: "connections", caption: "Connections", sortable: false },
-        { id: "bandwidth", caption: "Bandwidth", sortable: false },
-        { id: "zone", caption: "Zone", sortable: false },
-        { id: "provider", caption: "Provider", sortable: false },
+        { id: "name", caption: "Name" },
+        { id: "type", caption: "Protocol" },
+        { id: "region", caption: "Region" },
+        { id: "status", caption: "Status" },
+        { id: "version", caption: "Version" },
+        { id: "uptime", caption: "Uptime" },
+        { id: "requests", caption: "Requests/s" },
+        { id: "latency", caption: "Latency (ms)" },
+        { id: "errorRate", caption: "Error Rate" },
+        { id: "cpu", caption: "CPU %" },
+        { id: "memory", caption: "Memory %" },
+        { id: "connections", caption: "Connections" },
+        { id: "bandwidth", caption: "Bandwidth" },
+        { id: "zone", caption: "Zone" },
+        { id: "provider", caption: "Provider" },
       ];
 
       const rowData = useMemo(
@@ -680,7 +678,7 @@ describe("Table", () => {
                   {
                     id: "name",
                     caption: "Name",
-                    sortable: true,
+
                     styles: {
                       containerStyle: css`
                         background-color: red;
@@ -690,7 +688,6 @@ describe("Table", () => {
                   {
                     id: "type",
                     caption: "Type",
-                    sortable: true,
                   },
                 ]}
               />
@@ -712,7 +709,7 @@ describe("Table", () => {
                   {
                     id: "name",
                     caption: "Name",
-                    sortable: true,
+
                     styles: {
                       labelStyle: css`
                         color: blue;
@@ -722,7 +719,6 @@ describe("Table", () => {
                   {
                     id: "type",
                     caption: "Type",
-                    sortable: true,
                   },
                 ]}
               />
@@ -738,9 +734,7 @@ describe("Table", () => {
         });
       });
 
-      const TIP_MENU_ACTION = (
-        columnCaption: "from" | "content"
-      ): TableSubMenuList[] => {
+      const TIP_MENU_ACTION = (columnCaption: string): TableSubMenuList[] => {
         return [
           {
             caption: "Sort Ascending",
@@ -758,78 +752,6 @@ describe("Table", () => {
           },
         ];
       };
-
-      context("dropdownSortableStyle", () => {
-        context("when given width 400px", () => {
-          it("renders the dropdown with 400px", () => {
-            cy.mount(
-              <BasicTable
-                subMenuList={TIP_MENU_ACTION}
-                columns={[
-                  {
-                    id: "name",
-                    caption: "Name",
-                    sortable: true,
-                    styles: {
-                      dropdownSortableStyle: css`
-                        width: 400px;
-                      `,
-                    },
-                  },
-                  {
-                    id: "type",
-                    caption: "Type",
-                    sortable: true,
-                  },
-                ]}
-              />
-            );
-
-            cy.get("button").eq(0).click();
-            cy.findAllByLabelText("tip-menu")
-              .eq(0)
-              .should("have.css", "width", "400px");
-
-            // check also on default width
-            cy.get("button").eq(1).click();
-            cy.findAllByLabelText("tip-menu")
-              .eq(1)
-              .should("have.css", "width", "235px");
-          });
-        });
-      });
-      context("toggleSortableStyle", () => {
-        context("when given background red", () => {
-          it("renders the trigger style with rgb(255, 0, 0)", () => {
-            cy.mount(
-              <BasicTable
-                subMenuList={TIP_MENU_ACTION}
-                columns={[
-                  {
-                    id: "name",
-                    caption: "Name",
-                    sortable: true,
-                    styles: {
-                      toggleSortableStyle: css`
-                        background-color: red;
-                      `,
-                    },
-                  },
-                  {
-                    id: "type",
-                    caption: "Type",
-                    sortable: true,
-                  },
-                ]}
-              />
-            );
-
-            cy.get("button")
-              .eq(0)
-              .should("have.css", "background-color", "rgb(255, 0, 0)");
-          });
-        });
-      });
     });
   });
 
@@ -838,8 +760,8 @@ describe("Table", () => {
 
     function TableSeparateContent({ mode = "row" }: { mode?: SeparateMode }) {
       const columns: TableColumn[] = [
-        { id: "itemId", caption: "Item ID", sortable: true },
-        { id: "name", caption: "Name", sortable: true, width: "60%" },
+        { id: "itemId", caption: "Item ID" },
+        { id: "name", caption: "Name", width: "60%" },
       ];
 
       function TableSeparateRow({ test }: { test: boolean }) {
@@ -1460,6 +1382,7 @@ describe("Table", () => {
           },
         ]}
         searchable
+        selectable
       >
         {TABLE_SUMMARY?.map((groupValue, groupIndex) => (
           <Table.Row.Group
@@ -1767,19 +1690,16 @@ describe("Table", () => {
     {
       id: "title",
       caption: "Title",
-      sortable: false,
       width: "45%",
     },
     {
       id: "category",
       caption: "Category",
-      sortable: false,
       width: "30%",
     },
     {
       id: "author",
       caption: "Author",
-      sortable: false,
       width: "25%",
     },
   ];
@@ -2213,12 +2133,10 @@ describe("Table", () => {
           {
             id: "name",
             caption: "Name",
-            sortable: true,
           },
           {
             id: "type",
             caption: "Type",
-            sortable: true,
           },
         ];
 
@@ -2264,12 +2182,10 @@ describe("Table", () => {
           {
             id: "name",
             caption: "Name",
-            sortable: true,
           },
           {
             id: "type",
             caption: "Type",
-            sortable: true,
           },
         ];
         const selectedItems = [

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -196,684 +196,684 @@ describe("Table", () => {
     );
   }
 
-  // context("loose", () => {
-  //   function ProductTableLoose({ loose = true }: { loose?: boolean }) {
-  //     const { currentTheme } = useTheme();
-  //     const tableTheme = currentTheme?.table;
-
-  //     interface LoadBalancerRow {
-  //       id: string;
-  //       name: string;
-  //       type: string;
-  //       region: string;
-  //       status: string;
-  //       version: string;
-  //       uptime: string;
-
-  //       requests: number;
-  //       latency: number;
-  //       errorRate: number;
-  //       cpu: number;
-  //       memory: number;
-  //       connections: number;
-  //       bandwidth: number;
-
-  //       zone: string;
-  //       provider: string;
-  //     }
-
-  //     const TYPES_DATA = [
-  //       {
-  //         name: "HTTP",
-  //         description: "Standard protocol for transferring web pages.",
-  //       },
-  //       {
-  //         name: "HTTPS",
-  //         description: "Secure version of HTTP using TLS encryption.",
-  //       },
-  //       {
-  //         name: "TCP",
-  //         description: "Reliable, connection-oriented transport protocol.",
-  //       },
-  //       {
-  //         name: "UDP",
-  //         description:
-  //           "Fast, connectionless protocol for low-latency communication.",
-  //       },
-  //       {
-  //         name: "QUIC",
-  //         description:
-  //           "Modern transport protocol providing faster and more secure connections.",
-  //       },
-  //     ];
-  //     const REGIONS = ["SG", "ID", "US-W", "EU", "JP"];
-  //     const STATUS = ["active", "idle", "degraded"];
-  //     const PROVIDERS = [
-  //       "AWS",
-  //       "Google Cloud",
-  //       "Microsoft Azure",
-  //       "Cloudflare",
-  //       "DigitalOcean",
-  //       "Oracle Cloud",
-  //       "Alibaba Cloud",
-  //       "IBM Cloud",
-  //       "Linode",
-  //       "Vultr",
-  //       "Hetzner",
-  //       "Akamai",
-  //     ];
-
-  //     const initialRows = useMemo<LoadBalancerRow[]>(
-  //       () =>
-  //         Array.from({ length: 15 }, (_, i) => {
-  //           const type = TYPES_DATA[i % TYPES_DATA.length].name;
-  //           const region = REGIONS[i % REGIONS.length];
-  //           const status = STATUS[i % STATUS.length];
-
-  //           const seed = (i + 1) * 17;
-  //           const req = 200 + (seed % 200);
-  //           const lat = 50 + (seed % 50);
-  //           const errRate = (seed % 500) / 100;
-  //           const cpu = 80 + (seed % 80);
-  //           const mem = 70 + (seed % 70);
-  //           const conn = 1000 + (seed % 1000);
-  //           const bw = 100 + (seed % 100);
-  //           const provider = PROVIDERS[i % PROVIDERS.length];
-
-  //           return {
-  //             id: `lb-${i}`,
-  //             name: `lb-${region}-${i + 1}`,
-  //             type,
-  //             region,
-  //             status,
-  //             version: `v${1 + (i % 3)}.${i % 10}`,
-  //             uptime: `${10 + i}d`,
-
-  //             requests: req,
-  //             latency: lat,
-  //             errorRate: errRate,
-  //             cpu,
-  //             memory: mem,
-  //             connections: conn,
-  //             bandwidth: bw,
-
-  //             zone: `zone-${(i % 3) + 1}`,
-  //             provider,
-  //           };
-  //         }),
-  //       []
-  //     );
-
-  //     const [rows, setRows] = useState(initialRows);
-  //     const [activeTab, setActiveTab] = useState({
-  //       withCheckbox: false,
-  //       withActions: false,
-  //       withSummary: false,
-  //       withSorter: false,
-  //     });
-  //     const [status, setStatus] = useState<"desc" | "asc" | "original">(
-  //       "original"
-  //     );
-
-  //     const TOP_ACTIONS: TableAction[] = [
-  //       {
-  //         type: "button",
-  //         caption: "With Checkbox",
-  //         pressed: activeTab.withCheckbox,
-  //         icon: { image: RiCheckboxMultipleLine },
-  //         onClick: () =>
-  //           setActiveTab((prev) => ({
-  //             ...prev,
-  //             withCheckbox: !prev.withCheckbox,
-  //           })),
-  //       },
-  //       {
-  //         type: "button",
-  //         caption: "With Row Actions",
-  //         pressed: activeTab.withActions,
-  //         icon: { image: RiSettings3Line },
-  //         onClick: () =>
-  //           setActiveTab((prev) => ({
-  //             ...prev,
-  //             withActions: !prev.withActions,
-  //           })),
-  //       },
-  //       {
-  //         type: "button",
-  //         caption: "With Summary",
-  //         pressed: activeTab.withSummary,
-  //         icon: { image: RiBookMarkedLine },
-  //         onClick: () =>
-  //           setActiveTab((prev) => ({
-  //             ...prev,
-  //             withSummary: !prev.withSummary,
-  //           })),
-  //       },
-  //       {
-  //         type: "button",
-  //         caption: "With Sorter",
-  //         pressed: activeTab.withSorter,
-  //         icon: { image: RiArrowUpDownLine },
-  //         onClick: () =>
-  //           setActiveTab((prev) => ({ ...prev, withSorter: !prev.withSorter })),
-  //       },
-  //     ];
-
-  //     const ROW_ACTION = (rowId: string): TableSubMenuList[] => [
-  //       {
-  //         caption: "Edit",
-  //         icon: { image: RiArrowUpSLine },
-  //         onClick: () => console.log(`${rowId} was edited`),
-  //       },
-  //       {
-  //         caption: "Delete",
-  //         icon: { image: RiDeleteBin2Fill },
-  //         variant: "danger",
-  //         onClick: () => console.log(`${rowId} was deleted`),
-  //       },
-  //     ];
-
-  //     const handleSortingRequested = ({
-  //       mode,
-  //       column,
-  //     }: {
-  //       mode: "asc" | "desc" | "original";
-  //       column: keyof (typeof initialRows)[number];
-  //     }) => {
-  //       setStatus(mode);
-
-  //       if (mode === "original") {
-  //         setRows(initialRows);
-  //         return;
-  //       }
-
-  //       const sorted = [...rows].sort((a, b) => {
-  //         const aVal = a[column];
-  //         const bVal = b[column];
-
-  //         if (typeof aVal === "string" && typeof bVal === "string") {
-  //           return mode === "asc"
-  //             ? aVal.localeCompare(bVal)
-  //             : bVal.localeCompare(aVal);
-  //         }
-
-  //         if (typeof aVal === "number" && typeof bVal === "number") {
-  //           return mode === "asc" ? aVal - bVal : bVal - aVal;
-  //         }
-
-  //         return 0;
-  //       });
-
-  //       setRows(sorted);
-  //     };
-
-  //     const TIP_MENU_ACTION = (
-  //       columnCaption: keyof (typeof initialRows)[number]
-  //     ): TableSubMenuList[] => {
-  //       return [
-  //         {
-  //           caption: "Sort Ascending",
-  //           icon: {
-  //             image: RiArrowUpLine,
-  //           },
-  //           onClick: () => {
-  //             handleSortingRequested({ mode: "asc", column: columnCaption });
-  //           },
-  //         },
-  //         {
-  //           caption: "Sort Descending",
-  //           icon: {
-  //             image: RiArrowDownLine,
-  //           },
-  //           onClick: () => {
-  //             handleSortingRequested({ mode: "desc", column: columnCaption });
-  //           },
-  //         },
-  //         {
-  //           caption: "Reset Sorting",
-  //           icon: {
-  //             image: RiArrowUpDownLine,
-  //           },
-  //           onClick: () => {
-  //             handleSortingRequested({
-  //               mode: "original",
-  //               column: columnCaption,
-  //             });
-  //           },
-  //         },
-  //       ];
-  //     };
-
-  //     const imageStatus =
-  //       status === "asc"
-  //         ? RiArrowUpLine
-  //         : status === "desc"
-  //           ? RiArrowDownLine
-  //           : RiArrowUpDownLine;
-
-  //     const columnActions = (
-  //       id?: keyof (typeof initialRows)[number]
-  //     ): TableColumnAction => ({
-  //       subMenu: ({ list }) => list(TIP_MENU_ACTION(id)),
-  //       title: "Sorter Action",
-  //       icon: {
-  //         image: imageStatus,
-  //       },
-  //     });
-
-  //     const columnProtocol = (): TableColumnAction => ({
-  //       subMenu: ({ show }) =>
-  //         show(
-  //           TYPES_DATA.map((protocol, index) => (
-  //             <ProtocolItem $theme={tableTheme} key={index}>
-  //               <ProtocolName $theme={tableTheme}>{protocol.name}</ProtocolName>
-  //               <ProtocolDescription $theme={tableTheme}>
-  //                 {protocol.description}
-  //               </ProtocolDescription>
-  //             </ProtocolItem>
-  //           )),
-  //           {
-  //             drawerStyle: css`
-  //               padding: 6px;
-  //               gap: 6px;
-  //               display: flex;
-  //               flex-direction: column;
-  //             `,
-  //           }
-  //         ),
-  //       title: "Info Action",
-  //       icon: {
-  //         image: RiInformationLine,
-  //       },
-  //     });
-
-  //     const withSorter = activeTab.withSorter ? columnActions : null;
-
-  //     const columns: TableColumn[] = [
-  //       { id: "name", caption: "Name", actions: withSorter },
-  //       {
-  //         id: "type",
-  //         caption: "Protocol",
-  //         actions: activeTab?.withSorter ? columnProtocol : null,
-  //       },
-  //       { id: "region", caption: "Region", actions: withSorter },
-  //       { id: "status", caption: "Status", actions: withSorter },
-  //       { id: "version", caption: "Version", actions: withSorter },
-  //       { id: "uptime", caption: "Uptime", actions: withSorter },
-  //       { id: "requests", caption: "Requests/s", actions: withSorter },
-  //       { id: "latency", caption: "Latency (ms)", actions: withSorter },
-  //       { id: "errorRate", caption: "Error Rate", actions: withSorter },
-  //       { id: "cpu", caption: "CPU %", actions: withSorter },
-  //       { id: "memory", caption: "Memory %", actions: withSorter },
-  //       { id: "connections", caption: "Connections", actions: withSorter },
-  //       { id: "bandwidth", caption: "Bandwidth", actions: withSorter },
-  //       { id: "zone", caption: "Zone", actions: withSorter },
-  //       { id: "provider", caption: "Provider", actions: withSorter },
-  //     ];
-
-  //     const totals = useMemo(
-  //       () => ({
-  //         requests: rows.reduce((s, r) => s + r.requests, 0),
-  //         latency: Math.round(
-  //           rows.reduce((s, r) => s + r.latency, 0) / rows.length
-  //         ),
-  //         errorRate: (
-  //           rows.reduce((s, r) => s + r.errorRate, 0) / rows.length
-  //         ).toFixed(2),
-  //         cpu: Math.round(rows.reduce((s, r) => s + r.cpu, 0) / rows.length),
-  //         memory: Math.round(
-  //           rows.reduce((s, r) => s + r.memory, 0) / rows.length
-  //         ),
-  //         connections: rows.reduce((s, r) => s + r.connections, 0),
-  //         bandwidth: rows.reduce((s, r) => s + r.bandwidth, 0),
-  //       }),
-  //       [rows]
-  //     );
-
-  //     const sampleRows = rows.map((row) => (
-  //       <Table.Row
-  //         key={row.id}
-  //         rowId={row.id}
-  //         actions={activeTab.withActions ? ROW_ACTION : null}
-  //         content={[
-  //           row.name,
-  //           row.type,
-  //           row.region,
-  //           row.status,
-  //           row.version,
-  //           row.uptime,
-  //           row.requests,
-  //           row.latency,
-  //           row.errorRate,
-  //           row.cpu,
-  //           row.memory,
-  //           row.connections,
-  //           row.bandwidth,
-  //           row.zone,
-  //           row.provider,
-  //         ]}
-  //       />
-  //     ));
-
-  //     const sumRow: TableSummaryRowColumn[] = [
-  //       { content: "Totals / Avg", bold: true },
-  //       { content: "" },
-  //       { content: "" },
-  //       { content: "" },
-  //       { content: "" },
-  //       { content: "" },
-  //       { content: totals.requests, bold: true },
-  //       { content: `${totals.latency} ms`, bold: true },
-  //       { content: `${totals.errorRate}%`, bold: true },
-  //       { content: `${totals.cpu}%`, bold: true },
-  //       { content: `${totals.memory}%`, bold: true },
-  //       { content: totals.connections, bold: true },
-  //       { content: `${totals.bandwidth}Mbps`, bold: true },
-  //       { content: "" },
-  //       { content: "" },
-  //     ];
-
-  //     return (
-  //       <Table
-  //         styles={{
-  //           tableBodyStyle: css`
-  //             max-height: 250px;
-  //           `,
-  //         }}
-  //         loose={loose}
-  //         actions={TOP_ACTIONS}
-  //         columns={columns}
-  //         selectable={activeTab.withCheckbox}
-  //         sumRow={activeTab.withSummary && sumRow}
-  //       >
-  //         {sampleRows}
-  //       </Table>
-  //     );
-  //   }
-  //   context("when given false", () => {
-  //     it("should render the body element with overflow x hidden", () => {
-  //       cy.mount(<ProductTableLoose loose={false} />);
-
-  //       cy.findByLabelText("table-body")
-  //         .parent()
-  //         .should("have.css", "overflow-x", "hidden")
-  //         .and("have.css", "overflow-y", "scroll");
-  //     });
-  //   });
-
-  //   context("when given true", () => {
-  //     it("should render the by overflow auto in body element", () => {
-  //       cy.mount(<ProductTableLoose loose />);
-
-  //       cy.findByLabelText("table-body")
-  //         .parent()
-  //         .should("have.css", "overflow-x", "scroll")
-  //         .and("have.css", "overflow-y", "scroll");
-  //     });
-
-  //     context("loose effect", () => {
-  //       context("first column", () => {
-  //         it("shouldn't render loose effect on the first column", () => {
-  //           cy.mount(<ProductTableLoose loose />);
-
-  //           cy.findAllByLabelText("table-row-cell")
-  //             .first()
-  //             .then(($el) => {
-  //               const after = window.getComputedStyle($el[0], "::after");
-
-  //               expect(after.backgroundImage).to.not.equal(
-  //                 "linear-gradient(to right, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
-  //               );
-  //             });
-  //         });
-
-  //         context("when scrolling to the right", () => {
-  //           it("should render loose effect on the first column", () => {
-  //             cy.mount(<ProductTableLoose loose />);
-
-  //             cy.findByLabelText("table-body")
-  //               .parent()
-  //               .then(($el) => {
-  //                 const el = $el[0];
-
-  //                 const scrollToEnd = () => {
-  //                   const maxScroll = el.scrollWidth - el.clientWidth;
-  //                   el.scrollLeft = maxScroll;
-  //                   el.dispatchEvent(new Event("scroll", { bubbles: true }));
-
-  //                   if (el.scrollLeft < maxScroll) {
-  //                     scrollToEnd();
-  //                   }
-  //                 };
-
-  //                 scrollToEnd();
-  //               });
-  //             cy.wait(300);
-
-  //             cy.findAllByLabelText("table-row-cell")
-  //               .first()
-  //               .then(($el) => {
-  //                 const after = window.getComputedStyle($el[0], "::after");
-
-  //                 expect(after.backgroundImage).to.equal(
-  //                   "linear-gradient(to right, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
-  //                 );
-  //               });
-  //           });
-  //         });
-  //       });
-
-  //       context("last column", () => {
-  //         context("with actions", () => {
-  //           it("should render loose effect on the last column", () => {
-  //             cy.mount(<ProductTableLoose loose />);
-
-  //             cy.findAllByLabelText("action-button").eq(1).click();
-  //             cy.findAllByLabelText("action-button").eq(2).click();
-
-  //             cy.wait(300);
-
-  //             cy.get(".coneto-button")
-  //               .eq(4)
-  //               .then(($el) => {
-  //                 const after = window.getComputedStyle($el[0], "::before");
-
-  //                 expect(after.backgroundImage).to.equal(
-  //                   "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
-  //                 );
-  //               });
-  //           });
-
-  //           it("renders header loose actions with width 48px", () => {
-  //             cy.mount(<ProductTableLoose loose />);
-
-  //             cy.findAllByLabelText("action-button").eq(1).click();
-  //             cy.findAllByLabelText("action-button").eq(2).click();
-
-  //             cy.wait(300);
-
-  //             cy.findByLabelText("header-row-loose-action")
-  //               .should("have.css", "width", "48px")
-  //               .then(($el) => {
-  //                 const after = window.getComputedStyle($el[0], "::before");
-
-  //                 expect(after.backgroundImage).to.equal(
-  //                   "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
-  //                 );
-  //               });
-  //           });
-
-  //           it("renders summary row loose actions with width 48px", () => {
-  //             cy.mount(<ProductTableLoose loose />);
-
-  //             cy.findAllByLabelText("action-button").eq(1).click();
-  //             cy.findAllByLabelText("action-button").eq(2).click();
-
-  //             cy.wait(300);
-
-  //             cy.findByLabelText("summary-row-loose-action")
-  //               .should("have.css", "width", "48px")
-  //               .then(($el) => {
-  //                 const after = window.getComputedStyle($el[0], "::before");
-
-  //                 expect(after.backgroundImage).to.equal(
-  //                   "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
-  //                 );
-  //               });
-  //           });
-
-  //           context("when scrolling to the right", () => {
-  //             it("shouldn't render loose effect on the last column", () => {
-  //               cy.mount(<ProductTableLoose loose />);
-
-  //               cy.findAllByLabelText("action-button").eq(1).click();
-  //               cy.findAllByLabelText("action-button").eq(2).click();
-
-  //               cy.findByLabelText("table-body")
-  //                 .parent()
-  //                 .then(($el) => {
-  //                   const el = $el[0];
-
-  //                   const scrollToEnd = () => {
-  //                     const maxScroll = el.scrollWidth - el.clientWidth;
-  //                     el.scrollLeft = maxScroll;
-  //                     el.dispatchEvent(new Event("scroll", { bubbles: true }));
-
-  //                     if (el.scrollLeft < maxScroll) {
-  //                       scrollToEnd();
-  //                     }
-  //                   };
-
-  //                   scrollToEnd();
-  //                 });
-
-  //               cy.wait(300);
-
-  //               cy.get(".coneto-button")
-  //                 .eq(4)
-  //                 .then(($el) => {
-  //                   const after = window.getComputedStyle($el[0], "::before");
-
-  //                   expect(after.backgroundImage).to.not.equal(
-  //                     "linear-gradient(to right, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
-  //                   );
-  //                 });
-  //             });
-  //           });
-  //         });
-
-  //         context("when activate summary", () => {
-  //           it("renders the summary row loose action", () => {
-  //             cy.mount(<ProductTableLoose loose />);
-
-  //             cy.findAllByLabelText("action-button").eq(1).click();
-  //             cy.findAllByLabelText("action-button").eq(2).click();
-  //             cy.wait(300);
-
-  //             cy.findByLabelText("summary-row-loose-action")
-  //               .should("exist")
-  //               .and("have.css", "width", "48px");
-  //           });
-  //         });
-  //       });
-  //     });
-
-  //     context("with checkbox", () => {
-  //       it("renders checkbox stick in the left side", () => {
-  //         cy.mount(<ProductTableLoose loose />);
-
-  //         cy.findAllByLabelText("action-button").eq(0).click();
-
-  //         cy.get(".coneto-checkbox")
-  //           .eq(0)
-  //           .parent()
-  //           .should("be.visible")
-  //           .and("have.css", "position", "sticky")
-  //           .and("have.css", "left", "0px");
-
-  //         cy.findAllByText("AWS").eq(0).should("not.be.visible");
-
-  //         cy.findAllByText("AWS").eq(0).scrollIntoView().should("be.visible");
-
-  //         cy.get(".coneto-checkbox").eq(0).parent().should("be.visible");
-  //       });
-
-  //       it("renders height same with table-row-cell", () => {
-  //         cy.mount(<ProductTableLoose loose />);
-
-  //         cy.findAllByLabelText("action-button").eq(0).click();
-
-  //         ["field-lane-control", "table-row-cell"].forEach((label) => {
-  //           cy.findAllByLabelText(label)
-  //             .eq(0)
-  //             .should("have.css", "height", "48px");
-  //         });
-  //       });
-  //     });
-
-  //     context("with actions", () => {
-  //       it("renders the row actions sticky in the right side", () => {
-  //         cy.mount(<ProductTableLoose loose />);
-
-  //         cy.findAllByLabelText("action-button").eq(1).click();
-  //         cy.wait(300);
-
-  //         cy.get(".coneto-button")
-  //           .eq(4)
-  //           .should("have.css", "position", "sticky")
-  //           .and("have.css", "right", "0px");
-  //       });
-  //     });
-
-  //     context("with summary", () => {
-  //       it("renders the first column summary stick in the left side", () => {
-  //         cy.mount(<ProductTableLoose loose />);
-
-  //         cy.findAllByLabelText("action-button").eq(2).click();
-  //         cy.wait(300);
-
-  //         cy.findByText("Totals / Avg").should("be.visible");
-
-  //         cy.findAllByText("AWS").eq(0).should("not.be.visible");
-
-  //         cy.findAllByText("AWS").eq(0).scrollIntoView().should("be.visible");
-
-  //         cy.findByText("Totals / Avg").should("be.visible");
-  //       });
-  //     });
-
-  //     context("when scrolling to the right", () => {
-  //       it("shows the most right content", () => {
-  //         cy.mount(<ProductTableLoose loose />);
-
-  //         cy.findByLabelText("table-body")
-  //           .parent()
-  //           .should("have.css", "overflow-x", "scroll")
-  //           .and("have.css", "overflow-y", "scroll");
-
-  //         cy.findAllByText("AWS").eq(0).should("not.be.visible");
-
-  //         cy.findAllByText("AWS").eq(0).scrollIntoView().should("be.visible");
-  //       });
-
-  //       it("the first column still visible", () => {
-  //         cy.mount(<ProductTableLoose loose />);
-
-  //         cy.findByText("Name").should("be.visible");
-  //         cy.findByText("lb-SG-1").should("be.visible");
-  //         cy.findByText("lb-ID-2").should("be.visible");
-
-  //         cy.findAllByText("AWS").eq(0).should("not.be.visible");
-
-  //         cy.findAllByText("AWS").eq(0).scrollIntoView().should("be.visible");
-
-  //         cy.findByText("Name").should("be.visible");
-  //         cy.findByText("lb-SG-1").should("be.visible");
-  //         cy.findByText("lb-ID-2").should("be.visible");
-  //       });
-  //     });
-  //   });
-  // });
+  context("loose", () => {
+    function ProductTableLoose({ loose = true }: { loose?: boolean }) {
+      const { currentTheme } = useTheme();
+      const tableTheme = currentTheme?.table;
+
+      interface LoadBalancerRow {
+        id: string;
+        name: string;
+        type: string;
+        region: string;
+        status: string;
+        version: string;
+        uptime: string;
+
+        requests: number;
+        latency: number;
+        errorRate: number;
+        cpu: number;
+        memory: number;
+        connections: number;
+        bandwidth: number;
+
+        zone: string;
+        provider: string;
+      }
+
+      const TYPES_DATA = [
+        {
+          name: "HTTP",
+          description: "Standard protocol for transferring web pages.",
+        },
+        {
+          name: "HTTPS",
+          description: "Secure version of HTTP using TLS encryption.",
+        },
+        {
+          name: "TCP",
+          description: "Reliable, connection-oriented transport protocol.",
+        },
+        {
+          name: "UDP",
+          description:
+            "Fast, connectionless protocol for low-latency communication.",
+        },
+        {
+          name: "QUIC",
+          description:
+            "Modern transport protocol providing faster and more secure connections.",
+        },
+      ];
+      const REGIONS = ["SG", "ID", "US-W", "EU", "JP"];
+      const STATUS = ["active", "idle", "degraded"];
+      const PROVIDERS = [
+        "AWS",
+        "Google Cloud",
+        "Microsoft Azure",
+        "Cloudflare",
+        "DigitalOcean",
+        "Oracle Cloud",
+        "Alibaba Cloud",
+        "IBM Cloud",
+        "Linode",
+        "Vultr",
+        "Hetzner",
+        "Akamai",
+      ];
+
+      const initialRows = useMemo<LoadBalancerRow[]>(
+        () =>
+          Array.from({ length: 15 }, (_, i) => {
+            const type = TYPES_DATA[i % TYPES_DATA.length].name;
+            const region = REGIONS[i % REGIONS.length];
+            const status = STATUS[i % STATUS.length];
+
+            const seed = (i + 1) * 17;
+            const req = 200 + (seed % 200);
+            const lat = 50 + (seed % 50);
+            const errRate = (seed % 500) / 100;
+            const cpu = 80 + (seed % 80);
+            const mem = 70 + (seed % 70);
+            const conn = 1000 + (seed % 1000);
+            const bw = 100 + (seed % 100);
+            const provider = PROVIDERS[i % PROVIDERS.length];
+
+            return {
+              id: `lb-${i}`,
+              name: `lb-${region}-${i + 1}`,
+              type,
+              region,
+              status,
+              version: `v${1 + (i % 3)}.${i % 10}`,
+              uptime: `${10 + i}d`,
+
+              requests: req,
+              latency: lat,
+              errorRate: errRate,
+              cpu,
+              memory: mem,
+              connections: conn,
+              bandwidth: bw,
+
+              zone: `zone-${(i % 3) + 1}`,
+              provider,
+            };
+          }),
+        []
+      );
+
+      const [rows, setRows] = useState(initialRows);
+      const [activeTab, setActiveTab] = useState({
+        withCheckbox: false,
+        withActions: false,
+        withSummary: false,
+        withSorter: false,
+      });
+      const [status, setStatus] = useState<"desc" | "asc" | "original">(
+        "original"
+      );
+
+      const TOP_ACTIONS: TableAction[] = [
+        {
+          type: "button",
+          caption: "With Checkbox",
+          pressed: activeTab.withCheckbox,
+          icon: { image: RiCheckboxMultipleLine },
+          onClick: () =>
+            setActiveTab((prev) => ({
+              ...prev,
+              withCheckbox: !prev.withCheckbox,
+            })),
+        },
+        {
+          type: "button",
+          caption: "With Row Actions",
+          pressed: activeTab.withActions,
+          icon: { image: RiSettings3Line },
+          onClick: () =>
+            setActiveTab((prev) => ({
+              ...prev,
+              withActions: !prev.withActions,
+            })),
+        },
+        {
+          type: "button",
+          caption: "With Summary",
+          pressed: activeTab.withSummary,
+          icon: { image: RiBookMarkedLine },
+          onClick: () =>
+            setActiveTab((prev) => ({
+              ...prev,
+              withSummary: !prev.withSummary,
+            })),
+        },
+        {
+          type: "button",
+          caption: "With Sorter",
+          pressed: activeTab.withSorter,
+          icon: { image: RiArrowUpDownLine },
+          onClick: () =>
+            setActiveTab((prev) => ({ ...prev, withSorter: !prev.withSorter })),
+        },
+      ];
+
+      const ROW_ACTION = (rowId: string): TableSubMenuList[] => [
+        {
+          caption: "Edit",
+          icon: { image: RiArrowUpSLine },
+          onClick: () => console.log(`${rowId} was edited`),
+        },
+        {
+          caption: "Delete",
+          icon: { image: RiDeleteBin2Fill },
+          variant: "danger",
+          onClick: () => console.log(`${rowId} was deleted`),
+        },
+      ];
+
+      const handleSortingRequested = ({
+        mode,
+        column,
+      }: {
+        mode: "asc" | "desc" | "original";
+        column: keyof (typeof initialRows)[number];
+      }) => {
+        setStatus(mode);
+
+        if (mode === "original") {
+          setRows(initialRows);
+          return;
+        }
+
+        const sorted = [...rows].sort((a, b) => {
+          const aVal = a[column];
+          const bVal = b[column];
+
+          if (typeof aVal === "string" && typeof bVal === "string") {
+            return mode === "asc"
+              ? aVal.localeCompare(bVal)
+              : bVal.localeCompare(aVal);
+          }
+
+          if (typeof aVal === "number" && typeof bVal === "number") {
+            return mode === "asc" ? aVal - bVal : bVal - aVal;
+          }
+
+          return 0;
+        });
+
+        setRows(sorted);
+      };
+
+      const COLUMN_ACTIONS = (
+        columnId: keyof (typeof initialRows)[number]
+      ): TableSubMenuList[] => {
+        return [
+          {
+            caption: "Sort Ascending",
+            icon: {
+              image: RiArrowUpLine,
+            },
+            onClick: () => {
+              handleSortingRequested({ mode: "asc", column: columnId });
+            },
+          },
+          {
+            caption: "Sort Descending",
+            icon: {
+              image: RiArrowDownLine,
+            },
+            onClick: () => {
+              handleSortingRequested({ mode: "desc", column: columnId });
+            },
+          },
+          {
+            caption: "Reset Sorting",
+            icon: {
+              image: RiArrowUpDownLine,
+            },
+            onClick: () => {
+              handleSortingRequested({
+                mode: "original",
+                column: columnId,
+              });
+            },
+          },
+        ];
+      };
+
+      const imageStatus =
+        status === "asc"
+          ? RiArrowUpLine
+          : status === "desc"
+            ? RiArrowDownLine
+            : RiArrowUpDownLine;
+
+      const columnActions = (
+        id?: keyof (typeof initialRows)[number]
+      ): TableColumnAction => ({
+        subMenu: ({ list }) => list(COLUMN_ACTIONS(id)),
+        title: "Sorter Action",
+        icon: {
+          image: imageStatus,
+        },
+      });
+
+      const columnProtocol = (): TableColumnAction => ({
+        subMenu: ({ show }) =>
+          show(
+            TYPES_DATA.map((protocol, index) => (
+              <ProtocolItem $theme={tableTheme} key={index}>
+                <ProtocolName $theme={tableTheme}>{protocol.name}</ProtocolName>
+                <ProtocolDescription $theme={tableTheme}>
+                  {protocol.description}
+                </ProtocolDescription>
+              </ProtocolItem>
+            )),
+            {
+              drawerStyle: css`
+                padding: 6px;
+                gap: 6px;
+                display: flex;
+                flex-direction: column;
+              `,
+            }
+          ),
+        title: "Info Action",
+        icon: {
+          image: RiInformationLine,
+        },
+      });
+
+      const withSorter = activeTab.withSorter ? columnActions : null;
+
+      const columns: TableColumn[] = [
+        { id: "name", caption: "Name", actions: withSorter },
+        {
+          id: "type",
+          caption: "Protocol",
+          actions: activeTab?.withSorter ? columnProtocol : null,
+        },
+        { id: "region", caption: "Region", actions: withSorter },
+        { id: "status", caption: "Status", actions: withSorter },
+        { id: "version", caption: "Version", actions: withSorter },
+        { id: "uptime", caption: "Uptime", actions: withSorter },
+        { id: "requests", caption: "Requests/s", actions: withSorter },
+        { id: "latency", caption: "Latency (ms)", actions: withSorter },
+        { id: "errorRate", caption: "Error Rate", actions: withSorter },
+        { id: "cpu", caption: "CPU %", actions: withSorter },
+        { id: "memory", caption: "Memory %", actions: withSorter },
+        { id: "connections", caption: "Connections", actions: withSorter },
+        { id: "bandwidth", caption: "Bandwidth", actions: withSorter },
+        { id: "zone", caption: "Zone", actions: withSorter },
+        { id: "provider", caption: "Provider", actions: withSorter },
+      ];
+
+      const totals = useMemo(
+        () => ({
+          requests: rows.reduce((s, r) => s + r.requests, 0),
+          latency: Math.round(
+            rows.reduce((s, r) => s + r.latency, 0) / rows.length
+          ),
+          errorRate: (
+            rows.reduce((s, r) => s + r.errorRate, 0) / rows.length
+          ).toFixed(2),
+          cpu: Math.round(rows.reduce((s, r) => s + r.cpu, 0) / rows.length),
+          memory: Math.round(
+            rows.reduce((s, r) => s + r.memory, 0) / rows.length
+          ),
+          connections: rows.reduce((s, r) => s + r.connections, 0),
+          bandwidth: rows.reduce((s, r) => s + r.bandwidth, 0),
+        }),
+        [rows]
+      );
+
+      const sampleRows = rows.map((row) => (
+        <Table.Row
+          key={row.id}
+          rowId={row.id}
+          actions={activeTab.withActions ? ROW_ACTION : null}
+          content={[
+            row.name,
+            row.type,
+            row.region,
+            row.status,
+            row.version,
+            row.uptime,
+            row.requests,
+            row.latency,
+            row.errorRate,
+            row.cpu,
+            row.memory,
+            row.connections,
+            row.bandwidth,
+            row.zone,
+            row.provider,
+          ]}
+        />
+      ));
+
+      const sumRow: TableSummaryRowColumn[] = [
+        { content: "Totals / Avg", bold: true },
+        { content: "" },
+        { content: "" },
+        { content: "" },
+        { content: "" },
+        { content: "" },
+        { content: totals.requests, bold: true },
+        { content: `${totals.latency} ms`, bold: true },
+        { content: `${totals.errorRate}%`, bold: true },
+        { content: `${totals.cpu}%`, bold: true },
+        { content: `${totals.memory}%`, bold: true },
+        { content: totals.connections, bold: true },
+        { content: `${totals.bandwidth}Mbps`, bold: true },
+        { content: "" },
+        { content: "" },
+      ];
+
+      return (
+        <Table
+          styles={{
+            tableBodyStyle: css`
+              max-height: 250px;
+            `,
+          }}
+          loose={loose}
+          actions={TOP_ACTIONS}
+          columns={columns}
+          selectable={activeTab.withCheckbox}
+          sumRow={activeTab.withSummary && sumRow}
+        >
+          {sampleRows}
+        </Table>
+      );
+    }
+    context("when given false", () => {
+      it("should render the body element with overflow x hidden", () => {
+        cy.mount(<ProductTableLoose loose={false} />);
+
+        cy.findByLabelText("table-body")
+          .parent()
+          .should("have.css", "overflow-x", "hidden")
+          .and("have.css", "overflow-y", "scroll");
+      });
+    });
+
+    context("when given true", () => {
+      it("should render the by overflow auto in body element", () => {
+        cy.mount(<ProductTableLoose loose />);
+
+        cy.findByLabelText("table-body")
+          .parent()
+          .should("have.css", "overflow-x", "scroll")
+          .and("have.css", "overflow-y", "scroll");
+      });
+
+      context("loose effect", () => {
+        context("first column", () => {
+          it("shouldn't render loose effect on the first column", () => {
+            cy.mount(<ProductTableLoose loose />);
+
+            cy.findAllByLabelText("table-row-cell")
+              .first()
+              .then(($el) => {
+                const after = window.getComputedStyle($el[0], "::after");
+
+                expect(after.backgroundImage).to.not.equal(
+                  "linear-gradient(to right, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+                );
+              });
+          });
+
+          context("when scrolling to the right", () => {
+            it("should render loose effect on the first column", () => {
+              cy.mount(<ProductTableLoose loose />);
+
+              cy.findByLabelText("table-body")
+                .parent()
+                .then(($el) => {
+                  const el = $el[0];
+
+                  const scrollToEnd = () => {
+                    const maxScroll = el.scrollWidth - el.clientWidth;
+                    el.scrollLeft = maxScroll;
+                    el.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+                    if (el.scrollLeft < maxScroll) {
+                      scrollToEnd();
+                    }
+                  };
+
+                  scrollToEnd();
+                });
+              cy.wait(300);
+
+              cy.findAllByLabelText("table-row-cell")
+                .first()
+                .then(($el) => {
+                  const after = window.getComputedStyle($el[0], "::after");
+
+                  expect(after.backgroundImage).to.equal(
+                    "linear-gradient(to right, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+                  );
+                });
+            });
+          });
+        });
+
+        context("last column", () => {
+          context("with actions", () => {
+            it("should render loose effect on the last column", () => {
+              cy.mount(<ProductTableLoose loose />);
+
+              cy.findAllByLabelText("action-button").eq(1).click();
+              cy.findAllByLabelText("action-button").eq(2).click();
+
+              cy.wait(300);
+
+              cy.get(".coneto-button")
+                .eq(4)
+                .then(($el) => {
+                  const after = window.getComputedStyle($el[0], "::before");
+
+                  expect(after.backgroundImage).to.equal(
+                    "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+                  );
+                });
+            });
+
+            it("renders header loose actions with width 48px", () => {
+              cy.mount(<ProductTableLoose loose />);
+
+              cy.findAllByLabelText("action-button").eq(1).click();
+              cy.findAllByLabelText("action-button").eq(2).click();
+
+              cy.wait(300);
+
+              cy.findByLabelText("header-row-loose-action")
+                .should("have.css", "width", "48px")
+                .then(($el) => {
+                  const after = window.getComputedStyle($el[0], "::before");
+
+                  expect(after.backgroundImage).to.equal(
+                    "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+                  );
+                });
+            });
+
+            it("renders summary row loose actions with width 48px", () => {
+              cy.mount(<ProductTableLoose loose />);
+
+              cy.findAllByLabelText("action-button").eq(1).click();
+              cy.findAllByLabelText("action-button").eq(2).click();
+
+              cy.wait(300);
+
+              cy.findByLabelText("summary-row-loose-action")
+                .should("have.css", "width", "48px")
+                .then(($el) => {
+                  const after = window.getComputedStyle($el[0], "::before");
+
+                  expect(after.backgroundImage).to.equal(
+                    "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+                  );
+                });
+            });
+
+            context("when scrolling to the right", () => {
+              it("shouldn't render loose effect on the last column", () => {
+                cy.mount(<ProductTableLoose loose />);
+
+                cy.findAllByLabelText("action-button").eq(1).click();
+                cy.findAllByLabelText("action-button").eq(2).click();
+
+                cy.findByLabelText("table-body")
+                  .parent()
+                  .then(($el) => {
+                    const el = $el[0];
+
+                    const scrollToEnd = () => {
+                      const maxScroll = el.scrollWidth - el.clientWidth;
+                      el.scrollLeft = maxScroll;
+                      el.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+                      if (el.scrollLeft < maxScroll) {
+                        scrollToEnd();
+                      }
+                    };
+
+                    scrollToEnd();
+                  });
+
+                cy.wait(300);
+
+                cy.get(".coneto-button")
+                  .eq(4)
+                  .then(($el) => {
+                    const after = window.getComputedStyle($el[0], "::before");
+
+                    expect(after.backgroundImage).to.not.equal(
+                      "linear-gradient(to right, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+                    );
+                  });
+              });
+            });
+          });
+
+          context("when activate summary", () => {
+            it("renders the summary row loose action", () => {
+              cy.mount(<ProductTableLoose loose />);
+
+              cy.findAllByLabelText("action-button").eq(1).click();
+              cy.findAllByLabelText("action-button").eq(2).click();
+              cy.wait(300);
+
+              cy.findByLabelText("summary-row-loose-action")
+                .should("exist")
+                .and("have.css", "width", "48px");
+            });
+          });
+        });
+      });
+
+      context("with checkbox", () => {
+        it("renders checkbox stick in the left side", () => {
+          cy.mount(<ProductTableLoose loose />);
+
+          cy.findAllByLabelText("action-button").eq(0).click();
+
+          cy.get(".coneto-checkbox")
+            .eq(0)
+            .parent()
+            .should("be.visible")
+            .and("have.css", "position", "sticky")
+            .and("have.css", "left", "0px");
+
+          cy.findAllByText("AWS").eq(0).should("not.be.visible");
+
+          cy.findAllByText("AWS").eq(0).scrollIntoView().should("be.visible");
+
+          cy.get(".coneto-checkbox").eq(0).parent().should("be.visible");
+        });
+
+        it("renders height same with table-row-cell", () => {
+          cy.mount(<ProductTableLoose loose />);
+
+          cy.findAllByLabelText("action-button").eq(0).click();
+
+          ["field-lane-control", "table-row-cell"].forEach((label) => {
+            cy.findAllByLabelText(label)
+              .eq(0)
+              .should("have.css", "height", "48px");
+          });
+        });
+      });
+
+      context("with actions", () => {
+        it("renders the row actions sticky in the right side", () => {
+          cy.mount(<ProductTableLoose loose />);
+
+          cy.findAllByLabelText("action-button").eq(1).click();
+          cy.wait(300);
+
+          cy.get(".coneto-button")
+            .eq(4)
+            .should("have.css", "position", "sticky")
+            .and("have.css", "right", "0px");
+        });
+      });
+
+      context("with summary", () => {
+        it("renders the first column summary stick in the left side", () => {
+          cy.mount(<ProductTableLoose loose />);
+
+          cy.findAllByLabelText("action-button").eq(2).click();
+          cy.wait(300);
+
+          cy.findByText("Totals / Avg").should("be.visible");
+
+          cy.findAllByText("AWS").eq(0).should("not.be.visible");
+
+          cy.findAllByText("AWS").eq(0).scrollIntoView().should("be.visible");
+
+          cy.findByText("Totals / Avg").should("be.visible");
+        });
+      });
+
+      context("when scrolling to the right", () => {
+        it("shows the most right content", () => {
+          cy.mount(<ProductTableLoose loose />);
+
+          cy.findByLabelText("table-body")
+            .parent()
+            .should("have.css", "overflow-x", "scroll")
+            .and("have.css", "overflow-y", "scroll");
+
+          cy.findAllByText("AWS").eq(0).should("not.be.visible");
+
+          cy.findAllByText("AWS").eq(0).scrollIntoView().should("be.visible");
+        });
+
+        it("the first column still visible", () => {
+          cy.mount(<ProductTableLoose loose />);
+
+          cy.findByText("Name").should("be.visible");
+          cy.findByText("lb-SG-1").should("be.visible");
+          cy.findByText("lb-ID-2").should("be.visible");
+
+          cy.findAllByText("AWS").eq(0).should("not.be.visible");
+
+          cy.findAllByText("AWS").eq(0).scrollIntoView().should("be.visible");
+
+          cy.findByText("Name").should("be.visible");
+          cy.findByText("lb-SG-1").should("be.visible");
+          cy.findByText("lb-ID-2").should("be.visible");
+        });
+      });
+    });
+  });
 
   context("columns prop", () => {
     beforeEach(() => {
@@ -991,7 +991,7 @@ describe("Table", () => {
             const onDescending = cy.stub().as("onDescending");
             const onReset = cy.stub().as("onReset");
 
-            const TIP_MENU_ACTION = (): TableSubMenuList[] => [
+            const COLUMN_ACTIONS = (): TableSubMenuList[] => [
               {
                 caption: "Sort Ascending",
                 icon: { image: RiArrowUpLine },
@@ -1014,7 +1014,7 @@ describe("Table", () => {
                 id: "name",
                 caption: "Name",
                 actions: () => ({
-                  subMenu: ({ list }) => list(TIP_MENU_ACTION()),
+                  subMenu: ({ list }) => list(COLUMN_ACTIONS()),
                 }),
               },
               {
@@ -3171,7 +3171,7 @@ describe("Table", () => {
     function TableWithRowActions({
       actions,
     }: {
-      actions?: (columnCaption: string) => TableSubMenuList[];
+      actions?: (columnId: string) => TableSubMenuList[];
     }) {
       return (
         <Table

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -628,6 +628,7 @@ export interface TableThemeConfig extends Omit<BodyThemeConfig, "borderColor"> {
 
   headerActionBackgroundColor?: string;
   headerActionBorderColor?: string;
+  headerActionHoverBackgroundColor?: string;
 
   leftLooseEffectColor?: string;
   rightLooseEffectColor?: string;

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1611,11 +1611,15 @@ export function createTableTheme(
       textColor: body.textColor || "#111827",
       backgroundColor: body?.backgroundColor,
       boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
+
       headerActionBackgroundColor:
         "linear-gradient(to bottom, #fbf9f9, #f0f0f0)",
       headerActionBorderColor: "rgb(229, 231, 235)",
+      headerActionHoverBackgroundColor: "rgb(227, 227, 227)",
+
       headerBackgroundColor: "linear-gradient(to bottom, #f0f0f0, #e4e4e4)",
       headerBorderColor: "rgb(229, 231, 235)",
+
       rowGroupBackgroundColor: "rgb(249, 250, 251)",
       rowGroupSubtitleTextColor: "#1f2937",
       rowBackgroundColor: "rgb(249, 250, 251)",
@@ -1625,10 +1629,13 @@ export function createTableTheme(
       rowContentBackgroundColor:
         "linear-gradient(to bottom, #ececec 0%, #f6f6f6 35%, #f0f0f0 100%)",
       rowContentBoxShadow: "rgba(0, 0, 0, 0.15) 0px 4px 5px inset",
+
       summaryBackgroundColor: "linear-gradient(to bottom, #f0f0f0, #e4e4e4)",
       summaryBorderColor: "#d1d5db",
+
       scrollbarThumbColor: "rgba(145, 142, 142, 0.3)",
       scrollbarTrackColor: "rgba(168, 167, 167, 0.1)",
+
       toggleRowBackgroundColor: "#d4d4d4",
 
       leftLooseEffectColor:

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -728,6 +728,7 @@ const darkTable = createTableTheme(darkBody, {
   headerActionBackgroundColor:
     "linear-gradient(rgb(33, 33, 33), rgb(37, 38, 38))",
   headerActionBorderColor: "rgb(61, 61, 61)",
+  headerActionHoverBackgroundColor: "rgb(52, 52, 52)",
 
   headerBackgroundColor: "linear-gradient(rgb(42, 42, 42), rgb(41, 44, 46))",
   headerBorderColor: "rgb(39, 39, 48)",


### PR DESCRIPTION
Description:
This pull request improves the `Table` API action for column level to put only in the `columns` instead of using `subMenuList` and activate by sortable, which the flexibility not same when we put on this API.

```tsx
export interface TableColumn {
  caption: string;
  styles?: TableColumnStyle;
  width?: string;
  id: string;
  actions?: ((id?: string) => TableColumnAction) | TableColumnAction;
}
```

It also another related should be changes at all, and it also ensures the actions works properly 

Source:
[[Improvement] SYST-767: Change API of defining column-level action for `Table`](https://linear.app/systatum/issue/SYST-767/change-api-of-defining-column-level-action-for-table)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself