### PR TITLE
[Bug] SYST-786: `PaperDialog` issue on `Android`

### DIFF
--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -810,6 +810,7 @@ const MotionDialog = styled(motion.div)<{
 `;
 
 const DesktopResizeHandle = styled.div<{ $isLeft: boolean }>`
+  touch-action: none;
   position: absolute;
   top: 0;
   bottom: 0;
@@ -955,6 +956,8 @@ const DragIndicatorWrapper = styled(motion.div)<{
   display: flex;
   top: 0;
   justify-content: center;
+
+  touch-action: none;
 
   cursor: ${({ $resizable }) => ($resizable ? "ns-resize" : "grab")};
   width: 100dvw;

--- a/components/split-pane.tsx
+++ b/components/split-pane.tsx
@@ -404,6 +404,7 @@ const CellWrapper = styled.div<{
 
 const Divider = styled.div<{ $isVertical: boolean; $style?: CSSProp }>`
   position: relative;
+  touch-action: none;
   background-color: transparent;
   transition: background-color 0.3s;
   z-index: 100;

--- a/test/component/paper-dialog.cy.tsx
+++ b/test/component/paper-dialog.cy.tsx
@@ -102,6 +102,28 @@ describe("PaperDialog", () => {
   });
 
   context("resizable", () => {
+    it("renders the resizeable with touch-action none", () => {
+      cy.viewport(500, 700);
+
+      cy.mount(
+        <ProductPaperDialog
+          width="50dvw"
+          resizable={{
+            minWidth: "200px",
+          }}
+        />
+      );
+
+      cy.findAllByRole("button").eq(0).click();
+      cy.wait(500);
+
+      cy.findByLabelText("paper-dialog-resize-handle").should(
+        "have.css",
+        "touch-action",
+        "none"
+      );
+    });
+
     context("object", () => {
       context("minWidth", () => {
         it("does not resize below the minimum width", () => {
@@ -303,6 +325,29 @@ describe("PaperDialog", () => {
     });
 
     context("resizable", () => {
+      it("renders the resizeable with touch-action none", () => {
+        cy.viewport(500, 700);
+
+        cy.mount(
+          <ProductPaperDialog
+            mobile
+            width="50dvw"
+            resizable={{
+              minWidth: "200px",
+            }}
+          />
+        );
+
+        cy.findAllByRole("button").eq(0).click();
+        cy.wait(500);
+
+        cy.findByLabelText("paper-dialog-drag-indicator").should(
+          "have.css",
+          "touch-action",
+          "none"
+        );
+      });
+
       context("object", () => {
         context("minHeight", () => {
           it("does not resize below the minimum height", () => {

--- a/test/component/split-pane.cy.tsx
+++ b/test/component/split-pane.cy.tsx
@@ -223,6 +223,31 @@ describe("SplitPane", () => {
   });
 
   context("onResize", () => {
+    it("renders the drag indicator using touch-action none", () => {
+      const onResize = cy.stub().as("onResize");
+
+      cy.mount(
+        <SplitPane
+          orientation="horizontal"
+          styles={{
+            self: css`
+              height: 500px;
+            `,
+          }}
+          onResize={onResize}
+        >
+          <SplitPane.Cell>Top</SplitPane.Cell>
+          <SplitPane.Cell>Bottom</SplitPane.Cell>
+        </SplitPane>
+      );
+
+      cy.findByLabelText("split-pane-divider").should(
+        "have.css",
+        "touch-action",
+        "none"
+      );
+    });
+
     it("should call onResize rapid while dragging", () => {
       const onResize = cy.stub().as("onResize");
 


### PR DESCRIPTION
Description:
This pull request fixes the behavior on `Android` , after catch an issue in the `bil-quran` app, the `PaperDialog` doesn't work properly for `resizeable`, we should provides the `touch-action: none` on the drag, the real reason it causes from between `native` android gesture and `javascript` scroll, so we need to added it.

It also ensures the drag indicator provides properly, and make sure in real project, or in another devices would works correctly.

Source:
[[Bug] SYST-786: `PaperDialog` issue on `Android`](https://linear.app/systatum/issue/SYST-786/paperdialog-issue-on-android)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself