### PR TITLE
[Bug] SYST-792: Fix ugly loose table when it has only a few data

### DIFF
--- a/components/scrollbar.tsx
+++ b/components/scrollbar.tsx
@@ -17,6 +17,8 @@ interface ScrollbarProps {
   autoHideDelay?: number;
   onScroll?: () => void;
   style?: CSSProperties;
+  totalSize?: number;
+  scrollOffset?: number;
 }
 
 export interface ScrollbarRef {
@@ -32,6 +34,8 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
       autoHideDelay = 1500,
       onScroll,
       style,
+      totalSize,
+      scrollOffset,
     },
     ref
   ) => {
@@ -44,8 +48,6 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
 
     const [showY, setShowY] = useState(false);
     const [showX, setShowX] = useState(false);
-    const [thumbY, setThumbY] = useState({ height: 0, top: 0 });
-    const [thumbX, setThumbX] = useState({ width: 0, left: 0 });
 
     const [isDraggingXState, setIsDraggingXState] = useState(false);
     const [isDraggingYState, setIsDraggingYState] = useState(false);
@@ -58,9 +60,26 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
     const dragStartScrollTop = useRef(0);
     const dragStartScrollLeft = useRef(0);
 
+    const isControlledY = totalSize != null && scrollOffset != null;
+
     useImperativeHandle(ref, () => ({
       getViewport: () => viewportRef.current,
     }));
+
+    // Imperative thumb writes, avoid re-render by using React state for thumb scroll
+    const applyThumbY = useCallback((height: number, top: number) => {
+      const el = thumbYRef.current;
+      if (!el) return;
+      el.style.height = `${height}px`;
+      el.style.transform = `translateY(${top}px)`;
+    }, []);
+
+    const applyThumbX = useCallback((width: number, left: number) => {
+      const el = thumbXRef.current;
+      if (!el) return;
+      el.style.width = `${width}px`;
+      el.style.transform = `translateX(${left}px)`;
+    }, []);
 
     const updateThumbs = useCallback(() => {
       const el = viewportRef.current;
@@ -75,13 +94,17 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
         clientWidth,
       } = el;
 
-      if (overflowY === "scroll" && scrollHeight > clientHeight) {
+      if (
+        !isControlledY &&
+        overflowY === "scroll" &&
+        scrollHeight > clientHeight
+      ) {
         const heightRatio = clientHeight / scrollHeight;
         const thumbHeight = Math.max(heightRatio * clientHeight, 30);
         const maxScrollTop = scrollHeight - clientHeight;
         const maxThumbTop = clientHeight - thumbHeight;
         const thumbTop = (scrollTop / maxScrollTop) * maxThumbTop;
-        setThumbY({ height: thumbHeight - 4, top: thumbTop });
+        applyThumbY(thumbHeight - 4, thumbTop);
       }
 
       if (overflowX === "scroll" && scrollWidth > clientWidth) {
@@ -90,16 +113,41 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
         const maxScrollLeft = scrollWidth - clientWidth;
         const maxThumbLeft = clientWidth - thumbWidth;
         const thumbLeft = (scrollLeft / maxScrollLeft) * maxThumbLeft;
-        setThumbX({ width: thumbWidth - 4, left: thumbLeft });
+        applyThumbX(thumbWidth - 4, thumbLeft);
       }
-    }, [overflowX, overflowY]);
+    }, [overflowX, overflowY, isControlledY, applyThumbY, applyThumbX]);
+
+    // Virtualizer-derived thumbY (authoritative when provided)
+    useEffect(() => {
+      if (!isControlledY) return;
+      const el = viewportRef.current;
+      if (!el) return;
+
+      const clientHeight = el.clientHeight;
+      if (!clientHeight || totalSize <= clientHeight) {
+        applyThumbY(0, 0);
+        return;
+      }
+
+      const heightRatio = clientHeight / totalSize;
+      const thumbHeight = Math.max(heightRatio * clientHeight, 30);
+      const maxScrollTop = totalSize - clientHeight;
+      const maxThumbTop = clientHeight - thumbHeight;
+      const thumbTop =
+        maxScrollTop > 0 ? (scrollOffset / maxScrollTop) * maxThumbTop : 0;
+
+      applyThumbY(thumbHeight - 4, thumbTop);
+    }, [isControlledY, totalSize, scrollOffset, applyThumbY]);
 
     const showScrollbars = useCallback(() => {
       const el = viewportRef.current;
       if (!el) return;
 
-      if (overflowY === "scroll" && el.scrollHeight > el.clientHeight)
-        setShowY(true);
+      const scrollHeightCheck = isControlledY
+        ? (totalSize ?? 0) > el.clientHeight
+        : el.scrollHeight > el.clientHeight;
+
+      if (overflowY === "scroll" && scrollHeightCheck) setShowY(true);
       if (overflowX === "scroll" && el.scrollWidth > el.clientWidth)
         setShowX(true);
 
@@ -110,7 +158,7 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
           setShowX(false);
         }
       }, autoHideDelay);
-    }, [autoHideDelay, overflowX, overflowY]);
+    }, [autoHideDelay, overflowX, overflowY, isControlledY, totalSize]);
 
     const handleScroll = useCallback(() => {
       updateThumbs();
@@ -126,43 +174,50 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
       return () => ro.disconnect();
     }, [updateThumbs]);
 
-    const onMouseDownY = useCallback((e: React.MouseEvent) => {
-      e.preventDefault();
-      isDraggingY.current = true;
-      setIsDraggingYState(true);
-      dragStartY.current = e.clientY;
-      dragStartScrollTop.current = viewportRef.current?.scrollTop ?? 0;
+    const onMouseDownY = useCallback(
+      (e: React.MouseEvent) => {
+        e.preventDefault();
+        isDraggingY.current = true;
+        setIsDraggingYState(true);
+        dragStartY.current = e.clientY;
+        dragStartScrollTop.current = viewportRef.current?.scrollTop ?? 0;
 
-      const onMouseMove = (e: MouseEvent) => {
-        const el = viewportRef.current;
-        if (!el) return;
-        const delta = e.clientY - dragStartY.current;
-        const { scrollHeight, clientHeight } = el;
-        const thumbHeight = Math.max(
-          (clientHeight / scrollHeight) * clientHeight,
-          30
-        );
-        const scrollRatio =
-          (scrollHeight - clientHeight) / (clientHeight - thumbHeight);
-        el.scrollTop = dragStartScrollTop.current + delta * scrollRatio;
-      };
+        const onMouseMove = (e: MouseEvent) => {
+          const el = viewportRef.current;
+          if (!el) return;
+          const delta = e.clientY - dragStartY.current;
+          const { clientHeight } = el;
+          const effectiveScrollHeight = isControlledY
+            ? (totalSize ?? el.scrollHeight)
+            : el.scrollHeight;
+          const thumbHeight = Math.max(
+            (clientHeight / effectiveScrollHeight) * clientHeight,
+            30
+          );
+          const scrollRatio =
+            (effectiveScrollHeight - clientHeight) /
+            (clientHeight - thumbHeight);
+          el.scrollTop = dragStartScrollTop.current + delta * scrollRatio;
+        };
 
-      const onMouseUp = () => {
-        isDraggingY.current = false;
-        setIsDraggingYState(false);
-        window.removeEventListener("mousemove", onMouseMove);
-        window.removeEventListener("mouseup", onMouseUp);
+        const onMouseUp = () => {
+          isDraggingY.current = false;
+          setIsDraggingYState(false);
+          window.removeEventListener("mousemove", onMouseMove);
+          window.removeEventListener("mouseup", onMouseUp);
 
-        if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
-        hideTimerRef.current = setTimeout(() => {
-          setShowY(false);
-          setShowX(false);
-        }, 800);
-      };
+          if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+          hideTimerRef.current = setTimeout(() => {
+            setShowY(false);
+            setShowX(false);
+          }, 800);
+        };
 
-      window.addEventListener("mousemove", onMouseMove);
-      window.addEventListener("mouseup", onMouseUp);
-    }, []);
+        window.addEventListener("mousemove", onMouseMove);
+        window.addEventListener("mouseup", onMouseUp);
+      },
+      [isControlledY, totalSize]
+    );
 
     const onMouseDownX = useCallback((e: React.MouseEvent) => {
       e.preventDefault();
@@ -222,7 +277,7 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
               $theme={scrollbarTheme}
               $isDragging={isDraggingYState}
               ref={thumbYRef}
-              style={{ height: thumbY.height, top: thumbY.top }}
+              style={{ height: 0, top: 0 }}
               onMouseDown={onMouseDownY}
             />
           </TrackY>
@@ -238,7 +293,7 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
               $theme={scrollbarTheme}
               $isDragging={isDraggingXState}
               ref={thumbXRef}
-              style={{ width: thumbX.width, left: thumbX.left }}
+              style={{ width: 0, left: 0 }}
               onMouseDown={onMouseDownX}
             />
           </TrackX>
@@ -318,6 +373,8 @@ const Thumb = styled.div<{
   $isDragging?: boolean;
 }>`
   position: absolute;
+  top: 0;
+  left: 0;
   background-color: ${({ $theme, $isDragging }) =>
     $isDragging
       ? $theme?.scrollbarThumbActiveColor
@@ -326,6 +383,7 @@ const Thumb = styled.div<{
   cursor: pointer;
   width: 100%;
   height: 100%;
+  will-change: transform;
 
   &:hover {
     background-color: ${({ $theme }) => $theme?.scrollbarThumbActiveColor};

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -942,24 +942,91 @@ export const Loose: Story = {
       { content: "" },
     ];
 
+    const simpleColumn: TableColumn[] = [
+      { id: "name", caption: "Name" },
+      { id: "type", caption: "Protocol" },
+    ];
+
+    const simpleSampleRows = Array.from({ length: 20 }).map((_, index) => (
+      <Table.Row
+        key={index}
+        rowId={String(index)}
+        content={[
+          generateSentence({
+            minLen: 40,
+            maxLen: 50,
+            seed: 1 + index,
+          }),
+          generateSentence({
+            minLen: 40,
+            maxLen: 50,
+            seed: 11 + index,
+          }),
+        ]}
+      />
+    ));
+
     return (
-      <Table
-        styles={{
-          tableBodyStyle: css`
-            max-height: 250px;
-          `,
-        }}
-        loose
-        actions={TOP_ACTIONS}
-        columns={columns}
-        selectable={activeTab.withCheckbox}
-        sumRow={activeTab.withSummary && sumRow}
-      >
-        {sampleRows}
-      </Table>
+      <Wrapper>
+        <Section>
+          <Title>With Excessive Columns</Title>
+
+          <Table
+            styles={{
+              tableBodyStyle: css`
+                max-height: 250px;
+              `,
+            }}
+            loose
+            actions={TOP_ACTIONS}
+            columns={columns}
+            selectable={activeTab.withCheckbox}
+            sumRow={activeTab.withSummary && sumRow}
+          >
+            {sampleRows}
+          </Table>
+        </Section>
+
+        <Section>
+          <Title>Few Columns</Title>
+
+          <Table
+            styles={{
+              tableBodyStyle: css`
+                max-height: 250px;
+              `,
+            }}
+            loose
+            columns={simpleColumn}
+          >
+            {simpleSampleRows}
+          </Table>
+        </Section>
+      </Wrapper>
     );
   },
 };
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;
+
+const Section = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-radius: 12px;
+  background: #fff;
+`;
+
+const Title = styled.h2`
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.4;
+`;
 
 const ProtocolItem = styled.div<{ $theme?: TableThemeConfig }>`
   padding: 10px 12px;

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -651,7 +651,7 @@ export const Loose: Story = {
 
     const initialRows = useMemo<LoadBalancerRow[]>(
       () =>
-        Array.from({ length: 15 }, (_, i) => {
+        Array.from({ length: 400 }, (_, i) => {
           const type = TYPES_DATA[i % TYPES_DATA.length].name;
           const region = REGIONS[i % REGIONS.length];
           const status = STATUS[i % STATUS.length];

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -942,10 +942,7 @@ export const Loose: Story = {
       { content: "" },
     ];
 
-    const simpleColumn: TableColumn[] = [
-      { id: "name", caption: "Name" },
-      { id: "type", caption: "Protocol" },
-    ];
+    const simpleColumn: TableColumn[] = [{ id: "text", caption: "Text" }];
 
     const simpleSampleRows = Array.from({ length: 20 }).map((_, index) => (
       <Table.Row
@@ -956,11 +953,6 @@ export const Loose: Story = {
             minLen: 40,
             maxLen: 50,
             seed: 1 + index,
-          }),
-          generateSentence({
-            minLen: 40,
-            maxLen: 50,
-            seed: 11 + index,
           }),
         ]}
       />

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -1010,7 +1010,6 @@ const Section = styled.section`
   flex-direction: column;
   gap: 12px;
   border-radius: 12px;
-  background: #fff;
 `;
 
 const Title = styled.h2`

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -1002,14 +1002,13 @@ export const Loose: Story = {
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 20px;
 `;
 
 const Section = styled.section`
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  border-radius: 12px;
+  gap: 10px;
 `;
 
 const Title = styled.h2`

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -625,13 +625,9 @@ function Table({
                                 width: ${col.width};
                                 flex-direction: row;
                               `
-                            : loose
-                              ? css`
-                                  flex: unset;
-                                `
-                              : css`
-                                  flex: 1;
-                                `}
+                            : css`
+                                flex: 1;
+                              `}
 
                           ${finalColumnAction &&
                           css`
@@ -749,24 +745,24 @@ function Table({
                                     `
                                   : css`
                                       flex: 1;
-                                    `}
+                                    `};
+
                                 ${isLast &&
                                 css`
                                   padding-right: 36px;
-                                `}
+                                `};
 
                                 ${loose &&
                                 css`
-                                  flex: unset;
-
                                   ${isFirst &&
                                   css`
                                     z-index: 40;
                                     background: ${tableTheme?.summaryBackgroundColor ??
                                     "#e4e4e4"};
                                   `}
-                                `}
-                            ${col.styles?.self}
+                                `};
+
+                                ${col.styles?.self}
                               `}
                             >
                               {s === 0 ? col.content : ""}
@@ -2036,17 +2032,16 @@ const CellContent = styled.div<{
   white-space: pre-wrap;
   justify-content: space-between;
   position: relative;
+  flex: 1;
 
   ${({ $width, $loose }) =>
     $loose
       ? css`
           min-width: 160px;
-          flex: unset;
           width: 160px;
         `
       : !$width
         ? css`
-            flex: 1;
             height: fit-content;
             width: 100%;
           `

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -7,6 +7,7 @@ import React, {
   ReactNode,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -33,6 +34,7 @@ import { applyClassName } from "./../constants/classname";
 import { Figure } from "./figure";
 import { Scrollbar, ScrollbarRef } from "./scrollbar";
 import { Button, ButtonProps } from "./button";
+import { useVirtualizer } from "@tanstack/react-virtual";
 
 export interface TableColumn {
   caption: string;
@@ -224,6 +226,7 @@ function Table({
   const [allRowsLocal, setAllRowsLocal] = useState<string[]>([]);
   const [rowActions, setRowActions] = useState<TipMenuItemProps[]>([]);
   const [openRowId, setOpenRowId] = useState<string | null>("");
+  const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
 
   const [withRowActions, setWithRowActions] = useState(false);
 
@@ -281,72 +284,91 @@ function Table({
   };
   const flatChildren = resolveChildren(children);
 
-  const rowChildren = flatChildren.map((child, index) => {
-    const hasRowGroup = child.type === TableRowGroup;
-    const hasRow = child.type === TableRow;
+  const rowChildren = useMemo(
+    () =>
+      flatChildren.map((child, index) => {
+        const hasRowGroup = child.type === TableRowGroup;
+        const hasRow = child.type === TableRow;
 
-    if (hasRowGroup) {
-      return cloneElement(child, {
-        selectable,
-        selectedData,
-        handleSelect,
-        draggable,
-        openRowId,
-        setOpenRowId,
-        alwaysShowDragIcon,
-      } as TableRowGroupProps &
-        TableAlwaysShowDragIcon & {
-          selectedData?: string[];
-          handleSelect?: (data: string) => void;
-          draggable?: boolean;
-          isSelected?: boolean;
-        });
-    }
-
-    if (hasRow) {
-      const props = child.props as TableRowProps;
-
-      const isSelected = selectedData.some(
-        (d) => JSON.stringify(d) === JSON.stringify(props.rowId)
-      );
-
-      const isLast = index === Children.count(children) - 1;
-
-      return cloneElement(child, {
-        selectable,
-        isSelected,
-        handleSelect,
-        isLast,
-        onLastRowReached,
-        draggable,
-        openRowId,
-        setOpenRowId,
-        groupLength: Children?.count(children),
-        index: index,
-        alwaysShowDragIcon,
-        onDropItem: (newPosition: number) => {
-          if (dragItem) {
-            const { oldGroupId, newGroupId, oldPosition, id } = dragItem;
-            onDragged?.({
-              oldGroupId: oldGroupId || "",
-              newGroupId: newGroupId || "",
-              oldPosition,
-              newPosition,
-              id: id,
+        if (hasRowGroup) {
+          return cloneElement(child, {
+            selectable,
+            selectedData,
+            handleSelect,
+            draggable,
+            openRowId,
+            setOpenRowId,
+            alwaysShowDragIcon,
+          } as TableRowGroupProps &
+            TableAlwaysShowDragIcon & {
+              selectedData?: string[];
+              handleSelect?: (data: string) => void;
+              draggable?: boolean;
+              isSelected?: boolean;
             });
+        }
 
-            setDragItem(null);
-          }
-        },
-      } as TableRowProps & TableAlwaysShowDragIcon);
-    }
+        if (hasRow) {
+          const props = child.props as TableRowProps;
 
-    return null;
-  });
+          const isSelected = selectedData.some(
+            (d) => JSON.stringify(d) === JSON.stringify(props.rowId)
+          );
+
+          const isLast = index === Children.count(children) - 1;
+
+          return cloneElement(child, {
+            selectable,
+            isSelected,
+            handleSelect,
+            isLast,
+            onLastRowReached,
+            draggable,
+            openRowId,
+            setOpenRowId,
+            groupLength: Children?.count(children),
+            index: index,
+            alwaysShowDragIcon,
+            onDropItem: (newPosition: number) => {
+              if (dragItem) {
+                const { oldGroupId, newGroupId, oldPosition, id } = dragItem;
+                onDragged?.({
+                  oldGroupId: oldGroupId || "",
+                  newGroupId: newGroupId || "",
+                  oldPosition,
+                  newPosition,
+                  id: id,
+                });
+
+                setDragItem(null);
+              }
+            },
+          } as TableRowProps & TableAlwaysShowDragIcon);
+        }
+
+        return null;
+      }),
+    [
+      flatChildren,
+      selectable,
+      selectedData,
+      handleSelect,
+      draggable,
+      openRowId,
+      alwaysShowDragIcon,
+      dragItem,
+      onDragged,
+    ]
+  );
 
   const tableBodyRef = useRef<ScrollbarRef>(null);
 
   const getViewport = () => tableBodyRef.current?.getViewport();
+
+  // get scroll element for react-virtualizer
+  useEffect(() => {
+    setScrollElement(getViewport() ?? null);
+  }, []);
 
   useEffect(() => {
     const viewport = getViewport();
@@ -415,6 +437,13 @@ function Table({
     if (summaryScrollRef.current)
       summaryScrollRef.current.scrollLeft = scrollLeft;
   };
+
+  const rowVirtualizer = useVirtualizer({
+    count: rowChildren?.length,
+    getScrollElement: () => scrollElement,
+    estimateSize: () => 48,
+    overscan: 20,
+  });
 
   return (
     <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
@@ -667,14 +696,39 @@ function Table({
                   autoHideDelay={800}
                   onScroll={loose ? handleWrapperScroll : undefined}
                   ref={tableBodyRef}
+                  totalSize={rowVirtualizer.getTotalSize()}
+                  scrollOffset={rowVirtualizer.scrollOffset ?? 0}
                 >
                   <TableBody
                     $theme={tableTheme}
                     aria-label="table-body"
                     $loose={loose}
-                    $style={styles?.tableBodyStyle}
+                    $style={css`
+                      position: relative;
+                      height: ${rowVirtualizer.getTotalSize()}px;
+                      ${styles?.tableBodyStyle}
+                    `}
                   >
-                    {rowChildren}
+                    {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                      return (
+                        <div
+                          key={virtualRow.key}
+                          data-index={virtualRow.index}
+                          ref={rowVirtualizer.measureElement}
+                          style={{
+                            position: "absolute",
+                            top: 0,
+                            left: 0,
+                            width: "100%",
+                            display: "flex",
+                            flexDirection: "column",
+                            transform: `translateY(${virtualRow.start}px)`,
+                          }}
+                        >
+                          {rowChildren[virtualRow.index]}
+                        </div>
+                      );
+                    })}
                   </TableBody>
                 </Scrollbar>
               ) : (

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -1483,11 +1483,7 @@ function TableRow({
   const { loose, setWithRowActions, isScrolledRight } = useTableLoose();
 
   useEffect(() => {
-    if (actions) {
-      setWithRowActions(true);
-    } else {
-      setWithRowActions(false);
-    }
+    setWithRowActions(!!actions);
   }, [actions]);
 
   const [isOver, setIsOver] = useState(false);

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -1482,9 +1482,12 @@ function TableRow({
 
   const { loose, setWithRowActions, isScrolledRight } = useTableLoose();
 
+  const rowActions = actions?.(rowId ?? "");
+  const hasRowActions = (rowActions?.length ?? 0) > 0;
+
   useEffect(() => {
-    setWithRowActions(!!actions);
-  }, [actions]);
+    setWithRowActions(hasRowActions);
+  }, [hasRowActions]);
 
   const [isOver, setIsOver] = useState(false);
   const [dropPosition, setDropPosition] = useState<"top" | "bottom" | null>(

--- a/package.json
+++ b/package.json
@@ -400,6 +400,7 @@
     "@floating-ui/react": "^0.27.8",
     "@hookform/resolvers": "^5.0.1",
     "@remixicon/react": "^4.6.0",
+    "@tanstack/react-virtual": "^3.14.5",
     "framer-motion": "^12.12.1",
     "monaco-editor": "^0.55.1",
     "pdfjs-dist": "5.4.54",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@remixicon/react':
         specifier: ^4.6.0
         version: 4.6.0(react@19.1.1)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.5
+        version: 3.14.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       framer-motion:
         specifier: ^12.12.1
         version: 12.23.12(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -925,6 +928,15 @@ packages:
     resolution: {integrity: sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@tanstack/react-virtual@3.14.5':
+    resolution: {integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.3':
+    resolution: {integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==}
 
   '@testing-library/cypress@10.0.3':
     resolution: {integrity: sha512-TeZJMCNtiS59cPWalra7LgADuufO5FtbqQBYxuAgdX6ZFAR2D9CtQwAG8VbgvFcchW3K414va/+7P4OkQ80UVg==}
@@ -3910,6 +3922,14 @@ snapshots:
   '@storybook/theming@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
+
+  '@tanstack/react-virtual@3.14.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.3
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+
+  '@tanstack/virtual-core@3.17.3': {}
 
   '@testing-library/cypress@10.0.3(cypress@14.5.3)':
     dependencies:

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -197,7 +197,10 @@ describe("Table", () => {
   }
 
   context("loose", () => {
-    function ProductTableLoose({ loose = true }: { loose?: boolean }) {
+    function ProductTableLoose({
+      loose = true,
+      ...props
+    }: { loose?: boolean } & TableRowProps) {
       const { currentTheme } = useTheme();
       const tableTheme = currentTheme?.table;
 
@@ -554,6 +557,7 @@ describe("Table", () => {
             row.zone,
             row.provider,
           ]}
+          {...props}
         />
       ));
 
@@ -808,42 +812,70 @@ describe("Table", () => {
                 });
             });
 
-            it("renders header loose actions with width 48px", () => {
-              cy.mount(<ProductTableLoose loose />);
+            context("header loose actions", () => {
+              it("renders header loose actions with width 48px", () => {
+                cy.mount(<ProductTableLoose loose />);
 
-              cy.findAllByLabelText("action-button").eq(1).click();
-              cy.findAllByLabelText("action-button").eq(2).click();
+                cy.findAllByLabelText("action-button").eq(1).click();
+                cy.findAllByLabelText("action-button").eq(2).click();
 
-              cy.wait(300);
+                cy.wait(300);
 
-              cy.findByLabelText("header-row-loose-action")
-                .should("have.css", "width", "48px")
-                .then(($el) => {
-                  const after = window.getComputedStyle($el[0], "::before");
+                cy.findByLabelText("header-row-loose-action")
+                  .should("have.css", "width", "48px")
+                  .then(($el) => {
+                    const after = window.getComputedStyle($el[0], "::before");
 
-                  expect(after.backgroundImage).to.equal(
-                    "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+                    expect(after.backgroundImage).to.equal(
+                      "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+                    );
+                  });
+              });
+
+              context("when given empty action", () => {
+                it("not renders header loose", () => {
+                  cy.mount(<ProductTableLoose loose actions={() => []} />);
+
+                  cy.wait(300);
+
+                  cy.findByLabelText("header-row-loose-action").should(
+                    "not.exist"
                   );
                 });
+              });
             });
 
-            it("renders summary row loose actions with width 48px", () => {
-              cy.mount(<ProductTableLoose loose />);
+            context("summary loose actions", () => {
+              it("renders summary row loose actions with width 48px", () => {
+                cy.mount(<ProductTableLoose loose />);
 
-              cy.findAllByLabelText("action-button").eq(1).click();
-              cy.findAllByLabelText("action-button").eq(2).click();
+                cy.findAllByLabelText("action-button").eq(1).click();
+                cy.findAllByLabelText("action-button").eq(2).click();
 
-              cy.wait(300);
+                cy.wait(300);
 
-              cy.findByLabelText("summary-row-loose-action")
-                .should("have.css", "width", "48px")
-                .then(($el) => {
-                  const after = window.getComputedStyle($el[0], "::before");
+                cy.findByLabelText("summary-row-loose-action")
+                  .should("have.css", "width", "48px")
+                  .then(($el) => {
+                    const after = window.getComputedStyle($el[0], "::before");
 
-                  expect(after.backgroundImage).to.equal(
-                    "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+                    expect(after.backgroundImage).to.equal(
+                      "linear-gradient(to left, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0))"
+                    );
+                  });
+              });
+
+              context("when given empty action", () => {
+                it("not renders header loose", () => {
+                  cy.mount(<ProductTableLoose loose actions={() => []} />);
+
+                  cy.wait(300);
+
+                  cy.findByLabelText("summary-row-loose-action").should(
+                    "not.exist"
                   );
                 });
+              });
             });
 
             context("when scrolling to the right", () => {

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -614,6 +614,93 @@ describe("Table", () => {
           .and("have.css", "overflow-y", "scroll");
       });
 
+      context("when given few column", () => {
+        const simpleColumn: TableColumn[] = [
+          { id: "name", caption: "Name" },
+          { id: "type", caption: "Protocol" },
+        ];
+
+        const simpleSampleRows = Array.from({ length: 20 }).map((_, index) => (
+          <Table.Row
+            key={index}
+            rowId={String(index)}
+            content={[
+              generateSentence({
+                minLen: 40,
+                maxLen: 50,
+                seed: 1 + index,
+              }),
+              generateSentence({
+                minLen: 40,
+                maxLen: 50,
+                seed: 11 + index,
+              }),
+            ]}
+          />
+        ));
+
+        it("not broke the width between table (still with full width)", () => {
+          cy.mount(
+            <Table
+              styles={{
+                tableBodyStyle: css`
+                  max-height: 250px;
+                `,
+              }}
+              loose
+              columns={simpleColumn}
+            >
+              {simpleSampleRows}
+            </Table>
+          );
+
+          cy.findAllByLabelText("table-row-cell")
+            .eq(0)
+            .invoke("css", "width")
+            .then((width) => {
+              cy.findAllByLabelText("table-row-cell")
+                .eq(1)
+                .should("have.css", "width", width);
+            });
+
+          // have flex: 1
+          cy.findAllByLabelText("table-row-cell")
+            .eq(0)
+            .invoke("css", "flex")
+            .then((width) => {
+              cy.findAllByLabelText("table-row-cell")
+                .eq(1)
+                .should("have.css", "flex", width);
+            });
+        });
+
+        context("when hover", () => {
+          it("renders the normal hover row color", () => {
+            cy.mount(
+              <Table
+                styles={{
+                  tableBodyStyle: css`
+                    max-height: 250px;
+                  `,
+                }}
+                loose
+                columns={simpleColumn}
+              >
+                {simpleSampleRows}
+              </Table>
+            );
+
+            cy.findAllByLabelText("table-row")
+              .eq(0)
+              .should("have.css", "background-color", "rgb(249, 250, 251)");
+            cy.findAllByLabelText("table-row")
+              .eq(0)
+              .realHover()
+              .should("have.css", "background-color", "rgb(231, 242, 252)");
+          });
+        });
+      });
+
       context("height in table header", () => {
         it("renders height with 49px", () => {
           cy.mount(<ProductTableLoose loose />);


### PR DESCRIPTION
Description:
This pull request fixes the `table` component if only add a few column in condition provides `loose` as a feature. Previously causes the bug because the `flex` it was unset, so it's not make the width always full, after introduces the `loose` not use some content less than 5 column or more.

It also ensures the `loose` feature still works properly even we given a few column inside of the `Table`. 

Before:
<img width="698" height="326" alt="image" src="https://github.com/user-attachments/assets/003e1570-6ffa-4cd8-abe3-bec19d5b8f5e" />

After:
<img width="1426" height="714" alt="image" src="https://github.com/user-attachments/assets/8fb9584f-3d30-4d22-ad03-d59d11b9caad" />

Source:
[[Bug] SYST-792: Fix ugly loose table when it has only a few data](https://linear.app/systatum/issue/SYST-792/fix-ugly-loose-table-when-it-has-only-a-few-data)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself