### PR TITLE
[Mobile] SYST-782: Make split pane separator adjustable even using tap

### DIFF
--- a/components/split-pane.tsx
+++ b/components/split-pane.tsx
@@ -138,7 +138,7 @@ function SplitPane({
     [isVertical]
   );
 
-  const stopDrag = useCallback(
+  const onPointerUp = useCallback(
     (e?: globalThis.PointerEvent) => {
       if (
         e &&
@@ -157,13 +157,13 @@ function SplitPane({
       }
 
       document.removeEventListener("pointermove", onPointerMove);
-      document.removeEventListener("pointerup", stopDrag);
-      document.removeEventListener("pointercancel", stopDrag);
+      document.removeEventListener("pointerup", onPointerUp);
+      document.removeEventListener("pointercancel", onPointerUp);
     },
     [onPointerMove]
   );
 
-  const startDrag = useCallback(
+  const onPointerDown = useCallback(
     (index: number) => (e: React.PointerEvent) => {
       e.preventDefault();
 
@@ -188,10 +188,10 @@ function SplitPane({
       }
 
       document.addEventListener("pointermove", onPointerMove);
-      document.addEventListener("pointerup", stopDrag);
-      document.addEventListener("pointercancel", stopDrag);
+      document.addEventListener("pointerup", onPointerUp);
+      document.addEventListener("pointercancel", onPointerUp);
     },
-    [isVertical, sizes, onPointerMove, stopDrag]
+    [isVertical, sizes, onPointerMove, onPointerUp]
   );
 
   useEffect(() => {
@@ -230,7 +230,7 @@ function SplitPane({
               $style={styles?.dividerStyle}
               className="divider"
               aria-label={`split-pane-divider`}
-              onPointerDown={startDrag(index)}
+              onPointerDown={onPointerDown(index)}
               $isVertical={isVertical}
             />
           )}

--- a/components/split-pane.tsx
+++ b/components/split-pane.tsx
@@ -45,10 +45,8 @@ export interface SplitPaneStyles {
   dividerStyle?: CSSProp;
 }
 
-export interface SplitPaneCellProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  "style"
-> {
+export interface SplitPaneCellProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "style"> {
   children?: ReactNode;
   styles?: SplitPaneCellStyles;
   actions?: SplitPaneAction[];
@@ -89,10 +87,11 @@ function SplitPane({
   const draggingIndex = useRef<number | null>(null);
   const startPosition = useRef<number>(0);
   const startSizes = useRef<number[]>([]);
+  const activePointerId = useRef<number | null>(null);
   const runOnResize = useRafThrottle(onResize);
 
-  const onMouseMove = useCallback(
-    (e: globalThis.MouseEvent) => {
+  const onPointerMove = useCallback(
+    (e: globalThis.PointerEvent) => {
       if (draggingIndex.current === null || !containerRef.current) return;
 
       const container = containerRef.current;
@@ -139,19 +138,33 @@ function SplitPane({
     [isVertical]
   );
 
-  const stopDrag = useCallback(() => {
-    draggingIndex.current = null;
-    startSizes.current = [];
-    setIsDragging(false);
-    if (onResizeComplete) {
-      onResizeComplete();
-    }
-    document.removeEventListener("mousemove", onMouseMove);
-    document.removeEventListener("mouseup", stopDrag);
-  }, [onMouseMove]);
+  const stopDrag = useCallback(
+    (e?: globalThis.PointerEvent) => {
+      if (
+        e &&
+        activePointerId.current !== null &&
+        e.pointerId !== activePointerId.current
+      ) {
+        return;
+      }
+
+      draggingIndex.current = null;
+      startSizes.current = [];
+      activePointerId.current = null;
+      setIsDragging(false);
+      if (onResizeComplete) {
+        onResizeComplete();
+      }
+
+      document.removeEventListener("pointermove", onPointerMove);
+      document.removeEventListener("pointerup", stopDrag);
+      document.removeEventListener("pointercancel", stopDrag);
+    },
+    [onPointerMove]
+  );
 
   const startDrag = useCallback(
-    (index: number) => (e: MouseEvent) => {
+    (index: number) => (e: React.PointerEvent) => {
       e.preventDefault();
 
       draggingIndex.current = index;
@@ -165,10 +178,20 @@ function SplitPane({
         ? e.clientX - rect.left
         : e.clientY - rect.top;
 
-      document.addEventListener("mousemove", onMouseMove);
-      document.addEventListener("mouseup", stopDrag);
+      // Ensure this divider keeps receiving pointer events even if the
+      // finger/pointer moves off it (important for touch dragging).
+
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        // setPointerCapture can throw in some environments; safe to ignore.
+      }
+
+      document.addEventListener("pointermove", onPointerMove);
+      document.addEventListener("pointerup", stopDrag);
+      document.addEventListener("pointercancel", stopDrag);
     },
-    [isVertical, sizes, onMouseMove, stopDrag]
+    [isVertical, sizes, onPointerMove, stopDrag]
   );
 
   useEffect(() => {
@@ -207,7 +230,7 @@ function SplitPane({
               $style={styles?.dividerStyle}
               className="divider"
               aria-label={`split-pane-divider`}
-              onMouseDown={startDrag(index)}
+              onPointerDown={startDrag(index)}
               $isVertical={isVertical}
             />
           )}

--- a/test/component/split-pane.cy.tsx
+++ b/test/component/split-pane.cy.tsx
@@ -163,7 +163,7 @@ describe("SplitPane", () => {
 
     context("onMouseEnter", () => {
       context("when hovering", () => {
-        it("should give callback", () => {
+        it("should give the callback", () => {
           cy.window().then((win) => {
             cy.spy(win.console, "log").as("consoleLog");
           });

--- a/test/component/split-pane.cy.tsx
+++ b/test/component/split-pane.cy.tsx
@@ -241,15 +241,15 @@ describe("SplitPane", () => {
         </SplitPane>
       );
 
-      cy.findByLabelText("split-pane-divider").trigger("mousedown", {
+      cy.findByLabelText("split-pane-divider").trigger("pointerdown", {
         clientY: 250,
       });
 
       for (let i = 0; i < 100; i++) {
-        cy.get("body").trigger("mousemove", { clientY: 250 + i });
+        cy.get("body").trigger("pointermove", { clientY: 250 + i });
       }
 
-      cy.get("body").trigger("mouseup");
+      cy.get("body").trigger("pointerup");
       cy.get("@onResize").its("callCount").should("eq", 100);
     });
   });
@@ -309,11 +309,11 @@ describe("SplitPane", () => {
         cy.mount(<SplitPaneWithTextbox />);
 
         cy.findAllByLabelText("split-pane-divider")
-          .trigger("mousedown", {
+          .trigger("pointerdown", {
             clientY: 250,
           })
-          .trigger("mousemove", { clientY: 150 })
-          .trigger("mouseup");
+          .trigger("pointermove", { clientY: 150 })
+          .trigger("pointerup");
 
         cy.findAllByLabelText("split-pane-cell")
           .eq(1)

--- a/test/e2e/split-pane.cy.ts
+++ b/test/e2e/split-pane.cy.ts
@@ -27,13 +27,13 @@ describe("SplitPane", () => {
         .eq(1)
         .should("contain.text", "Down");
 
-      cy.findAllByLabelText("split-pane-divider").eq(0).trigger("mousedown", {
+      cy.findAllByLabelText("split-pane-divider").eq(0).trigger("pointerdown", {
         which: 1,
       });
       cy.wait(500);
-      cy.document().trigger("mousemove", { clientY: 300 });
+      cy.document().trigger("pointermove", { clientY: 300 });
       cy.wait(500);
-      cy.document().trigger("mouseup");
+      cy.document().trigger("pointerup");
     });
   });
 


### PR DESCRIPTION
Description:
This pull request improves the function to use `pointer` instead of using the `mouse`, it would not support in mobile behavior when dragging or resizing the separation content. It also ensures the pointer behavior would works properly in test, either by cypress or by our phone.

Source:
[[Mobile] SYST-782: Make split pane separator adjustable even using tap](https://linear.app/systatum/issue/SYST-782/make-split-pane-separator-adjustable-even-using-tap)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself