### PR TITLE
[Bug] SYST-775: Calendar stretch after open the `picker` mode

### DIFF
--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -560,6 +560,7 @@ function BaseCalendar({
               padding: 0.5rem;
               font-size: 0.875rem;
               min-width: 300px;
+              max-width: 300px;
               display: flex;
               flex-direction: column;
               gap: 0.5rem;

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -548,6 +548,7 @@ function BaseCalendar({
 
   return (
     <CalendarContainer
+      aria-label="calendar-wrapper"
       onMouseDown={(e) => e.preventDefault()}
       $style={
         floatingStyles

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -1254,7 +1254,7 @@ const DrawerWrapper = styled.ul<{
     const $height = $drawerHeight ?? "220px";
 
     return css`
-      min-height: fit-content;
+      height: fit-content;
       max-height: ${$height};
 
       ${$mobile &&

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -877,6 +877,8 @@ function ComboboxDrawer({
 
   const searchboxProps = typeof searchbox === "object" && searchbox;
 
+  const hasFewOptions = finalOptions?.length < 5;
+
   const mainCombobox = (
     <DrawerWrapper
       {...getFloatingProps()}
@@ -886,6 +888,7 @@ function ComboboxDrawer({
         }
         floatingRef.current = node;
       }}
+      $hasFewOptions={hasFewOptions}
       $hasNestedOptions={hasNestedOptions}
       style={mobile ? {} : { ...floatingStyles }}
       $theme={comboboxTheme}
@@ -1011,8 +1014,14 @@ function ComboboxDrawer({
               emptySlateStyle: css`
                 margin-left: 0px;
                 min-height: 36px;
-                margin-top: 0px;
+                margin-top: 4px;
+                margin-bottom: 4px;
                 border: none;
+                text-align: center;
+              `,
+              emptyItemSlateStyle: css`
+                margin-top: 4px;
+                margin-bottom: 4px;
               `,
               actionStyle: css`
                 padding-left: 12px;
@@ -1211,6 +1220,7 @@ const DrawerWrapper = styled.ul<{
   $mobile?: boolean;
   $searchbox?: boolean;
   $hasNestedOptions?: boolean;
+  $hasFewOptions?: boolean;
   $drawerHeight?: string;
 }>`
   *,
@@ -1250,11 +1260,18 @@ const DrawerWrapper = styled.ul<{
     border-radius: 4px;
   }
 
-  ${({ $mobile, $theme, $searchbox, $hasNestedOptions, $drawerHeight }) => {
+  ${({
+    $mobile,
+    $theme,
+    $searchbox,
+    $hasNestedOptions,
+    $drawerHeight,
+    $hasFewOptions,
+  }) => {
     const $height = $drawerHeight ?? "220px";
 
     return css`
-      height: fit-content;
+      height: ${$hasFewOptions ? "fit-content" : $height};
       max-height: ${$height};
 
       ${$mobile &&

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -495,7 +495,7 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
         aria-expanded={isOpen}
         $disabled={disabled}
         onClick={() => {
-          if (multiple) inputRef.current?.focus();
+          inputRef.current?.focus();
         }}
       >
         {isLoading && (

--- a/test/component/calendar.cy.tsx
+++ b/test/component/calendar.cy.tsx
@@ -45,6 +45,35 @@ describe("Calendar ", () => {
         .parent()
         .should("have.css", "border-color", borderColor);
     });
+
+    context("when opening the picker mode", () => {
+      it("should still consistently rendered with 300px", () => {
+        cy.mount(
+          <Calendar
+            selectedDates={valueWeekend}
+            monthNames={MONTH_NAMES}
+            disableWeekend
+          />
+        );
+        cy.findByLabelText("calendar-wrapper").should(
+          "have.css",
+          "width",
+          "300px"
+        );
+        cy.findByLabelText("combobox-month").should("not.exist");
+        cy.findByLabelText("combobox-year").should("not.exist");
+
+        cy.findAllByLabelText("calendar-select-date").eq(0).click();
+        cy.findByLabelText("combobox-month").should("exist");
+        cy.findByLabelText("combobox-year").should("exist");
+
+        cy.findByLabelText("calendar-wrapper").should(
+          "have.css",
+          "width",
+          "300px"
+        );
+      });
+    });
   });
 
   context("disable weekend", () => {

--- a/test/component/calendar.cy.tsx
+++ b/test/component/calendar.cy.tsx
@@ -73,6 +73,30 @@ describe("Calendar ", () => {
           "300px"
         );
       });
+
+      context("when clicking the combobox", () => {
+        it("would be focused on the combo input", () => {
+          cy.mount(
+            <Calendar
+              selectedDates={valueWeekend}
+              monthNames={MONTH_NAMES}
+              disableWeekend
+            />
+          );
+          cy.findByLabelText("calendar-wrapper").should(
+            "have.css",
+            "width",
+            "300px"
+          );
+          cy.findByLabelText("combobox-month").should("not.exist");
+
+          cy.findAllByLabelText("calendar-select-date").eq(0).click();
+          cy.findByLabelText("combobox-month")
+            .should("exist")
+            .and("not.be.focused");
+          cy.findByLabelText("combobox-month").click().and("be.focused");
+        });
+      });
     });
   });
 

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -164,6 +164,40 @@ describe("Combobox", () => {
           );
         });
       });
+
+      context("when typing and less than 5 option", () => {
+        it("should render drawer with fit content (less than 420px)", () => {
+          cy.viewport(500, 700);
+
+          cy.mount(
+            <ProductCombobox options={FRUIT_OPTIONS} drawerHeight={"60dvh"} />
+          );
+
+          cy.findByRole("textbox").click();
+
+          cy.window().then((win) => {
+            const expectedHeight = `${win.innerHeight * 0.6}px`;
+
+            cy.findByLabelText("combobox-drawer").should(
+              "have.css",
+              "height",
+              expectedHeight
+            );
+          });
+
+          cy.findByRole("textbox").click();
+
+          cy.window().then((win) => {
+            const expectedHeight = `${win.innerHeight * 0.6}px`;
+
+            cy.findByLabelText("combobox-drawer").should(
+              "have.css",
+              "height",
+              expectedHeight
+            );
+          });
+        });
+      });
     });
 
     context("when given mobile", () => {


### PR DESCRIPTION
Description:
This pull request fixes an issue where the `Calendar` component stretched after opening the changes mode for the `month` or `year` picker. 

The issue was caused by the `Calendar` wrapper not preserving a consistent width. This change adds the necessary guard to keep the Calendar width stable and ensures the issue does not occur again.

Additionally, this pull request fixes the height issue, now we're using `height` instead of `min-width` in the drawer. This combination caused the drawer to incorrectly expand and render for some case.

Source:
[[Bug] SYST-775: Calendar stretch after open the `picker` mode](https://linear.app/systatum/issue/SYST-775/calendar-stretch-after-open-the-picker-mode)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself