### PR TITLE
[Bug] SYST-774: Refine `Chips` badge `appearance` and `interaction`

### DIFF
--- a/components/badge.tsx
+++ b/components/badge.tsx
@@ -37,7 +37,7 @@ export interface BadgeStyles {
 }
 
 export interface BadgeAction extends Omit<BaseAction, "onClick" | "caption"> {
-  onClick?: (badge?: BadgeProps) => void;
+  onClick?: (props: { badge?: BadgeProps; event?: React.MouseEvent }) => void;
   size?: number;
   styles?: ButtonStyles;
   title?: string;
@@ -219,18 +219,21 @@ function Badge({
               icon={action.icon}
               styles={action?.styles}
               title={action.title}
-              onClick={(e) => {
-                e.stopPropagation();
+              onMouseDown={(event) => {
+                event.stopPropagation();
                 if (action.onClick) {
                   action.onClick({
-                    id,
-                    caption,
-                    metadata,
-                    variant,
-                    backgroundColor,
-                    textColor,
-                    circleColor,
-                    withCircle,
+                    badge: {
+                      id,
+                      caption,
+                      metadata,
+                      variant,
+                      backgroundColor,
+                      textColor,
+                      circleColor,
+                      withCircle,
+                    },
+                    event,
                   });
                 }
               }}

--- a/components/chips.stories.tsx
+++ b/components/chips.stories.tsx
@@ -377,15 +377,6 @@ export const Default: Story = {
       <Chips
         inputValue={inputValue.search}
         setInputValue={onChangeValue}
-        styles={{
-          chipOptionStyle: css`
-            width: 100%;
-            gap: 8px;
-          `,
-          chipsDrawerStyle: css`
-            max-width: 300px;
-          `,
-        }}
         onChange={handleOptionClicked}
         selectedOptions={inputValue.selectedOptions}
         options={BADGE_OPTIONS as BadgeProps[]}
@@ -609,12 +600,6 @@ export const Mobile: Story = {
         mobile
         inputValue={inputValue.search}
         setInputValue={onChangeValue}
-        styles={{
-          chipOptionStyle: css`
-            width: 100%;
-            gap: 8px;
-          `,
-        }}
         onChange={handleOptionClicked}
         selectedOptions={inputValue.selectedOptions}
         options={BADGE_OPTIONS as BadgeProps[]}
@@ -723,12 +708,6 @@ export const DarkBackground: Story = {
         setInputValue={(e) =>
           setInputValue((prev) => ({ ...prev, search: e.target.value }))
         }
-        styles={{
-          chipOptionStyle: css`
-            width: 100%;
-            gap: 8px;
-          `,
-        }}
         onChange={handleOptionClicked}
         selectedOptions={inputValue.selectedOptions}
         options={BADGE_OPTIONS as BadgeProps[]}
@@ -944,15 +923,6 @@ export const Deletable: Story = {
       <Chips
         inputValue={inputValue.search}
         setInputValue={onChangeValue}
-        styles={{
-          chipOptionStyle: css`
-            width: 100%;
-            gap: 8px;
-          `,
-          chipsDrawerStyle: css`
-            max-width: 250px;
-          `,
-        }}
         onChange={handleOptionClicked}
         selectedOptions={inputValue.selectedOptions}
         options={BADGE_OPTIONS}
@@ -1067,7 +1037,7 @@ export const CustomRenderer: Story = {
         style={{
           display: "flex",
           flexDirection: "column",
-          minWidth: "240px",
+          minWidth: "238px",
         }}
       >
         <div
@@ -1199,15 +1169,6 @@ export const CustomRenderer: Story = {
         combobox: {
           placeholder: "Search your role...",
           options: EMPLOYEE_OPTIONS,
-          styles: {
-            selectboxStyle: css`
-              border: 1px solid #d1d5db;
-              &:focus {
-                border-color: #61a9f9;
-                box-shadow: 0 0 0 1px #61a9f9;
-              }
-            `,
-          },
         },
       },
     ];
@@ -1273,16 +1234,6 @@ export const CustomRenderer: Story = {
       <Chips
         inputValue={inputValue.search}
         setInputValue={onChangeValue}
-        styles={{
-          chipOptionStyle: css`
-            width: 100%;
-            gap: 8px;
-          `,
-
-          chipsDrawerStyle: css`
-            max-width: 250px;
-          `,
-        }}
         renderer={({ id, caption }) => {
           const isOpen = openMap[id] || false;
           return (
@@ -1301,22 +1252,6 @@ export const CustomRenderer: Story = {
                 setOpenMap((prev) => ({ ...prev, [id]: isOpen }));
               }}
               dialog={contentDialog}
-              styles={{
-                containerStyle: css`
-                  width: fit-content;
-                `,
-                arrowStyle: css`
-                  background-color: #e5e7eb;
-                  border: 1px solid #e5e7eb;
-                `,
-                drawerStyle: css`
-                  width: fit-content;
-                  left: 1rem;
-                  background-color: white;
-                  color: black;
-                  border: 1px solid #e5e7eb;
-                `,
-              }}
             >
               <Badge
                 id={id}

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -187,6 +187,7 @@ function BaseChips({
 
             <Badge
               {...badge}
+              backgroundColor={badge?.backgroundColor ?? "transparent"}
               aria-label="chips-option"
               actions={badgeActions}
               onMouseDown={(e) => e.preventDefault()}
@@ -195,9 +196,6 @@ function BaseChips({
                   cursor: pointer;
                   border-color: transparent;
                   width: 100%;
-                  background-color: ${badge?.backgroundColor
-                    ? badge?.backgroundColor
-                    : "transparent"};
 
                   ${mobile &&
                   css`
@@ -307,7 +305,7 @@ function BaseChips({
               onClick={(e) => {
                 e.stopPropagation();
               }}
-              aria-label="chip-selected"
+              aria-label="chips-selected"
               variant={badge.variant}
               backgroundColor={badge.backgroundColor}
               circleColor={badge.circleColor}

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -156,6 +156,17 @@ function BaseChips({
         (selectedOption) => selectedOption === badge.id
       );
 
+      const badgeActions = badge?.actions?.map((action) => ({
+        ...action,
+        onClick: ({ badge, event }) => {
+          event?.preventDefault();
+          action?.onClick?.({
+            badge,
+            event,
+          });
+        },
+      }));
+
       return {
         text: badge.caption,
         value: badge.id,
@@ -177,6 +188,7 @@ function BaseChips({
             <Badge
               {...badge}
               aria-label="chips-option"
+              actions={badgeActions}
               onMouseDown={(e) => e.preventDefault()}
               styles={{
                 self: css`

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -181,9 +181,12 @@ function BaseChips({
               styles={{
                 self: css`
                   cursor: pointer;
-                  width: 100%;
-                  background-color: transparent;
                   border-color: transparent;
+                  width: 100%;
+                  background-color: ${badge?.backgroundColor
+                    ? badge?.backgroundColor
+                    : "transparent"};
+
                   ${mobile &&
                   css`
                     font-size: 18px;
@@ -400,11 +403,6 @@ function BaseChips({
               css`
                 padding: 0px;
               `};
-
-              ${mode === "create" &&
-              css`
-                min-width: 240px;
-              `}
 
               ${styles?.chipsDrawerStyle};
             `,

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -1254,7 +1254,7 @@ const DrawerWrapper = styled.ul<{
     const $height = $drawerHeight ?? "220px";
 
     return css`
-      min-height: ${$height};
+      min-height: fit-content;
       max-height: ${$height};
 
       ${$mobile &&

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -1421,8 +1421,6 @@ export const AllCase: Story = {
       },
     ];
 
-    console.log(value.chips.searchText);
-
     return (
       <StatefulForm
         styles={{

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -1059,16 +1059,6 @@ export const AllCase: Story = {
       },
     ];
 
-    const handleOptionClicked = (selectedOptions: string[]) => {
-      setValue((prev) => ({
-        ...prev,
-        chips: {
-          ...prev.chips,
-          selectedOptions,
-        },
-      }));
-    };
-
     const schema = z.object({
       text: z.string().min(3, "Text must be at least 3 characters"),
       email: z.string().email("Please enter a valid email address"),
@@ -1158,28 +1148,6 @@ export const AllCase: Story = {
         .optional(),
     });
 
-    const onChangeForm = (e?: StatefulOnChangeType) => {
-      if (e && "target" in e) {
-        const target = e.target;
-        const { name, value } = target;
-
-        let updatedValue: FormValueType = value;
-
-        if (target instanceof HTMLInputElement && target.type === "checkbox") {
-          updatedValue = target.checked;
-        }
-
-        if (target.name === "chips") {
-          setValue((prev) => ({
-            ...prev,
-            chips: { ...prev.chips, ["searchText"]: String(updatedValue) },
-          }));
-        } else {
-          setValue((prev) => ({ ...prev, [name]: updatedValue }));
-        }
-      }
-    };
-
     const onFileDropped = async ({
       error,
       files,
@@ -1261,7 +1229,6 @@ export const AllCase: Story = {
         title: "Time",
         type: "time",
         required: true,
-        placeholder: "Enter time",
         helper: "This field allows you to select a time",
       },
       {
@@ -1430,24 +1397,9 @@ export const AllCase: Story = {
         helper: "This field allows you to select multiple items",
         chips: {
           options: BADGE_OPTIONS,
-          styles: {
-            chipStyle: css`
-              width: 100%;
-              gap: 0.5rem;
-              border-color: transparent;
-            `,
-            chipContainerStyle: css`
-              gap: 4px;
-            `,
-            chipsDrawerStyle: css`
-              min-width: 250px;
-            `,
-          },
-          onOptionClicked: handleOptionClicked,
           selectedOptions: value.chips.selectedOptions,
           inputValue: value.chips.searchText,
         },
-        onChange: onChangeForm,
       },
       {
         name: "capsule",
@@ -1469,6 +1421,8 @@ export const AllCase: Story = {
       },
     ];
 
+    console.log(value.chips.searchText);
+
     return (
       <StatefulForm
         styles={{
@@ -1482,12 +1436,19 @@ export const AllCase: Story = {
           `,
         }}
         onChange={({ currentState }) => {
-          const { chips, ...rest } = currentState;
-          void chips;
+          const [[key, value]] = Object.entries(currentState);
 
           setValue((prev) => ({
             ...prev,
-            ...rest,
+            ...(key === "chips"
+              ? {
+                  chips: {
+                    ...prev.chips,
+                    [Array.isArray(value) ? "selectedOptions" : "searchText"]:
+                      value,
+                  },
+                }
+              : currentState),
           }));
         }}
         onValidityChange={setIsFormValid}

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -1777,6 +1777,20 @@ function FormFields<T extends FieldValues>({
                         controllerField?.onChange(e);
                         controllerField?.onBlur();
                         field.onChange?.(e);
+                        if (onChange) {
+                          onChange(field.name as keyof T, e.target.value);
+                        }
+                      }}
+                      onChange={(value) => {
+                        controllerField?.onChange(value);
+                        controllerField?.onBlur();
+                        const inputValueEvent = {
+                          target: { name: field.name ?? "chips", value },
+                        };
+                        field.onChange?.(inputValueEvent);
+                        if (onChange) {
+                          onChange(field.name as keyof T, value);
+                        }
                       }}
                       {...field.chips}
                       styles={{
@@ -2083,10 +2097,8 @@ function FormFields<T extends FieldValues>({
   );
 }
 
-export interface StatefulFormLabelProps extends Omit<
-  LabelHTMLAttributes<HTMLLabelElement>,
-  "label" | "style"
-> {
+export interface StatefulFormLabelProps
+  extends Omit<LabelHTMLAttributes<HTMLLabelElement>, "label" | "style"> {
   label?: string;
   helper?: string;
   styles: { self?: CSSProp };

--- a/test/component/chips.cy.tsx
+++ b/test/component/chips.cy.tsx
@@ -365,7 +365,31 @@ describe("Chips", () => {
       });
     });
 
-    context("chipContainerStyle", () => {});
+    context("chipsContainerStyle", () => {
+      context("when given gap 20px", () => {
+        it("should render gap with 20px between selected and button trigger", () => {
+          cy.mount(
+            <ProductChips
+              styles={{
+                chipsContainerStyle: css`
+                  gap: 20px;
+                `,
+              }}
+            />
+          );
+          cy.findByRole("button").click();
+
+          cy.findByText("Anime").click();
+          cy.findByText("Manga").click();
+
+          cy.findByLabelText("chips-container-input").should(
+            "have.css",
+            "gap",
+            "20px"
+          );
+        });
+      });
+    });
 
     context("chipsSelectedStyle", () => {
       context("when given radius 20px", () => {

--- a/test/component/chips.cy.tsx
+++ b/test/component/chips.cy.tsx
@@ -2,51 +2,56 @@ import { Chips, ChipsProps } from "./../../components/chips";
 import { BadgeProps } from "./../../components/badge";
 import { ChangeEvent, useState } from "react";
 import { css } from "styled-components";
+import { RiCloseLine } from "@remixicon/react";
 
 describe("Chips", () => {
-  function ProductChips(props: ChipsProps) {
-    const BADGE_OPTIONS: BadgeProps[] = [
-      {
-        id: "1",
-        caption: "Anime",
-      },
-      {
-        id: "2",
-        caption: "Manga",
-      },
-      {
-        id: "3",
-        caption: "Comics",
-      },
-      {
-        id: "4",
-        caption: "Movies",
-      },
-      {
-        id: "5",
-        caption: "Podcasts",
-      },
-      {
-        id: "6",
-        caption: "TV Shows",
-      },
-      {
-        id: "7",
-        caption: "Novels",
-      },
-      {
-        id: "8",
-        caption: "Music",
-      },
-      {
-        id: "9",
-        caption: "Games",
-      },
-      {
-        id: "10",
-        caption: "Webtoons",
-      },
-    ];
+  function ProductChips({
+    onActionClick,
+    ...props
+  }: ChipsProps & {
+    onActionClick?: (props?: {
+      badge?: BadgeProps;
+      event?: React.MouseEvent;
+    }) => void;
+  }) {
+    const BADGE_OPTIONS: BadgeProps[] = Array.from({ length: 10 }, (_, i) => ({
+      id: String(i + 1),
+      caption: (() => {
+        switch (i + 1) {
+          case 1:
+            return "Anime";
+          case 2:
+            return "Manga";
+          case 3:
+            return "Comics";
+          case 4:
+            return "Movies";
+          case 5:
+            return "Podcasts";
+          case 6:
+            return "TV Shows";
+          case 7:
+            return "Novels";
+          case 8:
+            return "Music";
+          case 9:
+            return "Games";
+          case 10:
+            return "Webtoons";
+          default:
+            return "";
+        }
+      })(),
+      actions: [
+        {
+          image: RiCloseLine,
+          onClick: ({ badge, event }) => {
+            onActionClick?.({ badge, event });
+          },
+          size: 16,
+        },
+      ],
+    }));
 
     interface InputValueProps {
       search: string;
@@ -84,15 +89,6 @@ describe("Chips", () => {
       <Chips
         inputValue={inputValue.search}
         setInputValue={onChangeValue}
-        styles={{
-          chipOptionStyle: css`
-            width: 100%;
-            gap: 8px;
-          `,
-          chipOptionWrapperStyle: css`
-            gap: 4px;
-          `,
-        }}
         onChange={(selectedOptions: string[]) =>
           setInputValue((prev) => ({
             ...prev,
@@ -140,6 +136,90 @@ describe("Chips", () => {
             "height",
             "400px"
           );
+        });
+      });
+    });
+  });
+
+  context("actions", () => {
+    context("when clicking", () => {
+      it("should stop propagate to the selection behavior", () => {
+        cy.mount(<ProductChips />);
+
+        cy.findByRole("button").click();
+
+        cy.findAllByLabelText("badge-action").eq(0).click();
+        cy.findAllByLabelText("chips-selected").should("not.exist");
+      });
+
+      it("should call the callback", () => {
+        const onClick = cy.stub().as("onClick");
+
+        cy.mount(<ProductChips onActionClick={onClick} />);
+
+        cy.findByRole("button").click();
+
+        cy.findAllByLabelText("badge-action").eq(0).click();
+
+        cy.get("@onClick").should("have.been.calledOnce");
+      });
+
+      context("when console the event", () => {
+        it("should shows the event mouse", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
+          });
+
+          cy.mount(
+            <ProductChips onActionClick={({ event }) => console.log(event)} />
+          );
+
+          cy.findByRole("button").click();
+
+          cy.findAllByLabelText("badge-action").eq(0).click();
+
+          cy.get("@consoleLog").then((spy: any) => {
+            expect(spy).to.have.been.calledOnce;
+
+            const event = spy.firstCall.args[0];
+
+            expect(event).to.exist;
+            expect(event.type).to.equal("mousedown");
+          });
+        });
+      });
+
+      context("when console the badge", () => {
+        it("should shows the badge clicked", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
+          });
+
+          cy.mount(
+            <ProductChips
+              onActionClick={({ badge }) => console.log(JSON.stringify(badge))}
+            />
+          );
+
+          cy.findByRole("button").click();
+
+          cy.findAllByLabelText("badge-action").eq(0).click();
+
+          cy.get("@consoleLog").then((spy: any) => {
+            expect(spy).to.have.been.calledOnce;
+
+            const logged = spy.firstCall.args[0];
+
+            expect(logged).to.equal(
+              JSON.stringify({
+                id: "1",
+                caption: "Anime",
+                variant: null,
+                backgroundColor: "transparent",
+                withCircle: true,
+              })
+            );
+          });
         });
       });
     });

--- a/test/component/chips.cy.tsx
+++ b/test/component/chips.cy.tsx
@@ -145,7 +145,7 @@ describe("Chips", () => {
     });
   });
 
-  context("styles", () => {
+  context("options", () => {
     it("renders the option with transparent badge option", () => {
       cy.mount(<ProductChips />);
 
@@ -157,6 +157,108 @@ describe("Chips", () => {
         .and("have.css", "border-color", "rgba(0, 0, 0, 0)");
     });
 
+    context("when given backgroundColor on the options", () => {
+      const BADGE_OPTIONS_WITH_COLORS: BadgeProps[] = [
+        {
+          id: "1",
+          backgroundColor: "#1c0f13",
+          textColor: "#ffffff",
+          caption: "Anime",
+          circleColor: "#ff6f61",
+        },
+        {
+          id: "2",
+          backgroundColor: "#120f1f",
+          textColor: "#ffffff",
+          caption: "Manga",
+          circleColor: "#6b5b95",
+        },
+        {
+          id: "3",
+          backgroundColor: "#0e1a0e",
+          textColor: "#ffffff",
+          caption: "Comics",
+          circleColor: "#88b04b",
+        },
+        {
+          id: "4",
+          backgroundColor: "#1a1212",
+          textColor: "#ffffff",
+          caption: "Movies",
+          circleColor: "#f7cac9",
+        },
+        {
+          id: "5",
+          backgroundColor: "#0e1626",
+          textColor: "#ffffff",
+          caption: "Podcasts",
+          circleColor: "#92a8d1",
+        },
+        {
+          id: "6",
+          backgroundColor: "#1b0d0d",
+          textColor: "#ffffff",
+          caption: "TV Shows",
+          circleColor: "#955251",
+        },
+        {
+          id: "7",
+          backgroundColor: "#160d18",
+          textColor: "#ffffff",
+          caption: "Novels",
+          circleColor: "#b565a7",
+        },
+        {
+          id: "8",
+          backgroundColor: "#0d1a17",
+          textColor: "#ffffff",
+          caption: "Music",
+          circleColor: "#009b77",
+        },
+        {
+          id: "9",
+          backgroundColor: "#1c0e0c",
+          textColor: "#ffffff",
+          caption: "Games",
+          circleColor: "#dd4124",
+        },
+        {
+          id: "10",
+          backgroundColor: "#0d1c1a",
+          textColor: "#ffffff",
+          caption: "Webtoons",
+          circleColor: "#45b8ac",
+        },
+      ];
+      it("renders options with coloring", () => {
+        cy.mount(<ProductChips options={BADGE_OPTIONS_WITH_COLORS} />);
+        cy.findByRole("button").click();
+
+        cy.findAllByLabelText("chips-option").should(
+          "not.have.css",
+          "background-color",
+          "rgba(0, 0, 0, 0)"
+        );
+      });
+
+      context("when select one option", () => {
+        it("renders option selected with coloring", () => {
+          cy.mount(<ProductChips options={BADGE_OPTIONS_WITH_COLORS} />);
+          cy.findByRole("button").click();
+
+          cy.findAllByLabelText("chips-option")
+            .eq(0)
+            .should("have.css", "background-color", "rgb(28, 15, 19)")
+            .click();
+          cy.wait(400);
+          cy.findAllByLabelText("chips-selected")
+            .eq(0)
+            .should("have.css", "background-color", "rgb(28, 15, 19)");
+        });
+      });
+    });
+  });
+  context("styles", () => {
     it("renders gap in option wrapper with 4px (by default)", () => {
       cy.mount(<ProductChips />);
       cy.findByRole("button").click();
@@ -201,7 +303,7 @@ describe("Chips", () => {
 
           cy.findByText("Anime").click();
 
-          cy.findByLabelText("chip-selected").should(
+          cy.findByLabelText("chips-selected").should(
             "have.css",
             "border-radius",
             "20px"

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -303,16 +303,6 @@ const ALL_INPUT: FormFieldGroup[] = [
     required: false,
     chips: {
       options: BADGE_OPTIONS_SHORT,
-      styles: {
-        chipOptionStyle: css`
-          width: 100%;
-          gap: 0.5rem;
-          border-color: transparent;
-        `,
-        chipsDrawerStyle: css`
-          min-width: 250px;
-        `,
-      },
       selectedOptions: allValue.chips.selectedOptions,
       inputValue: allValue.chips.searchText,
     },
@@ -334,6 +324,69 @@ const flattenFields = (groups: FormFieldGroup[]): FormFieldProps[] =>
   );
 
 describe("StatefulForm", () => {
+  context("chips", () => {
+    function StatefulChips() {
+      const [value, setValue] = useState({
+        chips: {
+          selectedOptions: [],
+          searchText: "",
+        },
+      });
+      return (
+        <StatefulForm
+          fields={[
+            {
+              name: "chips",
+              title: "Chips",
+              type: "chips",
+              required: false,
+              chips: {
+                options: BADGE_OPTIONS_SHORT,
+                selectedOptions: value.chips.selectedOptions,
+                inputValue: value.chips.searchText,
+              },
+            },
+          ]}
+          onChange={({ currentState }) => {
+            const [[key, value]] = Object.entries(currentState);
+
+            setValue((prev) => ({
+              ...prev,
+              ...(key === "chips"
+                ? {
+                    chips: {
+                      ...prev.chips,
+                      [Array.isArray(value) ? "selectedOptions" : "searchText"]:
+                        value,
+                    },
+                  }
+                : currentState),
+            }));
+          }}
+          formValues={value}
+          mode="onChange"
+        />
+      );
+    }
+
+    context("when select one option", () => {
+      it("renders option selected", () => {
+        cy.mount(<StatefulChips />);
+        cy.findByRole("button").click();
+
+        cy.findAllByLabelText("chips-selected").should("not.exist");
+
+        cy.findByText("Anime").click();
+        cy.findByText("Manga").click();
+
+        cy.wait(400);
+
+        cy.findAllByLabelText("chips-selected").eq(0).should("exist");
+        cy.findAllByLabelText("chips-selected").eq(1).should("exist");
+      });
+    });
+  });
+
   context("height", () => {
     it("mostly renders with 34px", () => {
       cy.mount(

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -381,8 +381,14 @@ describe("StatefulForm", () => {
 
         cy.wait(400);
 
-        cy.findAllByLabelText("chips-selected").eq(0).should("exist");
-        cy.findAllByLabelText("chips-selected").eq(1).should("exist");
+        cy.findAllByLabelText("chips-selected")
+          .eq(0)
+          .should("exist")
+          .should("have.css", "background-color", "rgb(255, 255, 255)");
+        cy.findAllByLabelText("chips-selected")
+          .eq(1)
+          .should("exist")
+          .should("have.css", "background-color", "rgb(255, 255, 255)");
       });
     });
   });


### PR DESCRIPTION
Description:
This ticket fixes an issue with **Chips** badge coloring. When a badge provided a `backgroundColor`, the option in the dropdown incorrectly inherited that background color. After introducing `transparent` as the default appearance, the option background always remained transparent, even when a custom color was provided.

**Source issue:**

* https://coneto.systatum.com/index.html?path=/story/input-elements-chips--dark-background

After this change, the **Dark Background** story renders as expected.

Additionally, this ticket fixes badge action behavior. Clicking a badge action should no longer trigger option selection, allowing the action to behave independently.

**Source issue:**

* https://coneto.systatum.com/index.html?path=/story/input-elements-chips--custom-renderer

To achieve this:

* Badge actions now use `onMouseDown` instead of `onClick` to prevent the input from losing focus when the action is clicked.
* The badge action callback has been enhanced to expose both the badge and the mouse event, allowing consumers to implement custom behavior.

```tsx
export interface BadgeAction extends Omit<BaseAction, "onClick" | "caption"> {
  onClick?: (props: { badge?: BadgeProps; event?: React.MouseEvent }) => void;
  size?: number;
  styles?: ButtonStyles;
  title?: string;
}
```

Finally, this ticket also removes the incorrect styling in the **Custom Renderer** [story](https://coneto.systatum.com/index.html?path=/story/input-elements-chips--custom-renderer).

Source:
[[Bug] SYST-774: Refine `Chips` badge `appearance` and `interaction`](https://linear.app/systatum/issue/SYST-774/refine-chips-badge-appearance-and-interaction)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself