### PR TITLE
[Mobile] SYST-762: Add `mobile` to `Datebox`

### DIFF
--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -1066,7 +1066,6 @@ const GridDay = styled.div<{ $theme?: CalendarThemeConfig }>`
   grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 0.25rem;
   text-align: center;
-  font-size: 0.75rem;
   font-weight: 500;
   margin-bottom: 0.25rem;
   user-select: none;

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -293,7 +293,9 @@ function BaseCalendar({
     [currentDate]
   );
 
-  const handleClickPrevMonth = () => {
+  const handleClickPrevMonth = (e: React.MouseEvent) => {
+    e.preventDefault();
+
     if (onCalendarPeriodChanged) {
       onCalendarPeriodChanged(prevMonth);
     }
@@ -306,7 +308,9 @@ function BaseCalendar({
     }));
   };
 
-  const handleClickNextMonth = () => {
+  const handleClickNextMonth = (e: React.MouseEvent) => {
+    e.preventDefault();
+
     setCurrentDate(nextMonth);
     if (onCalendarPeriodChanged) {
       onCalendarPeriodChanged(nextMonth);
@@ -544,6 +548,7 @@ function BaseCalendar({
 
   return (
     <CalendarContainer
+      onMouseDown={(e) => e.preventDefault()}
       $style={
         floatingStyles
           ? css`
@@ -591,7 +596,8 @@ function BaseCalendar({
                 `,
               }}
               aria-label="calendar-select-date"
-              onClick={() => {
+              onMouseDown={(e) => {
+                e.preventDefault();
                 if (!calendarState.open) {
                   handleClickMode("open");
                 }
@@ -622,7 +628,6 @@ function BaseCalendar({
                 styles={{
                   containerStyle: css`
                     min-width: 90px;
-                    max-width: 90px;
                   `,
                 }}
                 onChange={(value: string[]) => {
@@ -639,7 +644,6 @@ function BaseCalendar({
                 styles={{
                   containerStyle: css`
                     min-width: 75px;
-                    max-width: 75px;
                   `,
                 }}
                 onChange={(value: string[]) => {
@@ -708,7 +712,7 @@ function BaseCalendar({
                 size: 24,
               }}
               aria-label="previous-month"
-              onClick={handleClickPrevMonth}
+              onMouseDown={handleClickPrevMonth}
             />
 
             <Button
@@ -728,7 +732,7 @@ function BaseCalendar({
                   padding: 0px;
                 `,
               }}
-              onClick={handleClickNextMonth}
+              onMouseDown={handleClickNextMonth}
               aria-label="next-month"
               icon={{
                 image: RiArrowRightSLine,

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -1183,23 +1183,23 @@ const DrawerWrapper = styled.ul<{
   }
 
   ${({ $mobile, $theme, $multiple, $hasNestedOptions, $drawerHeight }) => {
-    const $mobileHeight = $drawerHeight ?? "220px";
+    const $height = $drawerHeight ?? "220px";
 
     return css`
-      min-height: ${$drawerHeight};
-      max-height: ${$drawerHeight};
+      min-height: ${$height};
+      max-height: ${$height};
 
       ${$mobile &&
       css`
         width: 100%;
         z-index: 9992999;
         border-radius: 14px;
-        min-height: ${$mobileHeight};
-        max-height: ${$mobileHeight};
+        min-height: ${$height};
+        max-height: ${$height};
         border-width: 0.5;
         ${!$multiple &&
         css`
-          padding: calc(${$mobileHeight} * 0.4545) 0;
+          padding: calc(${$height} * 0.4545) 0;
         `}
 
         background-color: ${$mobile && $hasNestedOptions

--- a/components/datebox.stories.tsx
+++ b/components/datebox.stories.tsx
@@ -231,6 +231,7 @@ export const Mobile: Story = {
           monthNames={MONTH_NAMES}
         />
         <Datebox
+          mobile
           id="mobile-range"
           label="Mobile Range Datebox"
           calendarSelectabilityMode="ranged"

--- a/components/datebox.stories.tsx
+++ b/components/datebox.stories.tsx
@@ -166,6 +166,85 @@ export const Default: Story = {
   },
 };
 
+export const Mobile: Story = {
+  parameters: {
+    layout: "padded",
+  },
+  render: () => {
+    const DAY_NAMES = [
+      { text: "Su", value: "1" },
+      { text: "Mo", value: "2" },
+      { text: "Tu", value: "3" },
+      { text: "We", value: "4" },
+      { text: "Th", value: "5" },
+      { text: "Fr", value: "6" },
+      { text: "Sa", value: "7" },
+    ];
+
+    const MONTH_NAMES = [
+      { text: "JAN", value: "1" },
+      { text: "FEB", value: "2" },
+      { text: "MAR", value: "3" },
+      { text: "APR", value: "4" },
+      { text: "MAY", value: "5" },
+      { text: "JUN", value: "6" },
+      { text: "JUL", value: "7" },
+      { text: "AUG", value: "8" },
+      { text: "SEP", value: "9" },
+      { text: "OCT", value: "10" },
+      { text: "NOV", value: "11" },
+      { text: "DEC", value: "12" },
+    ];
+
+    const [value1, setValue1] = useState<string[]>([]);
+    const [value2, setValue2] = useState<string[]>([]);
+    const [value3, setValue3] = useState<string[]>([]);
+
+    return (
+      <div
+        style={{
+          width: "300px",
+          gap: "4px",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <Datebox
+          mobile
+          id="mobile"
+          label="Mobile Datebox"
+          options={DAY_NAMES}
+          selectedDates={value1}
+          onChange={setValue1}
+          dayNames={DAY_NAMES}
+          monthNames={MONTH_NAMES}
+        />
+        <Datebox
+          mobile
+          id="mobile-multiple"
+          label="Mobile Multiple Datebox"
+          calendarSelectabilityMode="multiple"
+          options={DAY_NAMES}
+          selectedDates={value2}
+          onChange={setValue2}
+          dayNames={DAY_NAMES}
+          monthNames={MONTH_NAMES}
+        />
+        <Datebox
+          id="mobile-range"
+          label="Mobile Range Datebox"
+          calendarSelectabilityMode="ranged"
+          options={DAY_NAMES}
+          selectedDates={value3}
+          onChange={setValue3}
+          dayNames={DAY_NAMES}
+          monthNames={MONTH_NAMES}
+        />
+      </div>
+    );
+  },
+};
+
 export const WithLoading: Story = {
   render: () => {
     return (

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -148,7 +148,7 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
 });
 
 function CalendarDrawer(props: CalendarDrawerProps) {
-  const { mobile, ...rest } = props;
+  const { mobile, ...rest } = props ?? {};
   const { currentTheme } = useTheme();
   const calendarTheme = currentTheme?.calendar;
 
@@ -172,7 +172,7 @@ function CalendarDrawer(props: CalendarDrawerProps) {
     self: css`
       ${mobile &&
       css`
-        width: 350px;
+        width: 300px;
         left: 50%;
       `}
       ${props.styles?.self}

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -19,6 +19,7 @@ import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { applyClassName } from "./../constants/classname";
 import { CalendarThemeConfig } from "theme";
+import { createPortal } from "react-dom";
 
 type BaseDateboxProps = Omit<BaseCalendarProps, "selectabilityMode"> & {
   name?: string;
@@ -185,7 +186,7 @@ function CalendarDrawer(props: CalendarDrawerProps) {
     `,
   };
 
-  return (
+  return createPortal(
     <CalendarWrapper
       {...(props.getFloatingProps?.() ?? {})}
       ref={props.refs?.setFloating ?? null}
@@ -221,7 +222,8 @@ function CalendarDrawer(props: CalendarDrawerProps) {
         selectabilityMode={props.calendarSelectabilityMode}
         label={null}
       />
-    </CalendarWrapper>
+    </CalendarWrapper>,
+    document.body
   );
 }
 
@@ -249,6 +251,7 @@ const CalendarWrapper = styled.ul<{
   list-style: none;
   outline: none;
   z-index: 9992999;
+
   ${({ $theme, $showError, $mobile }) => css`
     background-color: ${$theme?.backgroundColor};
     border-color: ${$showError ? "#dc2626" : $theme?.borderColor};

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -18,6 +18,7 @@ import { FieldLaneDropdownOption, FieldLaneProps } from "./field-lane";
 import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { applyClassName } from "./../constants/classname";
+import { CalendarThemeConfig } from "theme";
 
 type BaseDateboxProps = Omit<BaseCalendarProps, "selectabilityMode"> & {
   name?: string;
@@ -89,6 +90,15 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
     id,
   });
 
+  const {
+    bodyStyle,
+    controlStyle,
+    selectboxStyle,
+    labelStyle,
+    containerStyle,
+    self,
+  } = styles ?? {};
+
   return (
     <Selectbox
       {...rest}
@@ -108,7 +118,9 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
       required={rest.required}
       isLoading={isLoading}
       styles={{
-        ...styles,
+        controlStyle,
+        bodyStyle,
+        labelStyle,
         self: css`
           ${dropdowns &&
           css`
@@ -116,7 +128,7 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
             border-bottom-left-radius: 0px;
           `}
 
-          ${styles?.selectboxStyle}
+          ${selectboxStyle}
         `,
       }}
       placeholder={placeholder}
@@ -136,7 +148,8 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
             disableWeekend={disableWeekend}
             calendarSelectabilityMode={calendarSelectabilityMode}
             styles={{
-              self: styles?.self,
+              self,
+              containerStyle,
             }}
             onChange={onChange}
             selectedDates={selectedDates}
@@ -148,24 +161,11 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
 });
 
 function CalendarDrawer(props: CalendarDrawerProps) {
-  const { mobile, ...rest } = props ?? {};
+  const { mobile, styles, ...rest } = props ?? {};
   const { currentTheme } = useTheme();
   const calendarTheme = currentTheme?.calendar;
 
-  const calendarMobileWrapper =
-    mobile &&
-    css`
-      position: fixed;
-      bottom: 20px;
-      min-width: 96dvw;
-      left: 50%;
-      transform: translateX(-50%);
-      padding: 20px;
-      border-radius: 14px;
-      border: 1px solid ${calendarTheme?.mobileBackgroundColor};
-      background-color: ${calendarTheme?.mobileBackgroundColor};
-      box-shadow: ${calendarTheme?.boxShadow};
-    `;
+  const { self, containerStyle } = styles ?? {};
 
   const calendarStyle: CalendarStyles = {
     ...props.styles,
@@ -175,7 +175,7 @@ function CalendarDrawer(props: CalendarDrawerProps) {
         width: 300px;
         left: 50%;
       `}
-      ${props.styles?.self}
+      ${self}
     `,
     controlStyle: css`
       ${mobile &&
@@ -193,17 +193,16 @@ function CalendarDrawer(props: CalendarDrawerProps) {
         !mobile
           ? {
               ...(props.floatingStyles ?? {}),
-              backgroundColor: calendarTheme?.backgroundColor,
-              borderColor: props.showError
-                ? "#dc2626"
-                : calendarTheme?.borderColor,
             }
           : {}
       }
+      $mobile={mobile}
+      $showError={props?.showError}
+      $theme={calendarTheme}
       tabIndex={-1}
       role="listbox"
-      aria-label="Calendar"
-      $style={calendarMobileWrapper}
+      aria-label="calendar"
+      $style={containerStyle}
     >
       <Calendar
         {...rest}
@@ -228,6 +227,9 @@ function CalendarDrawer(props: CalendarDrawerProps) {
 
 const CalendarWrapper = styled.ul<{
   $style?: CSSProp;
+  $theme?: CalendarThemeConfig;
+  $mobile?: boolean;
+  $showError?: boolean;
 }>`
   list-style: none;
   margin: 0;
@@ -247,6 +249,23 @@ const CalendarWrapper = styled.ul<{
   list-style: none;
   outline: none;
   z-index: 9992999;
+  ${({ $theme, $showError, $mobile }) => css`
+    background-color: ${$theme?.backgroundColor};
+    border-color: ${$showError ? "#dc2626" : $theme?.borderColor};
+    ${$mobile &&
+    css`
+      position: fixed;
+      bottom: 20px;
+      min-width: 96dvw;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 20px;
+      border-radius: 14px;
+      border: 1px solid ${$theme?.mobileBackgroundColor};
+      background-color: ${$theme?.mobileBackgroundColor};
+      box-shadow: ${$theme?.boxShadow};
+    `};
+  `};
 
   ${({ $style }) => $style}
 `;

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -161,9 +161,10 @@ function CalendarDrawer(props: CalendarDrawerProps) {
       left: 50%;
       transform: translateX(-50%);
       padding: 20px;
-      border-radius: 20px;
+      border-radius: 14px;
       border: 1px solid ${calendarTheme?.mobileBackgroundColor};
       background-color: ${calendarTheme?.mobileBackgroundColor};
+      box-shadow: ${calendarTheme?.boxShadow};
     `;
 
   const calendarStyle: CalendarStyles = {

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -10,6 +10,7 @@ import {
   Calendar,
   BaseCalendarProps,
   CalendarSelectabilityMode,
+  CalendarStyles,
 } from "./calendar";
 import styled, { css, CSSProp } from "styled-components";
 import { forwardRef, ReactNode } from "react";
@@ -18,7 +19,7 @@ import { StatefulForm } from "./stateful-form";
 import { useTheme } from "./../theme/provider";
 import { applyClassName } from "./../constants/classname";
 
-type BaseDateboxProps = BaseCalendarProps & {
+type BaseDateboxProps = Omit<BaseCalendarProps, "selectabilityMode"> & {
   name?: string;
   label?: string;
   showError?: boolean;
@@ -32,6 +33,7 @@ type BaseDateboxProps = BaseCalendarProps & {
   helper?: string;
   id?: string;
   isLoading?: boolean;
+  mobile?: boolean;
   labels?: SelectboxLabels;
 };
 
@@ -41,6 +43,7 @@ type CalendarDrawerProps = BaseCalendarProps &
   Partial<
     DrawerProps & {
       selectedOptionsLocal?: SelectboxOption;
+      mobile?: boolean;
       setSelectedOptionsLocal?: (option: SelectboxOption) => void;
       calendarFooter?: ReactNode;
       calendarTodayButtonCaption?: string;
@@ -145,24 +148,65 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
 });
 
 function CalendarDrawer(props: CalendarDrawerProps) {
+  const { mobile, ...rest } = props;
   const { currentTheme } = useTheme();
   const calendarTheme = currentTheme?.calendar;
+
+  const calendarMobileWrapper =
+    mobile &&
+    css`
+      position: fixed;
+      bottom: 20px;
+      min-width: 96dvw;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 20px;
+      border-radius: 20px;
+      border: 1px solid ${calendarTheme?.mobileBackgroundColor};
+      background-color: ${calendarTheme?.mobileBackgroundColor};
+    `;
+
+  const calendarStyle: CalendarStyles = {
+    ...props.styles,
+    self: css`
+      ${mobile &&
+      css`
+        width: 350px;
+        left: 50%;
+      `}
+      ${props.styles?.self}
+    `,
+    controlStyle: css`
+      ${mobile &&
+      css`
+        justify-content: center;
+      `}
+    `,
+  };
 
   return (
     <CalendarWrapper
       {...(props.getFloatingProps?.() ?? {})}
       ref={props.refs?.setFloating ?? null}
-      style={{
-        ...(props.floatingStyles ?? {}),
-        backgroundColor: calendarTheme?.backgroundColor,
-        borderColor: props.showError ? "#dc2626" : calendarTheme?.borderColor,
-      }}
+      style={
+        !mobile
+          ? {
+              ...(props.floatingStyles ?? {}),
+              backgroundColor: calendarTheme?.backgroundColor,
+              borderColor: props.showError
+                ? "#dc2626"
+                : calendarTheme?.borderColor,
+            }
+          : {}
+      }
       tabIndex={-1}
       role="listbox"
       aria-label="Calendar"
+      $style={calendarMobileWrapper}
     >
       <Calendar
-        {...props}
+        {...rest}
+        styles={calendarStyle}
         footer={props.calendarFooter}
         onChange={(data: string[]) => {
           if (props.onChange) {

--- a/test/component/datebox.cy.tsx
+++ b/test/component/datebox.cy.tsx
@@ -6,8 +6,101 @@ import {
   RiSettings2Line,
   RiUser2Line,
 } from "@remixicon/react";
+import { css } from "styled-components";
 
 describe("Datebox", () => {
+  context("mobile", () => {
+    it("renders in with fixed and bottom of screen", () => {
+      cy.viewport(500, 750);
+      cy.mount(<Datebox mobile />);
+      cy.findByPlaceholderText("mm/dd/yyyy").click();
+
+      cy.findByLabelText("calendar")
+        .should("have.css", "position", "fixed")
+        .and("have.css", "bottom", "20px");
+    });
+
+    it("renders in with 96dvh (480px from 500px)", () => {
+      cy.viewport(500, 750);
+      cy.mount(<Datebox mobile />);
+      cy.findByPlaceholderText("mm/dd/yyyy").click();
+
+      cy.findByLabelText("calendar").should("have.css", "width", "480px");
+    });
+
+    context("with light mode", () => {
+      it("renders in with background rgb(249, 250, 251)", () => {
+        cy.viewport(500, 750);
+        cy.mount(<Datebox mobile />);
+        cy.findByPlaceholderText("mm/dd/yyyy").click();
+
+        cy.findByLabelText("calendar").should(
+          "have.css",
+          "background-color",
+          "rgb(249, 250, 251)"
+        );
+      });
+    });
+
+    context("with dark mode", () => {
+      it("renders in with background rgb(44, 44, 46)", () => {
+        cy.viewport(500, 750);
+        cy.mount(<Datebox mobile />, {
+          mode: "dark",
+        });
+        cy.findByPlaceholderText("mm/dd/yyyy").click();
+
+        cy.findByLabelText("calendar").should(
+          "have.css",
+          "background-color",
+          "rgb(44, 44, 46)"
+        );
+      });
+    });
+  });
+
+  context("styles", () => {
+    context("containerStyle", () => {
+      context("when given padding 40px", () => {
+        it("should render padding with 40px", () => {
+          cy.mount(
+            <Datebox
+              mobile
+              styles={{
+                containerStyle: css`
+                  padding: 40px;
+                `,
+              }}
+            />
+          );
+          cy.findByPlaceholderText("mm/dd/yyyy").click();
+
+          cy.findByLabelText("calendar").should("have.css", "padding", "40px");
+        });
+      });
+    });
+    context("self", () => {
+      context("when given font-size 20px", () => {
+        it("should render the date text with 20px", () => {
+          cy.mount(
+            <Datebox
+              mobile
+              styles={{
+                self: css`
+                  font-size: 20px;
+                `,
+              }}
+            />
+          );
+          cy.findByPlaceholderText("mm/dd/yyyy").click();
+          ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"].map((day) => {
+            cy.findByText(day).should("have.css", "font-size", "20px");
+          });
+        });
+      });
+    });
+  });
+
   context("labels", () => {
     context("loadingText", () => {
       context("when not given text within isLoading true", () => {

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -93,6 +93,9 @@ export interface CalendarThemeConfig extends BodyThemeConfig {
   highlightedDateTextColor?: string;
   hightlightDateColor?: string;
 
+  mobileBackgroundColor?: string;
+  mobileBorderColor?: string;
+
   boxShadow?: string;
 }
 

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -359,6 +359,8 @@ export function createCalendarTheme(
       backgroundColor: body.backgroundColor || "#ffffff",
       borderColor: fieldLane?.borderColor || "#d1d5db",
       textColor: body.textColor || "#111827",
+      mobileBackgroundColor: "rgb(249, 250, 251)",
+      mobileBorderColor: "rgb(249, 250, 251)",
 
       dayTextColor: "#6b7280",
 

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -270,6 +270,9 @@ const darkCalendar = createCalendarTheme(darkBody, darkFieldLane, {
   highlightedDateTextColor: "#ffffff",
 
   boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.25)",
+
+  mobileBorderColor: "#2c2c2e",
+  mobileBackgroundColor: "#2c2c2e",
 });
 
 const darkCapsule = createCapsuleTheme(darkBody, darkFieldLane, {


### PR DESCRIPTION
Description:
This change introduces a `mobile` prop to the `Datebox` component so it can render differently on mobile devices.

Instead of rendering the calendar popup attached to the input element, the `Datebox` should renders it at the bottom of the screen. The appearance would be similar like `Combobox` component.

Source:
[[Mobile] SYST-762: Add `mobile` to `Datebox`](https://linear.app/systatum/issue/SYST-762/add-mobile-to-datebox)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself