### PR TITLE
[Bug] SYST-779: Fix Bil-Quran paper dialog cannot be easily maximized on mobile

### DIFF
--- a/components/overlay-blocker.tsx
+++ b/components/overlay-blocker.tsx
@@ -60,7 +60,6 @@ export const OverlayBlocker = forwardRef<
       ".coneto-paper-dialog",
       ".coneto-dialog",
       ".coneto-sidebar",
-      ".sbdocs",
       ...(_exemptRegions ?? []),
     ];
 
@@ -69,13 +68,9 @@ export const OverlayBlocker = forwardRef<
     useEffect(() => {
       if (!visible) return;
 
-      const safeRegions = exemptRegions ?? [];
+      if (document.querySelector(".sbdocs-content")) return;
 
-      // Check if the overlay is rendered inside a safe region
-      const isRenderedInsideSafeZone = isInSafeZone(
-        document.querySelector('[aria-label="overlay-blocker"]'),
-        safeRegions
-      );
+      const safeRegions = exemptRegions ?? [];
 
       const scrollY = window.scrollY;
       const body = document.body;
@@ -87,13 +82,10 @@ export const OverlayBlocker = forwardRef<
         width: body.style.width,
       };
 
-      // Only lock the body if NOT inside a safe zone
-      if (!isRenderedInsideSafeZone) {
-        body.style.overflow = "hidden";
-        body.style.position = "fixed";
-        body.style.top = `-${scrollY}px`;
-        body.style.width = "100%";
-      }
+      body.style.overflow = "hidden";
+      body.style.position = "fixed";
+      body.style.top = `-${scrollY}px`;
+      body.style.width = "100%";
 
       const allow = (target: EventTarget | null) =>
         isInSafeZone(target, safeRegions);
@@ -112,16 +104,15 @@ export const OverlayBlocker = forwardRef<
       window.addEventListener("touchmove", blockTouch, { passive: false });
 
       return () => {
-        if (!isRenderedInsideSafeZone) {
-          body.style.overflow = prev.overflow;
-          body.style.position = prev.position;
-          body.style.top = prev.top;
-          body.style.width = prev.width;
-          window.scrollTo(0, scrollY);
-        }
+        body.style.overflow = prev.overflow;
+        body.style.position = prev.position;
+        body.style.top = prev.top;
+        body.style.width = prev.width;
 
         window.removeEventListener("wheel", blockWheel);
         window.removeEventListener("touchmove", blockTouch);
+
+        window.scrollTo(0, scrollY);
       };
     }, [exemptRegions, visible]);
 


### PR DESCRIPTION
Description:
This pull request fixes an issue on the `overlay-blocker` not handle properly for `background` on the overlay opened scrolling, it causes after refactors the `Table.documentation` error.

Basically just adjustment using previous code, because it's totally work, but for fix documentation issue, just guard with specialization on the `documentation.storybook`, because this documentation only using `body` for scrolling behavior.

```tsx
    useEffect(() => {
      if (!visible) return;

      if (document.querySelector(".sbdocs-content")) return;

      const safeRegions = exemptRegions ?? [];

      const scrollY = window.scrollY;
      const body = document.body;

      const prev = {
        overflow: body.style.overflow,
        position: body.style.position,
        top: body.style.top,
        width: body.style.width,
      };

      body.style.overflow = "hidden";
      body.style.position = "fixed";
      body.style.top = `-${scrollY}px`;
      body.style.width = "100%";

      const allow = (target: EventTarget | null) =>
        isInSafeZone(target, safeRegions);

      const blockWheel = (e: WheelEvent) => {
        if (allow(e.target)) return;
        e.preventDefault();
      };

      const blockTouch = (e: TouchEvent) => {
        if (allow(e.target)) return;
        e.preventDefault();
      };

      window.addEventListener("wheel", blockWheel, { passive: false });
      window.addEventListener("touchmove", blockTouch, { passive: false });

      return () => {
        body.style.overflow = prev.overflow;
        body.style.position = prev.position;
        body.style.top = prev.top;
        body.style.width = prev.width;

        window.removeEventListener("wheel", blockWheel);
        window.removeEventListener("touchmove", blockTouch);

        window.scrollTo(0, scrollY);
      };
    }, [exemptRegions, visible]);
```

Source:
[[Bug] SYST-779: Fix Bil-Quran paper dialog cannot be easily maximized on mobile](https://linear.app/systatum/issue/SYST-779/fix-bil-quran-paper-dialog-cannot-be-easily-maximized-on-mobile)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself