### PR TITLE
[Bug] SYST-769: Fix cannot build on `main`

### DIFF
--- a/components/title.tsx
+++ b/components/title.tsx
@@ -221,6 +221,7 @@ export interface TitleSectionAction extends BaseAction {
   styles?: TitleSectionActionStyles;
   id?: string;
   className?: string;
+  mobile?: boolean;
 }
 
 export type TitleSectionActionIcon = FigureProps;


### PR DESCRIPTION
Description:
This pull request fixes an issue when we build the `component` inside of the coneto, it would be error, caused from `mobile` prop in the `Title` was deleted.

Source:
[[Bug] SYST-769: Fix cannot build on `main`](https://linear.app/systatum/issue/SYST-769/fix-cannot-build-on-main)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[] I have created/updated any relevant test code
[x] I have tested it myself