### PR TITLE
[Improvement] SYST-770: Enrich flexibility `styles` in `Rating` component

### DIFF
--- a/components/rating.tsx
+++ b/components/rating.tsx
@@ -26,8 +26,9 @@ interface BaseRatingProps {
   id?: string;
 }
 interface BaseRatingStyles {
-  containerStyle?: CSSProp;
-  labelStyle?: CSSProp;
+  ratingWrapperStyle?: CSSProp;
+  starsWrapperStyle?: CSSProp;
+  ratingLabelStyle?: CSSProp;
 }
 
 function BaseRating({
@@ -39,6 +40,7 @@ function BaseRating({
   size = "md",
   name,
   disabled,
+  styles,
 }: BaseRatingProps) {
   const { currentTheme } = useTheme();
   const ratingTheme = currentTheme?.rating;
@@ -137,8 +139,11 @@ function BaseRating({
   };
 
   return (
-    <RatingWrapper aria-label="rating-wrapper">
-      <StarsWrapper>
+    <RatingWrapper
+      aria-label="rating-wrapper"
+      $style={styles?.ratingWrapperStyle}
+    >
+      <StarsWrapper $style={styles?.starsWrapperStyle}>
         {Array.from({ length: 5 }).map((_, i) => (
           <StarSpan
             role="img"
@@ -162,7 +167,12 @@ function BaseRating({
       />
 
       {withLabel && (
-        <RatingLabel $disabled={disabled} $theme={ratingTheme} $size={size}>
+        <RatingLabel
+          $disabled={disabled}
+          $theme={ratingTheme}
+          $size={size}
+          $style={styles?.ratingLabelStyle}
+        >
           {ratingLocal.toFixed(1)} / 5
         </RatingLabel>
       )}
@@ -204,7 +214,7 @@ function Rating({
     controlStyle,
     containerStyle,
     labelStyle,
-    ...RatingStyles
+    ...ratingStyles
   } = styles ?? {};
 
   return (
@@ -233,22 +243,24 @@ function Rating({
         disabled={disabled}
         name={name}
         id={inputId}
-        styles={RatingStyles}
+        styles={ratingStyles}
       />
     </FieldLane>
   );
 }
 
-const RatingWrapper = styled.div`
+const RatingWrapper = styled.div<{ $style?: CSSProp }>`
   display: flex;
   align-items: center;
   gap: 8px;
+  ${({ $style }) => $style}
 `;
 
-const StarsWrapper = styled.div`
+const StarsWrapper = styled.div<{ $style?: CSSProp }>`
   display: flex;
   flex-direction: row;
   gap: 2px;
+  ${({ $style }) => $style}
 `;
 
 const StarSpan = styled.span<{ $editable?: boolean; $disabled?: boolean }>`
@@ -269,6 +281,7 @@ const RatingLabel = styled.span<{
   $size: "sm" | "md" | "lg";
   $theme: RatingThemeConfig;
   $disabled?: boolean;
+  $style?: CSSProp;
 }>`
   font-weight: 500;
   color: ${({ $disabled, $theme }) =>
@@ -289,6 +302,8 @@ const RatingLabel = styled.span<{
         `;
     }
   }}
+
+  ${({ $style }) => $style}
 `;
 
 export { Rating };

--- a/components/rating.tsx
+++ b/components/rating.tsx
@@ -143,7 +143,10 @@ function BaseRating({
       aria-label="rating-wrapper"
       $style={styles?.ratingWrapperStyle}
     >
-      <StarsWrapper $style={styles?.starsWrapperStyle}>
+      <StarsWrapper
+        aria-label="rating-stars-wrapper"
+        $style={styles?.starsWrapperStyle}
+      >
         {Array.from({ length: 5 }).map((_, i) => (
           <StarSpan
             role="img"
@@ -168,6 +171,7 @@ function BaseRating({
 
       {withLabel && (
         <RatingLabel
+          aria-label="rating-label"
           $disabled={disabled}
           $theme={ratingTheme}
           $size={size}

--- a/test/component/rating.cy.tsx
+++ b/test/component/rating.cy.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { Rating, RatingProps } from "./../../components/rating";
+import { css } from "styled-components";
+
+describe("Rating", () => {
+  function ProductRating(props?: RatingProps) {
+    const [value, setValue] = useState("4.5");
+
+    return (
+      <Rating
+        editable
+        rating={value}
+        onChange={(e) => setValue(e.target.value)}
+        withLabel
+        {...props}
+      />
+    );
+  }
+
+  context("styles", () => {
+    context("ratingWrapperStyle", () => {
+      context("when given gap 10px", () => {
+        it("renders gap 10px between stars and label", () => {
+          cy.mount(
+            <ProductRating
+              styles={{
+                ratingWrapperStyle: css`
+                  gap: 10px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("rating-wrapper").should(
+            "have.css",
+            "gap",
+            "10px"
+          );
+        });
+      });
+    });
+
+    context("starsWrapperStyle", () => {
+      context("when given gap 10px", () => {
+        it("renders gap 10px between stars", () => {
+          cy.mount(
+            <ProductRating
+              styles={{
+                starsWrapperStyle: css`
+                  gap: 10px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("rating-stars-wrapper").should(
+            "have.css",
+            "gap",
+            "10px"
+          );
+        });
+      });
+    });
+
+    context("ratingLabelStyle", () => {
+      context("when given font-size 30px", () => {
+        it("renders font-size with 30px", () => {
+          cy.mount(
+            <ProductRating
+              styles={{
+                ratingLabelStyle: css`
+                  font-size: 30px;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("rating-label").should(
+            "have.css",
+            "font-size",
+            "30px"
+          );
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Description:
Previously, the `Rating` component did not expose enough styling option on it's base component. In particularly, it was not possible to customize the `stars wrapper`, `base root level`, and `label placeholder` , which limited flexibility when additional styling was needed.

Additionally, the `StatefulForm.Mobile` view required styling adjustment for the stars wrapper to improve its appearance.

<img width="505" height="133" alt="Screenshot 2026-06-30 at 14 18 36" src="https://github.com/user-attachments/assets/eb9d3ff5-b674-4ef9-a51e-597e91d9868f" />

This pull request enhances the `Rating` component by introducing `ratingWrapperStyle`, `starsWrapperStyle` and `ratingLabelStyle` in `BaseStyles` prop, providing greater customization and making it easier to style the component in different contexts.

```tsx
interface BaseRatingStyles {
  ratingWrapperStyle?: CSSProp;
  starsWrapperStyle?: CSSProp;
  ratingLabelStyle?: CSSProp;
}
```

Source:
[[Improvement] SYST-770: Enrich flexibility `styles` in `Rating` component](https://linear.app/systatum/issue/SYST-770/enrich-flexibility-styles-in-rating-component)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself