### PR TITLE
[Bug] SYST-791: Refactors `width` uses if not using `mobile` on the `StatefulForm.Combobox`

### DIFF
--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -2200,7 +2200,8 @@ function FormFields<T extends FieldValues>({
                                 ${field.combobox?.styles?.bodyStyle}
                               `,
                               controlStyle: css`
-                                ${field.title &&
+                                ${mobile &&
+                                field.title &&
                                 css`
                                   ${mobileControlStyle}
                                   min-width: 140px;

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -165,7 +165,6 @@ const ALL_INPUT: FormFieldGroup[] = [
     title: "Time",
     type: "time",
     required: true,
-    placeholder: "Enter time",
   },
   {
     name: "number",
@@ -890,7 +889,6 @@ describe("StatefulForm", () => {
                   title: "Time",
                   type: "time",
                   required: true,
-                  placeholder: "Enter time",
                 },
               ]}
               formValues={{}}
@@ -1072,6 +1070,40 @@ describe("StatefulForm", () => {
 
     it("should shows value from formValues", () => {
       cy.get("#combobox-combo").should("have.value", "Grape");
+    });
+
+    context("when given four comboboxes in a row", () => {
+      it("renders each with a width smaller than 140px (min-width)", () => {
+        cy.viewport(500, 750);
+        const fields = Array.from({ length: 4 }, (_, i) => ({
+          id: `combo-${i + 1}`,
+          name: `combo${i + 1}`,
+          title: `Combo ${i + 1}`,
+          type: "combo" as const,
+          required: true,
+          placeholder: "Select a fruit...",
+          combobox: {
+            options: FRUIT_OPTIONS,
+          },
+        }));
+        cy.mount(<StatefulForm fields={[fields]} formValues={{}} />);
+
+        cy.then(() => {
+          const widths: number[] = [];
+
+          cy.wrap(fields).each((field: (typeof fields)[number]) => {
+            cy.get(`#${field.id}`).then(($el) => {
+              widths.push($el[0].getBoundingClientRect().width);
+            });
+          });
+
+          cy.then(() => {
+            widths.forEach((width) => {
+              expect(width).to.be.closeTo(110.5, 1);
+            });
+          });
+        });
+      });
     });
 
     context("when given value from selectedOptions", () => {
@@ -2089,7 +2121,6 @@ describe("StatefulForm", () => {
           title: "Time",
           type: "time",
           required: false,
-          placeholder: "Enter time",
           id: "field-time-⏰ something",
         },
         {
@@ -3227,6 +3258,44 @@ describe("StatefulForm", () => {
                 expect(elWidth).to.be.closeTo(222.5, 10);
               });
           }
+        });
+      });
+
+      context("when using small screen", () => {
+        it("still render input elements with sizing", () => {
+          const INPUT_WITH_WIDTH = ALL_INPUT.map((group) =>
+            Array.isArray(group)
+              ? group.map((item) => ({ ...item, width: "50%" }))
+              : { ...group, width: "50%" }
+          );
+
+          cy.viewport(440, 750);
+          // assume this in phone
+
+          cy.mount(
+            <StatefulForm
+              fields={INPUT_WITH_WIDTH}
+              formValues={allValue}
+              mode="onChange"
+            />
+          );
+
+          flattenFields(INPUT_WITH_WIDTH).forEach((prop) => {
+            if (prop.name === "country_code") return;
+            if (prop.name === "toggle") {
+              cy.findByLabelText("toggle-row-wrapper").then(($el) => {
+                const width = $el.width();
+                expect(width).to.be.closeTo(197.5, 10);
+              });
+            } else {
+              cy.findByText(prop.title)
+                .parent()
+                .then(($el) => {
+                  const elWidth = $el.width();
+                  expect(elWidth).to.be.closeTo(197.5, 10);
+                });
+            }
+          });
         });
       });
     });


### PR DESCRIPTION
Description:
Previously, The `combobox` inside of the `Stateful` causes bug for uses `min-width: 140px` in `Combobox` after `introduces` a `mobile` appearance. This pull request fixes that issue. It also ensures the `width` works properly if using `percentage` in `non-mobile` case, if not using mobile appearance.

<img width="464" height="83" alt="Screenshot 2026-07-09 at 11 46 13" src="https://github.com/user-attachments/assets/237810d5-dc9c-45e2-b9d5-eab33d682715" />

Source:
[[Bug] SYST-791: Refactors `width` uses if not using `mobile` on the `StatefulForm.Combobox`](https://linear.app/systatum/issue/SYST-791/refactors-width-uses-if-not-using-mobile-on-the-statefulformcombobox)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself