### PR TITLE
[Mobile] SYST-771: Add `mobile` to `Phonebox`

### DIFF
--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -493,7 +493,7 @@ function ComboboxDrawer({
     if (
       highlightedIndex !== null &&
       listRef.current[highlightedIndex] &&
-      multiple &&
+      withSearchbox &&
       interactionMode === "keyboard"
     ) {
       const element = listRef.current[highlightedIndex];
@@ -516,7 +516,7 @@ function ComboboxDrawer({
         }
       }
     }
-  }, [highlightedIndex, multiple, interactionMode]);
+  }, [highlightedIndex, withSearchbox, interactionMode]);
 
   const filteredActions: TreeListAction[] = Array.isArray(actions)
     ? actions

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -388,6 +388,7 @@ function ComboboxDrawer({
   setSelectedOptionsLocal,
   selectedOptionsLocal,
   selectedOptions,
+  isOpen,
   setIsOpen,
   actions,
   onClick,
@@ -460,6 +461,12 @@ function ComboboxDrawer({
 
     onChange(castValue(values[0], selectedOptions));
   };
+
+  useEffect(() => {
+    if (isOpen && selectedIndex) {
+      setHighlightedIndex(selectedIndex);
+    }
+  }, [isOpen]);
 
   useEffect(() => {
     if (
@@ -714,6 +721,19 @@ function ComboboxDrawer({
 
     return (options ?? []).filter((opt) => !opt.hidden).map(mapToContent);
   };
+
+  const content = useMemo(
+    () => generateContent(),
+    [
+      options,
+      finalSelectedOptions,
+      highlightedIndex,
+      highlightOnMatch,
+      flatIndexMap,
+      multiple,
+      mobile,
+    ]
+  );
 
   const onMouseDown = (props: {
     event: React.MouseEvent;
@@ -1089,7 +1109,7 @@ function ComboboxDrawer({
               `,
             }}
             showHierarchyLine
-            content={generateContent()}
+            content={content}
           />
         </>
       )}

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -1,8 +1,10 @@
 import {
   forwardRef,
+  ForwardRefExoticComponent,
   KeyboardEvent,
   ReactNode,
   Ref,
+  RefAttributes,
   RefObject,
   useEffect,
   useMemo,
@@ -58,6 +60,7 @@ interface BaseComboboxProps {
   labels?: ComboboxLabelsProps;
   mobile?: boolean;
   drawerHeight?: string;
+  withSearchbox?: boolean;
 }
 
 export const ComboboxGroupInitialState = {
@@ -98,7 +101,7 @@ export interface ComboboxStyles extends Omit<SelectboxStyles, "self"> {
 
 export type ComboboxAction = TreeListAction;
 
-type ComboboxDrawerProps = Omit<DrawerProps, "refs"> &
+export type ComboboxDrawerProps = Omit<DrawerProps, "refs"> &
   BaseComboboxProps & {
     inputRef?: Ref<HTMLInputElement>;
     handleKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
@@ -347,6 +350,7 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
               inputRef={props.ref}
               name={name}
               disabled={disabled}
+              withSearchbox={multiple}
               selectedOptions={selectedOptions}
               onChange={onChange}
               highlightOnMatch={highlightOnMatch}
@@ -365,7 +369,11 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       </Selectbox>
     );
   }
-);
+) as ForwardRefExoticComponent<
+  ComboboxProps & RefAttributes<HTMLInputElement>
+> & {
+  Drawer: typeof ComboboxDrawer;
+};
 
 function ComboboxDrawer({
   floatingStyles,
@@ -398,6 +406,7 @@ function ComboboxDrawer({
   navigableOptions,
   mobile,
   drawerHeight,
+  withSearchbox,
 }: ComboboxDrawerProps) {
   const { mode, currentTheme } = useTheme();
   const comboboxTheme = currentTheme?.combobox;
@@ -527,7 +536,7 @@ function ComboboxDrawer({
               self: css`
                 ${rowStyle({
                   interactionMode,
-                  multiple,
+                  multiple: withSearchbox,
                   theme: comboboxTheme,
                   mobile: !!mobile,
                   hasNestedOptions,
@@ -546,7 +555,7 @@ function ComboboxDrawer({
     const map: Record<string, number> = {};
     const offset = filteredActions.length;
 
-    navigableOptions.forEach((opt, i) => {
+    navigableOptions?.forEach((opt, i) => {
       map[String(opt.value)] = i + offset;
     });
 
@@ -745,7 +754,7 @@ function ComboboxDrawer({
       if (hasChildren) return;
 
       setIsOpen(false);
-      setConfirmedValue(option);
+      setConfirmedValue?.(option);
       setSelectedOptionsLocal(option);
       handleOnChange([optionValue]);
       setHasInteracted(false);
@@ -833,8 +842,8 @@ function ComboboxDrawer({
         },
       })}
       ref={(node) => {
-        if (typeof refs.setFloating === "function") {
-          refs.setFloating(node);
+        if (typeof refs?.setFloating === "function") {
+          refs?.setFloating(node);
         }
         floatingRef.current = node;
       }}
@@ -845,14 +854,14 @@ function ComboboxDrawer({
       id="combo-list"
       aria-label="combobox-drawer"
       role="listbox"
-      $width={refs.reference.current?.getBoundingClientRect().width}
+      $width={refs?.reference?.current?.getBoundingClientRect().width}
       $mobile={mobile}
       $style={styles?.drawerStyle}
-      $multiple={multiple}
+      $withSearchbox={withSearchbox}
     >
       {(finalOptions || actions) && (
         <>
-          {multiple && (
+          {withSearchbox && (
             <Searchbox
               onKeyDown={handleKeyDown}
               onChange={(e) => {
@@ -876,7 +885,7 @@ function ComboboxDrawer({
                   height: 38px;
                   top: 0;
                   ${mobile &&
-                  !multiple &&
+                  !withSearchbox &&
                   css`
                     transform: translateY(-90px);
                   `};
@@ -1094,7 +1103,7 @@ function ComboboxDrawer({
         $theme={comboboxTheme}
         $mobile={mobile}
       >
-        {!multiple && (
+        {!withSearchbox && (
           <FadeTop
             aria-label="combobox-fade-top"
             $theme={comboboxTheme}
@@ -1141,7 +1150,7 @@ const DrawerWrapper = styled.ul<{
   $theme: ComboboxThemeConfig;
   $style?: CSSProp;
   $mobile?: boolean;
-  $multiple?: boolean;
+  $withSearchbox?: boolean;
   $hasNestedOptions?: boolean;
   $drawerHeight?: string;
 }>`
@@ -1182,7 +1191,7 @@ const DrawerWrapper = styled.ul<{
     border-radius: 4px;
   }
 
-  ${({ $mobile, $theme, $multiple, $hasNestedOptions, $drawerHeight }) => {
+  ${({ $mobile, $theme, $withSearchbox, $hasNestedOptions, $drawerHeight }) => {
     const $height = $drawerHeight ?? "220px";
 
     return css`
@@ -1197,7 +1206,7 @@ const DrawerWrapper = styled.ul<{
         min-height: ${$height};
         max-height: ${$height};
         border-width: 0.5;
-        ${!$multiple &&
+        ${!$withSearchbox &&
         css`
           padding: calc(${$height} * 0.4545) 0;
         `}
@@ -1332,5 +1341,7 @@ const FadeBottom = styled.div<{
 
   ${({ $style }) => $style}
 `;
+
+Combobox.Drawer = ComboboxDrawer;
 
 export { Combobox };

--- a/components/phonebox.stories.tsx
+++ b/components/phonebox.stories.tsx
@@ -96,6 +96,9 @@ export const Mobile: Story = {
     label: "Phone Number",
     placeholder: "Enter your phone number",
   },
+  parameters: {
+    layout: "padded",
+  },
   render: (args) => {
     interface ValueProps {
       phone?: string;
@@ -122,6 +125,11 @@ export const Mobile: Story = {
         value={value.phone}
         countryCodeValue={value.country_code}
         mobile
+        styles={{
+          self: css`
+            width: 400px;
+          `,
+        }}
         onChange={handleChange}
       />
     );

--- a/components/phonebox.stories.tsx
+++ b/components/phonebox.stories.tsx
@@ -126,8 +126,8 @@ export const Mobile: Story = {
         countryCodeValue={value.country_code}
         mobile
         styles={{
-          self: css`
-            width: 400px;
+          inputWrapperStyle: css`
+            max-width: 400px;
           `,
         }}
         onChange={handleChange}

--- a/components/phonebox.stories.tsx
+++ b/components/phonebox.stories.tsx
@@ -25,6 +25,7 @@ const meta: Meta = {
 
 ### ✨ Features
 - 🌐 **Country code selector**: Choose your country code with flags and search.
+- 📱 **Mobile-friendly**: Optimized for touch interactions and mobile keyboards.
 - 🔢 **Phone input formatting**: Formats the number automatically based on selected country.
 - 👆 **Keyboard & mouse navigation**: Supports arrow keys, Enter, and Escape in dropdown.
 - ⚠️ **Error handling**: Visual feedback and optional error messages.
@@ -54,7 +55,7 @@ export default meta;
 
 type Story = StoryObj<typeof Phonebox>;
 
-export const DefaultPhonebox: Story = {
+export const Default: Story = {
   args: {
     label: "Phone Number",
     placeholder: "Enter your phone number",
@@ -84,6 +85,43 @@ export const DefaultPhonebox: Story = {
         {...args}
         value={value.phone}
         countryCodeValue={value.country_code}
+        onChange={handleChange}
+      />
+    );
+  },
+};
+
+export const Mobile: Story = {
+  args: {
+    label: "Phone Number",
+    placeholder: "Enter your phone number",
+  },
+  render: (args) => {
+    interface ValueProps {
+      phone?: string;
+      country_code?: PhoneboxCountryCode;
+    }
+
+    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
+      (data) => data.id === "US"
+    )!;
+
+    const [value, setValue] = useState<ValueProps>({
+      phone: "",
+      country_code: DEFAULT_COUNTRY_CODES,
+    });
+
+    const handleChange = (e: StatefulOnChangeType) => {
+      const { name, value } = e.target;
+      setValue((prev) => ({ ...prev, [name]: value }));
+    };
+
+    return (
+      <Phonebox
+        {...args}
+        value={value.phone}
+        countryCodeValue={value.country_code}
+        mobile
         onChange={handleChange}
       />
     );

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -76,6 +76,7 @@ export interface PhoneboxStyles {
   self?: CSSProp;
   inputWrapperStyle?: CSSProp;
   toggleStyle?: CSSProp;
+  drawerStyle?: CSSProp;
 }
 
 export type PhoneboxDropdownOption = FieldLaneDropdownOption;
@@ -338,6 +339,9 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
 
         {isOpen && (
           <Combobox.Drawer
+            styles={{
+              drawerStyle: styles?.drawerStyle,
+            }}
             isOpen={isOpen}
             setIsOpen={setIsOpen}
             refs={refs as unknown as ComboboxDrawerProps["refs"]}

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -4,6 +4,7 @@ import React, {
   KeyboardEvent,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -29,10 +30,11 @@ import {
 } from "./field-lane";
 import { Figure } from "./figure";
 import { StatefulForm } from "./stateful-form";
-import { Searchbox } from "./searchbox";
 import { PhoneboxThemeConfig } from "./../theme";
 import { useTheme } from "./../theme/provider";
 import { applyClassName } from "./../constants/classname";
+import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox";
+import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox";
 
 export interface PhoneboxCountryCode {
   id: string;
@@ -67,6 +69,7 @@ interface BasePhoneboxProps {
   styles?: PhoneboxStyles;
   id?: string;
   required?: boolean;
+  mobile?: boolean;
 }
 
 export interface PhoneboxStyles {
@@ -91,6 +94,7 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
       id,
       required,
       onBlur,
+      mobile,
     },
     ref
   ) => {
@@ -105,18 +109,53 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
     const [selectedCountry, setSelectedCountry] =
       useState<PhoneboxCountryCode>(countryCodeState);
     const [phoneNumber, setPhoneNumber] = useState("");
+
     const [highlightedIndex, setHighlightedIndex] = useState(0);
+    const [interactionMode, setInteractionMode] = useState<
+      "mouse" | "keyboard"
+    >("keyboard");
+    const [hasInteracted, setHasInteracted] = useState(false);
 
     const searchInputRef = useRef<HTMLInputElement>(null);
     const phoneInputRef = useRef<HTMLInputElement>(null);
 
     useImperativeHandle(ref, () => phoneInputRef.current!);
 
-    const FILTERED_COUNTRIES = COUNTRY_CODES.filter(
-      (country) =>
-        country.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        country.code.includes(searchTerm)
+    const FINAL_COUNTRY_OPTIONS: ComboboxOption[] = COUNTRY_CODES.map(
+      (country) => ({
+        value: country.id,
+        text: `${country.code}-${country.flag}`,
+        render: (
+          <>
+            <span style={{ marginRight: "8px" }}>{country.flag}</span>
+            <span>{country.name}</span>
+            <span
+              style={{
+                marginLeft: "auto",
+                color: "#6a7282",
+              }}
+            >
+              {country.code}
+            </span>
+          </>
+        ),
+      })
     );
+
+    const FILTERED_COUNTRY_OPTIONS: ComboboxOption[] = useMemo(() => {
+      if (!hasInteracted || !searchTerm) return FINAL_COUNTRY_OPTIONS;
+
+      const search = searchTerm.toLowerCase();
+
+      return FINAL_COUNTRY_OPTIONS.filter((opt) => {
+        const country = COUNTRY_CODES.find((c) => c.id === opt.value);
+        if (!country) return false;
+        return (
+          country.name.toLowerCase().includes(search) ||
+          country.code.includes(searchTerm)
+        );
+      });
+    }, [hasInteracted, searchTerm, FINAL_COUNTRY_OPTIONS]);
 
     const { refs, floatingStyles, context } = useFloating({
       placement: "bottom-start" as Placement,
@@ -149,23 +188,24 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
       setPhoneNumber(formatted);
     }, [value]);
 
-    const listRef = useRef<(HTMLDivElement | null)[]>([]);
+    const listRef = useRef<(HTMLLIElement | null)[]>([]);
+
     useEffect(() => {
       if (isOpen && listRef.current[highlightedIndex]) {
         listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });
       }
     }, [highlightedIndex, isOpen]);
 
-    const handleDropdownKeyDown = async (
-      e: React.KeyboardEvent<HTMLInputElement>
-    ) => {
+    const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (disabled) return;
+
+      setInteractionMode("keyboard");
 
       if (e.key === "ArrowDown") {
         e.preventDefault();
         if (!isOpen) await setIsOpen(true);
         await setHighlightedIndex((prev) =>
-          Math.min(prev + 1, FILTERED_COUNTRIES.length - 1)
+          Math.min(prev + 1, FILTERED_COUNTRY_OPTIONS.length - 1)
         );
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
@@ -173,9 +213,12 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
         await setHighlightedIndex((prev) => Math.max(prev - 1, 0));
       } else if (e.key === "Enter") {
         e.preventDefault();
-        const selected = FILTERED_COUNTRIES[highlightedIndex];
-        if (selected) {
-          await handleSelectCountry(selected);
+        const selectedOption = FILTERED_COUNTRY_OPTIONS[highlightedIndex];
+        const selectedCountry = COUNTRY_CODES.find(
+          (country) => country.id === selectedOption.value
+        );
+        if (selectedCountry) {
+          await handleSelectCountry(selectedCountry);
         }
       } else if (e.key === "Escape") {
         e.preventDefault();
@@ -296,86 +339,43 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
         </InputWrapper>
 
         {isOpen && (
-          <DropdownContainer
-            aria-label="phonebox-drawer"
-            {...getFloatingProps({
-              ref: refs.setFloating,
-              id: "country-listbox",
-              role: "listbox",
-              style: {
-                ...floatingStyles,
-                width: refs.reference.current?.getBoundingClientRect().width,
-              },
-              tabIndex: -1,
-            })}
-            $theme={phoneboxTheme}
-          >
-            <Searchbox
-              type="text"
-              disabled={disabled}
-              ref={searchInputRef}
-              placeholder="Search your country..."
-              value={searchTerm}
-              onChange={(e) => {
-                setSearchTerm(e.target.value);
-                setHighlightedIndex(0);
-              }}
-              styles={{
-                containerStyle: css`
-                  position: sticky;
-                  top: 0;
-                  padding: 4px;
-                  margin: 0px;
-                  min-width: 0;
-                  width: 100%;
-                  background-color: ${phoneboxTheme?.backgroundColor};
-                `,
-                self: css`
-                  border-radius: 2px;
-                  max-height: 28px;
-                  width: 100%;
-                `,
-              }}
-              onKeyDown={handleDropdownKeyDown}
-              aria-label="phonebox-search-countries"
-              autoComplete="off"
-            />
-
-            {FILTERED_COUNTRIES.length > 0 ? (
-              FILTERED_COUNTRIES.map((country, index) => (
-                <CountryOption
-                  key={country.id}
-                  $theme={phoneboxTheme}
-                  id={`country-option-${index}`}
-                  role="option"
-                  aria-selected={highlightedIndex === index}
-                  tabIndex={-1}
-                  ref={(el) => {
-                    listRef.current[index] = el;
-                  }}
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    handleSelectCountry(country);
-                  }}
-                  onMouseEnter={() => setHighlightedIndex(index)}
-                  $highlighted={highlightedIndex === index}
-                >
-                  <span style={{ marginRight: "8px" }}>{country.flag}</span>
-                  <span>{country.name}</span>
-                  <span
-                    style={{
-                      marginLeft: "auto",
-                      color: "#6a7282",
-                    }}
-                  >
-                    {country.code}
-                  </span>
-                </CountryOption>
-              ))
-            ) : (
-              <EmptyOption>No country found.</EmptyOption>
-            )}
-          </DropdownContainer>
+          <Combobox.Drawer
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+            refs={refs as unknown as ComboboxDrawerProps["refs"]}
+            highlightedIndex={highlightedIndex}
+            setHighlightedIndex={setHighlightedIndex}
+            interactionMode={interactionMode}
+            setInteractionMode={setInteractionMode}
+            selectedOptions={countryCodeValue.id}
+            selectedOptionsLocal={{
+              text: searchTerm,
+              value: "",
+            }}
+            onChange={async (selectedOptions?: SelectboxSelectedOptions) => {
+              const selectedCountry = await COUNTRY_CODES.find(
+                (c) => c.id === selectedOptions
+              );
+              if (selectedCountry) {
+                await handleSelectCountry(selectedCountry);
+              }
+            }}
+            setSelectedOptionsLocal={(
+              selectedOptionsLocal?: SelectboxOption
+            ) => {
+              setSearchTerm(selectedOptionsLocal?.text);
+            }}
+            setHasInteracted={setHasInteracted}
+            options={FILTERED_COUNTRY_OPTIONS}
+            navigableOptions={FILTERED_COUNTRY_OPTIONS}
+            inputRef={searchInputRef}
+            mobile={mobile}
+            withSearchbox
+            floatingStyles={floatingStyles}
+            getFloatingProps={getFloatingProps}
+            listRef={listRef}
+            handleKeyDown={handleKeyDown}
+          />
         )}
       </>
     );
@@ -383,8 +383,7 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
 );
 
 export interface PhoneboxProps
-  extends
-    Omit<BasePhoneboxProps, "styles">,
+  extends Omit<BasePhoneboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "onChange" | "actions"> {
   styles?: PhoneboxStyles & FieldLaneStyles;
 }
@@ -581,56 +580,6 @@ const PhoneInput = styled.input<{
   }
 
   ${({ $style }) => $style}
-`;
-
-const DropdownContainer = styled.div<{
-  $theme: PhoneboxThemeConfig;
-}>`
-  position: absolute;
-  left: 0;
-  border-radius: var(--radius-xs);
-  max-height: 240px;
-  overflow-y: auto;
-  z-index: 9992999;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-  background-color: ${({ $theme }) => $theme?.backgroundColor};
-  border: 1px solid ${({ $theme }) => $theme?.borderColor};
-
-  &::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: #d1d5db;
-    border-radius: 4px;
-  }
-`;
-
-const CountryOption = styled.div<{
-  $highlighted?: boolean;
-  $theme: PhoneboxThemeConfig;
-}>`
-  display: flex;
-  align-items: center;
-  padding: 8px 12px;
-  font-size: 12px;
-  cursor: pointer;
-  ${({ $highlighted, $theme }) =>
-    $highlighted &&
-    css`
-      background-color: ${$theme?.optionHighlightedBackground};
-    `}
-`;
-
-const EmptyOption = styled.div`
-  padding: 12px;
-  text-align: center;
-  font-size: 12px;
-  color: #6b7280;
 `;
 
 function trimPhone(input: string): string {

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -70,6 +70,7 @@ interface BasePhoneboxProps {
   id?: string;
   required?: boolean;
   mobile?: boolean;
+  drawerHeight?: string;
 }
 
 export interface PhoneboxStyles {
@@ -96,6 +97,7 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
       required,
       onBlur,
       mobile,
+      drawerHeight,
     },
     ref
   ) => {
@@ -342,6 +344,7 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
             styles={{
               drawerStyle: styles?.drawerStyle,
             }}
+            drawerHeight={drawerHeight}
             isOpen={isOpen}
             setIsOpen={setIsOpen}
             refs={refs as unknown as ComboboxDrawerProps["refs"]}

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -121,25 +121,22 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
 
     useImperativeHandle(ref, () => phoneInputRef.current!);
 
-    const FINAL_COUNTRY_OPTIONS: ComboboxOption[] = COUNTRY_CODES.map(
-      (country) => ({
-        value: country.id,
-        text: `${country.code}-${country.flag}`,
-        render: (
-          <>
-            <span style={{ marginRight: "8px" }}>{country.flag}</span>
-            <span>{country.name}</span>
-            <span
-              style={{
-                marginLeft: "auto",
-                color: "#6a7282",
-              }}
-            >
-              {country.code}
-            </span>
-          </>
-        ),
-      })
+    const FINAL_COUNTRY_OPTIONS: ComboboxOption[] = useMemo(
+      () =>
+        COUNTRY_CODES.map((country) => ({
+          value: country.id,
+          text: `${country.code}-${country.flag}`,
+          render: (
+            <>
+              <span style={{ marginRight: "8px" }}>{country.flag}</span>
+              <span>{country.name}</span>
+              <span style={{ marginLeft: "auto", color: "#6a7282" }}>
+                {country.code}
+              </span>
+            </>
+          ),
+        })),
+      []
     );
 
     const FILTERED_COUNTRY_OPTIONS: ComboboxOption[] = useMemo(() => {
@@ -190,6 +187,7 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
 
     const listRef = useRef<(HTMLLIElement | null)[]>([]);
 
+    // Keep the highlighted option visible while navigating the list.
     useEffect(() => {
       if (isOpen && listRef.current[highlightedIndex]) {
         listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -412,6 +412,14 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
       ...rest
     } = props;
 
+    const {
+      bodyStyle,
+      containerStyle,
+      controlStyle,
+      labelStyle,
+      ...phoneboxStyle
+    } = styles ?? {};
+
     const inputId = StatefulForm.sanitizeId({
       prefix: "phonebox",
       name: props.name,
@@ -434,10 +442,10 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
         className={applyClassName("phonebox", className)}
         required={rest.required}
         styles={{
-          bodyStyle: styles?.bodyStyle,
-          controlStyle: styles?.controlStyle,
-          containerStyle: styles?.containerStyle,
-          labelStyle: styles?.labelStyle,
+          bodyStyle,
+          controlStyle,
+          containerStyle,
+          labelStyle,
         }}
       >
         <BasePhonebox
@@ -446,15 +454,14 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
           showError={showError}
           disabled={disabled}
           styles={{
-            self: styles?.self,
-            toggleStyle: styles?.toggleStyle,
+            ...phoneboxStyle,
             inputWrapperStyle: css`
               ${dropdowns &&
               css`
                 border-top-left-radius: 0px;
                 border-bottom-left-radius: 0px;
               `}
-              ${styles?.self}
+              ${phoneboxStyle?.inputWrapperStyle}
             `,
           }}
           onChange={onChange}

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -307,7 +307,7 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
             onClick={handleToggleDropdown}
             disabled={disabled}
             $disabled={disabled}
-            aria-label="Select country code"
+            aria-label="phonebox-country-toggle"
             tabIndex={0}
             $hasError={showError}
             $style={styles?.toggleStyle}
@@ -335,7 +335,7 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
             onKeyDown={(e) => onKeyDown?.(e)}
             disabled={disabled}
             $disabled={disabled}
-            aria-label="phonebox-number"
+            aria-label="phonebox-input-number"
           />
         </InputWrapper>
 
@@ -352,7 +352,7 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
             setHighlightedIndex={setHighlightedIndex}
             interactionMode={interactionMode}
             setInteractionMode={setInteractionMode}
-            selectedOptions={countryCodeValue.id}
+            selectedOptions={countryCodeState?.id}
             selectedOptionsLocal={{
               text: searchTerm,
               value: "",

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -147,8 +147,10 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
 
       const search = searchTerm.toLowerCase();
 
-      return FINAL_COUNTRY_OPTIONS.filter((opt) => {
-        const country = COUNTRY_CODES.find((c) => c.id === opt.value);
+      return FINAL_COUNTRY_OPTIONS.filter((option) => {
+        const country = COUNTRY_CODES.find(
+          (country) => country.id === option.value
+        );
         if (!country) return false;
         return (
           country.name.toLowerCase().includes(search) ||
@@ -359,7 +361,7 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
             }}
             onChange={async (selectedOptions?: SelectboxSelectedOptions) => {
               const selectedCountry = await COUNTRY_CODES.find(
-                (c) => c.id === selectedOptions
+                (country) => country.id === selectedOptions
               );
               if (selectedCountry) {
                 await handleSelectCountry(selectedCountry);

--- a/test/component/phonebox.cy.tsx
+++ b/test/component/phonebox.cy.tsx
@@ -1,4 +1,8 @@
-import { Phonebox } from "./../../components/phonebox";
+import {
+  Phonebox,
+  PhoneboxCountryCode,
+  PhoneboxProps,
+} from "./../../components/phonebox";
 import { Button } from "./../../components/button";
 import {
   RiHome2Line,
@@ -7,8 +11,76 @@ import {
   RiUser2Line,
 } from "@remixicon/react";
 import { css } from "styled-components";
+import { useState } from "react";
+import { COUNTRY_CODES } from "./../../constants/countries";
+import { StatefulOnChangeType } from "./../../components/stateful-form";
 
 describe("Phonebox", () => {
+  function ProductPhonebox(props?: PhoneboxProps) {
+    interface ValueProps {
+      phone?: string;
+      country_code?: PhoneboxCountryCode;
+    }
+
+    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
+      (data) => data.id === "US"
+    )!;
+
+    const [value, setValue] = useState<ValueProps>({
+      phone: "",
+      country_code: DEFAULT_COUNTRY_CODES,
+    });
+
+    const handleChange = (e: StatefulOnChangeType) => {
+      const { name, value } = e.target;
+      setValue((prev) => ({ ...prev, [name]: value }));
+    };
+
+    return (
+      <Phonebox
+        mobile
+        value={value.phone}
+        countryCodeValue={value.country_code}
+        onChange={handleChange}
+        {...props}
+      />
+    );
+  }
+  context("mobile", () => {
+    it("renders the drawer with in the bottom screen", () => {
+      cy.mount(<ProductPhonebox mobile />);
+      cy.findByLabelText("phonebox-country-toggle").click();
+      cy.findByLabelText("combobox-drawer-mobile")
+        .should("have.css", "bottom", "10px")
+        .and("have.css", "position", "fixed");
+    });
+
+    it("renders the drawer with height 220px", () => {
+      cy.mount(<ProductPhonebox mobile />);
+
+      cy.findByLabelText("phonebox-country-toggle").click();
+      cy.findByLabelText("combobox-drawer-mobile").should(
+        "have.css",
+        "height",
+        "220px"
+      );
+    });
+
+    context("drawerHeight", () => {
+      context("when given 400px", () => {
+        it("renders the drawer with height 400px", () => {
+          cy.mount(<ProductPhonebox mobile drawerHeight="400px" />);
+          cy.findByLabelText("phonebox-country-toggle").click();
+          cy.findByLabelText("combobox-drawer-mobile").should(
+            "have.css",
+            "height",
+            "400px"
+          );
+        });
+      });
+    });
+  });
+
   context("with dropdowns", () => {
     it("renders initialize drawer with min-width 200px", () => {
       cy.mount(
@@ -162,7 +234,7 @@ describe("Phonebox", () => {
 
   context("country code drawer", () => {
     context("searchbox", () => {
-      it("renders correctly depends on the width (-8px from padding drawer)", () => {
+      it("renders always less than drawer width", () => {
         cy.mount(
           <Phonebox
             styles={{
@@ -173,14 +245,16 @@ describe("Phonebox", () => {
           />
         );
 
-        cy.findByLabelText("phonebox-drawer").should("not.exist");
-        cy.findByRole("button").click();
-        cy.findByLabelText("phonebox-drawer")
-          .should("exist")
-          .and("have.css", "width", "260px");
-        cy.findByLabelText("textbox-search-wrapper")
-          .should("exist")
-          .and("have.css", "width", "252px");
+        cy.findByLabelText("combobox-drawer").should("not.exist");
+        cy.findByLabelText("phonebox-country-toggle").click();
+        cy.findByLabelText("combobox-drawer").then(($drawer) => {
+          const drawerWidth = $drawer[0].getBoundingClientRect().width;
+
+          cy.findByLabelText("textbox-search").then(($textbox) => {
+            const textboxWidth = $textbox[0].getBoundingClientRect().width;
+            expect(textboxWidth).to.be.lessThan(drawerWidth);
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Description:
This pull request enhances the `Phonebox` to provide an appearance consistent with the `Combobox` when mobile props are provided, reusing the `Combobox.Drawer` implementation.

This enables full support for `StatefulForm.Mobile`, completing the mobile experience. It also ensures the `Phonebox` drawer is displayed correctly and supports custom styling through the drawer style props.

Source:
[[Mobile] SYST-771: Add `mobile` to `Phonebox`](https://linear.app/systatum/issue/SYST-771/add-mobile-to-phonebox)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself