### PR TITLE
[Improvement] SYST-723: Add `subMenu` with: `list`, `show`, `render` on separator action

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -367,16 +367,19 @@ function Button({
           >
             {subMenu({
               list: (subMenuList, { withFilter } = {}) => (
-                <TipMenu
-                  setIsOpen={() => {
-                    setIsOpen(false);
+                <>
+                  <Spacer aria-label="tip-menu-spacer" $placement={placement} />
+                  <TipMenu
+                    setIsOpen={() => {
+                      setIsOpen(false);
 
-                    setHovered("original");
-                  }}
-                  withFilter={withFilter ?? false}
-                  subMenuList={subMenuList}
-                  size={tipMenuSize}
-                />
+                      setHovered("original");
+                    }}
+                    withFilter={withFilter ?? false}
+                    subMenuList={subMenuList}
+                    size={tipMenuSize}
+                  />
+                </>
               ),
               show: (children, { withArrow, arrowStyle, drawerStyle } = {}) => (
                 <Tooltip.Container
@@ -401,7 +404,12 @@ function Button({
                   dialog={children}
                 />
               ),
-              render: (children) => children,
+              render: (children) => (
+                <>
+                  <Spacer aria-label="render-spacer" $placement={placement} />
+                  {children}
+                </>
+              ),
             })}
           </DropdownWrapper>,
           document.body
@@ -420,6 +428,25 @@ const DropdownWrapper = styled.div<{ $style?: CSSProp }>`
   z-index: 9992999;
 
   ${({ $style }) => $style};
+`;
+
+const Spacer = styled.div<{ $placement?: Placement; $spacerStyle?: CSSProp }>`
+  position: absolute;
+  background-color: transparent;
+  width: 100%;
+  height: 30px;
+  left: 0;
+
+  ${({ $placement }) =>
+    $placement?.startsWith("top")
+      ? css`
+          bottom: -18px;
+        `
+      : css`
+          top: -8px;
+        `}
+
+  ${({ $spacerStyle }) => $spacerStyle}
 `;
 
 const ButtonLabel = styled.span<{

--- a/components/separator.stories.tsx
+++ b/components/separator.stories.tsx
@@ -8,14 +8,12 @@ import {
   RiCalendar2Fill,
   RiDeleteBinLine,
   RiFileCopyLine,
-  RiFileList3Line,
   RiGitBranchLine,
   RiInboxArchiveLine,
   RiUserAddLine,
 } from "@remixicon/react";
 import { Calendar } from "./calendar";
 import { css } from "styled-components";
-import { useTheme } from "./../theme";
 
 const meta: Meta<typeof Separator> = {
   title: "Stage/Separator",
@@ -151,30 +149,14 @@ export const WithActions: Story = {
   },
   render: (args) => {
     const ACTIONS: SeparatorAction[] = [
-      { icon: { image: RiUserAddLine }, caption: "Invite" },
-      { icon: { image: RiGitBranchLine }, caption: "Branch" },
-      { icon: { image: RiFileList3Line }, caption: "Specs", alwaysShow: false },
-    ];
-
-    return <Separator {...args} actions={ACTIONS} />;
-  },
-};
-
-export const WithSubMenu: Story = {
-  args: {
-    title: "Introduces the Antrikan Mobile",
-  },
-  render: (args) => {
-    const { currentTheme } = useTheme();
-    const bodyTheme = currentTheme.body;
-
-    const ACTIONS: SeparatorAction[] = [
       {
         icon: { image: RiUserAddLine },
+        caption: "Invite",
         subMenu: ({ list }) => list(TIP_MENU_PROJECT),
       },
       {
         icon: { image: RiGitBranchLine },
+        caption: "Branch",
         subMenu: ({ show }) =>
           show(
             <>
@@ -187,8 +169,6 @@ export const WithSubMenu: Story = {
             {
               drawerStyle: css`
                 padding: 10px;
-                color: ${bodyTheme.textColor};
-                background-color: ${bodyTheme.backgroundColor};
                 display: flex;
                 flex-direction: column;
               `,
@@ -197,6 +177,7 @@ export const WithSubMenu: Story = {
       },
       {
         icon: { image: RiCalendar2Fill },
+        alwaysShow: false,
         subMenu: ({ render }) => render(<Calendar />),
       },
     ];

--- a/components/separator.stories.tsx
+++ b/components/separator.stories.tsx
@@ -178,6 +178,7 @@ export const WithActions: Story = {
       {
         icon: { image: RiCalendar2Fill },
         alwaysShow: false,
+        caption: "Calendar",
         subMenu: ({ render }) => render(<Calendar />),
       },
     ];

--- a/components/separator.stories.tsx
+++ b/components/separator.stories.tsx
@@ -1,10 +1,21 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Separator, SeparatorAction } from "./separator";
 import {
+  Separator,
+  SeparatorAction,
+  SeparatorActionSubMenuList,
+} from "./separator";
+import {
+  RiCalendar2Fill,
+  RiDeleteBinLine,
+  RiFileCopyLine,
   RiFileList3Line,
   RiGitBranchLine,
+  RiInboxArchiveLine,
   RiUserAddLine,
 } from "@remixicon/react";
+import { Calendar } from "./calendar";
+import { css } from "styled-components";
+import { useTheme } from "./../theme";
 
 const meta: Meta<typeof Separator> = {
   title: "Stage/Separator",
@@ -143,6 +154,76 @@ export const WithActions: Story = {
       { icon: { image: RiUserAddLine }, caption: "Invite" },
       { icon: { image: RiGitBranchLine }, caption: "Branch" },
       { icon: { image: RiFileList3Line }, caption: "Specs", alwaysShow: false },
+    ];
+
+    return <Separator {...args} actions={ACTIONS} />;
+  },
+};
+
+export const WithSubMenu: Story = {
+  args: {
+    title: "Introduces the Antrikan Mobile",
+  },
+  render: (args) => {
+    const { currentTheme } = useTheme();
+    const bodyTheme = currentTheme.body;
+
+    const ACTIONS: SeparatorAction[] = [
+      {
+        icon: { image: RiUserAddLine },
+        subMenu: ({ list }) => list(TIP_MENU_PROJECT),
+      },
+      {
+        icon: { image: RiGitBranchLine },
+        subMenu: ({ show }) =>
+          show(
+            <>
+              <span>
+                <strong>Branch:</strong>{" "}
+                mobile/introduces-the-antrikan-mobile-app-design
+              </span>
+              <span>Last updated 2 hours ago.</span>
+            </>,
+            {
+              drawerStyle: css`
+                padding: 10px;
+                color: ${bodyTheme.textColor};
+                background-color: ${bodyTheme.backgroundColor};
+                display: flex;
+                flex-direction: column;
+              `,
+            }
+          ),
+      },
+      {
+        icon: { image: RiCalendar2Fill },
+        subMenu: ({ render }) => render(<Calendar />),
+      },
+    ];
+
+    const TIP_MENU_PROJECT: SeparatorActionSubMenuList[] = [
+      {
+        caption: "Duplicate Project",
+        icon: {
+          image: RiFileCopyLine,
+        },
+        onClick: () => console.log("Duplicate project"),
+      },
+      {
+        caption: "Archive Project",
+        icon: {
+          image: RiInboxArchiveLine,
+        },
+        onClick: () => console.log("Archive project"),
+      },
+      {
+        caption: "Delete Project",
+        icon: {
+          image: RiDeleteBinLine,
+        },
+        variant: "danger",
+        onClick: () => console.log("Delete project"),
+      },
     ];
 
     return <Separator {...args} actions={ACTIONS} />;

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -6,6 +6,7 @@ import { BaseAction } from "../constants/action";
 import { applyClassName } from "./../constants/classname";
 import { ReactNode, useState } from "react";
 import { TipMenuItemProps } from "./tip-menu";
+import { DialogPlacement } from "@/lib/floating-placement";
 
 export const SeparatorTextFloat = {
   Left: "left",
@@ -77,17 +78,20 @@ function Separator({
             key={index}
             {...action}
             alwaysShow={action?.alwaysShow ?? true}
+            dialogPlacement={
+              action?.dialogPlacement ??
+              (textFloat === "right" ? "bottom-left" : "bottom-right")
+            }
             styles={{
               ...action?.styles,
               arrowStyle: css`
                 ${textFloat === "right"
                   ? css`
-                      right: 9px;
+                      left: 8px;
                     `
                   : css`
-                      left: 9px;
-                    `}
-
+                      right: 8px;
+                    `};
                 ${action?.styles?.arrowStyle}
               `,
               containerStyle: css`
@@ -168,6 +172,7 @@ export interface SeparatorAction extends BaseAction {
   safeAreaAriaLabels?: string[];
   className?: string;
   subMenu?: (props: SeparatorActionSubMenu) => ReactNode;
+  dialogPlacement?: DialogPlacement;
 }
 
 export type SeparatorActionSubMenu = ButtonSubMenu;
@@ -190,6 +195,7 @@ function SeparatorAction({
   disabled,
   subMenu,
   className,
+  dialogPlacement,
   id,
   safeAreaAriaLabels: _safeAreaAriaLabels = [],
 }: SeparatorAction) {
@@ -231,9 +237,10 @@ function SeparatorAction({
     <Tooltip
       id={id}
       className={applyClassName("separator-action", className)}
-      dialog={subMenu ? null : caption}
-      onVisibilityChange={(isOpen) => setIsOpen(isOpen)}
+      dialog={caption}
+      open={isOpen}
       safeAreaAriaLabels={safeAreaArialabels}
+      dialogPlacement={dialogPlacement}
       styles={{
         arrowStyle: styles?.arrowStyle,
         containerStyle: css`
@@ -267,9 +274,11 @@ function SeparatorAction({
         id={id}
         variant="default"
         icon={icon}
-        open={isOpen}
+        onMouseEnter={() => setIsOpen(true)}
+        onMouseLeave={() => setIsOpen(false)}
         aria-label="separator-action"
         subMenu={finalSubMenu}
+        dialogPlacement={dialogPlacement}
         showSubMenuOn="self"
         onMouseDown={(e) => onClick?.(e)}
         disabled={disabled}

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonSubMenu } from "./button";
 import { Tooltip } from "./tooltip";
 import { BaseAction } from "../constants/action";
 import { applyClassName } from "./../constants/classname";
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { TipMenuItemProps } from "./tip-menu";
 
 export const SeparatorTextFloat = {
@@ -165,6 +165,7 @@ export interface SeparatorAction extends BaseAction {
   alwaysShow?: boolean;
   styles?: SeparatorActionStyles;
   id?: string;
+  safeAreaAriaLabels?: string[];
   className?: string;
   subMenu?: (props: SeparatorActionSubMenu) => ReactNode;
 }
@@ -190,10 +191,14 @@ function SeparatorAction({
   subMenu,
   className,
   id,
+  safeAreaAriaLabels: _safeAreaAriaLabels = [],
 }: SeparatorAction) {
   const { currentTheme } = useTheme();
   const bodyTheme = currentTheme?.body;
+  const buttonTheme = currentTheme?.button;
   const separatorTheme = currentTheme?.separator;
+
+  const [isOpen, setIsOpen] = useState(false);
 
   if (hidden) {
     return;
@@ -214,11 +219,21 @@ function SeparatorAction({
         }),
     });
 
+  const safeAreaArialabels = [
+    "tip-menu",
+    "tip-menu-spacer",
+    "calendar",
+    "render-spacer",
+    ..._safeAreaAriaLabels,
+  ];
+
   return (
     <Tooltip
       id={id}
       className={applyClassName("separator-action", className)}
-      dialog={caption}
+      dialog={subMenu ? null : caption}
+      onVisibilityChange={(isOpen) => setIsOpen(isOpen)}
+      safeAreaAriaLabels={safeAreaArialabels}
       styles={{
         arrowStyle: styles?.arrowStyle,
         containerStyle: css`
@@ -232,6 +247,7 @@ function SeparatorAction({
             transform 0.2s ease;
 
           ${!alwaysShow &&
+          !isOpen &&
           css`
             opacity: 0;
             pointer-events: none;
@@ -249,8 +265,9 @@ function SeparatorAction({
     >
       <Button
         id={id}
-        variant="outline-default"
+        variant="default"
         icon={icon}
+        open={isOpen}
         aria-label="separator-action"
         subMenu={finalSubMenu}
         showSubMenuOn="self"
@@ -265,10 +282,16 @@ function SeparatorAction({
             height: 24px;
             width: 24px;
             padding: 2px;
+            border: 1px solid ${bodyTheme?.borderColor};
             background-color: ${separatorTheme?.backgroundTitleColor};
             &:hover {
               color: inherit;
             }
+            ${isOpen &&
+            css`
+              background-color: ${buttonTheme?.["default"]
+                ?.activeBackgroundColor};
+            `}
             ${styles?.self}
           `,
         }}

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -192,11 +192,27 @@ function SeparatorAction({
   id,
 }: SeparatorAction) {
   const { currentTheme } = useTheme();
+  const bodyTheme = currentTheme?.body;
   const separatorTheme = currentTheme?.separator;
 
   if (hidden) {
     return;
   }
+
+  const finalSubMenu = (props: SeparatorActionSubMenu) =>
+    subMenu?.({
+      ...props,
+      show: (content, options) =>
+        props?.show(content, {
+          ...options,
+          drawerStyle: css`
+            color: ${bodyTheme?.textColor};
+            background-color: ${separatorTheme?.tooltipBackgroundColor};
+
+            ${options?.drawerStyle}
+          `,
+        }),
+    });
 
   return (
     <Tooltip
@@ -236,7 +252,7 @@ function SeparatorAction({
         variant="outline-default"
         icon={icon}
         aria-label="separator-action"
-        subMenu={subMenu}
+        subMenu={finalSubMenu}
         showSubMenuOn="self"
         onMouseDown={(e) => onClick?.(e)}
         disabled={disabled}

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -4,7 +4,8 @@ import { Button, ButtonSubMenu } from "./button";
 import { Tooltip } from "./tooltip";
 import { BaseAction } from "../constants/action";
 import { applyClassName } from "./../constants/classname";
-import { ReactNode, useState } from "react";
+import { ReactNode } from "react";
+import { TipMenuItemProps } from "./tip-menu";
 
 export const SeparatorTextFloat = {
   Left: "left",
@@ -169,6 +170,7 @@ export interface SeparatorAction extends BaseAction {
 }
 
 export type SeparatorActionSubMenu = ButtonSubMenu;
+export type SeparatorActionSubMenuList = TipMenuItemProps;
 
 export interface SeparatorActionStyles {
   self?: CSSProp;

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -1,9 +1,10 @@
 import styled, { css, CSSProp } from "styled-components";
 import { useTheme } from "./../theme/provider";
-import { Button } from "./button";
+import { Button, ButtonSubMenu } from "./button";
 import { Tooltip } from "./tooltip";
 import { BaseAction } from "../constants/action";
 import { applyClassName } from "./../constants/classname";
+import { ReactNode, useState } from "react";
 
 export const SeparatorTextFloat = {
   Left: "left",
@@ -164,12 +165,15 @@ export interface SeparatorAction extends BaseAction {
   styles?: SeparatorActionStyles;
   id?: string;
   className?: string;
+  subMenu?: (props: SeparatorActionSubMenu) => ReactNode;
 }
+
+export type SeparatorActionSubMenu = ButtonSubMenu;
 
 export interface SeparatorActionStyles {
   self?: CSSProp;
   containerStyle?: CSSProp;
-  drawerStyle?: CSSProp;
+  captionDrawerStyle?: CSSProp;
   arrowStyle?: CSSProp;
 }
 
@@ -181,6 +185,7 @@ function SeparatorAction({
   onClick,
   styles,
   disabled,
+  subMenu,
   className,
   id,
 }: SeparatorAction) {
@@ -221,7 +226,7 @@ function SeparatorAction({
 
           ${styles?.containerStyle}
         `,
-        drawerStyle: styles?.drawerStyle,
+        drawerStyle: styles?.captionDrawerStyle,
       }}
     >
       <Button
@@ -229,6 +234,8 @@ function SeparatorAction({
         variant="outline-default"
         icon={icon}
         aria-label="separator-action"
+        subMenu={subMenu}
+        showSubMenuOn="self"
         onClick={(e) => onClick?.(e)}
         disabled={disabled}
         styles={{

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -204,7 +204,8 @@ function SeparatorAction({
   const buttonTheme = currentTheme?.button;
   const separatorTheme = currentTheme?.separator;
 
-  const [isOpen, setIsOpen] = useState(false);
+  const [isCaptionOpen, setIsCaptionOpen] = useState(false);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   if (hidden) {
     return;
@@ -238,7 +239,7 @@ function SeparatorAction({
       id={id}
       className={applyClassName("separator-action", className)}
       dialog={caption}
-      open={isOpen}
+      open={isCaptionOpen}
       safeAreaAriaLabels={safeAreaArialabels}
       dialogPlacement={dialogPlacement}
       styles={{
@@ -254,7 +255,7 @@ function SeparatorAction({
             transform 0.2s ease;
 
           ${!alwaysShow &&
-          !isOpen &&
+          !isDrawerOpen &&
           css`
             opacity: 0;
             pointer-events: none;
@@ -274,8 +275,10 @@ function SeparatorAction({
         id={id}
         variant="default"
         icon={icon}
-        onMouseEnter={() => setIsOpen(true)}
-        onMouseLeave={() => setIsOpen(false)}
+        onMouseEnter={() => setIsCaptionOpen(true)}
+        onMouseLeave={() => setIsCaptionOpen(false)}
+        open={isDrawerOpen}
+        onOpen={(isDrawerOpen) => setIsDrawerOpen(isDrawerOpen)}
         aria-label="separator-action"
         subMenu={finalSubMenu}
         dialogPlacement={dialogPlacement}
@@ -296,7 +299,7 @@ function SeparatorAction({
             &:hover {
               color: inherit;
             }
-            ${isOpen &&
+            ${isDrawerOpen &&
             css`
               background-color: ${buttonTheme?.["default"]
                 ?.activeBackgroundColor};

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -238,7 +238,7 @@ function SeparatorAction({
         aria-label="separator-action"
         subMenu={subMenu}
         showSubMenuOn="self"
-        onClick={(e) => onClick?.(e)}
+        onMouseDown={(e) => onClick?.(e)}
         disabled={disabled}
         styles={{
           containerStyle: css`

--- a/components/tooltip.tsx
+++ b/components/tooltip.tsx
@@ -40,6 +40,7 @@ export type TooltipProps = {
   hideDialogOn?: TooltipDialogPosition;
   dialogPlacement?: TooltipDialogPlacement;
   onVisibilityChange?: (open?: boolean) => void;
+  open?: boolean;
   safeAreaAriaLabels?: string[];
   showDelayPeriod?: number;
   styles?: TooltipStyles;
@@ -74,23 +75,27 @@ const TooltipBase = forwardRef<TooltipRef, TooltipProps>(
       showDelayPeriod = 0,
       styles,
       onClick,
+      open,
       id,
       className,
     },
     ref
   ) => {
-    const [isOpen, setIsOpen] = useState(false);
     const delayTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const [isOpenLocal, setIsOpenLocal] = useState(false);
+    const isControlled = open !== undefined;
+    const isOpen = isControlled ? open : isOpenLocal;
 
     useImperativeHandle(ref, () => ({
       open: () => {
-        setIsOpen(true);
+        setIsOpenLocal(true);
         if (onVisibilityChange) {
           onVisibilityChange(true);
         }
       },
       close: () => {
-        setIsOpen(false);
+        setIsOpenLocal(false);
         if (onVisibilityChange) {
           onVisibilityChange(false);
         }
@@ -99,8 +104,8 @@ const TooltipBase = forwardRef<TooltipRef, TooltipProps>(
 
     const { floatingStyles, refs, placement } = useFloating({
       placement: getFloatingPlacement(dialogPlacement),
-      open: isOpen,
-      onOpenChange: setIsOpen,
+      open: open,
+      onOpenChange: setIsOpenLocal,
       middleware: [offset(8), flip()],
       whileElementsMounted: autoUpdate,
     });
@@ -133,7 +138,7 @@ const TooltipBase = forwardRef<TooltipRef, TooltipProps>(
           referenceEl instanceof HTMLElement &&
           !referenceEl.contains(event.target as Node)
         ) {
-          setIsOpen(false);
+          setIsOpenLocal(false);
           onVisibilityChange(false);
         }
       }
@@ -160,7 +165,7 @@ const TooltipBase = forwardRef<TooltipRef, TooltipProps>(
         onMouseEnter={() => {
           if (showDialogOn === "hover") {
             delayTimeoutRef.current = setTimeout(() => {
-              setIsOpen(true);
+              setIsOpenLocal(true);
               if (onVisibilityChange) {
                 onVisibilityChange(true);
               }
@@ -171,7 +176,7 @@ const TooltipBase = forwardRef<TooltipRef, TooltipProps>(
           if (hideDialogOn === "hover") {
             clearTimeout(delayTimeoutRef.current);
 
-            setIsOpen(false);
+            setIsOpenLocal(false);
             if (onVisibilityChange) {
               onVisibilityChange(false);
             }
@@ -188,7 +193,7 @@ const TooltipBase = forwardRef<TooltipRef, TooltipProps>(
               onClick(e);
             }
             if (showDialogOn === "click") {
-              setIsOpen((prev) => {
+              setIsOpenLocal((prev) => {
                 const next = !prev;
                 if (onVisibilityChange) {
                   onVisibilityChange(next);
@@ -359,8 +364,8 @@ const TooltipArrow = styled.div<{
   z-index: -1;
   pointer-events: none;
 
-  ${({ $placement }) =>
-    $placement === "bottom-start"
+  ${({ $placement }) => {
+    return $placement === "bottom-start"
       ? css`
           top: -4px;
           left: 10%;
@@ -369,6 +374,7 @@ const TooltipArrow = styled.div<{
         ? css`
             top: -4px;
             right: 10%;
+            left: auto;
           `
         : $placement === "bottom"
           ? css`
@@ -424,7 +430,8 @@ const TooltipArrow = styled.div<{
                                 top: 50%;
                                 transform: translateY(-50%) rotate(45deg);
                               `
-                            : null}
+                            : null;
+  }};
 
   ${({ $arrowStyle }) => $arrowStyle}
 `;

--- a/test/component/separator.cy.tsx
+++ b/test/component/separator.cy.tsx
@@ -107,13 +107,13 @@ describe("Separator", () => {
 
     context("when given list()", () => {
       it("shows the tip menu", () => {
-        cy.findAllByLabelText("separator-action").eq(0).click();
+        cy.findAllByLabelText("separator-action").eq(0).realHover();
         cy.findByLabelText("tip-menu").should("exist");
       });
 
       context("when clicking the tip menu item", () => {
         it("should render the console", () => {
-          cy.findAllByLabelText("separator-action").eq(0).click();
+          cy.findAllByLabelText("separator-action").eq(0).realHover();
           cy.findByLabelText("tip-menu").should("exist");
           cy.findByText("Duplicate Project").click();
           cy.get("@onDuplicate").should("have.been.calledOnce");
@@ -124,7 +124,7 @@ describe("Separator", () => {
     context("with given show()", () => {
       context("with clicking the button", () => {
         it("should renders the show with tooltip container", () => {
-          cy.findAllByLabelText("separator-action").eq(1).click();
+          cy.findAllByLabelText("separator-action").eq(1).realHover();
           cy.findByLabelText("tooltip-drawer").should("exist");
           cy.findByText("Branch:").should("exist");
           cy.findByText(
@@ -137,7 +137,7 @@ describe("Separator", () => {
     context("with given render()", () => {
       context("with given Calendar component", () => {
         it("should the customize rendering", () => {
-          cy.findAllByLabelText("separator-action").eq(2).click();
+          cy.findAllByLabelText("separator-action").eq(2).realHover();
           cy.get(".coneto-calendar").should("exist");
         });
       });

--- a/test/component/separator.cy.tsx
+++ b/test/component/separator.cy.tsx
@@ -22,18 +22,64 @@ describe("Separator", () => {
       icon: { image: RiUserAddLine },
       caption: "Invite",
       onClick: () => console.log("this is invite"),
+      subMenu: ({ list }) => list(TIP_MENU_PROJECT),
     },
     {
       icon: { image: RiGitBranchLine },
       caption: "Branch",
       onClick: () => console.log("this is branch"),
+      subMenu: ({ show }) =>
+        show(
+          <>
+            <span>
+              <strong>Branch:</strong>{" "}
+              mobile/introduces-the-antrikan-mobile-app-design
+            </span>
+            <span>Last updated 2 hours ago.</span>
+          </>,
+          {
+            drawerStyle: css`
+              padding: 10px;
+              display: flex;
+              flex-direction: column;
+            `,
+          }
+        ),
     },
     {
-      icon: { image: RiFileList3Line },
-      caption: "Specs",
-      onClick: () => console.log("this is specs"),
+      icon: { image: RiCalendar2Fill },
+      alwaysShow: false,
+      caption: "Calendar",
+      onClick: () => console.log("this is calendar"),
+      subMenu: ({ render }) => render(<Calendar />),
     },
   ];
+
+  const TIP_MENU_PROJECT: SeparatorActionSubMenuList[] = [
+    {
+      caption: "Duplicate Project",
+      icon: {
+        image: RiFileCopyLine,
+      },
+      onClick: () => console.log("Duplicate project"),
+    },
+    {
+      caption: "Archive Project",
+      icon: {
+        image: RiInboxArchiveLine,
+      },
+      onClick: () => console.log("Archive project"),
+    },
+    {
+      caption: "Delete Project",
+      icon: {
+        image: RiDeleteBinLine,
+      },
+      variant: "danger",
+      onClick: () => console.log("Delete project"),
+    },
+  ];
+
   function ProductSeparator(props: SeparatorProps) {
     return (
       <Separator actions={ACTIONS} title="Antrikan App Redesign" {...props} />
@@ -41,82 +87,95 @@ describe("Separator", () => {
   }
 
   context("subMenu", () => {
-    beforeEach(() => {
-      const onDuplicate = cy.stub().as("onDuplicate");
-      const onArchive = cy.stub().as("onArchive");
-      const onDelete = cy.stub().as("onDelete");
-
-      const TIP_MENU_PROJECT: SeparatorActionSubMenuList[] = [
-        {
-          caption: "Duplicate Project",
-          icon: {
-            image: RiFileCopyLine,
-          },
-          onClick: () => onDuplicate(),
-        },
-        {
-          caption: "Archive Project",
-          icon: {
-            image: RiInboxArchiveLine,
-          },
-          onClick: () => onArchive(),
-        },
-        {
-          caption: "Delete Project",
-          icon: {
-            image: RiDeleteBinLine,
-          },
-          variant: "danger",
-          onClick: () => onDelete(),
-        },
-      ];
-
-      const ACTIONS: SeparatorAction[] = [
-        {
-          icon: { image: RiUserAddLine },
-          subMenu: ({ list }) => list(TIP_MENU_PROJECT),
-        },
-        {
-          icon: { image: RiGitBranchLine },
-          subMenu: ({ show }) =>
-            show(
-              <>
-                <span>
-                  <strong>Branch:</strong>{" "}
-                  mobile/introduces-the-antrikan-mobile-app-design
-                </span>
-                <span>Last updated 2 hours ago.</span>
-              </>,
-              {
-                drawerStyle: css`
-                  padding: 10px;
-                  display: flex;
-                  flex-direction: column;
-                `,
-              }
-            ),
-        },
-        {
-          icon: { image: RiCalendar2Fill },
-          subMenu: ({ render }) => render(<Calendar />),
-        },
-      ];
-
-      cy.mount(<ProductSeparator actions={ACTIONS} />);
-    });
-
     context("when given list()", () => {
+      beforeEach(() => {
+        const onDuplicate = cy.stub().as("onDuplicate");
+        const onArchive = cy.stub().as("onArchive");
+        const onDelete = cy.stub().as("onDelete");
+
+        const TIP_MENU_PROJECT: SeparatorActionSubMenuList[] = [
+          {
+            caption: "Duplicate Project",
+            icon: {
+              image: RiFileCopyLine,
+            },
+            onClick: () => onDuplicate(),
+          },
+          {
+            caption: "Archive Project",
+            icon: {
+              image: RiInboxArchiveLine,
+            },
+            onClick: () => onArchive(),
+          },
+          {
+            caption: "Delete Project",
+            icon: {
+              image: RiDeleteBinLine,
+            },
+            variant: "danger",
+            onClick: () => onDelete(),
+          },
+        ];
+
+        const ACTIONS: SeparatorAction[] = [
+          {
+            icon: { image: RiUserAddLine },
+            caption: "Invite",
+            subMenu: ({ list }) => list(TIP_MENU_PROJECT),
+          },
+          {
+            icon: { image: RiGitBranchLine },
+            caption: "Branch",
+            subMenu: ({ show }) =>
+              show(
+                <>
+                  <span>
+                    <strong>Branch:</strong>{" "}
+                    mobile/introduces-the-antrikan-mobile-app-design
+                  </span>
+                  <span>Last updated 2 hours ago.</span>
+                </>,
+                {
+                  drawerStyle: css`
+                    padding: 10px;
+                    display: flex;
+                    flex-direction: column;
+                  `,
+                }
+              ),
+          },
+          {
+            icon: { image: RiCalendar2Fill },
+            alwaysShow: false,
+            caption: "Calendar",
+            subMenu: ({ render }) => render(<Calendar />),
+          },
+        ];
+
+        cy.mount(<ProductSeparator actions={ACTIONS} />);
+      });
       it("shows the tip menu", () => {
-        cy.findAllByLabelText("separator-action").eq(0).realHover();
+        cy.findAllByLabelText("separator-action").eq(0).realClick();
         cy.findByLabelText("tip-menu").should("exist");
       });
 
       context("when clicking the tip menu item", () => {
         it("should render the console", () => {
-          cy.findAllByLabelText("separator-action").eq(0).realHover();
+          cy.findAllByLabelText("separator-action").eq(0).realClick();
           cy.findByLabelText("tip-menu").should("exist");
-          cy.findByText("Duplicate Project").click();
+          cy.findByText("Duplicate Project").realClick();
           cy.get("@onDuplicate").should("have.been.calledOnce");
+        });
+      });
+
+      context("when hovering the tip menu item", () => {
+        it("should not render the caption", () => {
+          cy.findAllByLabelText("separator-action").eq(0).realClick();
+          cy.findByText("Invite").should("exist");
+          cy.findByLabelText("tip-menu").should("exist");
+          cy.findByText("Delete Project").realHover();
+          cy.findByText("Invite").should("not.exist");
         });
       });
     });
@@ -124,8 +183,9 @@ describe("Separator", () => {
     context("with given show()", () => {
       context("with clicking the button", () => {
         it("should renders the show with tooltip container", () => {
-          cy.findAllByLabelText("separator-action").eq(1).realHover();
-          cy.findByLabelText("tooltip-drawer").should("exist");
+          cy.mount(<ProductSeparator />);
+          cy.findAllByLabelText("separator-action").eq(1).realClick();
+          cy.findAllByLabelText("tooltip-drawer").eq(0).should("exist");
           cy.findByText("Branch:").should("exist");
           cy.findByText(
             "mobile/introduces-the-antrikan-mobile-app-design"
@@ -137,7 +197,9 @@ describe("Separator", () => {
     context("with given render()", () => {
       context("with given Calendar component", () => {
         it("should the customize rendering", () => {
-          cy.findAllByLabelText("separator-action").eq(2).realHover();
+          cy.mount(<ProductSeparator />);
+
+          cy.findAllByLabelText("separator-action").eq(2).realClick();
           cy.get(".coneto-calendar").should("exist");
         });
       });
@@ -186,7 +248,7 @@ describe("Separator", () => {
               .should("not.be.visible")
               .and("have.length", 1);
 
-            cy.findByLabelText("separator-container").realHover().wait(100);
+            cy.findByLabelText("separator-container").realClick().wait(100);
             cy.findAllByLabelText("separator-action")
               .should("be.visible")
               .and("have.length", 1);
@@ -197,6 +259,8 @@ describe("Separator", () => {
 
     context("when given", () => {
       it("should shows the actions", () => {
+        cy.mount(<ProductSeparator />);
+
         cy.findAllByLabelText("separator-action")
           .should("exist")
           .and("have.length", 3);
@@ -211,7 +275,10 @@ describe("Separator", () => {
 
         cy.mount(<ProductSeparator />);
 
-        cy.findAllByLabelText("separator-action").should("exist").eq(0).click();
+        cy.findAllByLabelText("separator-action")
+          .should("exist")
+          .eq(0)
+          .realClick();
 
         cy.get("@consoleLog").should("have.been.calledWith", "this is invite");
       });
@@ -223,7 +290,7 @@ describe("Separator", () => {
         cy.findAllByLabelText("separator-action")
           .should("exist")
           .eq(0)
-          .realHover()
+          .realClick()
           .wait(100);
         cy.findByText("Invite").should("exist");
       });

--- a/test/component/separator.cy.tsx
+++ b/test/component/separator.cy.tsx
@@ -230,6 +230,7 @@ describe("Separator", () => {
                   caption: "Invite",
                   onClick: () => console.log("this is invite"),
                   alwaysShow: false,
+                  subMenu: ({ list }) => list(TIP_MENU_PROJECT),
                 },
               ]}
             />
@@ -242,8 +243,8 @@ describe("Separator", () => {
             .and("have.length", 1);
         });
 
-        context("when hovering the separator", () => {
-          it("should shows the actions", () => {
+        context("when opening the drawer", () => {
+          it("the button not hide", () => {
             cy.findAllByLabelText("separator-action")
               .should("not.be.visible")
               .and("have.length", 1);
@@ -252,6 +253,25 @@ describe("Separator", () => {
             cy.findAllByLabelText("separator-action")
               .should("be.visible")
               .and("have.length", 1);
+          });
+        });
+
+        context("when hovering the separator", () => {
+          it("should shows the actions", () => {
+            cy.findAllByLabelText("separator-action")
+              .should("not.be.visible")
+              .and("have.length", 1);
+
+            cy.findByLabelText("separator-container").realClick().wait(100);
+            cy.findByLabelText("tip-menu").should("not.exist");
+
+            cy.findAllByLabelText("separator-action")
+              .should("be.visible")
+              .and("have.length", 1)
+              .click();
+
+            cy.findByLabelText("tip-menu").should("exist");
+            cy.findAllByLabelText("separator-action").should("be.visible");
           });
         });
       });

--- a/test/component/separator.cy.tsx
+++ b/test/component/separator.cy.tsx
@@ -1,13 +1,20 @@
 import {
+  RiCalendar2Fill,
+  RiDeleteBinLine,
+  RiFileCopyLine,
   RiFileList3Line,
   RiGitBranchLine,
+  RiInboxArchiveLine,
   RiUserAddLine,
 } from "@remixicon/react";
 import {
   Separator,
   SeparatorAction,
+  SeparatorActionSubMenuList,
   SeparatorProps,
 } from "./../../components/separator";
+import { Calendar } from "./../../components/calendar";
+import { css } from "styled-components";
 
 describe("Separator", () => {
   const ACTIONS: SeparatorAction[] = [
@@ -32,6 +39,111 @@ describe("Separator", () => {
       <Separator actions={ACTIONS} title="Antrikan App Redesign" {...props} />
     );
   }
+
+  context("subMenu", () => {
+    beforeEach(() => {
+      const onDuplicate = cy.stub().as("onDuplicate");
+      const onArchive = cy.stub().as("onArchive");
+      const onDelete = cy.stub().as("onDelete");
+
+      const TIP_MENU_PROJECT: SeparatorActionSubMenuList[] = [
+        {
+          caption: "Duplicate Project",
+          icon: {
+            image: RiFileCopyLine,
+          },
+          onClick: () => onDuplicate(),
+        },
+        {
+          caption: "Archive Project",
+          icon: {
+            image: RiInboxArchiveLine,
+          },
+          onClick: () => onArchive(),
+        },
+        {
+          caption: "Delete Project",
+          icon: {
+            image: RiDeleteBinLine,
+          },
+          variant: "danger",
+          onClick: () => onDelete(),
+        },
+      ];
+
+      const ACTIONS: SeparatorAction[] = [
+        {
+          icon: { image: RiUserAddLine },
+          subMenu: ({ list }) => list(TIP_MENU_PROJECT),
+        },
+        {
+          icon: { image: RiGitBranchLine },
+          subMenu: ({ show }) =>
+            show(
+              <>
+                <span>
+                  <strong>Branch:</strong>{" "}
+                  mobile/introduces-the-antrikan-mobile-app-design
+                </span>
+                <span>Last updated 2 hours ago.</span>
+              </>,
+              {
+                drawerStyle: css`
+                  padding: 10px;
+                  display: flex;
+                  flex-direction: column;
+                `,
+              }
+            ),
+        },
+        {
+          icon: { image: RiCalendar2Fill },
+          subMenu: ({ render }) => render(<Calendar />),
+        },
+      ];
+
+      cy.mount(<ProductSeparator actions={ACTIONS} />);
+    });
+
+    context("when given list()", () => {
+      it("shows the tip menu", () => {
+        cy.findAllByLabelText("separator-action").eq(0).click();
+        cy.findByLabelText("tip-menu").should("exist");
+      });
+
+      context("when clicking the tip menu item", () => {
+        it("should render the console", () => {
+          cy.findAllByLabelText("separator-action").eq(0).click();
+          cy.findByLabelText("tip-menu").should("exist");
+          cy.findByText("Duplicate Project").click();
+          cy.get("@onDuplicate").should("have.been.calledOnce");
+        });
+      });
+    });
+
+    context("with given show()", () => {
+      context("with clicking the button", () => {
+        it("should renders the show with tooltip container", () => {
+          cy.findAllByLabelText("separator-action").eq(1).click();
+          cy.findByLabelText("tooltip-drawer").should("exist");
+          cy.findByText("Branch:").should("exist");
+          cy.findByText(
+            "mobile/introduces-the-antrikan-mobile-app-design"
+          ).should("exist");
+        });
+      });
+    });
+
+    context("with given render()", () => {
+      context("with given Calendar component", () => {
+        it("should the customize rendering", () => {
+          cy.findAllByLabelText("separator-action").eq(2).click();
+          cy.get(".coneto-calendar").should("exist");
+        });
+      });
+    });
+  });
+
   context("actions", () => {
     beforeEach(() => {
       cy.mount(<ProductSeparator />);

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -574,6 +574,7 @@ export interface SeparatorThemeConfig {
   lineShadow?: string;
   titleColor?: string;
   backgroundTitleColor?: string;
+  tooltipBackgroundColor?: string;
 }
 
 // signbox.tsx

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1445,6 +1445,7 @@ export function createSeparatorTheme(
       lineShadow: "inset 0 2px 2px #ffffff, inset 0 -1px 1px #7a7a7a",
       titleColor: "#6b7280",
       backgroundTitleColor: body.backgroundColor,
+      tooltipBackgroundColor: "rgb(236, 236, 236)",
     },
     ...themeConfigurations
   );

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -664,6 +664,7 @@ const darkSeparator = createSeparatorTheme(darkBody, {
     "rgb(43, 43, 43) 0px 2px 2px inset, rgb(130, 130, 130) 0px -1px 1px inset",
   titleColor: "rgb(171, 171, 171)",
   backgroundTitleColor: "#1f2023",
+  tooltipBackgroundColor: "rgb(62, 69, 89)",
 });
 
 const darkSignbox = createSignboxTheme(darkBody, darkFieldLane);


### PR DESCRIPTION
Description:
This pull request introduces a `subMenu` on the `Separator` component, have similar behavior shared from `Button` component can customize the drawer through the functionality, such as  `list()`, `show()`, and `render()`. It also ensures the `subMenu` works properly on the `SeparatorAction`.

Source:
[[Improvement] SYST-723: Add `subMenu` with: `list`, `show`, `render` on separator action](https://linear.app/systatum/issue/SYST-723/add-submenu-with-list-show-render-on-separator-action)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself