### PR TITLE
[Mobile] SYST-773: Add `mobile` to `Chips`

### DIFF
--- a/components/badge.tsx
+++ b/components/badge.tsx
@@ -190,11 +190,11 @@ function Badge({
 
   return (
     <BadgeWrapper
+      aria-label="badge"
       {...props}
+      onClick={onClick}
       id={String(id)}
       className={applyClassName("badge", className)}
-      onClick={onClick}
-      aria-label="badge"
       $theme={badgeTheme}
       $backgroundColor={badgeBackgroundColor}
       $textColor={badgeTextColor}

--- a/components/chips.stories.tsx
+++ b/components/chips.stories.tsx
@@ -622,9 +622,6 @@ export const Mobile: Story = {
           chipContainerStyle: css`
             gap: 4px;
           `,
-          chipsDrawerStyle: css`
-            max-width: 300px;
-          `,
         }}
         onChange={handleOptionClicked}
         selectedOptions={inputValue.selectedOptions}

--- a/components/chips.stories.tsx
+++ b/components/chips.stories.tsx
@@ -378,13 +378,9 @@ export const Default: Story = {
         inputValue={inputValue.search}
         setInputValue={onChangeValue}
         styles={{
-          chipStyle: css`
+          chipOptionStyle: css`
             width: 100%;
             gap: 8px;
-            border-color: transparent;
-          `,
-          chipContainerStyle: css`
-            gap: 4px;
           `,
           chipsDrawerStyle: css`
             max-width: 300px;
@@ -614,13 +610,9 @@ export const Mobile: Story = {
         inputValue={inputValue.search}
         setInputValue={onChangeValue}
         styles={{
-          chipStyle: css`
+          chipOptionStyle: css`
             width: 100%;
             gap: 8px;
-            border-color: transparent;
-          `,
-          chipContainerStyle: css`
-            gap: 4px;
           `,
         }}
         onChange={handleOptionClicked}
@@ -732,14 +724,9 @@ export const DarkBackground: Story = {
           setInputValue((prev) => ({ ...prev, search: e.target.value }))
         }
         styles={{
-          chipStyle: css`
+          chipOptionStyle: css`
             width: 100%;
             gap: 8px;
-            border-color: transparent;
-          `,
-          chipContainerStyle: css`
-            gap: 8px;
-            justify-content: start;
           `,
         }}
         onChange={handleOptionClicked}
@@ -958,13 +945,9 @@ export const Deletable: Story = {
         inputValue={inputValue.search}
         setInputValue={onChangeValue}
         styles={{
-          chipStyle: css`
+          chipOptionStyle: css`
             width: 100%;
             gap: 8px;
-            border-color: transparent;
-          `,
-          chipContainerStyle: css`
-            gap: 4px;
           `,
           chipsDrawerStyle: css`
             max-width: 250px;
@@ -1291,14 +1274,11 @@ export const CustomRenderer: Story = {
         inputValue={inputValue.search}
         setInputValue={onChangeValue}
         styles={{
-          chipStyle: css`
+          chipOptionStyle: css`
             width: 100%;
             gap: 8px;
-            border-color: transparent;
           `,
-          chipContainerStyle: css`
-            gap: 4px;
-          `,
+
           chipsDrawerStyle: css`
             max-width: 250px;
           `,

--- a/components/chips.stories.tsx
+++ b/components/chips.stories.tsx
@@ -66,7 +66,7 @@ const meta: Meta<typeof Chips> = {
       control: "boolean",
       description: "If true, allows creating new chips not present in options.",
     },
-    onOptionClicked: {
+    onChange: {
       action: "clicked",
       description: "Callback fired when a chip option is clicked.",
     },
@@ -390,7 +390,7 @@ export const Default: Story = {
             max-width: 300px;
           `,
         }}
-        onOptionClicked={handleOptionClicked}
+        onChange={handleOptionClicked}
         selectedOptions={inputValue.selectedOptions}
         options={BADGE_OPTIONS as BadgeProps[]}
         missingOptionForm={MissingOptionForm}
@@ -626,7 +626,7 @@ export const Mobile: Story = {
             max-width: 300px;
           `,
         }}
-        onOptionClicked={handleOptionClicked}
+        onChange={handleOptionClicked}
         selectedOptions={inputValue.selectedOptions}
         options={BADGE_OPTIONS as BadgeProps[]}
         missingOptionForm={MissingOptionForm}
@@ -745,7 +745,7 @@ export const DarkBackground: Story = {
             justify-content: start;
           `,
         }}
-        onOptionClicked={handleOptionClicked}
+        onChange={handleOptionClicked}
         selectedOptions={inputValue.selectedOptions}
         options={BADGE_OPTIONS as BadgeProps[]}
       />
@@ -973,7 +973,7 @@ export const Deletable: Story = {
             max-width: 250px;
           `,
         }}
-        onOptionClicked={handleOptionClicked}
+        onChange={handleOptionClicked}
         selectedOptions={inputValue.selectedOptions}
         options={BADGE_OPTIONS}
         missingOptionForm={MissingOptionForm}
@@ -1363,7 +1363,7 @@ export const CustomRenderer: Story = {
             </Tooltip>
           );
         }}
-        onOptionClicked={handleOptionClicked}
+        onChange={handleOptionClicked}
         selectedOptions={inputValue.selectedOptions}
         options={BADGE_OPTIONS as BadgeProps[]}
         missingOptionForm={MissingOptionForm}

--- a/components/chips.stories.tsx
+++ b/components/chips.stories.tsx
@@ -211,7 +211,7 @@ export const Default: Story = {
       background_color: string;
       text_color: string;
       circle_color: string;
-      selectedOptions: BadgeProps[];
+      selectedOptions: string[];
     }
 
     const [inputValue, setInputValue] = useState<InputValueProps>({
@@ -237,16 +237,250 @@ export const Default: Story = {
       }
     };
 
-    const handleOptionClicked = (badge: BadgeProps) => {
-      const isAlreadySelected = inputValue.selectedOptions.some(
-        (data) => data.id === badge.id
-      );
-
+    const handleOptionClicked = (badgeIds: string[]) => {
       setInputValue((prev) => ({
         ...prev,
-        selectedOptions: isAlreadySelected
-          ? prev.selectedOptions.filter((data) => data.id !== badge.id)
-          : [...prev.selectedOptions, badge],
+        selectedOptions: badgeIds,
+      }));
+    };
+
+    const handleNewTagClicked = () => {
+      console.log("clicked new tag");
+    };
+
+    console.log(inputValue);
+
+    const MissingOptionForm = ({
+      firstInputRef,
+      closeForm,
+    }: MissingOptionFormProps) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          minWidth: "240px",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            padding: "8px 12px",
+            gap: "8px",
+            fontSize: "0.75rem",
+            fontWeight: 500,
+            alignItems: "center",
+          }}
+        >
+          <RiAddBoxFill size={18} />
+          <span
+            style={{
+              paddingTop: "2px",
+            }}
+          >
+            Create a new tag
+          </span>
+        </div>
+        <Divider aria-label="divider" />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            padding: "12px",
+            gap: "12px",
+          }}
+        >
+          <Textbox
+            ref={firstInputRef}
+            id="colorbox-name-tag"
+            name="name_tag"
+            placeholder={"Create a new label"}
+            value={inputValue.name_tag}
+            autoComplete="off"
+            onChange={onChangeValue}
+          />
+          <Colorbox
+            id="colorbox-background-color"
+            placeholder="Select background color..."
+            name={"background_color"}
+            value={inputValue.background_color}
+            onChange={onChangeValue}
+          />
+          <Colorbox
+            id="colorbox-text-color"
+            placeholder="Select text color..."
+            name={"text_color"}
+            value={inputValue.text_color}
+            onChange={onChangeValue}
+          />
+          <Colorbox
+            id="colorbox-circle-color"
+            placeholder="Select circle color..."
+            name={"circle_color"}
+            value={inputValue.circle_color}
+            onChange={onChangeValue}
+          />
+          <Badge
+            textColor={inputValue.text_color}
+            backgroundColor={inputValue.background_color}
+            circleColor={inputValue.circle_color}
+            caption={inputValue.name_tag}
+            withCircle
+          />
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "space-between",
+              width: "100%",
+            }}
+          >
+            <Button
+              onClick={async () => {
+                const inputSearchEvent = {
+                  target: {
+                    name: "search",
+                    value: inputValue.name_tag,
+                  },
+                } as ChangeEvent<HTMLInputElement>;
+                await onChangeValue(inputSearchEvent);
+                await closeForm();
+              }}
+              size="sm"
+              styles={{
+                self: {
+                  fontSize: "12px",
+                },
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleNewTagClicked}
+              size="sm"
+              variant="primary"
+              styles={{
+                self: {
+                  fontSize: "12px",
+                },
+              }}
+            >
+              Add
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+
+    return (
+      <Chips
+        inputValue={inputValue.search}
+        setInputValue={onChangeValue}
+        styles={{
+          chipStyle: css`
+            width: 100%;
+            gap: 8px;
+            border-color: transparent;
+          `,
+          chipContainerStyle: css`
+            gap: 4px;
+          `,
+          chipsDrawerStyle: css`
+            max-width: 300px;
+          `,
+        }}
+        onOptionClicked={handleOptionClicked}
+        selectedOptions={inputValue.selectedOptions}
+        options={BADGE_OPTIONS as BadgeProps[]}
+        missingOptionForm={MissingOptionForm}
+        creatable
+      />
+    );
+  },
+};
+
+export const Mobile: Story = {
+  render: () => {
+    const BADGE_OPTIONS: BadgeProps[] = [
+      {
+        id: "1",
+        caption: "Anime",
+      },
+      {
+        id: "2",
+        caption: "Manga",
+      },
+      {
+        id: "3",
+        caption: "Comics",
+      },
+      {
+        id: "4",
+        caption: "Movies",
+      },
+      {
+        id: "5",
+        caption: "Podcasts",
+      },
+      {
+        id: "6",
+        caption: "TV Shows",
+      },
+      {
+        id: "7",
+        caption: "Novels",
+      },
+      {
+        id: "8",
+        caption: "Music",
+      },
+      {
+        id: "9",
+        caption: "Games",
+      },
+      {
+        id: "10",
+        caption: "Webtoons",
+      },
+    ];
+
+    interface InputValueProps {
+      search: string;
+      name_tag: string;
+      background_color: string;
+      text_color: string;
+      circle_color: string;
+      selectedOptions: string[];
+    }
+
+    const [inputValue, setInputValue] = useState<InputValueProps>({
+      search: "",
+      name_tag: "",
+      background_color: "",
+      text_color: "",
+      circle_color: "",
+      selectedOptions: [],
+    });
+
+    const onChangeValue = (e: ChangeEvent<HTMLInputElement>) => {
+      const { name, value } = e.target;
+
+      if (name === "chips") {
+        setInputValue((prev) => ({
+          ...prev,
+          ["search"]: value,
+          ["name_tag"]: value,
+        }));
+      } else {
+        setInputValue((prev) => ({ ...prev, [name]: value }));
+      }
+    };
+
+    const handleOptionClicked = (badgeIds: string[]) => {
+      setInputValue((prev) => ({
+        ...prev,
+        selectedOptions: badgeIds,
       }));
     };
 
@@ -303,6 +537,7 @@ export const Default: Story = {
             onChange={onChangeValue}
           />
           <Colorbox
+            id="colorbox-background"
             placeholder="Select background color..."
             name={"background_color"}
             value={inputValue.background_color}
@@ -375,6 +610,7 @@ export const Default: Story = {
 
     return (
       <Chips
+        mobile
         inputValue={inputValue.search}
         setInputValue={onChangeValue}
         styles={{
@@ -476,7 +712,7 @@ export const DarkBackground: Story = {
     ];
     interface InputValueProps {
       search: string;
-      selectedOptions: BadgeProps[];
+      selectedOptions: string[];
     }
 
     const [inputValue, setInputValue] = useState<InputValueProps>({
@@ -484,24 +720,19 @@ export const DarkBackground: Story = {
       selectedOptions: [],
     });
 
-    const handleOptionClicked = (badge: BadgeProps) => {
-      const isAlreadySelected = inputValue.selectedOptions.some(
-        (data) => data.id === badge.id
-      );
-
+    const handleOptionClicked = (selectedOptions: string[]) => {
       setInputValue((prev) => ({
         ...prev,
-        selectedOptions: isAlreadySelected
-          ? prev.selectedOptions.filter((data) => data.id !== badge.id)
-          : [...prev.selectedOptions, badge],
+        selectedOptions,
       }));
     };
 
     return (
       <Chips
+        name="search"
         inputValue={inputValue.search}
         setInputValue={(e) =>
-          setInputValue((prev) => ({ ...prev, searchText: e.target.value }))
+          setInputValue((prev) => ({ ...prev, search: e.target.value }))
         }
         styles={{
           chipStyle: css`
@@ -530,7 +761,7 @@ export const Deletable: Story = {
       background_color: string;
       text_color: string;
       circle_color: string;
-      selectedOptions: BadgeProps[];
+      selectedOptions: string[];
     }
 
     const BADGE_OPTIONS: BadgeProps[] = Array.from({ length: 10 }, (_, i) => ({
@@ -595,16 +826,10 @@ export const Deletable: Story = {
       }
     };
 
-    const handleOptionClicked = (badge: BadgeProps) => {
-      const isAlreadySelected = inputValue.selectedOptions.some(
-        (data) => data.id === badge.id
-      );
-
+    const handleOptionClicked = (selectedOptions: string[]) => {
       setInputValue((prev) => ({
         ...prev,
-        selectedOptions: isAlreadySelected
-          ? prev.selectedOptions.filter((data) => data.id !== badge.id)
-          : [...prev.selectedOptions, badge],
+        selectedOptions,
       }));
     };
 
@@ -766,7 +991,7 @@ export const CustomRenderer: Story = {
       background_color: string;
       text_color: string;
       circle_color: string;
-      selectedOptions: BadgeProps[];
+      selectedOptions: string[];
     }
 
     const BADGE_OPTIONS: BadgeProps[] = Array.from({ length: 10 }, (_, i) => ({
@@ -843,16 +1068,10 @@ export const CustomRenderer: Story = {
       }
     };
 
-    const handleOptionClicked = (badge: BadgeProps) => {
-      const isAlreadySelected = inputValue.selectedOptions.some(
-        (data) => data.id === badge.id
-      );
-
+    const handleOptionClicked = (selectedOptions: string[]) => {
       setInputValue((prev) => ({
         ...prev,
-        selectedOptions: isAlreadySelected
-          ? prev.selectedOptions.filter((data) => data.id !== badge.id)
-          : [...prev.selectedOptions, badge],
+        selectedOptions,
       }));
     };
 

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -386,7 +386,6 @@ function BaseChips({
               css`
                 width: fit-content;
                 max-width: 240px;
-                background-color: ${chipsTheme.backgroundColor};
               `};
 
               ${finalDrawerHeight &&

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -211,6 +211,7 @@ function BaseChips({
                 self: css`
                   cursor: pointer;
                   width: 100%;
+                  background-color: transparent;
                   ${mobile &&
                   css`
                     font-size: 18px;

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -31,6 +31,9 @@ import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
 import { useTheme } from "./../theme/provider";
 import { ChipsThemeConfig } from "./../theme";
 import { applyClassName } from "./../constants/classname";
+import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox";
+import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox";
+import { props } from "cypress/types/bluebird";
 
 export type ChipAction = BadgeAction;
 
@@ -45,8 +48,8 @@ interface BaseChipsProps {
   filterPlaceholder?: string;
   missingOptionLabel?: string;
   creatable?: boolean;
-  onOptionClicked?: (badge: ChipProps) => void;
-  selectedOptions?: ChipProps[];
+  selectedOptions?: string[];
+  onOptionClicked?: (badgeIds: string[]) => void;
   missingOptionForm?:
     | ReactNode
     | ((props?: MissingOptionFormProps) => ReactNode);
@@ -56,6 +59,8 @@ interface BaseChipsProps {
   name?: string;
   id?: string;
   disabled?: boolean;
+  mobile?: boolean;
+  drawerHeight?: string;
 }
 
 export interface BaseChipsStyles {
@@ -79,16 +84,45 @@ export interface MissingOptionFormProps {
   closeForm?: () => void;
 }
 
-function BaseChips(props: BaseChipsProps) {
+function BaseChips({
+  creatable,
+  disabled,
+  emptySlate = null,
+  filterPlaceholder = "Change or add labels...",
+  inputValue,
+  missingOptionLabel = "Create a new label:",
+  id,
+  missingOptionForm,
+  name = "search",
+  onOptionClicked,
+  options = [],
+  renderer,
+  selectedOptions = [],
+  setInputValue,
+  styles,
+  mobile,
+  drawerHeight,
+}: BaseChipsProps) {
   const { currentTheme } = useTheme();
   const chipsTheme = currentTheme.chips;
 
+  const inputRef = useRef<HTMLInputElement>(null);
+  const inputMissingRef = useRef<HTMLInputElement>(null);
+
+  const [mode, setMode] = useState<"idle" | "create">("idle");
+
   const [isOpen, setIsOpen] = useState(false);
   const [hasInteracted, setHasInteracted] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [interactionMode, setInteractionMode] = useState<"mouse" | "keyboard">(
+    "keyboard"
+  );
+
+  const listRef = useRef<(HTMLLIElement | null)[]>([]);
 
   const { refs, floatingStyles, context } = useFloating({
     open: isOpen,
-    onOpenChange: props?.disabled ? null : setIsOpen,
+    onOpenChange: disabled ? null : setIsOpen,
     middleware: [
       offset(6),
       flip({ fallbackPlacements: ["bottom-end", "top-start", "top-end"] }),
@@ -107,38 +141,110 @@ function BaseChips(props: BaseChipsProps) {
     role,
   ]);
 
-  const ALL_OPTIONS = useMemo(() => {
-    const selectedIds = new Set(props.selectedOptions.map((d) => d.id));
+  // Keep selected options at the top, following the order in selectedOptions.
+  // Unselected options preserve their original order.
+  const sortedOptions = [...options].sort((a, b) => {
+    const aIndex = selectedOptions?.findIndex((id) => id === a.id) ?? -1;
+    const bIndex = selectedOptions?.findIndex((id) => id === b.id) ?? -1;
 
-    const clickedOptions = props.selectedOptions;
-    const unClickedOptions = props.options.filter(
-      (opt) => !selectedIds.has(opt.id)
-    );
-
-    const allOpts = [...clickedOptions, ...unClickedOptions];
-
-    if (hasInteracted && props.inputValue) {
-      return allOpts.filter((opt) =>
-        opt.caption.toLowerCase().includes(props.inputValue.toLowerCase())
-      );
+    if (aIndex !== -1 && bIndex !== -1) {
+      return aIndex - bIndex;
     }
 
-    return allOpts;
-  }, [props.selectedOptions, props.options, props.inputValue, hasInteracted]);
+    if (aIndex !== -1) return -1;
+    if (bIndex !== -1) return 1;
 
-  const CLICKED_OPTIONS = props.selectedOptions;
+    return 0;
+  });
+
+  const FINAL_OPTIONS: ComboboxOption[] = useMemo(() => {
+    return sortedOptions.map((badge, index) => {
+      const isSelected = selectedOptions?.some(
+        (selectedOption) => selectedOption === badge.id
+      );
+
+      return {
+        text: badge.caption,
+        value: badge.id,
+        render: (
+          <Fragment key={badge.id}>
+            {index > 0 &&
+              sortedOptions[index - 1] &&
+              selectedOptions?.some(
+                (selectedOption) =>
+                  selectedOption === sortedOptions[index - 1].id
+              ) &&
+              !isSelected && (
+                <Divider $theme={chipsTheme} aria-label="divider" />
+              )}
+
+            <Badge
+              {...badge}
+              onMouseDown={(e) => e.preventDefault()}
+              styles={{
+                self: css`
+                  cursor: pointer;
+                  width: 100%;
+                  ${mobile
+                    ? css`
+                        margin-top: 2px;
+
+                        font-size: 18px;
+                      `
+                    : css`
+                        margin-top: 2px;
+                      `}
+
+                  ${styles?.chipStyle}
+                `,
+              }}
+              withCircle
+            />
+          </Fragment>
+        ),
+      };
+    });
+  }, [sortedOptions, selectedOptions, styles?.chipStyle, chipsTheme]);
+
+  const FILTERED_OPTIONS: ComboboxOption[] = useMemo(() => {
+    if (!hasInteracted || !inputValue) return FINAL_OPTIONS;
+
+    const search = inputValue.toLowerCase();
+
+    return FINAL_OPTIONS.filter((option) => {
+      return option.text?.toLowerCase().includes(search);
+    });
+  }, [hasInteracted, inputValue, FINAL_OPTIONS]);
+
+  const hasNoFilter = FILTERED_OPTIONS.length === 0 && inputValue.length > 1;
+
+  const RENDER_SELECTED_OPTIONS: BadgeProps[] = useMemo(() => {
+    return sortedOptions.filter((badge) =>
+      selectedOptions?.some((selectedOption) => selectedOption === badge.id)
+    );
+  }, [sortedOptions, selectedOptions]);
+
+  useEffect(() => {
+    if (isOpen && mode === "idle") {
+      inputRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  const finalDrawerHeight = mobile
+    ? (drawerHeight ?? "320px")
+    : (drawerHeight ?? "220px");
 
   return (
     <>
       <InputGroup
-        id={props?.id}
+        id={id}
         aria-label="chip-input"
-        $disabled={props?.disabled}
-        $containerStyle={props?.styles?.chipsContainerStyle}
+        $disabled={disabled}
+        $containerStyle={styles?.chipsContainerStyle}
       >
-        {CLICKED_OPTIONS.map((badge) =>
-          typeof props.renderer === "function" ? (
-            props.renderer({
+        {RENDER_SELECTED_OPTIONS.map((badge) =>
+          typeof renderer === "function" ? (
+            renderer({
               id: badge.id,
               caption: badge.caption,
               metadata: badge.metadata,
@@ -148,7 +254,6 @@ function BaseChips(props: BaseChipsProps) {
               key={badge.id}
               onClick={(e) => {
                 e.stopPropagation();
-                dismiss;
               }}
               variant={badge.variant}
               backgroundColor={badge.backgroundColor}
@@ -156,7 +261,7 @@ function BaseChips(props: BaseChipsProps) {
               styles={{
                 self: css`
                   border-radius: 4px;
-                  ${props.styles?.chipSelectedStyle}
+                  ${styles?.chipSelectedStyle}
                 `,
               }}
               textColor={badge.textColor}
@@ -168,7 +273,7 @@ function BaseChips(props: BaseChipsProps) {
 
         <AddButton
           $theme={chipsTheme}
-          $disabled={props?.disabled}
+          $disabled={disabled}
           ref={refs.setReference}
           role="button"
           $isOpen={isOpen}
@@ -177,14 +282,157 @@ function BaseChips(props: BaseChipsProps) {
       </InputGroup>
 
       {isOpen && (
-        <ChipsDrawer
-          {...props}
-          getFloatingProps={getFloatingProps}
+        <Combobox.Drawer
+          emptySlate={emptySlate}
+          isOpen={isOpen}
+          setIsOpen={setIsOpen}
+          withSearchbox={mobile && mode === "idle"}
+          refs={refs as unknown as ComboboxDrawerProps["refs"]}
+          highlightedIndex={highlightedIndex}
+          setHighlightedIndex={setHighlightedIndex}
+          interactionMode={interactionMode}
+          setInteractionMode={setInteractionMode}
+          selectedOptions={selectedOptions}
+          multiple
+          selectedOptionsLocal={{
+            text: inputValue,
+            value: "",
+          }}
+          styles={{
+            drawerStyle: css`
+              ${!mobile &&
+              css`
+                width: fit-content;
+                max-width: 240px;
+                background-color: ${chipsTheme.backgroundColor};
+              `};
+
+              ${finalDrawerHeight &&
+              css`
+                min-height: ${finalDrawerHeight};
+                max-height: ${finalDrawerHeight};
+              `};
+
+              ${FILTERED_OPTIONS?.length < 5 && mobile
+                ? css`
+                    min-height: 80px;
+                  `
+                : FILTERED_OPTIONS?.length < 5 &&
+                  !mobile &&
+                  css`
+                    min-height: fit-content;
+                  `};
+
+              ${mobile &&
+              mode === "create" &&
+              css`
+                padding: 0px;
+              `};
+
+              ${mode === "create" &&
+              css`
+                min-width: 240px;
+              `}
+            `,
+          }}
+          onChange={async (selectedOptions?: SelectboxSelectedOptions) => {
+            if (!Array.isArray(selectedOptions)) return;
+            onOptionClicked?.(selectedOptions as string[]);
+          }}
+          setSelectedOptionsLocal={(selectedOptionsLocal?: SelectboxOption) => {
+            setInputValue?.({
+              target: {
+                name,
+                value: selectedOptionsLocal?.text || "",
+              },
+            } as ChangeEvent<HTMLInputElement>);
+          }}
           setHasInteracted={setHasInteracted}
+          options={mode === "idle" ? FILTERED_OPTIONS : []}
+          navigableOptions={mode === "idle" ? FILTERED_OPTIONS : []}
+          mobile={mobile}
           floatingStyles={floatingStyles}
-          refs={refs}
-          options={ALL_OPTIONS}
-        />
+          getFloatingProps={getFloatingProps}
+          listRef={listRef}
+          inputRef={inputRef}
+        >
+          {mode === "idle" && (
+            <>
+              {!mobile && (
+                <>
+                  <Textbox
+                    ref={inputRef}
+                    name={name}
+                    type="text"
+                    aria-label="chip-input-box"
+                    placeholder={filterPlaceholder}
+                    value={inputValue}
+                    styles={{
+                      containerStyle: css`
+                        position: sticky;
+                        top: 1px;
+                        z-index: 99993999;
+                      `,
+                      self: css`
+                        border: none;
+                        min-height: 34px;
+                        border-radius: 0;
+                        border-width: 2px;
+                      `,
+                    }}
+                    autoComplete="off"
+                    onChange={(e) => {
+                      setHasInteracted?.(true);
+                      setInputValue(e);
+                      setHighlightedIndex(0);
+                      setInteractionMode("keyboard");
+                    }}
+                  />
+                  <Divider $theme={chipsTheme} aria-label="divider" />
+                </>
+              )}
+
+              {hasNoFilter && creatable && (
+                <EmptyOptionContainer
+                  onClick={async () => {
+                    await setMode("create");
+                    await inputMissingRef?.current?.focus();
+                  }}
+                  $hovered={highlightedIndex === 0}
+                  $theme={chipsTheme}
+                >
+                  <RiAddLine size={14} style={{ minWidth: "14px" }} />
+                  <span
+                    style={{
+                      fontWeight: 500,
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {missingOptionLabel}&nbsp;
+                    <span style={{ color: chipsTheme?.mutedTextColor }}>
+                      "{inputValue}"
+                    </span>
+                  </span>
+                </EmptyOptionContainer>
+              )}
+            </>
+          )}
+          {mode === "create" && (
+            <>
+              {typeof missingOptionForm === "function"
+                ? missingOptionForm({
+                    firstInputRef: inputMissingRef,
+                    closeForm: async () => {
+                      await setMode("idle");
+                      await inputRef.current?.focus();
+                    },
+                  })
+                : missingOptionForm}
+            </>
+          )}
+        </Combobox.Drawer>
       )}
     </>
   );
@@ -244,252 +492,6 @@ const AddButton = styled(RiAddLine)<{
     `}
 `;
 
-type ChipsDrawerProps = BaseChipsProps & {
-  getFloatingProps: ReturnType<typeof useInteractions>["getFloatingProps"];
-  floatingStyles: CSSProperties;
-  refs: ReturnType<typeof useFloating>["refs"];
-  setHasInteracted: (data: boolean) => void;
-};
-
-function ChipsDrawer({
-  floatingStyles,
-  getFloatingProps,
-  refs,
-  setHasInteracted,
-  filterPlaceholder = "Change or add labels...",
-  inputValue,
-  missingOptionLabel = "Create a new label:",
-  options,
-  setInputValue,
-  creatable,
-  onOptionClicked,
-  selectedOptions,
-  missingOptionForm,
-  emptySlate,
-  name = "chips",
-  styles,
-}: ChipsDrawerProps) {
-  const { currentTheme } = useTheme();
-  const chipsTheme = currentTheme.chips;
-
-  const [hovered, setHovered] = useState<string | null>(null);
-  const [mode, setMode] = useState<"idle" | "create">("idle");
-  const [isTyping, setIsTyping] = useState(false);
-
-  const inputRef = useRef<HTMLInputElement>(null);
-  const inputMissingRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (mode === "idle") {
-      inputRef.current?.focus();
-    }
-  }, []);
-
-  useEffect(() => {
-    if (isTyping) setTimeout(() => setIsTyping(false), 50);
-  }, [isTyping]);
-
-  const filteredSearch = options.filter(
-    (opt) => opt.caption.toLowerCase() === inputValue.toLowerCase()
-  );
-
-  const hasNoFilter = filteredSearch.length === 0 && inputValue.length > 1;
-
-  useEffect(() => {
-    if (isTyping && hasNoFilter && creatable) {
-      setHovered("0");
-    } else if (isTyping && options && options.length > 0) {
-      setHovered(options[0]?.id);
-    }
-  }, [inputValue, options, mode, creatable, hasNoFilter, isTyping]);
-
-  const handleKeyDown = async (e: KeyboardEvent<HTMLUListElement>) => {
-    if (mode !== "idle") return;
-
-    const index = options.findIndex((opt) => opt.id === hovered);
-    const hasCreateOption = hasNoFilter && creatable;
-    const allOptions = [{ id: "0" }, ...options];
-
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-
-      if (hasCreateOption) {
-        const currentIndex = allOptions.findIndex((opt) => opt.id === hovered);
-        const nextIndex = (currentIndex + 1) % allOptions.length;
-        setHovered(allOptions[nextIndex].id);
-      } else {
-        const nextIndex = (index + 1) % options.length;
-        setHovered(options[nextIndex].id);
-      }
-    }
-
-    if (e.key === "ArrowUp") {
-      e.preventDefault();
-
-      if (hasCreateOption) {
-        const currentIndex = allOptions.findIndex((opt) => opt.id === hovered);
-        const prevIndex =
-          (currentIndex - 1 + allOptions.length) % allOptions.length;
-        setHovered(allOptions[prevIndex].id);
-      } else {
-        const prevIndex = (index - 1 + options.length) % options.length;
-        setHovered(options[prevIndex].id);
-      }
-    }
-
-    if (e.key === "Enter") {
-      e.preventDefault();
-      e.stopPropagation();
-      const selected = options.find((opt) => opt.id === hovered);
-      if (hovered === "0") {
-        await setMode("create");
-        await inputMissingRef.current?.focus();
-      } else if (selected && onOptionClicked) {
-        onOptionClicked(selected);
-      }
-    }
-  };
-
-  return (
-    <ChipsDrawerWrapper
-      {...getFloatingProps()}
-      ref={refs.setFloating}
-      style={floatingStyles}
-      tabIndex={-1}
-      role="listbox"
-      $theme={chipsTheme}
-      $style={styles?.chipsDrawerStyle}
-      onKeyDown={handleKeyDown}
-    >
-      {mode === "idle" && (
-        <>
-          <Textbox
-            ref={inputRef}
-            name={name}
-            type="text"
-            aria-label="chip-input-box"
-            placeholder={filterPlaceholder}
-            value={inputValue}
-            styles={{
-              self: {
-                border: "none",
-                minHeight: "34px",
-                borderRadius: 0,
-              },
-            }}
-            autoComplete="off"
-            onChange={(e) => {
-              setHasInteracted?.(true);
-              setInputValue(e);
-              setIsTyping(true);
-            }}
-          />
-          <Divider $theme={chipsTheme} aria-label="divider" />
-
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "4px",
-              padding: "4px",
-            }}
-          >
-            {hasNoFilter && creatable && (
-              <EmptyOptionContainer
-                onClick={async () => {
-                  await setMode("create");
-                  await inputMissingRef.current?.focus();
-                }}
-                onMouseEnter={() => setHovered("0")}
-                $hovered={hovered === "0"}
-                $theme={chipsTheme}
-              >
-                <RiAddLine size={14} style={{ minWidth: "14px" }} />
-                <span
-                  style={{
-                    fontWeight: 500,
-                    whiteSpace: "nowrap",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                  }}
-                >
-                  {missingOptionLabel}&nbsp;
-                  <span style={{ color: chipsTheme?.mutedTextColor }}>
-                    "{inputValue}"
-                  </span>
-                </span>
-              </EmptyOptionContainer>
-            )}
-
-            {options && options.length > 0 ? (
-              <>
-                {options.map((chip, index) => {
-                  const isClicked = selectedOptions?.some(
-                    (clicked) => clicked.id === chip.id
-                  );
-
-                  return (
-                    <div key={chip.id}>
-                      {index > 0 &&
-                        options[index - 1] &&
-                        selectedOptions?.some(
-                          (clicked) => clicked.id === options[index - 1].id
-                        ) &&
-                        !isClicked && (
-                          <Divider $theme={chipsTheme} aria-label="divider" />
-                        )}
-                      <ChipsItem
-                        chip={chip}
-                        chipContainerStyle={styles?.chipContainerStyle}
-                        hovered={hovered}
-                        isClicked={isClicked}
-                        inputRef={inputRef}
-                        setHovered={setHovered}
-                        onOptionClicked={onOptionClicked}
-                        chipStyle={styles?.chipStyle}
-                      />
-                    </div>
-                  );
-                })}
-              </>
-            ) : hasNoFilter && emptySlate && !creatable ? (
-              <Fragment>{emptySlate}</Fragment>
-            ) : (
-              hasNoFilter &&
-              !creatable && (
-                <span
-                  style={{
-                    fontSize: "0.75rem",
-                    color: "#4b5563",
-                    textAlign: "center",
-                    padding: "8px",
-                  }}
-                >
-                  No matching actions
-                </span>
-              )
-            )}
-          </div>
-        </>
-      )}
-
-      {mode === "create" && (
-        <Fragment>
-          {typeof missingOptionForm === "function"
-            ? missingOptionForm({
-                firstInputRef: inputMissingRef,
-                closeForm: async () => {
-                  await setMode("idle");
-                  await inputRef.current?.focus();
-                },
-              })
-            : missingOptionForm}
-        </Fragment>
-      )}
-    </ChipsDrawerWrapper>
-  );
-}
-
 export type ChipsStyles = BaseChipsStyles & FieldLaneStyles;
 
 export interface ChipsProps
@@ -505,13 +507,14 @@ function Chips({
   errorMessage,
   helper,
   disabled,
-  name,
+  name = "chips",
   id,
   labelGap,
   labelWidth,
   labelPosition,
   className,
-  ...rest
+  required,
+  ...props
 }: ChipsProps) {
   const inputId = StatefulForm.sanitizeId({
     prefix: "chips",
@@ -539,7 +542,7 @@ function Chips({
       labelWidth={labelWidth}
       labelPosition={labelPosition}
       className={applyClassName("chips", className)}
-      required={rest.required}
+      required={required}
       styles={{
         bodyStyle: css`
           align-items: center;
@@ -551,8 +554,9 @@ function Chips({
       }}
     >
       <BaseChips
-        {...rest}
+        {...props}
         id={inputId}
+        name={name}
         styles={baseChipStyles}
         disabled={disabled}
       />
@@ -563,38 +567,13 @@ function Chips({
 const Divider = styled.div<{
   $theme?: ChipsThemeConfig;
 }>`
-  width: 100%;
+  position: absolute;
+  top: 0;
+  width: calc(100%);
+  transform: translateX(-8%);
   height: 1px;
 
   border-bottom: 1px solid ${({ $theme }) => $theme?.dividerColor};
-`;
-
-const ChipsDrawerWrapper = styled.ul<{
-  $style?: CSSProp;
-  $theme?: ChipsThemeConfig;
-}>`
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-
-  background-color: ${({ $theme }) => $theme.backgroundColor};
-  border: 1px solid ${({ $theme }) => $theme.borderColor};
-  color: ${({ $theme }) => $theme.textColor};
-
-  font-size: 0.875rem;
-  border-radius: 2px;
-  width: fit-content;
-  max-width: 240px;
-
-  box-shadow: ${({ $theme }) => $theme.boxShadow};
-
-  list-style: none;
-  outline: none;
-  z-index: 9992999;
-
-  ${({ $style }) => $style}
 `;
 
 const EmptyOptionContainer = styled.div<{
@@ -614,137 +593,18 @@ const EmptyOptionContainer = styled.div<{
 
   width: 100%;
   border-radius: 2px;
+  cursor: pointer;
 
-  ${({ $hovered, $theme }) =>
-    $hovered &&
+  ${({ $hovered, $theme }) => css`
+    &:hover {
+      background-color: ${$theme.hoverBackgroundColor};
+    }
+
+    ${$hovered &&
     css`
-      cursor: pointer;
       background-color: ${$theme.hoverBackgroundColor};
     `}
+  `}
 `;
-
-function ChipsItem({
-  chip,
-  isClicked,
-  hovered,
-  setHovered,
-  onOptionClicked,
-  chipContainerStyle,
-  chipStyle,
-  inputRef,
-}: {
-  chip: ChipProps;
-  isClicked: boolean;
-  hovered: string | null;
-  setHovered: (number: string) => void;
-  onOptionClicked?: (badge: ChipProps) => void;
-  chipStyle?: CSSProp;
-  chipContainerStyle?: CSSProp;
-  inputRef?: RefObject<HTMLInputElement>;
-}) {
-  const { currentTheme } = useTheme();
-  const chipsTheme = currentTheme.chips;
-
-  const finalValueActions =
-    chip.actions
-      ?.filter((action) => !action?.hidden)
-      .map((action) => ({
-        ...action,
-        styles: {
-          self: css`
-            opacity: 0;
-            ${hovered === chip.id &&
-            css`
-              opacity: 1;
-            `}
-          `,
-        },
-        size: 14,
-        onClick: () => action.onClick && action.onClick?.(chip),
-      })) ?? [];
-
-  return (
-    <ChipItemWrapper
-      $hovered={hovered === chip.id}
-      $style={chipContainerStyle}
-      onMouseDown={async (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        await onOptionClicked?.(chip);
-      }}
-      $theme={chipsTheme}
-      onMouseEnter={() => setHovered(chip.id)}
-    >
-      <Checkbox
-        checked={isClicked}
-        styles={{
-          boxStyle: css`
-            width: 14px;
-            height: 14px;
-          `,
-          self: css`
-            width: 14px;
-            height: 14px;
-          `,
-          containerStyle: css`
-            margin-bottom: 1px;
-            width: fit-content;
-          `,
-          iconStyle: css`
-            min-width: 9px;
-            min-height: 9px;
-          `,
-        }}
-        readOnly
-      />
-      <Badge
-        {...chip}
-        styles={{
-          self: css`
-            cursor: pointer;
-            ${finalValueActions &&
-            css`
-              padding-right: 0px;
-            `}
-
-            ${chipStyle}
-          `,
-        }}
-        actions={finalValueActions}
-        withCircle
-      />
-    </ChipItemWrapper>
-  );
-}
-
-const ChipItemWrapper = styled.div<{
-  $hovered: boolean;
-  $style?: CSSProp;
-  $theme: ChipsThemeConfig;
-}>`
-  display: flex;
-  flex-direction: row;
-  padding: 4px 12px;
-  gap: 2px;
-  align-items: center;
-  justify-content: space-between;
-  cursor: pointer;
-  position: relative;
-
-  ${({ $hovered, $theme }) =>
-    $hovered &&
-    css`
-      background-color: ${$theme?.selectedBackgroundColor};
-
-      [aria-label="badge-action"] {
-        opacity: 1;
-        transition: opacity 0.2s;
-      }
-    `}
-
-  ${({ $style }) => $style}
-`;
-
-Chips.Item = ChipsItem;
 
 export { Chips };

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -380,8 +380,11 @@ function BaseChips({
               align-items: center;
             `,
             rowContainerStyle: css`
-              padding: 0px 12px;
-              min-height: 32px;
+              ${!mobile &&
+              css`
+                padding: 0px 12px;
+                min-height: 32px;
+              `}
             `,
             drawerStyle: css`
               ${!mobile &&

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -59,9 +59,9 @@ interface BaseChipsProps {
 
 export interface BaseChipsStyles {
   chipsContainerStyle?: CSSProp;
-  chipContainerStyle?: CSSProp;
   chipSelectedStyle?: CSSProp;
-  chipStyle?: CSSProp;
+  chipOptionWrapperStyle?: CSSProp;
+  chipOptionStyle?: CSSProp;
   chipsDrawerStyle?: CSSProp;
 }
 
@@ -124,36 +124,6 @@ function BaseChips({
     placement: "bottom-start",
   });
 
-  // Keep the highlighted option visible while navigating the list.
-  useEffect(() => {
-    if (
-      listRef.current[highlightedIndex] &&
-      !mobile &&
-      mode === "idle" &&
-      interactionMode === "keyboard"
-    ) {
-      const element = listRef.current[highlightedIndex];
-      const container = refs.floating.current;
-
-      if (element && container) {
-        const searchboxHeight = 34;
-        const elementTop = element.offsetTop;
-        const containerScrollTop = container.scrollTop;
-        const containerHeight = container.clientHeight;
-
-        if (elementTop < containerScrollTop + searchboxHeight) {
-          container.scrollTop = elementTop - searchboxHeight;
-        } else if (
-          elementTop + element.clientHeight >
-          containerScrollTop + containerHeight
-        ) {
-          container.scrollTop =
-            elementTop + element.clientHeight - containerHeight;
-        }
-      }
-    }
-  }, [highlightedIndex, mobile, mode, interactionMode, refs.floating]);
-
   const click = useClick(context);
   const dismiss = useDismiss(context);
   const role = useRole(context);
@@ -206,18 +176,20 @@ function BaseChips({
 
             <Badge
               {...badge}
+              aria-label="chips-option"
               onMouseDown={(e) => e.preventDefault()}
               styles={{
                 self: css`
                   cursor: pointer;
                   width: 100%;
                   background-color: transparent;
+                  border-color: transparent;
                   ${mobile &&
                   css`
                     font-size: 18px;
                   `};
 
-                  ${styles?.chipStyle}
+                  ${styles?.chipOptionStyle}
                 `,
               }}
               withCircle
@@ -226,7 +198,7 @@ function BaseChips({
         ),
       };
     });
-  }, [sortedOptions, selectedOptions, styles?.chipStyle, chipsTheme]);
+  }, [sortedOptions, selectedOptions, styles?.chipOptionStyle, chipsTheme]);
 
   const FILTERED_OPTIONS: ComboboxOption[] = useMemo(() => {
     if (!hasInteracted || !inputValue) return FINAL_OPTIONS;
@@ -303,7 +275,7 @@ function BaseChips({
     <>
       <InputGroup
         id={id}
-        aria-label="chip-input"
+        aria-label="chips-container-input"
         $disabled={disabled}
         $containerStyle={styles?.chipsContainerStyle}
       >
@@ -320,6 +292,7 @@ function BaseChips({
               onClick={(e) => {
                 e.stopPropagation();
               }}
+              aria-label="chip-selected"
               variant={badge.variant}
               backgroundColor={badge.backgroundColor}
               circleColor={badge.circleColor}
@@ -342,7 +315,11 @@ function BaseChips({
           ref={refs.setReference}
           role="button"
           $isOpen={isOpen}
-          {...getReferenceProps()}
+          {...getReferenceProps({
+            onClick: (e) => {
+              e.preventDefault();
+            },
+          })}
         />
       </InputGroup>
 
@@ -379,13 +356,21 @@ function BaseChips({
             rowStyle: css`
               justify-content: center;
               align-items: center;
+              ${mobile
+                ? css`
+                    padding: 6px 15px;
+                    gap: 14px;
+                  `
+                : css`
+                    padding: 0px 12px;
+                    min-height: 32px;
+                    gap: 4px;
+                  `};
+              ${styles?.chipOptionWrapperStyle}
             `,
             rowContainerStyle: css`
-              ${!mobile &&
-              css`
-                padding: 0px 12px;
-                min-height: 32px;
-              `}
+              min-height: 0px;
+              padding: 0px;
             `,
             drawerStyle: css`
               ${!mobile &&

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -130,6 +130,36 @@ function BaseChips({
     placement: "bottom-start",
   });
 
+  // Keep the highlighted option visible while navigating the list.
+  useEffect(() => {
+    if (
+      listRef.current[highlightedIndex] &&
+      !mobile &&
+      mode === "idle" &&
+      interactionMode === "keyboard"
+    ) {
+      const element = listRef.current[highlightedIndex];
+      const container = refs.floating.current;
+
+      if (element && container) {
+        const searchboxHeight = 34;
+        const elementTop = element.offsetTop;
+        const containerScrollTop = container.scrollTop;
+        const containerHeight = container.clientHeight;
+
+        if (elementTop < containerScrollTop + searchboxHeight) {
+          container.scrollTop = elementTop - searchboxHeight;
+        } else if (
+          elementTop + element.clientHeight >
+          containerScrollTop + containerHeight
+        ) {
+          container.scrollTop =
+            elementTop + element.clientHeight - containerHeight;
+        }
+      }
+    }
+  }, [highlightedIndex, mobile, mode, interactionMode, refs.floating]);
+
   const click = useClick(context);
   const dismiss = useDismiss(context);
   const role = useRole(context);
@@ -232,6 +262,42 @@ function BaseChips({
     }
   }, [isOpen]);
 
+  const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) return;
+
+    setInteractionMode("keyboard");
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!isOpen) await setIsOpen(true);
+      await setHighlightedIndex((prev) =>
+        Math.min(prev + 1, FILTERED_OPTIONS.length - 1)
+      );
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!isOpen) await setIsOpen(true);
+      await setHighlightedIndex((prev) => Math.max(prev - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const selectedOption = FILTERED_OPTIONS[highlightedIndex];
+      if (!selectedOption) return;
+
+      const optionId = String(selectedOption.value);
+      const isSelected = selectedOptions?.some((id) => id === optionId);
+
+      const finalSelectedOptions = isSelected
+        ? selectedOptions?.filter((id) => id !== optionId)
+        : [...(selectedOptions ?? []), optionId];
+
+      if (onChange) {
+        onChange(finalSelectedOptions);
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      await setIsOpen(false);
+    }
+  };
+
   const finalDrawerHeight = mobile
     ? (drawerHeight ?? "320px")
     : (drawerHeight ?? "220px");
@@ -285,6 +351,7 @@ function BaseChips({
 
       {isOpen && (
         <Combobox.Drawer
+          handleKeyDown={handleKeyDown}
           emptySlate={emptySlate}
           isOpen={isOpen}
           setIsOpen={setIsOpen}
@@ -366,6 +433,7 @@ function BaseChips({
               {!mobile && (
                 <>
                   <Textbox
+                    onKeyDown={handleKeyDown}
                     ref={inputRef}
                     name={name}
                     type="text"

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -335,6 +335,7 @@ function BaseChips({
               `}
             `,
           }}
+          fadeEffect={hasNoFilter ? [] : ["bottom"]}
           onChange={async (selectedOptions?: SelectboxSelectedOptions) => {
             if (!Array.isArray(selectedOptions)) return;
             onChange?.(selectedOptions as string[]);

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -1,14 +1,10 @@
 import { RiAddLine } from "@remixicon/react";
 import { Badge, BadgeAction, BadgeProps } from "./badge";
-import { Checkbox } from "./checkbox";
 import {
   ChangeEvent,
-  CSSProperties,
   Fragment,
-  KeyboardEvent,
   ReactNode,
   Ref,
-  RefObject,
   useEffect,
   useMemo,
   useRef,
@@ -24,7 +20,6 @@ import {
   useInteractions,
   useRole,
 } from "@floating-ui/react";
-import { Textbox } from "./textbox";
 import styled, { css, CSSProp } from "styled-components";
 import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
@@ -33,7 +28,6 @@ import { ChipsThemeConfig } from "./../theme";
 import { applyClassName } from "./../constants/classname";
 import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox";
 import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox";
-import { props } from "cypress/types/bluebird";
 
 export type ChipAction = BadgeAction;
 
@@ -217,15 +211,10 @@ function BaseChips({
                 self: css`
                   cursor: pointer;
                   width: 100%;
-                  ${mobile
-                    ? css`
-                        margin-top: 2px;
-
-                        font-size: 18px;
-                      `
-                    : css`
-                        margin-top: 2px;
-                      `}
+                  ${mobile &&
+                  css`
+                    font-size: 18px;
+                  `};
 
                   ${styles?.chipStyle}
                 `,
@@ -279,18 +268,23 @@ function BaseChips({
       await setHighlightedIndex((prev) => Math.max(prev - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      const selectedOption = FILTERED_OPTIONS[highlightedIndex];
-      if (!selectedOption) return;
+      if (hasNoFilter) {
+        await setMode("create");
+        await inputMissingRef?.current?.focus();
+      } else {
+        const selectedOption = FILTERED_OPTIONS[highlightedIndex];
+        if (!selectedOption) return;
 
-      const optionId = String(selectedOption.value);
-      const isSelected = selectedOptions?.some((id) => id === optionId);
+        const optionId = String(selectedOption.value);
+        const isSelected = selectedOptions?.some((id) => id === optionId);
 
-      const finalSelectedOptions = isSelected
-        ? selectedOptions?.filter((id) => id !== optionId)
-        : [...(selectedOptions ?? []), optionId];
+        const finalSelectedOptions = isSelected
+          ? selectedOptions?.filter((id) => id !== optionId)
+          : [...(selectedOptions ?? []), optionId];
 
-      if (onChange) {
-        onChange(finalSelectedOptions);
+        if (onChange) {
+          onChange(finalSelectedOptions);
+        }
       }
     } else if (e.key === "Escape") {
       e.preventDefault();
@@ -301,6 +295,8 @@ function BaseChips({
   const finalDrawerHeight = mobile
     ? (drawerHeight ?? "320px")
     : (drawerHeight ?? "220px");
+
+  const hasFewOptions = FILTERED_OPTIONS?.length < 5;
 
   return (
     <>
@@ -355,7 +351,24 @@ function BaseChips({
           emptySlate={emptySlate}
           isOpen={isOpen}
           setIsOpen={setIsOpen}
-          withSearchbox={mobile && mode === "idle"}
+          checkbox={{
+            styles: {
+              containerStyle: css`
+                ${mobile
+                  ? css`
+                      margin-top: 10px;
+                    `
+                  : css`
+                      margin-top: 5px;
+                    `}
+              `,
+            },
+          }}
+          searchbox={
+            mode === "idle" && {
+              placeholder: filterPlaceholder,
+            }
+          }
           refs={refs as unknown as ComboboxDrawerProps["refs"]}
           highlightedIndex={highlightedIndex}
           setHighlightedIndex={setHighlightedIndex}
@@ -382,11 +395,11 @@ function BaseChips({
                 max-height: ${finalDrawerHeight};
               `};
 
-              ${FILTERED_OPTIONS?.length < 5 && mobile
+              ${hasFewOptions && mobile
                 ? css`
                     min-height: 80px;
                   `
-                : FILTERED_OPTIONS?.length < 5 &&
+                : hasFewOptions &&
                   !mobile &&
                   css`
                     min-height: fit-content;
@@ -406,7 +419,7 @@ function BaseChips({
               ${styles?.chipsDrawerStyle};
             `,
           }}
-          fadeEffect={hasNoFilter ? [] : ["bottom"]}
+          fadeEffect={hasFewOptions ? [] : ["bottom"]}
           onChange={async (selectedOptions?: SelectboxSelectedOptions) => {
             if (!Array.isArray(selectedOptions)) return;
             onChange?.(selectedOptions as string[]);
@@ -428,72 +441,30 @@ function BaseChips({
           listRef={listRef}
           inputRef={inputRef}
         >
-          {mode === "idle" && (
-            <>
-              {!mobile && (
-                <>
-                  <Textbox
-                    onKeyDown={handleKeyDown}
-                    ref={inputRef}
-                    name={name}
-                    type="text"
-                    aria-label="chip-input-box"
-                    placeholder={filterPlaceholder}
-                    value={inputValue}
-                    styles={{
-                      containerStyle: css`
-                        position: sticky;
-                        top: 0px;
-                        z-index: 99993999;
-                      `,
-                      self: css`
-                        border: none;
-                        min-height: 34px;
-                        border-radius: 0;
-                        border-width: 2px;
-                        &:focus {
-                          border-color: ${textboxTheme?.borderColor};
-                          box-shadow: 0 0 0 0.5px ${textboxTheme?.borderColor};
-                        }
-                      `,
-                    }}
-                    autoComplete="off"
-                    onChange={(e) => {
-                      setHasInteracted?.(true);
-                      setInputValue(e);
-                      setHighlightedIndex(0);
-                      setInteractionMode("keyboard");
-                    }}
-                  />
-                </>
-              )}
-
-              {hasNoFilter && creatable && (
-                <EmptyOptionContainer
-                  onClick={async () => {
-                    await setMode("create");
-                    await inputMissingRef?.current?.focus();
-                  }}
-                  $hovered={highlightedIndex === 0}
-                  $theme={chipsTheme}
-                >
-                  <RiAddLine size={14} style={{ minWidth: "14px" }} />
-                  <span
-                    style={{
-                      fontWeight: 500,
-                      whiteSpace: "nowrap",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                    }}
-                  >
-                    {missingOptionLabel}&nbsp;
-                    <span style={{ color: chipsTheme?.mutedTextColor }}>
-                      "{inputValue}"
-                    </span>
-                  </span>
-                </EmptyOptionContainer>
-              )}
-            </>
+          {mode === "idle" && hasNoFilter && creatable && (
+            <EmptyOptionContainer
+              onClick={async () => {
+                await setMode("create");
+                await inputMissingRef?.current?.focus();
+              }}
+              $hovered={highlightedIndex === 0}
+              $theme={chipsTheme}
+            >
+              <RiAddLine size={14} style={{ minWidth: "14px" }} />
+              <span
+                style={{
+                  fontWeight: 500,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {missingOptionLabel}&nbsp;
+                <span style={{ color: chipsTheme?.mutedTextColor }}>
+                  "{inputValue}"
+                </span>
+              </span>
+            </EmptyOptionContainer>
           )}
           {mode === "create" && (
             <>

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -49,7 +49,7 @@ interface BaseChipsProps {
   missingOptionLabel?: string;
   creatable?: boolean;
   selectedOptions?: string[];
-  onOptionClicked?: (badgeIds: string[]) => void;
+  onChange?: (selectedOptions: string[]) => void;
   missingOptionForm?:
     | ReactNode
     | ((props?: MissingOptionFormProps) => ReactNode);
@@ -94,7 +94,7 @@ function BaseChips({
   id,
   missingOptionForm,
   name = "search",
-  onOptionClicked,
+  onChange,
   options = [],
   renderer,
   selectedOptions = [],
@@ -337,7 +337,7 @@ function BaseChips({
           }}
           onChange={async (selectedOptions?: SelectboxSelectedOptions) => {
             if (!Array.isArray(selectedOptions)) return;
-            onOptionClicked?.(selectedOptions as string[]);
+            onChange?.(selectedOptions as string[]);
           }}
           setSelectedOptionsLocal={(selectedOptionsLocal?: SelectboxOption) => {
             setInputValue?.({

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -354,13 +354,7 @@ function BaseChips({
           checkbox={{
             styles: {
               containerStyle: css`
-                ${mobile
-                  ? css`
-                      margin-top: 10px;
-                    `
-                  : css`
-                      margin-top: 5px;
-                    `}
+                margin: 0px;
               `,
             },
           }}
@@ -381,6 +375,14 @@ function BaseChips({
             value: "",
           }}
           styles={{
+            rowStyle: css`
+              justify-content: center;
+              align-items: center;
+            `,
+            rowContainerStyle: css`
+              padding: 0px 12px;
+              min-height: 32px;
+            `,
             drawerStyle: css`
               ${!mobile &&
               css`

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -53,7 +53,7 @@ interface BaseChipsProps {
   missingOptionForm?:
     | ReactNode
     | ((props?: MissingOptionFormProps) => ReactNode);
-  emptySlate?: ReactNode;
+  emptySlate?: string;
   renderer?: (props: ChipRendererProps) => ReactNode;
   styles?: BaseChipsStyles;
   name?: string;

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -68,9 +68,7 @@ export interface BaseChipsStyles {
   chipContainerStyle?: CSSProp;
   chipSelectedStyle?: CSSProp;
   chipStyle?: CSSProp;
-  labelStyle?: CSSProp;
   chipsDrawerStyle?: CSSProp;
-  containerStyle?: CSSProp;
 }
 
 export interface ChipRendererProps {
@@ -105,6 +103,7 @@ function BaseChips({
 }: BaseChipsProps) {
   const { currentTheme } = useTheme();
   const chipsTheme = currentTheme.chips;
+  const textboxTheme = currentTheme.textbox;
 
   const inputRef = useRef<HTMLInputElement>(null);
   const inputMissingRef = useRef<HTMLInputElement>(null);
@@ -175,7 +174,10 @@ function BaseChips({
                   selectedOption === sortedOptions[index - 1].id
               ) &&
               !isSelected && (
-                <Divider $theme={chipsTheme} aria-label="divider" />
+                <Divider
+                  $theme={chipsTheme}
+                  aria-label="chips-option-divider"
+                />
               )}
 
             <Badge
@@ -333,6 +335,8 @@ function BaseChips({
               css`
                 min-width: 240px;
               `}
+
+              ${styles?.chipsDrawerStyle};
             `,
           }}
           fadeEffect={hasNoFilter ? [] : ["bottom"]}
@@ -371,7 +375,7 @@ function BaseChips({
                     styles={{
                       containerStyle: css`
                         position: sticky;
-                        top: 1px;
+                        top: 0px;
                         z-index: 99993999;
                       `,
                       self: css`
@@ -379,6 +383,10 @@ function BaseChips({
                         min-height: 34px;
                         border-radius: 0;
                         border-width: 2px;
+                        &:focus {
+                          border-color: ${textboxTheme?.borderColor};
+                          box-shadow: 0 0 0 0.5px ${textboxTheme?.borderColor};
+                        }
                       `,
                     }}
                     autoComplete="off"
@@ -389,7 +397,6 @@ function BaseChips({
                       setInteractionMode("keyboard");
                     }}
                   />
-                  <Divider $theme={chipsTheme} aria-label="divider" />
                 </>
               )}
 
@@ -571,8 +578,9 @@ const Divider = styled.div<{
   position: absolute;
   top: 0;
   width: calc(100%);
-  transform: translateX(-8%);
   height: 1px;
+  left: 50%;
+  transform: translateX(-50%);
 
   border-bottom: 1px solid ${({ $theme }) => $theme?.dividerColor};
 `;

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -118,7 +118,16 @@ export type ComboboxDrawerProps = Omit<DrawerProps, "refs"> &
     children?: ReactNode;
     navigableOptions?: SelectboxOption[];
     withSearchbox?: boolean;
+    fadeEffect?: ComboboxDrawerFadeEffect[];
   };
+
+export const ComboboxDrawerFadeEffect = {
+  Top: "top",
+  Bottom: "bottom",
+} as const;
+
+export type ComboboxDrawerFadeEffect =
+  (typeof ComboboxDrawerFadeEffect)[keyof typeof ComboboxDrawerFadeEffect];
 
 export interface ComboboxProps
   extends BaseComboboxProps,
@@ -410,6 +419,7 @@ function ComboboxDrawer({
   drawerHeight,
   withSearchbox,
   children,
+  fadeEffect,
 }: ComboboxDrawerProps) {
   const { mode, currentTheme } = useTheme();
   const comboboxTheme = currentTheme?.combobox;
@@ -1114,24 +1124,29 @@ function ComboboxDrawer({
   );
 
   if (mobile) {
+    const finalFadeEffect =
+      fadeEffect ?? (withSearchbox ? ["bottom"] : ["top", "bottom"]);
+
     return createPortal(
       <DrawerContainer
         aria-label="combobox-drawer-mobile"
         $theme={comboboxTheme}
         $mobile={mobile}
       >
-        {!withSearchbox && (
+        {finalFadeEffect?.includes("top") && (
           <FadeTop
             aria-label="combobox-fade-top"
             $theme={comboboxTheme}
             $visible={showFadeTop}
           />
         )}
-        <FadeBottom
-          aria-label="combobox-fade-bottom"
-          $theme={comboboxTheme}
-          $visible={showFadeBottom}
-        />
+        {finalFadeEffect?.includes("bottom") && (
+          <FadeBottom
+            aria-label="combobox-fade-bottom"
+            $theme={comboboxTheme}
+            $visible={showFadeBottom}
+          />
+        )}
         {mainCombobox}
       </DrawerContainer>,
       document.body

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -55,12 +55,10 @@ interface BaseComboboxProps {
   onClick?: () => void;
   strict?: boolean;
   options: ComboboxOption[];
-  navigableOptions?: SelectboxOption[];
   isLoading?: boolean;
   labels?: ComboboxLabelsProps;
   mobile?: boolean;
   drawerHeight?: string;
-  withSearchbox?: boolean;
 }
 
 export const ComboboxGroupInitialState = {
@@ -109,7 +107,7 @@ export type ComboboxDrawerProps = Omit<DrawerProps, "refs"> &
     setSelectedOptionsLocal: (value: SelectboxOption) => void;
     setHasInteracted?: (value: boolean) => void;
     setConfirmedValue?: (option: SelectboxOption | null) => void;
-    openedCategoryGroup?: Set<String>;
+    openedCategoryGroup?: Set<string>;
     setOpenedCategoryGroup?: (
       updater: (prev: Set<string>) => Set<string>
     ) => void;
@@ -117,6 +115,9 @@ export type ComboboxDrawerProps = Omit<DrawerProps, "refs"> &
       setFloating?: Ref<HTMLUListElement>;
       reference?: Ref<HTMLElement> & { current?: HTMLElement | null };
     };
+    children?: ReactNode;
+    navigableOptions?: SelectboxOption[];
+    withSearchbox?: boolean;
   };
 
 export interface ComboboxProps
@@ -408,6 +409,7 @@ function ComboboxDrawer({
   mobile,
   drawerHeight,
   withSearchbox,
+  children,
 }: ComboboxDrawerProps) {
   const { mode, currentTheme } = useTheme();
   const comboboxTheme = currentTheme?.combobox;
@@ -852,15 +854,7 @@ function ComboboxDrawer({
 
   const mainCombobox = (
     <DrawerWrapper
-      {...getFloatingProps({
-        onMouseDown: (e: React.MouseEvent) => {
-          e.preventDefault();
-        },
-        onClick: (e: React.MouseEvent) => {
-          e.preventDefault();
-          e.stopPropagation(); // handles touch-generated click on mobile
-        },
-      })}
+      {...getFloatingProps()}
       ref={(node) => {
         if (typeof refs?.setFloating === "function") {
           refs?.setFloating(node);
@@ -879,66 +873,69 @@ function ComboboxDrawer({
       $style={styles?.drawerStyle}
       $withSearchbox={withSearchbox}
     >
-      {(finalOptions || actions) && (
-        <>
-          {withSearchbox && (
-            <Searchbox
-              onKeyDown={handleKeyDown}
-              onChange={(e) => {
-                const { value } = e.target;
-                setHasInteracted(true);
-                setHighlightedIndex(0);
-                setSelectedOptionsLocal({
-                  ...selectedOptionsLocal,
-                  text: value,
-                });
-              }}
-              ref={inputRef}
-              value={selectedOptionsLocal.text}
-              styles={{
-                containerStyle: css`
-                  position: sticky;
-                  background-color: ${mobile
-                    ? comboboxTheme?.mobileBackgroundColor
-                    : comboboxTheme?.backgroundColor};
-                  z-index: 10000;
-                  height: 38px;
-                  top: 0;
-                  ${mobile &&
-                  !withSearchbox &&
-                  css`
-                    transform: translateY(-90px);
-                  `};
-                  ${mobile &&
-                  css`
-                    max-height: 46px;
-                    height: 46px;
-                  `}
-                `,
-                iconStyle: css`
-                  left: 16px;
-                `,
-                self: css`
-                  max-height: 35px;
-                  margin-top: 7px;
-                  margin-bottom: 7px;
-                  padding-bottom: 7px;
-                  padding-top: 7px;
-                  margin-left: 4px;
-                  margin-right: 4px;
-                  background-color: ${mobile
-                    ? comboboxTheme?.mobileBackgroundColor
-                    : comboboxTheme?.backgroundColor};
-                  &:focus {
-                    background-color: ${mobile
-                      ? comboboxTheme?.mobileBackgroundColor
-                      : comboboxTheme?.backgroundColor};
-                  }
-                `,
-              }}
-            />
-          )}
+      {withSearchbox && (
+        <Searchbox
+          onKeyDown={handleKeyDown}
+          onChange={(e) => {
+            const { value } = e.target;
+            setHasInteracted(true);
+            setHighlightedIndex(0);
+            setSelectedOptionsLocal({
+              ...selectedOptionsLocal,
+              text: value,
+            });
+          }}
+          autoComplete="off"
+          ref={inputRef}
+          value={selectedOptionsLocal.text}
+          styles={{
+            containerStyle: css`
+              position: sticky;
+              background-color: ${mobile
+                ? comboboxTheme?.mobileBackgroundColor
+                : comboboxTheme?.backgroundColor};
+              z-index: 10000;
+              height: 38px;
+              top: 0;
+              ${mobile &&
+              !withSearchbox &&
+              css`
+                transform: translateY(-90px);
+              `};
+              ${mobile &&
+              css`
+                max-height: 46px;
+                height: 46px;
+              `}
+            `,
+            iconStyle: css`
+              left: 16px;
+            `,
+            self: css`
+              max-height: 35px;
+              margin-top: 7px;
+              margin-bottom: 7px;
+              padding-bottom: 7px;
+              padding-top: 7px;
+              margin-left: 4px;
+              margin-right: 4px;
+              background-color: ${mobile
+                ? comboboxTheme?.mobileBackgroundColor
+                : comboboxTheme?.backgroundColor};
+              &:focus {
+                background-color: ${mobile
+                  ? comboboxTheme?.mobileBackgroundColor
+                  : comboboxTheme?.backgroundColor};
+              }
+            `,
+          }}
+        />
+      )}
 
+      {children}
+
+      {(finalOptions || actions || children) && (
+        <>
           <TreeList
             ref={({ el, item }) => {
               const index = flatIndexMap[item.id];

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -33,8 +33,8 @@ import {
   TreeListItem,
   TreeListItemAction,
 } from "./treelist";
-import { Searchbox } from "./searchbox";
-import { Checkbox } from "./checkbox";
+import { Searchbox, SearchboxProps } from "./searchbox";
+import { Checkbox, CheckboxProps } from "./checkbox";
 import { createPortal } from "react-dom";
 
 interface BaseComboboxProps {
@@ -117,8 +117,9 @@ export type ComboboxDrawerProps = Omit<DrawerProps, "refs"> &
     };
     children?: ReactNode;
     navigableOptions?: SelectboxOption[];
-    withSearchbox?: boolean;
     fadeEffect?: ComboboxDrawerFadeEffect[];
+    searchbox?: SearchboxProps | boolean;
+    checkbox?: CheckboxProps | boolean;
   };
 
 export const ComboboxDrawerFadeEffect = {
@@ -360,7 +361,6 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
               inputRef={props.ref}
               name={name}
               disabled={disabled}
-              withSearchbox={multiple}
               selectedOptions={selectedOptions}
               onChange={onChange}
               highlightOnMatch={highlightOnMatch}
@@ -370,6 +370,8 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
               options={filteredForDrawer}
               drawerHeight={drawerHeight}
               maxSelectableItems={maxSelectableItems}
+              searchbox={multiple}
+              checkbox={multiple}
               multiple={multiple}
               openedCategoryGroup={openedCategoryGroup}
               setOpenedCategoryGroup={setOpenedCategoryGroup}
@@ -417,8 +419,9 @@ function ComboboxDrawer({
   navigableOptions,
   mobile,
   drawerHeight,
-  withSearchbox,
+  searchbox,
   children,
+  checkbox,
   fadeEffect,
 }: ComboboxDrawerProps) {
   const { mode, currentTheme } = useTheme();
@@ -505,7 +508,7 @@ function ComboboxDrawer({
     if (
       highlightedIndex !== null &&
       listRef.current[highlightedIndex] &&
-      withSearchbox &&
+      searchbox &&
       interactionMode === "keyboard"
     ) {
       const element = listRef.current[highlightedIndex];
@@ -528,7 +531,7 @@ function ComboboxDrawer({
         }
       }
     }
-  }, [highlightedIndex, withSearchbox, interactionMode]);
+  }, [highlightedIndex, searchbox, interactionMode]);
 
   const filteredActions: TreeListAction[] = Array.isArray(actions)
     ? actions
@@ -555,7 +558,7 @@ function ComboboxDrawer({
               self: css`
                 ${rowStyle({
                   interactionMode,
-                  multiple: withSearchbox,
+                  multiple: !!searchbox,
                   theme: comboboxTheme,
                   mobile: !!mobile,
                   hasNestedOptions,
@@ -581,6 +584,8 @@ function ComboboxDrawer({
     return map;
   }, [navigableOptions, filteredActions.length]);
 
+  const checkboxProps = typeof checkbox === "object" && checkbox;
+
   const generateContent = (): TreeListContent[] => {
     optionByTreeId.current = {};
 
@@ -605,15 +610,20 @@ function ComboboxDrawer({
 
       return (
         <>
-          {multiple && (
+          {checkbox && (
             <Checkbox
+              type="checkbox"
+              checked={isSelected}
+              onChange={() => {}}
+              {...checkboxProps}
               styles={{
+                ...checkboxProps?.styles,
                 containerStyle: css`
                   margin-top: 2px;
                   ${mobile &&
                   css`
                     margin-top: 7px;
-                  `}
+                  `};
 
                   ${mobile && opt?.render
                     ? css`
@@ -622,7 +632,9 @@ function ComboboxDrawer({
                     : opt?.render &&
                       css`
                         margin-top: 7px;
-                      `}
+                      `};
+
+                  ${checkboxProps?.styles?.containerStyle}
                 `,
                 iconStyle: css`
                   ${mobile
@@ -633,7 +645,9 @@ function ComboboxDrawer({
                     : css`
                         width: 8px;
                         height: 8px;
-                      `}
+                      `};
+
+                  ${checkboxProps?.styles?.iconStyle};
                 `,
                 self: css`
                   ${mobile
@@ -644,12 +658,11 @@ function ComboboxDrawer({
                     : css`
                         width: 14px;
                         height: 14px;
-                      `}
+                      `};
+
+                  ${checkboxProps?.styles?.self};
                 `,
               }}
-              type="checkbox"
-              checked={isSelected}
-              onChange={() => {}}
             />
           )}
           {label}
@@ -862,6 +875,8 @@ function ComboboxDrawer({
     return () => container.removeEventListener("scroll", updateFade);
   }, [selectedIndex, finalOptions.length]);
 
+  const searchboxProps = typeof searchbox === "object" && searchbox;
+
   const mainCombobox = (
     <DrawerWrapper
       {...getFloatingProps()}
@@ -881,9 +896,9 @@ function ComboboxDrawer({
       $width={refs?.reference?.current?.getBoundingClientRect().width}
       $mobile={mobile}
       $style={styles?.drawerStyle}
-      $withSearchbox={withSearchbox}
+      $searchbox={!!searchbox}
     >
-      {withSearchbox && (
+      {searchbox && (
         <Searchbox
           onKeyDown={handleKeyDown}
           onChange={(e) => {
@@ -898,7 +913,9 @@ function ComboboxDrawer({
           autoComplete="off"
           ref={inputRef}
           value={selectedOptionsLocal.text}
+          {...searchboxProps}
           styles={{
+            ...searchboxProps?.styles,
             containerStyle: css`
               position: sticky;
               background-color: ${mobile
@@ -908,7 +925,7 @@ function ComboboxDrawer({
               height: 38px;
               top: 0;
               ${mobile &&
-              !withSearchbox &&
+              !searchbox &&
               css`
                 transform: translateY(-90px);
               `};
@@ -916,10 +933,12 @@ function ComboboxDrawer({
               css`
                 max-height: 46px;
                 height: 46px;
-              `}
+              `};
+              ${searchboxProps?.styles?.containerStyle};
             `,
             iconStyle: css`
               left: 16px;
+              ${searchboxProps?.styles?.iconStyle};
             `,
             self: css`
               max-height: 35px;
@@ -937,6 +956,8 @@ function ComboboxDrawer({
                   ? comboboxTheme?.mobileBackgroundColor
                   : comboboxTheme?.backgroundColor};
               }
+
+              ${searchboxProps?.styles?.self};
             `,
           }}
         />
@@ -1125,7 +1146,7 @@ function ComboboxDrawer({
 
   if (mobile) {
     const finalFadeEffect =
-      fadeEffect ?? (withSearchbox ? ["bottom"] : ["top", "bottom"]);
+      fadeEffect ?? (searchbox ? ["bottom"] : ["top", "bottom"]);
 
     return createPortal(
       <DrawerContainer
@@ -1182,7 +1203,7 @@ const DrawerWrapper = styled.ul<{
   $theme: ComboboxThemeConfig;
   $style?: CSSProp;
   $mobile?: boolean;
-  $withSearchbox?: boolean;
+  $searchbox?: boolean;
   $hasNestedOptions?: boolean;
   $drawerHeight?: string;
 }>`
@@ -1223,7 +1244,7 @@ const DrawerWrapper = styled.ul<{
     border-radius: 4px;
   }
 
-  ${({ $mobile, $theme, $withSearchbox, $hasNestedOptions, $drawerHeight }) => {
+  ${({ $mobile, $theme, $searchbox, $hasNestedOptions, $drawerHeight }) => {
     const $height = $drawerHeight ?? "220px";
 
     return css`
@@ -1238,7 +1259,7 @@ const DrawerWrapper = styled.ul<{
         min-height: ${$height};
         max-height: ${$height};
         border-width: 0.5;
-        ${!$withSearchbox &&
+        ${!$searchbox &&
         css`
           padding: calc(${$height} * 0.4545) 0;
         `}

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -91,10 +91,10 @@ export type ComboboxDropdownOption = FieldLaneDropdownOption;
 export interface ComboboxLabelsProps extends SelectboxLabels {}
 
 export interface ComboboxStyles extends Omit<SelectboxStyles, "self"> {
-  containerStyle?: CSSProp;
   selectboxStyle?: CSSProp;
-  labelStyle?: CSSProp;
   drawerStyle?: CSSProp;
+  rowStyle?: CSSProp;
+  rowContainerStyle?: CSSProp;
 }
 
 export type ComboboxAction = TreeListAction;
@@ -563,7 +563,7 @@ function ComboboxDrawer({
                   mobile: !!mobile,
                   hasNestedOptions,
                   level: 0,
-                })}
+                })};
                 ${action?.styles?.self}
               `,
             },
@@ -1066,6 +1066,8 @@ function ComboboxDrawer({
                 })}
 
                 gap: 20px;
+
+                ${styles?.rowContainerStyle};
               `,
               hierarchyLineStyle: css`
                 border-left-width: 2px;
@@ -1104,6 +1106,8 @@ function ComboboxDrawer({
                 &[data-has-options="false"] {
                   font-weight: 400;
                 }
+
+                ${styles?.rowStyle};
               `,
               arrowGroupStyle: css`
                 [data-has-options="true"] & {
@@ -1134,6 +1138,8 @@ function ComboboxDrawer({
                   level,
                 })}
                 gap: 6px;
+
+                ${styles?.rowStyle}
               `,
             }}
             showHierarchyLine

--- a/components/moneybox.tsx
+++ b/components/moneybox.tsx
@@ -393,7 +393,7 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
             navigableOptions={FILTERED_CURRENCY_OPTIONS}
             inputRef={currencyInputRef}
             mobile={mobile}
-            withSearchbox
+            searchbox
             floatingStyles={floatingStyles}
             getFloatingProps={getFloatingProps}
             listRef={listRef}

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -377,7 +377,7 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
             navigableOptions={FILTERED_COUNTRY_OPTIONS}
             inputRef={searchInputRef}
             mobile={mobile}
-            withSearchbox
+            searchbox
             floatingStyles={floatingStyles}
             getFloatingProps={getFloatingProps}
             listRef={listRef}

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -976,7 +976,7 @@ export const AllCase: Story = {
       check: boolean;
       chips?: {
         searchText: string;
-        selectedOptions: BadgeProps[];
+        selectedOptions: string[];
       };
       color: string;
       combo: string[];
@@ -1059,32 +1059,15 @@ export const AllCase: Story = {
       },
     ];
 
-    const handleOptionClicked = (badge: BadgeProps) => {
-      const isAlreadySelected = value.chips.selectedOptions.some(
-        (data) => data.id === badge.id
-      );
-
+    const handleOptionClicked = (selectedOptions: string[]) => {
       setValue((prev) => ({
         ...prev,
         chips: {
           ...prev.chips,
-          selectedOptions: isAlreadySelected
-            ? prev.chips.selectedOptions.filter((data) => data.id !== badge.id)
-            : [...prev.chips.selectedOptions, badge],
+          selectedOptions,
         },
       }));
     };
-
-    const badgeSchema = z.object({
-      id: z.string().optional(),
-      metadata: z.record(z.unknown()).optional(),
-      variant: z.string().optional(),
-      withCircle: z.boolean().optional(),
-      caption: z.string().optional(),
-      backgroundColor: z.string().optional(),
-      textColor: z.string().optional(),
-      circleColor: z.string().optional(),
-    });
 
     const schema = z.object({
       text: z.string().min(3, "Text must be at least 3 characters"),
@@ -1098,7 +1081,7 @@ export const AllCase: Story = {
       check: z.boolean(),
       chips: z.object({
         searchText: z.string().optional(),
-        selectedOptions: z.array(badgeSchema).optional(),
+        selectedOptions: z.array(z.string()).optional(),
       }),
       color: z.string().min(4, "Color is required"),
       combo: z
@@ -1532,7 +1515,7 @@ export const AllCaseDisabled: Story = {
       check: boolean;
       chips?: {
         searchText: string;
-        selectedOptions: BadgeProps[];
+        selectedOptions: string[];
       };
       color: string;
       combo: string[];

--- a/components/treelist.tsx
+++ b/components/treelist.tsx
@@ -18,16 +18,17 @@ import { TreeListThemeConfig } from "./../theme";
 import { BaseAction } from "../constants/action";
 import { applyClassName } from "./../constants/classname";
 
-export interface TreeListProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  | "style"
-  | "onChange"
-  | "content"
-  | "onMouseDown"
-  | "onMouseMove"
-  | "onKeyDown"
-  | "onMouseEnter"
-> {
+export interface TreeListProps
+  extends Omit<
+    HTMLAttributes<HTMLDivElement>,
+    | "style"
+    | "onChange"
+    | "content"
+    | "onMouseDown"
+    | "onMouseMove"
+    | "onKeyDown"
+    | "onMouseEnter"
+  > {
   content: TreeListContent[];
   children?: ReactNode;
   emptySlate?: ReactNode;
@@ -135,10 +136,8 @@ export interface TreeListContent {
   collapsible?: boolean;
 }
 
-export interface TreeListContentAction extends Omit<
-  ContextMenuAction,
-  "onClick"
-> {
+export interface TreeListContentAction
+  extends Omit<ContextMenuAction, "onClick"> {
   onClick?: (id?: string) => void;
 }
 
@@ -734,11 +733,11 @@ function TreeList({
               </GroupWrapper>
             );
           })
-        ) : (
+        ) : emptySlate ? (
           <EmptyContent $style={styles?.emptySlateStyle}>
             {emptySlate}
           </EmptyContent>
-        )}
+        ) : null}
 
         {children}
       </TreeListWrapper>

--- a/test/component/chips.cy.tsx
+++ b/test/component/chips.cy.tsx
@@ -54,7 +54,7 @@ describe("Chips", () => {
       background_color: string;
       text_color: string;
       circle_color: string;
-      selectedOptions: BadgeProps[];
+      selectedOptions: string[];
     }
 
     const [inputValue, setInputValue] = useState<InputValueProps>({
@@ -80,19 +80,6 @@ describe("Chips", () => {
       }
     };
 
-    const handleOptionClicked = (badge: BadgeProps) => {
-      const isAlreadySelected = inputValue.selectedOptions.some(
-        (data) => data.id === badge.id
-      );
-
-      setInputValue((prev) => ({
-        ...prev,
-        selectedOptions: isAlreadySelected
-          ? prev.selectedOptions.filter((data) => data.id !== badge.id)
-          : [...prev.selectedOptions, badge],
-      }));
-    };
-
     return (
       <Chips
         inputValue={inputValue.search}
@@ -110,7 +97,12 @@ describe("Chips", () => {
             max-width: 300px;
           `,
         }}
-        onOptionClicked={handleOptionClicked}
+        onChange={(selectedOptions: string[]) =>
+          setInputValue((prev) => ({
+            ...prev,
+            selectedOptions,
+          }))
+        }
         selectedOptions={inputValue.selectedOptions}
         options={BADGE_OPTIONS as BadgeProps[]}
         creatable

--- a/test/component/chips.cy.tsx
+++ b/test/component/chips.cy.tsx
@@ -1,10 +1,10 @@
-import { Chips } from "./../../components/chips";
+import { Chips, ChipsProps } from "./../../components/chips";
 import { BadgeProps } from "./../../components/badge";
 import { ChangeEvent, useState } from "react";
 import { css } from "styled-components";
 
 describe("Chips", () => {
-  function ProductChips() {
+  function ProductChips(props: ChipsProps) {
     const BADGE_OPTIONS: BadgeProps[] = [
       {
         id: "1",
@@ -85,16 +85,12 @@ describe("Chips", () => {
         inputValue={inputValue.search}
         setInputValue={onChangeValue}
         styles={{
-          chipStyle: css`
+          chipOptionStyle: css`
             width: 100%;
             gap: 8px;
-            border-color: transparent;
           `,
-          chipContainerStyle: css`
+          chipOptionWrapperStyle: css`
             gap: 4px;
-          `,
-          chipsDrawerStyle: css`
-            max-width: 300px;
           `,
         }}
         onChange={(selectedOptions: string[]) =>
@@ -106,16 +102,168 @@ describe("Chips", () => {
         selectedOptions={inputValue.selectedOptions}
         options={BADGE_OPTIONS as BadgeProps[]}
         creatable
+        {...props}
       />
     );
   }
+
+  context("mobile", () => {
+    it("renders the drawer with in the bottom screen", () => {
+      cy.mount(<ProductChips mobile />);
+      cy.findByRole("button").click();
+
+      cy.findByLabelText("combobox-drawer-mobile")
+        .should("have.css", "bottom", "10px")
+        .and("have.css", "position", "fixed");
+    });
+
+    it("renders the drawer with height 320px", () => {
+      cy.mount(<ProductChips mobile />);
+
+      cy.findByRole("button").click();
+
+      cy.findByLabelText("combobox-drawer-mobile").should(
+        "have.css",
+        "height",
+        "320px"
+      );
+    });
+
+    context("drawerHeight", () => {
+      context("when given 400px", () => {
+        it("renders the drawer with height 400px", () => {
+          cy.mount(<ProductChips mobile drawerHeight="400px" />);
+          cy.findByRole("button").click();
+
+          cy.findByLabelText("combobox-drawer-mobile").should(
+            "have.css",
+            "height",
+            "400px"
+          );
+        });
+      });
+    });
+  });
+
+  context("styles", () => {
+    it("renders the option with transparent badge option", () => {
+      cy.mount(<ProductChips />);
+
+      cy.findByRole("button").click();
+
+      cy.findAllByLabelText("chips-option")
+        .eq(0)
+        .should("have.css", "background-color", "rgba(0, 0, 0, 0)")
+        .and("have.css", "border-color", "rgba(0, 0, 0, 0)");
+    });
+
+    it("renders gap in option wrapper with 4px (by default)", () => {
+      cy.mount(<ProductChips />);
+      cy.findByRole("button").click();
+
+      cy.findAllByRole("option").eq(0).should("have.css", "gap", "4px");
+    });
+
+    context("chipOptionWrapperStyle", () => {
+      context("when given gap 20px", () => {
+        it("should render gap with 20px between checkbox and badge", () => {
+          cy.mount(
+            <ProductChips
+              styles={{
+                chipOptionWrapperStyle: css`
+                  gap: 20px;
+                `,
+              }}
+            />
+          );
+          cy.findByRole("button").click();
+
+          cy.findAllByRole("option").eq(0).should("have.css", "gap", "20px");
+        });
+      });
+    });
+
+    context("chipContainerStyle", () => {});
+
+    context("chipsSelectedStyle", () => {
+      context("when given radius 20px", () => {
+        it("should render the chips selected with radius 20px", () => {
+          cy.mount(
+            <ProductChips
+              styles={{
+                chipSelectedStyle: css`
+                  border-radius: 20px;
+                `,
+              }}
+            />
+          );
+          cy.findByRole("button").click();
+
+          cy.findByText("Anime").click();
+
+          cy.findByLabelText("chip-selected").should(
+            "have.css",
+            "border-radius",
+            "20px"
+          );
+        });
+      });
+    });
+
+    context("chipOptionStyle", () => {
+      context("when given border red", () => {
+        it("should render option chip with border red", () => {
+          cy.mount(
+            <ProductChips
+              styles={{
+                chipOptionStyle: css`
+                  border-color: red;
+                `,
+              }}
+            />
+          );
+          cy.findByRole("button").click();
+
+          cy.findAllByLabelText("chips-option").should(
+            "have.css",
+            "border-color",
+            "rgb(255, 0, 0)"
+          );
+        });
+      });
+    });
+
+    context("chipsDrawerStyle", () => {
+      context("when given min-height 400px", () => {
+        it("should render the drawer with 400px", () => {
+          cy.mount(
+            <ProductChips
+              styles={{
+                chipsDrawerStyle: css`
+                  min-height: 400px;
+                `,
+              }}
+            />
+          );
+          cy.findByRole("button").click();
+
+          cy.findByLabelText("combobox-drawer").should(
+            "have.css",
+            "height",
+            "400px"
+          );
+        });
+      });
+    });
+  });
+
   context("focus behavior", () => {
     context("when clicking open the searchbox", () => {
       it("focusing to the searchbox", () => {
         cy.mount(<ProductChips />);
         cy.findByRole("button").click();
 
-        cy.findByLabelText("chip-input-box")
+        cy.findByLabelText("textbox-search")
           .should("be.focused")
           .and("have.css", "border-color", "rgb(97, 169, 249)");
       });
@@ -128,7 +276,7 @@ describe("Chips", () => {
           const onFocus = cy.stub().as("focus");
           const onBlur = cy.stub().as("blur");
 
-          cy.findByLabelText("chip-input-box")
+          cy.findByLabelText("textbox-search")
             .should("be.focused")
             .and("have.css", "border-color", "rgb(97, 169, 249)")
             .then(($input) => {
@@ -140,7 +288,7 @@ describe("Chips", () => {
 
           cy.findByText("Anime").click();
 
-          cy.findByLabelText("chip-input-box")
+          cy.findByLabelText("textbox-search")
             .should("be.focused")
             .and("have.css", "border-color", "rgb(97, 169, 249)");
 

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -304,13 +304,10 @@ const ALL_INPUT: FormFieldGroup[] = [
     chips: {
       options: BADGE_OPTIONS_SHORT,
       styles: {
-        chipStyle: css`
+        chipOptionStyle: css`
           width: 100%;
           gap: 0.5rem;
           border-color: transparent;
-        `,
-        chipContainerStyle: css`
-          gap: 4px;
         `,
         chipsDrawerStyle: css`
           min-width: 250px;
@@ -828,7 +825,7 @@ describe("StatefulForm", () => {
         cy.findAllByLabelText("field-lane-wrapper")
           .should("have.css", "cursor", "not-allowed")
           .and("have.css", "user-select", "none");
-        cy.findAllByLabelText("chip-input")
+        cy.findAllByLabelText("chips-container-input")
           .should("have.css", "cursor", "not-allowed")
           .and("have.css", "user-select", "none");
         cy.findAllByLabelText("file-drop-box-container")
@@ -890,7 +887,7 @@ describe("StatefulForm", () => {
           cy.findAllByLabelText("field-lane-wrapper")
             .should("have.css", "cursor", "not-allowed")
             .and("have.css", "user-select", "none");
-          cy.findAllByLabelText("chip-input")
+          cy.findAllByLabelText("chips-container-input")
             .should("have.css", "cursor", "not-allowed")
             .and("have.css", "user-select", "none");
           cy.findAllByLabelText("file-drop-box-container")

--- a/test/e2e/chips.cy.ts
+++ b/test/e2e/chips.cy.ts
@@ -16,9 +16,8 @@ describe("Chips", () => {
     context("when double select", () => {
       it("should deselect a chip", () => {
         cy.findByRole("button").click();
-        cy.findByRole("textbox").type("Anime");
+        cy.findByRole("textbox").type("Anim");
         cy.findByText("Anime").dblclick();
-        cy.findByRole("button").click();
       });
     });
   });


### PR DESCRIPTION
Description:
This pull request introduces a `mobile` prop to the `Chips` component so it can be used with `Combobox.Drawer` while preserving the existing `creatable` behavior. 

It also fixes an issue where the `creatable` input could not be opened because the wrapper was calling `preventDefault` and `stopPropagation`, preventing the input from receiving focus.

After the mobile refactor, the `fadeEffect` on the top and bottom sides was also displayed incorrectly in the creatable mobile experience. This pull request moves that logic into `Combobox.Drawer` so the fade effect is not shown when using the creatable mobile variant.

```tsx
export const ComboboxDrawerFadeEffect = {
  Top: "top",
  Bottom: "bottom",
} as const;

export type ComboboxDrawerFadeEffect =
  (typeof ComboboxDrawerFadeEffect)[keyof typeof ComboboxDrawerFadeEffect];
```

Finally, this pull request ensures the existing `creatable` behavior continues to work correctly with the existing tests, while also verifying that the mobile implementation behaves as expected whether using the `mobile` prop, `drawerHeight` prop and `styles` prop.

**Note:**
- It also improves `Combobox.Drawer` by:
  - Introducing a customizable `fadeEffect` prop.
  - Adding `rowStyle` for row customization.
  - Supporting `children` for custom row rendering (previously only intended for the default row selection).
  - Refactoring `withSearchbox` into a more flexible `searchbox` prop with the `SearchboxProps | boolean` interface.
  - Introducing a `checkbox` prop with the `CheckboxProps | boolean` interface to customize the checkbox appearance.
- Includes related fixes and refactors in `Combobox.Drawer`.

Source:
[[Mobile] SYST-773: Add `mobile` to `Chips`](https://linear.app/systatum/issue/SYST-773/add-mobile-to-chips)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself