### PR TITLE
[Bug] SYST-793: Fix `virtualization` on the `Table`

### DIFF
--- a/components/scrollbar.tsx
+++ b/components/scrollbar.tsx
@@ -62,6 +62,12 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
 
     const isControlledY = totalSize != null && scrollOffset != null;
 
+    // Always-fresh mirror of the controlled props, read synchronously inside
+    // the scroll handler so the thumb never waits on a React re-render /
+    // effect round-trip to catch up with the virtualizer.
+    const controlledRef = useRef({ totalSize, scrollOffset });
+    controlledRef.current = { totalSize, scrollOffset };
+
     useImperativeHandle(ref, () => ({
       getViewport: () => viewportRef.current,
     }));
@@ -117,34 +123,48 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
       }
     }, [overflowX, overflowY, isControlledY, applyThumbY, applyThumbX]);
 
-    // Virtualizer-derived thumbY (authoritative when provided)
-    useEffect(() => {
-      if (!isControlledY) return;
+    // Synchronous controlled-Y thumb update, driven by the native scroll
+    // event itself (via controlledRef) rather than by waiting for
+    // totalSize/scrollOffset props to propagate through a re-render.
+    const updateControlledThumbY = useCallback(() => {
       const el = viewportRef.current;
-      if (!el) return;
+      if (!el || !isControlledY) return;
 
+      const { totalSize, scrollOffset } = controlledRef.current;
       const clientHeight = el.clientHeight;
-      if (!clientHeight || totalSize <= clientHeight) {
+
+      if (!clientHeight || (totalSize ?? 0) <= clientHeight) {
         applyThumbY(0, 0);
         return;
       }
 
-      const heightRatio = clientHeight / totalSize;
+      const heightRatio = clientHeight / (totalSize as number);
       const thumbHeight = Math.max(heightRatio * clientHeight, 30);
-      const maxScrollTop = totalSize - clientHeight;
+      const maxScrollTop = (totalSize as number) - clientHeight;
       const maxThumbTop = clientHeight - thumbHeight;
       const thumbTop =
-        maxScrollTop > 0 ? (scrollOffset / maxScrollTop) * maxThumbTop : 0;
+        maxScrollTop > 0
+          ? ((scrollOffset ?? 0) / maxScrollTop) * maxThumbTop
+          : 0;
 
       applyThumbY(thumbHeight - 4, thumbTop);
-    }, [isControlledY, totalSize, scrollOffset, applyThumbY]);
+    }, [isControlledY, applyThumbY]);
+
+    // Virtualizer-derived thumbY (authoritative when provided).
+    // Kept as a fallback for cases where totalSize/scrollOffset change
+    // WITHOUT a native scroll event (e.g. rows loading in, resize, filtering),
+    // since handleScroll won't fire in those cases.
+    useEffect(() => {
+      if (!isControlledY) return;
+      updateControlledThumbY();
+    }, [isControlledY, totalSize, scrollOffset, updateControlledThumbY]);
 
     const showScrollbars = useCallback(() => {
       const el = viewportRef.current;
       if (!el) return;
 
       const scrollHeightCheck = isControlledY
-        ? (totalSize ?? 0) > el.clientHeight
+        ? (controlledRef.current.totalSize ?? 0) > el.clientHeight
         : el.scrollHeight > el.clientHeight;
 
       if (overflowY === "scroll" && scrollHeightCheck) setShowY(true);
@@ -158,21 +178,59 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
           setShowX(false);
         }
       }, autoHideDelay);
-    }, [autoHideDelay, overflowX, overflowY, isControlledY, totalSize]);
+    }, [autoHideDelay, overflowX, overflowY, isControlledY]);
 
     const handleScroll = useCallback(() => {
-      updateThumbs();
+      // Controlled-Y thumb position is driven by the virtualizer's
+      // scrollOffset, not the DOM's own scrollTop, so update it
+      // synchronously here rather than through updateThumbs().
+      if (isControlledY) {
+        updateControlledThumbY();
+        if (overflowX === "scroll") {
+          // X axis still tracks the DOM directly since totalSize/scrollOffset
+          // only ever describe the virtualized (vertical) axis.
+          const el = viewportRef.current;
+          if (el) {
+            const { scrollLeft, scrollWidth, clientWidth } = el;
+            if (scrollWidth > clientWidth) {
+              const widthRatio = clientWidth / scrollWidth;
+              const thumbWidth = Math.max(widthRatio * clientWidth, 30);
+              const maxScrollLeft = scrollWidth - clientWidth;
+              const maxThumbLeft = clientWidth - thumbWidth;
+              const thumbLeft = (scrollLeft / maxScrollLeft) * maxThumbLeft;
+              applyThumbX(thumbWidth - 4, thumbLeft);
+            }
+          }
+        }
+      } else {
+        updateThumbs();
+      }
+
       showScrollbars();
       onScroll?.();
-    }, [updateThumbs, showScrollbars, onScroll]);
+    }, [
+      isControlledY,
+      updateControlledThumbY,
+      updateThumbs,
+      showScrollbars,
+      onScroll,
+      overflowX,
+      applyThumbX,
+    ]);
 
     useEffect(() => {
       const el = viewportRef.current;
       if (!el) return;
-      const ro = new ResizeObserver(() => updateThumbs());
+      const ro = new ResizeObserver(() => {
+        if (isControlledY) {
+          updateControlledThumbY();
+        } else {
+          updateThumbs();
+        }
+      });
       ro.observe(el);
       return () => ro.disconnect();
-    }, [updateThumbs]);
+    }, [updateThumbs, updateControlledThumbY, isControlledY]);
 
     const onMouseDownY = useCallback(
       (e: React.MouseEvent) => {
@@ -188,7 +246,7 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
           const delta = e.clientY - dragStartY.current;
           const { clientHeight } = el;
           const effectiveScrollHeight = isControlledY
-            ? (totalSize ?? el.scrollHeight)
+            ? (controlledRef.current.totalSize ?? el.scrollHeight)
             : el.scrollHeight;
           const thumbHeight = Math.max(
             (clientHeight / effectiveScrollHeight) * clientHeight,
@@ -216,7 +274,7 @@ const Scrollbar = forwardRef<ScrollbarRef, ScrollbarProps>(
         window.addEventListener("mousemove", onMouseMove);
         window.addEventListener("mouseup", onMouseUp);
       },
-      [isControlledY, totalSize]
+      [isControlledY]
     );
 
     const onMouseDownX = useCallback((e: React.MouseEvent) => {

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -2091,7 +2091,6 @@ const CellContent = styled.div<{
   ${({ $width, $loose }) =>
     $loose
       ? css`
-          min-width: 160px;
           width: 160px;
         `
       : !$width

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -1101,7 +1101,7 @@ const TableHeader = styled.div<{
   box-shadow: ${({ $theme }) =>
     $theme?.boxShadow || "0 1px 2px 0 rgba(0, 0, 0, 0.05)"};
   align-items: stretch;
-  background-color: ${({ $theme }) => $theme?.headerBackgroundColor};
+  background: ${({ $theme }) => $theme?.headerBackgroundColor};
 
   ${({ $loose }) =>
     $loose &&
@@ -1157,7 +1157,7 @@ const TableSummary = styled.div<{
       z-index: 40;
 
       --row-bg: ${$theme?.summaryBackgroundColor ?? "#e4e4e4"};
-    `}
+    `};
 `;
 
 const EmptyState = styled.div<{ $theme?: TableThemeConfig }>`
@@ -2123,7 +2123,13 @@ const CellContent = styled.div<{
       }
     `}
 
-  width: ${({ $width }) => $width};
+  ${({ $width }) =>
+    $width &&
+    css`
+      flex: 0 1 ${$width};
+      width: ${$width};
+    `}
+
   min-height: inherit;
   ${({ $bold }) =>
     $bold &&

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -34,6 +34,7 @@ import { applyClassName } from "./../constants/classname";
 import { Figure } from "./figure";
 import { Scrollbar, ScrollbarRef } from "./scrollbar";
 import { Button, ButtonProps } from "./button";
+import { useVirtualizer } from "@tanstack/react-virtual";
 
 export interface TableColumn {
   caption: string;
@@ -225,6 +226,7 @@ function Table({
   const [allRowsLocal, setAllRowsLocal] = useState<string[]>([]);
   const [rowActions, setRowActions] = useState<TipMenuItemProps[]>([]);
   const [openRowId, setOpenRowId] = useState<string | null>("");
+  const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
 
   const [withRowActions, setWithRowActions] = useState(false);
 
@@ -363,6 +365,11 @@ function Table({
 
   const getViewport = () => tableBodyRef.current?.getViewport();
 
+  // get scroll element for react-virtualizer
+  useEffect(() => {
+    setScrollElement(getViewport() ?? null);
+  }, [rowChildren.length > 0]);
+
   useEffect(() => {
     const viewport = getViewport();
     if (!viewport || openRowId === null) return;
@@ -430,6 +437,13 @@ function Table({
     if (summaryScrollRef.current)
       summaryScrollRef.current.scrollLeft = scrollLeft;
   };
+
+  const rowVirtualizer = useVirtualizer({
+    count: rowChildren?.length,
+    getScrollElement: () => scrollElement,
+    estimateSize: () => 48,
+    overscan: 20,
+  });
 
   return (
     <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
@@ -682,14 +696,39 @@ function Table({
                   autoHideDelay={800}
                   onScroll={loose ? handleWrapperScroll : undefined}
                   ref={tableBodyRef}
+                  totalSize={rowVirtualizer.getTotalSize()}
+                  scrollOffset={rowVirtualizer.scrollOffset ?? 0}
                 >
                   <TableBody
                     $theme={tableTheme}
                     aria-label="table-body"
                     $loose={loose}
                     $style={styles?.tableBodyStyle}
+                    style={{
+                      position: "relative",
+                      height: `${rowVirtualizer.getTotalSize()}px`,
+                    }}
                   >
-                    {rowChildren}
+                    {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                      return (
+                        <div
+                          key={virtualRow.key}
+                          data-index={virtualRow.index}
+                          ref={rowVirtualizer.measureElement}
+                          style={{
+                            position: "absolute",
+                            top: 0,
+                            left: 0,
+                            width: "100%",
+                            display: "flex",
+                            flexDirection: "column",
+                            transform: `translateY(${virtualRow.start}px)`,
+                          }}
+                        >
+                          {rowChildren[virtualRow.index]}
+                        </div>
+                      );
+                    })}
                   </TableBody>
                 </Scrollbar>
               ) : (

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -703,11 +703,11 @@ function Table({
                     $theme={tableTheme}
                     aria-label="table-body"
                     $loose={loose}
-                    $style={css`
-                      position: relative;
-                      height: ${rowVirtualizer.getTotalSize()}px;
-                      ${styles?.tableBodyStyle}
-                    `}
+                    $style={styles?.tableBodyStyle}
+                    style={{
+                      position: "relative",
+                      height: `${rowVirtualizer.getTotalSize()}px`,
+                    }}
                   >
                     {rowVirtualizer.getVirtualItems().map((virtualRow) => {
                       return (
@@ -1730,6 +1730,7 @@ function TableRow({
               return cloneElement(child, {
                 ...(isTableRowCell
                   ? {
+                      _index: i,
                       width: child.props.width ?? widthColumn,
                       contentStyle: isLast
                         ? css`

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -34,7 +34,6 @@ import { applyClassName } from "./../constants/classname";
 import { Figure } from "./figure";
 import { Scrollbar, ScrollbarRef } from "./scrollbar";
 import { Button, ButtonProps } from "./button";
-import { useVirtualizer } from "@tanstack/react-virtual";
 
 export interface TableColumn {
   caption: string;
@@ -226,7 +225,6 @@ function Table({
   const [allRowsLocal, setAllRowsLocal] = useState<string[]>([]);
   const [rowActions, setRowActions] = useState<TipMenuItemProps[]>([]);
   const [openRowId, setOpenRowId] = useState<string | null>("");
-  const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
 
   const [withRowActions, setWithRowActions] = useState(false);
 
@@ -365,11 +363,6 @@ function Table({
 
   const getViewport = () => tableBodyRef.current?.getViewport();
 
-  // get scroll element for react-virtualizer
-  useEffect(() => {
-    setScrollElement(getViewport() ?? null);
-  }, []);
-
   useEffect(() => {
     const viewport = getViewport();
     if (!viewport || openRowId === null) return;
@@ -437,13 +430,6 @@ function Table({
     if (summaryScrollRef.current)
       summaryScrollRef.current.scrollLeft = scrollLeft;
   };
-
-  const rowVirtualizer = useVirtualizer({
-    count: rowChildren?.length,
-    getScrollElement: () => scrollElement,
-    estimateSize: () => 48,
-    overscan: 20,
-  });
 
   return (
     <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
@@ -696,39 +682,14 @@ function Table({
                   autoHideDelay={800}
                   onScroll={loose ? handleWrapperScroll : undefined}
                   ref={tableBodyRef}
-                  totalSize={rowVirtualizer.getTotalSize()}
-                  scrollOffset={rowVirtualizer.scrollOffset ?? 0}
                 >
                   <TableBody
                     $theme={tableTheme}
                     aria-label="table-body"
                     $loose={loose}
                     $style={styles?.tableBodyStyle}
-                    style={{
-                      position: "relative",
-                      height: `${rowVirtualizer.getTotalSize()}px`,
-                    }}
                   >
-                    {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-                      return (
-                        <div
-                          key={virtualRow.key}
-                          data-index={virtualRow.index}
-                          ref={rowVirtualizer.measureElement}
-                          style={{
-                            position: "absolute",
-                            top: 0,
-                            left: 0,
-                            width: "100%",
-                            display: "flex",
-                            flexDirection: "column",
-                            transform: `translateY(${virtualRow.start}px)`,
-                          }}
-                        >
-                          {rowChildren[virtualRow.index]}
-                        </div>
-                      );
-                    })}
+                    {rowChildren}
                   </TableBody>
                 </Scrollbar>
               ) : (

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -366,6 +366,8 @@ function Table({
   const getViewport = () => tableBodyRef.current?.getViewport();
 
   // get scroll element for react-virtualizer
+  // re-check the viewport whenever rows are rendered, since the scroll
+  // element may not be available on the initial mount.
   useEffect(() => {
     setScrollElement(getViewport() ?? null);
   }, [rowChildren.length > 0]);
@@ -704,6 +706,7 @@ function Table({
                     aria-label="table-body"
                     $loose={loose}
                     $style={styles?.tableBodyStyle}
+                    // Reserve the full virtualized height so rows can be positioned correctly.
                     style={{
                       position: "relative",
                       height: `${rowVirtualizer.getTotalSize()}px`,
@@ -2060,6 +2063,10 @@ function TableRowCell({
   );
 }
 
+/*
+ * use the provided `width` as the flex-basis while allowing the column to shrink.
+ * avoid flex: 1, which would force all columns to grow and ignore the intended width.
+ */
 const CellContent = styled.div<{
   $width?: string;
   $contentStyle?: CSSProp;
@@ -2121,14 +2128,14 @@ const CellContent = styled.div<{
           : "transparent"};
         pointer-events: none;
       }
-    `}
+    `};
 
   ${({ $width }) =>
     $width &&
     css`
       flex: 0 1 ${$width};
       width: ${$width};
-    `}
+    `};
 
   min-height: inherit;
   ${({ $bold }) =>

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -12,7 +12,6 @@ import {
   RiForbid2Line,
   RiInformationLine,
   RiReactjsLine,
-  RiRefreshLine,
   RiSettings3Line,
   RiSpam2Line,
 } from "@remixicon/react";
@@ -32,7 +31,7 @@ import styled, { css } from "styled-components";
 import { CapsuleTab } from "./../../components/capsule";
 import { Button } from "./../../components/button";
 import { Card } from "./../../components/card";
-import { ReactNode, useMemo, useState } from "react";
+import { ReactNode, useEffect, useMemo, useState } from "react";
 import { generateSentence } from "./../../lib/text";
 import { TableThemeConfig, useTheme } from "./../../theme";
 
@@ -195,6 +194,40 @@ describe("Table", () => {
       </Table>
     );
   }
+
+  context("when the content is delayed", () => {
+    it("still shows the table-body after delayed", () => {
+      function DelayedTable() {
+        const [rows, setRows] = useState([]);
+
+        useEffect(() => {
+          setTimeout(() => {
+            setRows(rawRows);
+          }, 500);
+        }, []);
+
+        return (
+          <Table columns={columnsBasic}>
+            {rows.map((row, index) => (
+              <Table.Row key={index} rowId={`${row.name}-${row.type}`}>
+                {[row.name, row.type].map((rowCell) => (
+                  <Table.Row.Cell key={`${row.name}-${row.type}-${rowCell}`}>
+                    {rowCell}
+                  </Table.Row.Cell>
+                ))}
+              </Table.Row>
+            ))}
+          </Table>
+        );
+      }
+
+      cy.mount(<DelayedTable />);
+
+      cy.findByLabelText("table-body").should("not.exist");
+      cy.wait(600);
+      cy.findByLabelText("table-body").should("exist");
+    });
+  });
 
   context("loose", () => {
     function ProductTableLoose({


### PR DESCRIPTION
Description:
This pull request fixes the `virtualization` issue when not get the real scroll element after fetch the `content`. It also ensures not shows the content on the table never  happen again.

Source:
[[Bug] SYST-793: Fix `virtualization` on the `Table`](https://linear.app/systatum/issue/SYST-793/fix-virtualization-on-the-table)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself