### PR TITLE
[Bug] SYST-777: `Hidden` prop issue on the `Title`

### DIFF
--- a/components/title.tsx
+++ b/components/title.tsx
@@ -275,13 +275,15 @@ function BaseTitleSection({
 
           const resolvedIconSize = ICON_SIZE[size] * 0.8;
 
-          const filteredActionsWithSize = filteredActions?.map((action) => ({
-            ...action,
-            icon: {
-              ...action.icon,
-              size: action?.icon?.size ?? resolvedIconSize,
-            },
-          }));
+          const filteredActionsWithSize = filteredActions
+            ?.filter((action) => !action?.hidden)
+            ?.map((action) => ({
+              ...action,
+              icon: {
+                ...action.icon,
+                size: action?.icon?.size ?? resolvedIconSize,
+              },
+            }));
 
           return filteredActionsWithSize.map((action, actionIndex) => {
             const variant = action?.variant ?? "ghost";


### PR DESCRIPTION
Description:
This ticket fixes a hidden prop on the `Title` component, I don't know what's the real culprit before causes this buggy, before I've add the filtering to not shows if `hidden` is provided, even on the testing it was applied in the `title.cy.tsx`.

Source:
[[Bug] SYST-777: Hidden prop issue on the `Title`](https://linear.app/systatum/issue/SYST-777/hidden-prop-issue-on-the-title)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself