### PR TITLE
[Mobile] SYST-620: Add `mobile` to `CapsuleTab`

### DIFF
--- a/components/capsule-tab.stories.tsx
+++ b/components/capsule-tab.stories.tsx
@@ -232,31 +232,90 @@ export const Default: Story = {
       },
     ];
 
-    return (
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: "4px",
-          width: "100%",
-        }}
-      >
-        <CapsuleTab tabs={TABS_ITEMS} activeTab={"2"} />
+    return <CapsuleTab tabs={TABS_ITEMS} activeTab={"2"} />;
+  },
+};
+
+export const Mobile: Story = {
+  render: () => {
+    const WriteTabContent = () => {
+      const [value, setValue] = useState({
+        write: "",
+      });
+
+      const onChangeValue = (e: ChangeEvent<HTMLTextAreaElement>) => {
+        const { name, value } = e.target;
+        setValue((prev) => ({ ...prev, [name]: value }));
+      };
+      return (
         <div
           style={{
+            padding: "0.8rem",
+            fontSize: "0.875rem",
             display: "flex",
-            flexDirection: "row",
-            gap: "4px",
-            width: "100%",
-            justifyContent: "end",
+            flexDirection: "column",
+            gap: "0.5rem",
           }}
         >
-          <Button>Close</Button>
-          <Button disabled variant="primary">
-            Comment
-          </Button>
+          <h3
+            style={{
+              fontWeight: 500,
+            }}
+          >
+            Write Tab
+          </h3>
+          <p>{generateSentence()}</p>
+
+          <Textbox name="write" value={value.write} onChange={onChangeValue} />
         </div>
-      </div>
-    );
+      );
+    };
+
+    const ReviewTabContent = () => {
+      return (
+        <div
+          style={{
+            padding: "0.8rem",
+            fontSize: "0.875rem",
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.5rem",
+          }}
+        >
+          <h3
+            style={{
+              fontWeight: 500,
+            }}
+          >
+            Review Tab
+          </h3>
+          <p>
+            This tab is meant to review the content that has been submitted. It
+            includes multiple paragraphs to simulate a longer layout.
+          </p>
+          <p>
+            Vestibulum feugiat, libero a viverra consequat, lacus mi laoreet
+            enim, at tristique velit quam a urna. Suspendisse potenti. In hac
+            habitasse platea dictumst. Proin vel justo ac mauris laoreet
+            sagittis.
+          </p>
+        </div>
+      );
+    };
+
+    const TABS_ITEMS: CapsuleTabTab[] = [
+      {
+        id: "1",
+        title: "Write",
+        content: <WriteTabContent key={"write-tab"} />,
+      },
+      {
+        id: "2",
+        title: "Review",
+        content: <ReviewTabContent key={"review-tab"} />,
+      },
+    ];
+
+    return <CapsuleTab mobile tabs={TABS_ITEMS} activeTab={"2"} />;
   },
 };

--- a/components/capsule-tab.stories.tsx
+++ b/components/capsule-tab.stories.tsx
@@ -22,6 +22,7 @@ It supports both **controlled** and **uncontrolled** modes, allowing flexible st
 ### ✨ Features
 - 🧭 **Tab navigation** using capsule-style UI
 - 🔁 Supports **controlled & uncontrolled state**
+- 📱 Optional \`mobile\` appearance with larger touch targets
 - 🎨 Customizable **active tab background**
 - 🧩 Flexible **content rendering per tab**
 - 🎯 Fully customizable **styles per section**
@@ -38,12 +39,18 @@ It supports both **controlled** and **uncontrolled** modes, allowing flexible st
 - Controlled via \`activeTab\` + \`onTabChange\`
 - Parent manages selected tab state
 
+#### Mobile Mode
+- Enable the \`mobile\` prop to render larger tabs optimized for touch interactions
+- Uses a \`40px\` height and \`16px\` font size
+- Tabs are centered within the available width for a consistent mobile layout
+
 ---
 
 ### 📌 Usage Guidelines
 - Use for **section switching** inside a single page
 - Keep tab titles **short and clear**
 - Use controlled mode when syncing with URL / global state
+- Use the \`mobile\` prop for mobile layouts or interfaces that benefit from larger touch targets
         `,
       },
     },

--- a/components/capsule-tab.tsx
+++ b/components/capsule-tab.tsx
@@ -10,6 +10,7 @@ export interface CapsuleTabProps {
   activeTab?: string;
   activeBackgroundColor?: string;
   styles?: CapsuleTabStyles;
+  mobile?: boolean;
   onTabChange?: (id: string) => void;
   children?: ReactNode;
   id?: string;
@@ -39,6 +40,7 @@ function CapsuleTab({
   onTabChange,
   children,
   className,
+  mobile,
   id,
 }: CapsuleTabProps) {
   const { currentTheme } = useTheme();
@@ -64,6 +66,21 @@ function CapsuleTab({
 
   const activeContent = tabs.filter((tab) => tab.id === selected);
 
+  const mobileCapsuleWrapperStyle =
+    mobile &&
+    css`
+      justify-content: center;
+    `;
+
+  const mobileTabStyle =
+    mobile &&
+    css`
+      text-align: center;
+      justify-content: center;
+      font-size: 16px;
+      height: 40px;
+    `;
+
   return (
     <CapsuleTabWrapper
       $theme={capsuleTabTheme}
@@ -73,11 +90,14 @@ function CapsuleTab({
       id={id}
     >
       <Capsule
+        mobile={mobile}
         styles={{
           capsuleWrapperStyle: css`
             padding-left: 5px;
             padding-right: 5px;
             background-color: ${capsuleTabTheme?.backgroundColor};
+
+            ${mobileCapsuleWrapperStyle}
 
             ${styles?.capsuleWrapperStyle};
           `,
@@ -87,6 +107,8 @@ function CapsuleTab({
           `,
           tabStyle: css`
             border-radius: 12px;
+            ${mobileTabStyle};
+
             ${styles?.tabStyle};
           `,
         }}

--- a/components/capsule.tsx
+++ b/components/capsule.tsx
@@ -29,6 +29,7 @@ interface BaseCapsuleProps {
   fontSize?: number;
   disabled?: boolean;
   showError?: boolean;
+  mobile?: boolean;
 }
 
 interface BaseCapsuleStyles {
@@ -48,6 +49,7 @@ function BaseCapsule({
   fontSize = 12,
   disabled,
   showError,
+  mobile,
 }: BaseCapsuleProps) {
   const { currentTheme } = useTheme();
   const capsuleTheme = currentTheme.capsule;
@@ -191,25 +193,27 @@ function BaseCapsule({
         }}
       />
 
-      <HoverBorder
-        aria-label="hover-capsule-box"
-        $style={styles?.tabStyle}
-        $theme={capsuleTheme}
-        $activeBackgroundColor={activeBackgroundColor}
-        initial={{
-          left: hoverPosition.left,
-          width: hoverPosition.width,
-        }}
-        animate={{
-          left: hoverPosition.left,
-          width: hoverPosition.width,
-        }}
-        transition={{
-          type: "spring",
-          stiffness: 250,
-          damping: 30,
-        }}
-      />
+      {!mobile && (
+        <HoverBorder
+          aria-label="hover-capsule-box"
+          $style={styles?.tabStyle}
+          $theme={capsuleTheme}
+          $activeBackgroundColor={activeBackgroundColor}
+          initial={{
+            left: hoverPosition.left,
+            width: hoverPosition.width,
+          }}
+          animate={{
+            left: hoverPosition.left,
+            width: hoverPosition.width,
+          }}
+          transition={{
+            type: "spring",
+            stiffness: 250,
+            damping: 30,
+          }}
+        />
+      )}
 
       {tabs.map((tab, index) => {
         const isActive = activeTab === tab.id;

--- a/components/capsule.tsx
+++ b/components/capsule.tsx
@@ -245,6 +245,7 @@ function BaseCapsule({
             $isActive={isActive}
             $activeColor={activeColor}
             $disabled={disabled}
+            $tabsLength={tabs?.length}
             role="tab"
             key={index}
             $mobile={mobile}
@@ -436,6 +437,7 @@ const Tab = styled.div<{
   $theme?: CapsuleThemeConfig;
   $mobile?: boolean;
   $width?: number;
+  $tabsLength?: number;
 }>`
   display: flex;
   flex-direction: row;
@@ -457,12 +459,16 @@ const Tab = styled.div<{
 
   font-size: ${({ $fontSize }) => `${$fontSize}px`};
 
-  ${({ $mobile, $width }) =>
-    $mobile &&
-    !!$width &&
-    css`
-      width: ${$width}px;
-    `};
+  ${({ $mobile, $width, $tabsLength }) =>
+    $mobile && $tabsLength >= 4
+      ? css`
+          width: 100%;
+        `
+      : $mobile &&
+        !!$width &&
+        css`
+          width: ${$width}px;
+        `};
 
   ${({ $disabled }) =>
     $disabled &&

--- a/components/capsule.tsx
+++ b/components/capsule.tsx
@@ -64,6 +64,27 @@ function BaseCapsule({
   const [tabSizes, setTabSizes] = useState<{ width: number; left: number }[]>(
     []
   );
+
+  const [maxTabWidth, setMaxTabWidth] = useState<number>(0);
+
+  useEffect(() => {
+    if (!mobile || !tabRefs.current.length) return;
+
+    const calculateMaxWidth = () => {
+      if (!mobile || !tabRefs.current.length) return;
+
+      const widths: number[] = tabRefs.current.map(
+        (el) => el?.getBoundingClientRect().width ?? 0
+      );
+
+      const largest: number = widths.length ? Math.max(...widths) : 0;
+
+      setMaxTabWidth((prev) => (prev !== largest ? largest : prev));
+    };
+
+    calculateMaxWidth();
+  }, [tabs, mobile]);
+
   const [isInitialized, setIsInitialized] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -226,6 +247,8 @@ function BaseCapsule({
             $disabled={disabled}
             role="tab"
             key={index}
+            $mobile={mobile}
+            $width={mobile ? maxTabWidth : undefined}
             className={applyClassName("capsule-pill", tab?.className)}
             id={tab?.id}
             ref={setTabRef(index)}
@@ -411,6 +434,8 @@ const Tab = styled.div<{
   $disabled?: boolean;
   $activeColor?: string;
   $theme?: CapsuleThemeConfig;
+  $mobile?: boolean;
+  $width?: number;
 }>`
   display: flex;
   flex-direction: row;
@@ -432,6 +457,13 @@ const Tab = styled.div<{
 
   font-size: ${({ $fontSize }) => `${$fontSize}px`};
 
+  ${({ $mobile, $width }) =>
+    $mobile &&
+    !!$width &&
+    css`
+      width: ${$width}px;
+    `};
+
   ${({ $disabled }) =>
     $disabled &&
     css`
@@ -439,9 +471,7 @@ const Tab = styled.div<{
       user-select: none;
     `};
 
-  ${({ $activeTabStyle }) => css`
-    ${$activeTabStyle}
-  `}
+  ${({ $activeTabStyle }) => $activeTabStyle}
 `;
 
 export { Capsule };

--- a/test/component/capsule-tab.cy.tsx
+++ b/test/component/capsule-tab.cy.tsx
@@ -3,6 +3,7 @@ import {
   CapsuleTab,
   CapsuleTabTab,
   CapsuleTabStyles,
+  CapsuleTabProps,
 } from "./../../components/capsule-tab";
 import { useState } from "react";
 
@@ -14,18 +15,15 @@ describe("Capsule Tab", () => {
 
   function ProductCapsuleTab({
     withCallback,
-    styles,
-    tabs,
+    ...props
   }: {
-    styles?: CapsuleTabStyles;
     withCallback?: boolean;
-    tabs?: CapsuleTabTab[];
-  }) {
+  } & Partial<CapsuleTabProps>) {
     const [activeTab, setActiveTab] = useState("2");
 
     return (
       <CapsuleTab
-        tabs={tabs ? tabs : TABS_ITEMS}
+        tabs={TABS_ITEMS}
         activeTab={activeTab}
         onTabChange={
           withCallback
@@ -35,10 +33,36 @@ describe("Capsule Tab", () => {
               }
             : undefined
         }
-        styles={styles}
+        {...props}
       />
     );
   }
+
+  context("mobile", () => {
+    it("render with justify-center for the whole screen", () => {
+      cy.mount(<ProductCapsuleTab mobile />);
+      cy.findAllByLabelText("capsule")
+        .eq(0)
+        .should("have.css", "justify-content", "center");
+    });
+
+    it("render with pill capsule with height 40px and font-size 16px", () => {
+      cy.mount(<ProductCapsuleTab mobile />);
+      cy.findAllByRole("tab")
+        .eq(0)
+        .should("have.css", "height", "40px")
+        .and("have.css", "font-size", "16px");
+      cy.findAllByRole("tab")
+        .eq(1)
+        .should("have.css", "height", "40px")
+        .and("have.css", "font-size", "16px");
+    });
+
+    it("render without hover capsule", () => {
+      cy.mount(<ProductCapsuleTab mobile />);
+      cy.findByLabelText("hover-capsule-box").should("not.exist");
+    });
+  });
 
   context("styles", () => {
     context("capsuleWrapperStyle", () => {

--- a/test/component/capsule-tab.cy.tsx
+++ b/test/component/capsule-tab.cy.tsx
@@ -58,6 +58,61 @@ describe("Capsule Tab", () => {
         .and("have.css", "font-size", "16px");
     });
 
+    it("render the pill capsule with same width get from the biggest", () => {
+      const TABS_ITEMS: CapsuleTabTab[] = [
+        { id: "1", title: "Write", content: "Write Tab" },
+        { id: "2", title: "Reviewing this tab", content: "Review Tab" },
+      ];
+      cy.mount(<ProductCapsuleTab mobile tabs={TABS_ITEMS} />);
+      cy.findAllByRole("tab").then(($tabs) => {
+        const firstWidth = $tabs.eq(0).outerWidth();
+        const secondWidth = $tabs.eq(1).outerWidth();
+
+        expect(firstWidth).to.equal(secondWidth);
+      });
+    });
+
+    context("when given 3 capsule", () => {
+      it("render the pill capsule with same width get from the biggest", () => {
+        const TABS_ITEMS: CapsuleTabTab[] = [
+          { id: "1", title: "Write", content: "Write Tab" },
+          { id: "2", title: "Reviewing this tab", content: "Review Tab" },
+          { id: "3", title: "Nothing", content: "Review Tab" },
+        ];
+        cy.mount(<ProductCapsuleTab mobile tabs={TABS_ITEMS} />);
+        cy.findAllByRole("tab").then(($tabs) => {
+          const firstWidth = $tabs.eq(0).outerWidth();
+          const secondWidth = $tabs.eq(1).outerWidth();
+          const thirdWidth = $tabs.eq(2).outerWidth();
+
+          expect(firstWidth).to.equal(secondWidth);
+          expect(firstWidth).to.equal(thirdWidth);
+        });
+      });
+    });
+
+    context("when given 4 capsule", () => {
+      it("render the pill capsule with 100% width", () => {
+        const TABS_ITEMS: CapsuleTabTab[] = [
+          { id: "1", title: "Write", content: "Write Tab" },
+          { id: "2", title: "Reviewing this tab", content: "Review Tab" },
+          { id: "3", title: "Nothing", content: "Review Tab" },
+          { id: "4", title: "Test", content: "Review Tab" },
+        ];
+        cy.mount(<ProductCapsuleTab mobile tabs={TABS_ITEMS} />);
+        cy.findAllByRole("tab").then(($tabs) => {
+          const firstWidth = $tabs.eq(0).outerWidth();
+          const secondWidth = $tabs.eq(1).outerWidth();
+          const thirdWidth = $tabs.eq(2).outerWidth();
+          const fourthWidth = $tabs.eq(3).outerWidth();
+
+          expect(firstWidth).to.equal(secondWidth);
+          expect(firstWidth).to.equal(thirdWidth);
+          expect(firstWidth).to.equal(fourthWidth);
+        });
+      });
+    });
+
     it("render without hover capsule", () => {
       cy.mount(<ProductCapsuleTab mobile />);
       cy.findByLabelText("hover-capsule-box").should("not.exist");


### PR DESCRIPTION
Description:
This pull request introduces a `mobile` prop for the `CapsuleTab` component. When enable, the tab would renders a larger appearance than not using the `mobile` prop, with `height: 40px` and `font-size: 16px`.

Additionally, the wrapper should using `justify-content: center` to ensure the tabs are always centered across the available width. It also ensures that appearance applied consistently when the `mobile` prop is provided.

Source:
[[Mobile] SYST-620: Add `mobile` to `CapsuleTab`](https://linear.app/systatum/issue/SYST-620/add-mobile-to-capsuletab)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself