### PR TITLE
[Improvement] SYST-778: Allow applying more style to mobile stateful form

### DIFF
--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -591,8 +591,8 @@ function FormFields<T extends FieldValues>({
                 align-items: ${rowAlignedItem};
               `};
 
-              ${rowStyleItem};
               ${styles?.mobileFieldGroupStyle};
+              ${rowStyleItem};
             `}
             key={indexGroup}
           >

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -128,9 +128,10 @@ export interface StatefulFormProps<Z extends ZodTypeAny> {
 
 export interface StatefulFormStyles {
   containerStyle?: CSSProp;
-  rowStyle?: CSSProp;
   frameContainerStyle?: CSSProp;
   frameTitleStyle?: CSSProp;
+  mobileFieldGroupStyle?: CSSProp;
+  mobileFieldGroupRowDividerStyle?: CSSProp;
 }
 
 export type FormFieldGroup = FormFieldProps | FormFieldProps[];
@@ -483,14 +484,16 @@ function FormFields<T extends FieldValues>({
         }
 
         const rowJustifiedContent = visibleFields.find(
-          (f) => f.rowJustifyPosition
+          (field) => field.rowJustifyPosition
         )?.rowJustifyPosition;
 
         const rowAlignedItem = visibleFields.find(
-          (f) => f.rowItemsAlignment
+          (field) => field.rowItemsAlignment
         )?.rowItemsAlignment;
 
-        const rowStyleItem = visibleFields.find((f) => f.rowStyle)?.rowStyle;
+        const rowStyleItem = visibleFields.find(
+          (field) => field.rowStyle
+        )?.rowStyle;
 
         const nonButtonFields = visibleFields.filter(
           (f) => f.type !== "button"
@@ -566,9 +569,10 @@ function FormFields<T extends FieldValues>({
 
         return (
           <RowFormField
-            aria-label="stateful-form-row"
+            aria-label={
+              mobile ? "stateful-form-field-group" : "stateful-form-row"
+            }
             $style={css`
-              ${styles?.rowStyle}
               ${rowJustifiedContent &&
               css`
                 justify-content: ${rowJustifiedContent};
@@ -587,7 +591,8 @@ function FormFields<T extends FieldValues>({
                 align-items: ${rowAlignedItem};
               `};
 
-              ${rowStyleItem}
+              ${rowStyleItem};
+              ${styles?.mobileFieldGroupStyle};
             `}
             key={indexGroup}
           >
@@ -596,7 +601,7 @@ function FormFields<T extends FieldValues>({
                 ? (field?.labelPosition ?? "left")
                 : field?.labelPosition;
               const isLast = index === visibleFields.length - 1;
-              const showSeparator =
+              const showDivider =
                 mobile && !isLast && Array.isArray(group) && !isButtonRow;
               const label = mobile ? null : field?.title;
               const placeholder = mobile
@@ -2716,7 +2721,13 @@ function FormFields<T extends FieldValues>({
               return (
                 <Fragment key={index}>
                   {fieldNode}
-                  {showSeparator && <Separator $theme={statefulFormTheme} />}
+                  {showDivider && (
+                    <Divider
+                      aria-label="stateful-form-field-group-divider"
+                      $style={styles?.mobileFieldGroupRowDividerStyle}
+                      $theme={statefulFormTheme}
+                    />
+                  )}
                 </Fragment>
               );
             })}
@@ -2727,11 +2738,16 @@ function FormFields<T extends FieldValues>({
   );
 }
 
-const Separator = styled.div<{ $theme?: StatefulFormThemeConfig }>`
+const Divider = styled.div<{
+  $theme?: StatefulFormThemeConfig;
+  $style?: CSSProp;
+}>`
   width: 100%;
   height: 1px;
   background-color: ${({ $theme }) =>
     $theme?.borderColor ?? "rgba(0,0,0,0.08)"};
+
+  ${({ $style }) => $style}
 `;
 
 export interface StatefulFormLabelProps

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -325,6 +325,59 @@ const flattenFields = (groups: FormFieldGroup[]): FormFieldProps[] =>
 
 describe("StatefulForm", () => {
   context("mobile", () => {
+    context("styles", () => {
+      context("mobileFieldGroupStyle", () => {
+        context("when given padding 30px", () => {
+          it("should render the padding in all side with 30px", () => {
+            cy.mount(
+              <StatefulForm
+                fields={ALL_INPUT}
+                formValues={allValue}
+                mode="onChange"
+                mobile
+                styles={{
+                  mobileFieldGroupStyle: css`
+                    padding: 30px;
+                  `,
+                }}
+              />
+            );
+
+            cy.findAllByLabelText("stateful-form-field-group").should(
+              "have.css",
+              "padding",
+              "30px"
+            );
+          });
+        });
+      });
+
+      context("mobileFieldGroupRowDividerStyle", () => {
+        context("when given color red", () => {
+          it("should render the color with rgb(255, 0, 0)", () => {
+            cy.mount(
+              <StatefulForm
+                fields={ALL_INPUT}
+                formValues={allValue}
+                mode="onChange"
+                mobile
+                styles={{
+                  mobileFieldGroupRowDividerStyle: css`
+                    background-color: red;
+                  `,
+                }}
+              />
+            );
+
+            cy.findAllByLabelText("stateful-form-field-group-divider").should(
+              "have.css",
+              "background-color",
+              "rgb(255, 0, 0)"
+            );
+          });
+        });
+      });
+    });
     it("renders with background rgb(236, 236, 236)", () => {
       cy.mount(
         <StatefulForm
@@ -335,7 +388,7 @@ describe("StatefulForm", () => {
         />
       );
 
-      cy.findAllByLabelText("stateful-form-row").should(
+      cy.findAllByLabelText("stateful-form-field-group").should(
         "have.css",
         "background-color",
         "rgb(236, 236, 236)"
@@ -352,7 +405,7 @@ describe("StatefulForm", () => {
         />
       );
 
-      cy.findAllByLabelText("stateful-form-row")
+      cy.findAllByLabelText("stateful-form-field-group")
         .should("have.css", "border-radius", "24px")
         .and("have.css", "padding", "10px 20px");
     });
@@ -380,7 +433,7 @@ describe("StatefulForm", () => {
           );
           cy.get("@onChangeValue").should("not.have.been.calledOnce");
 
-          cy.findAllByLabelText("stateful-form-row").click("center");
+          cy.findAllByLabelText("stateful-form-field-group").click("center");
 
           cy.get("@onChangeValue").should("have.been.calledOnce");
         });
@@ -410,7 +463,7 @@ describe("StatefulForm", () => {
           );
           cy.get("@onChangeValue").should("not.have.been.calledOnce");
 
-          cy.findAllByLabelText("stateful-form-row").click("center");
+          cy.findAllByLabelText("stateful-form-field-group").click("center");
 
           cy.get("@onChangeValue").should("have.been.calledOnce");
         });
@@ -450,7 +503,7 @@ describe("StatefulForm", () => {
             />
           );
 
-          cy.findAllByLabelText("stateful-form-row")
+          cy.findAllByLabelText("stateful-form-field-group")
             .should("have.css", "flex-direction", "row")
             .and("have.css", "width", "460px");
 
@@ -499,7 +552,7 @@ describe("StatefulForm", () => {
             />
           );
 
-          cy.findAllByLabelText("stateful-form-row")
+          cy.findAllByLabelText("stateful-form-field-group")
             .should("have.css", "flex-direction", "column")
             .and("have.css", "width", "460px");
 


### PR DESCRIPTION
Description:
This pull request introduces a part of `styles` prop on the `StatefulForm` to use properly on group level using `mobileFieldGroupStyle` and `mobileFieldGroupRowDividerStyle` for divider inside of `mobile` appearance. 

It also ensures that appearance would works correctly without add `!important` after re-sort the `styles` on the `FieldGroup`.

Source:
[[Improvement] SYST-778: Allow applying more style to mobile stateful form](https://linear.app/systatum/issue/SYST-778/allow-applying-more-style-to-mobile-stateful-form)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself