### PR TITLE
[Mobile] SYST-610: Add `mobile`, `styles` props to `NavTab`

### DIFF
--- a/components/figure.tsx
+++ b/components/figure.tsx
@@ -1,4 +1,3 @@
-import { c } from "framer-motion/dist/types.d-Cjd591yU";
 import { applyClassName } from "./../constants/classname";
 import { ComponentType, HTMLAttributes } from "react";
 import styled, { CSSProp } from "styled-components";
@@ -9,7 +8,14 @@ export interface FigureProps
   size?: number;
   color?: string;
   styles?: FigureStyles;
-  notification?: string;
+  notification?: FigureNotification;
+}
+
+export interface FigureNotification {
+  content?: string;
+  backgroundColor?: string;
+  frameSize?: string;
+  fontSize?: string;
 }
 
 export interface FigureStyles {
@@ -36,8 +42,14 @@ function Figure({
       $style={styles?.self}
     >
       {notification && (
-        <Notification $size={size} $style={styles?.notificationStyle}>
-          {notification}
+        <Notification
+          $size={size}
+          $fontSize={notification?.fontSize}
+          $backgroundColor={notification?.backgroundColor}
+          $frameSize={notification?.frameSize}
+          $style={styles?.notificationStyle}
+        >
+          {notification.content}
         </Notification>
       )}
 
@@ -72,23 +84,29 @@ const Wrapper = styled.span<{ $style?: CSSProp }>`
   ${({ $style }) => $style}
 `;
 
-const Notification = styled.span<{ $style?: CSSProp; $size?: number }>`
+const Notification = styled.span<{
+  $style?: CSSProp;
+  $size?: number;
+  $frameSize?: string;
+  $fontSize?: string;
+  $backgroundColor?: string;
+}>`
   position: absolute;
   top: 5%;
   right: 5%;
   transform: translate(50%, -50%);
 
   border-radius: 9999px;
-  background-color: red;
+  background-color: ${({ $backgroundColor }) => $backgroundColor ?? "red"};
 
   display: flex;
   align-items: center;
   justify-content: center;
 
   color: white;
-  width: ${({ $size = 16 }) => `${$size * 0.8}px`};
-  height: ${({ $size = 16 }) => `${$size * 0.8}px`};
-  font-size: ${({ $size = 16 }) => `${$size * 0.4}px`};
+  width: ${({ $size, $frameSize }) => $frameSize ?? `${$size * 0.8}px`};
+  height: ${({ $size, $frameSize }) => $frameSize ?? `${$size * 0.8}px`};
+  font-size: ${({ $size, $fontSize }) => $fontSize ?? `${$size * 0.4}px`};
   line-height: 1;
 
   ${({ $style }) => $style}

--- a/components/figure.tsx
+++ b/components/figure.tsx
@@ -110,11 +110,16 @@ const Notification = styled.span<{
     $contentLength >= 3 ? "fit-content" : ($frameSize ?? `${$size * 0.8}px`)};
   height: ${({ $size, $frameSize }) => $frameSize ?? `${$size * 0.8}px`};
   font-size: ${({ $size, $fontSize }) => $fontSize ?? `${$size * 0.4}px`};
-  ${({ $contentLength }) =>
-    $contentLength >= 3 &&
-    css`
-      padding: 0px 3px;
-    `};
+  ${({ $contentLength, $size }) =>
+    $contentLength === 0
+      ? css`
+          height: ${$size * 0.6}px;
+          width: ${$size * 0.6}px;
+        `
+      : $contentLength >= 3 &&
+        css`
+          padding: 0px 3px;
+        `};
 
   ${({ $style }) => $style};
 `;

--- a/components/figure.tsx
+++ b/components/figure.tsx
@@ -1,6 +1,6 @@
 import { applyClassName } from "./../constants/classname";
 import { ComponentType, HTMLAttributes } from "react";
-import styled, { CSSProp } from "styled-components";
+import styled, { css, CSSProp } from "styled-components";
 
 export interface FigureProps
   extends Omit<HTMLAttributes<HTMLSpanElement>, "style"> {
@@ -48,6 +48,7 @@ function Figure({
           $backgroundColor={notification?.backgroundColor}
           $frameSize={notification?.frameSize}
           $style={styles?.notificationStyle}
+          $contentLength={notification?.content?.length}
         >
           {notification.content}
         </Notification>
@@ -90,6 +91,7 @@ const Notification = styled.span<{
   $frameSize?: string;
   $fontSize?: string;
   $backgroundColor?: string;
+  $contentLength?: number;
 }>`
   position: absolute;
   top: 5%;
@@ -104,11 +106,16 @@ const Notification = styled.span<{
   justify-content: center;
 
   color: white;
-  width: ${({ $size, $frameSize }) => $frameSize ?? `${$size * 0.8}px`};
+  width: ${({ $size, $frameSize, $contentLength }) =>
+    $contentLength >= 3 ? "fit-content" : ($frameSize ?? `${$size * 0.8}px`)};
   height: ${({ $size, $frameSize }) => $frameSize ?? `${$size * 0.8}px`};
   font-size: ${({ $size, $fontSize }) => $fontSize ?? `${$size * 0.4}px`};
-  line-height: 1;
+  ${({ $contentLength }) =>
+    $contentLength >= 3 &&
+    css`
+      padding: 0px 3px;
+    `};
 
-  ${({ $style }) => $style}
+  ${({ $style }) => $style};
 `;
 export { Figure };

--- a/components/figure.tsx
+++ b/components/figure.tsx
@@ -8,7 +8,7 @@ export interface FigureProps
   size?: number;
   color?: string;
   styles?: FigureStyles;
-  notification?: FigureNotification;
+  notificationBadge?: FigureNotification;
 }
 
 export interface FigureNotification {
@@ -20,7 +20,7 @@ export interface FigureNotification {
 
 export interface FigureStyles {
   self?: CSSProp;
-  notificationStyle?: CSSProp;
+  notificationBadgeStyle?: CSSProp;
 }
 
 function Figure({
@@ -30,7 +30,7 @@ function Figure({
   styles,
   "aria-label": ariaLabel,
   className,
-  notification,
+  notificationBadge,
   ...rest
 }: FigureProps) {
   if (!Icon) return null;
@@ -41,16 +41,16 @@ function Figure({
       className={applyClassName("figure", className)}
       $style={styles?.self}
     >
-      {notification && (
+      {notificationBadge && (
         <Notification
           $size={size}
-          $fontSize={notification?.fontSize}
-          $backgroundColor={notification?.backgroundColor}
-          $frameSize={notification?.frameSize}
-          $style={styles?.notificationStyle}
-          $contentLength={notification?.content?.length}
+          $fontSize={notificationBadge?.fontSize}
+          $backgroundColor={notificationBadge?.backgroundColor}
+          $frameSize={notificationBadge?.frameSize}
+          $style={styles?.notificationBadgeStyle}
+          $contentLength={notificationBadge?.content?.length}
         >
-          {notification.content}
+          {notificationBadge.content}
         </Notification>
       )}
 

--- a/components/figure.tsx
+++ b/components/figure.tsx
@@ -1,3 +1,4 @@
+import { c } from "framer-motion/dist/types.d-Cjd591yU";
 import { applyClassName } from "./../constants/classname";
 import { ComponentType, HTMLAttributes } from "react";
 import styled, { CSSProp } from "styled-components";
@@ -8,10 +9,12 @@ export interface FigureProps
   size?: number;
   color?: string;
   styles?: FigureStyles;
+  notification?: string;
 }
 
 export interface FigureStyles {
   self?: CSSProp;
+  notificationStyle?: CSSProp;
 }
 
 function Figure({
@@ -21,6 +24,7 @@ function Figure({
   styles,
   "aria-label": ariaLabel,
   className,
+  notification,
   ...rest
 }: FigureProps) {
   if (!Icon) return null;
@@ -31,6 +35,12 @@ function Figure({
       className={applyClassName("figure", className)}
       $style={styles?.self}
     >
+      {notification && (
+        <Notification $size={size} $style={styles?.notificationStyle}>
+          {notification}
+        </Notification>
+      )}
+
       {typeof Icon === "string" ? (
         <img
           alt="figure-icon"
@@ -57,8 +67,30 @@ function Figure({
 const Wrapper = styled.span<{ $style?: CSSProp }>`
   color: inherit;
   align-items: center;
+  position: relative;
 
   ${({ $style }) => $style}
 `;
 
+const Notification = styled.span<{ $style?: CSSProp; $size?: number }>`
+  position: absolute;
+  top: 5%;
+  right: 5%;
+  transform: translate(50%, -50%);
+
+  border-radius: 9999px;
+  background-color: red;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  color: white;
+  width: ${({ $size = 16 }) => `${$size * 0.8}px`};
+  height: ${({ $size = 16 }) => `${$size * 0.8}px`};
+  font-size: ${({ $size = 16 }) => `${$size * 0.4}px`};
+  line-height: 1;
+
+  ${({ $style }) => $style}
+`;
 export { Figure };

--- a/components/nav-tab.stories.tsx
+++ b/components/nav-tab.stories.tsx
@@ -17,11 +17,14 @@ import {
   RiExchangeDollarLine,
   RiFlashlightLine,
   RiHome3Line,
+  RiLogoutBoxFill,
   RiMenuLine,
   RiPieChartLine,
   RiSearchLine,
   RiSettings5Line,
   RiTable2,
+  RiTranslate2,
+  RiUserLine,
   RiWallet2Line,
 } from "@remixicon/react";
 import { TableColumn, Table, TableSubMenuList } from "./table";
@@ -643,30 +646,6 @@ export const Mobile: Story = {
   render: () => {
     const [activeTab, setActiveTab] = useState("2");
 
-    const TYPES_DATA = ["HTTP", "HTTPS", "TCP", "UDP", "QUIC"];
-
-    const sampleRows = Array.from({ length: 20 }, (_, i) => {
-      const type = TYPES_DATA[i % TYPES_DATA.length];
-      return (
-        <Table.Row
-          rowId={`${type}`}
-          key={i}
-          content={[`Load Balancer ${i + 1}`, type]}
-        />
-      );
-    });
-
-    const columns: TableColumn[] = [
-      {
-        id: "name",
-        caption: "Name",
-      },
-      {
-        id: "type",
-        caption: "Type",
-      },
-    ];
-
     const TABS_ITEMS: NavTabTab[] = [
       {
         id: "1",
@@ -701,6 +680,7 @@ export const Mobile: Story = {
         onClick: () => {
           console.log("test tab 1");
         },
+        withCircle: true,
       },
       {
         id: "4",
@@ -726,42 +706,24 @@ export const Mobile: Story = {
         },
         subItems: [
           {
-            id: "2-1",
-            icon: { image: RiTable2 },
-            caption: "Table View",
-            content: (
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "4px",
-                }}
-              >
-                <h2
-                  style={{
-                    fontSize: "18px",
-                  }}
-                >
-                  Table Content
-                </h2>
-                <Table
-                  styles={{
-                    tableBodyStyle: css`
-                      max-height: 400px;
-                    `,
-                  }}
-                  columns={columns}
-                >
-                  {sampleRows}
-                </Table>
-              </div>
-            ),
+            id: "5-1",
+            icon: { image: RiUserLine },
+            caption: "Privacy & security settings",
+            content: "This is privacy and security settings content",
           },
           {
-            id: "2-2",
-            icon: { image: RiCharacterRecognitionLine },
-            caption: "Chart",
-            content: "This is chart content",
+            id: "5-2",
+            icon: { image: RiTranslate2 },
+            caption: "Language",
+            content: "This is language content",
+          },
+          {
+            id: "5-3",
+            icon: { image: RiLogoutBoxFill },
+            caption: "Logout",
+            onClick: () => {
+              console.log("logout");
+            },
           },
         ],
       },
@@ -771,6 +733,7 @@ export const Mobile: Story = {
       <NavTab
         mobile
         tabs={TABS_ITEMS}
+        activeColor="red"
         activeTab={activeTab}
         onChange={(activeTab) => setActiveTab(activeTab)}
       />

--- a/components/nav-tab.stories.tsx
+++ b/components/nav-tab.stories.tsx
@@ -669,7 +669,7 @@ export const Mobile: Story = {
         content: <WriteTabContent />,
         badge: {
           image: RiAddBoxLine,
-          notification: "20",
+          notification: { content: "99+" },
         },
         onClick: () => {
           console.log("test tab 1");

--- a/components/nav-tab.stories.tsx
+++ b/components/nav-tab.stories.tsx
@@ -14,10 +14,15 @@ import {
   RiCarouselView,
   RiCharacterRecognitionLine,
   RiCropLine,
+  RiExchangeDollarLine,
   RiFlashlightLine,
+  RiHome3Line,
+  RiMenuLine,
+  RiPieChartLine,
   RiSearchLine,
   RiSettings5Line,
   RiTable2,
+  RiWallet2Line,
 } from "@remixicon/react";
 import { TableColumn, Table, TableSubMenuList } from "./table";
 import { css } from "styled-components";
@@ -665,11 +670,11 @@ export const Mobile: Story = {
     const TABS_ITEMS: NavTabTab[] = [
       {
         id: "1",
-        title: "Write",
-        content: <WriteTabContent />,
+        title: "Home",
+        content: "This is home content",
         badge: {
-          image: RiAddBoxLine,
-          notification: { content: "99+" },
+          image: RiHome3Line,
+          notification: { content: "99+", fontSize: "8px" },
         },
         onClick: () => {
           console.log("test tab 1");
@@ -677,13 +682,47 @@ export const Mobile: Story = {
       },
       {
         id: "2",
-        title: "Review",
+        title: "Account",
         badge: {
-          image: RiCarouselView,
+          image: RiWallet2Line,
         },
-        content: <ReviewTabContent />,
+        content: "This is account content",
         onClick: () => {
           console.log("test tab 2");
+        },
+      },
+      {
+        id: "3",
+        title: "Transfer",
+        content: "This is transfer content",
+        badge: {
+          image: RiExchangeDollarLine,
+        },
+        onClick: () => {
+          console.log("test tab 1");
+        },
+      },
+      {
+        id: "4",
+        title: "Household",
+        content: "This is household content",
+        badge: {
+          image: RiPieChartLine,
+          notification: { content: "99+", fontSize: "8px" },
+        },
+        onClick: () => {
+          console.log("test tab 1");
+        },
+      },
+      {
+        id: "5",
+        title: "Menu",
+        content: "This is setting content",
+        badge: {
+          image: RiMenuLine,
+        },
+        onClick: () => {
+          console.log("test tab 1");
         },
         subItems: [
           {
@@ -732,15 +771,6 @@ export const Mobile: Story = {
       <NavTab
         mobile
         tabs={TABS_ITEMS}
-        actions={[
-          {
-            caption: "Add",
-            icon: { image: RiAddBoxLine },
-            onClick: () => {
-              console.log(`Add button was clicked`);
-            },
-          },
-        ]}
         activeTab={activeTab}
         onChange={(activeTab) => setActiveTab(activeTab)}
       />

--- a/components/nav-tab.stories.tsx
+++ b/components/nav-tab.stories.tsx
@@ -11,7 +11,6 @@ import { Button } from "./button";
 import {
   RiAddBoxLine,
   RiAtLine,
-  RiCarouselView,
   RiCharacterRecognitionLine,
   RiCropLine,
   RiExchangeDollarLine,

--- a/components/nav-tab.stories.tsx
+++ b/components/nav-tab.stories.tsx
@@ -633,6 +633,104 @@ export const WithSubItems: Story = {
   },
 };
 
+export const Mobile: Story = {
+  render: () => {
+    const [activeTab, setActiveTab] = useState("2");
+
+    const TYPES_DATA = ["HTTP", "HTTPS", "TCP", "UDP", "QUIC"];
+
+    const sampleRows = Array.from({ length: 20 }, (_, i) => {
+      const type = TYPES_DATA[i % TYPES_DATA.length];
+      return (
+        <Table.Row
+          rowId={`${type}`}
+          key={i}
+          content={[`Load Balancer ${i + 1}`, type]}
+        />
+      );
+    });
+
+    const columns: TableColumn[] = [
+      {
+        id: "name",
+        caption: "Name",
+      },
+      {
+        id: "type",
+        caption: "Type",
+      },
+    ];
+
+    const TABS_ITEMS: NavTabTab[] = [
+      {
+        id: "1",
+        title: "Write",
+        content: <WriteTabContent />,
+        onClick: () => {
+          console.log("test tab 1");
+        },
+      },
+      {
+        id: "2",
+        title: "Review",
+        content: <ReviewTabContent />,
+        onClick: () => {
+          console.log("test tab 2");
+        },
+        subItems: [
+          {
+            id: "2-1",
+            icon: { image: RiTable2 },
+            caption: "Table View",
+            content: (
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "4px",
+                }}
+              >
+                <h2
+                  style={{
+                    fontSize: "18px",
+                  }}
+                >
+                  Table Content
+                </h2>
+                <Table
+                  styles={{
+                    tableBodyStyle: css`
+                      max-height: 400px;
+                    `,
+                  }}
+                  columns={columns}
+                >
+                  {sampleRows}
+                </Table>
+              </div>
+            ),
+          },
+          {
+            id: "2-2",
+            icon: { image: RiCharacterRecognitionLine },
+            caption: "Chart",
+            content: "This is chart content",
+          },
+        ],
+      },
+    ];
+
+    return (
+      <NavTab
+        mobile
+        tabs={TABS_ITEMS}
+        activeTab={activeTab}
+        onChange={(activeTab) => setActiveTab(activeTab)}
+      />
+    );
+  },
+};
+
 export const WriteTabContent = () => {
   const [value, setValue] = useState({
     write: "",

--- a/components/nav-tab.stories.tsx
+++ b/components/nav-tab.stories.tsx
@@ -733,7 +733,6 @@ export const Mobile: Story = {
       <NavTab
         mobile
         tabs={TABS_ITEMS}
-        activeColor="red"
         activeTab={activeTab}
         onChange={(activeTab) => setActiveTab(activeTab)}
       />

--- a/components/nav-tab.stories.tsx
+++ b/components/nav-tab.stories.tsx
@@ -11,6 +11,7 @@ import { Button } from "./button";
 import {
   RiAddBoxLine,
   RiAtLine,
+  RiCarouselView,
   RiCharacterRecognitionLine,
   RiCropLine,
   RiFlashlightLine,
@@ -666,6 +667,10 @@ export const Mobile: Story = {
         id: "1",
         title: "Write",
         content: <WriteTabContent />,
+        badge: {
+          image: RiAddBoxLine,
+          notification: "20",
+        },
         onClick: () => {
           console.log("test tab 1");
         },
@@ -673,6 +678,9 @@ export const Mobile: Story = {
       {
         id: "2",
         title: "Review",
+        badge: {
+          image: RiCarouselView,
+        },
         content: <ReviewTabContent />,
         onClick: () => {
           console.log("test tab 2");
@@ -724,6 +732,15 @@ export const Mobile: Story = {
       <NavTab
         mobile
         tabs={TABS_ITEMS}
+        actions={[
+          {
+            caption: "Add",
+            icon: { image: RiAddBoxLine },
+            onClick: () => {
+              console.log(`Add button was clicked`);
+            },
+          },
+        ]}
         activeTab={activeTab}
         onChange={(activeTab) => setActiveTab(activeTab)}
       />

--- a/components/nav-tab.stories.tsx
+++ b/components/nav-tab.stories.tsx
@@ -31,7 +31,7 @@ import { css } from "styled-components";
 import { generateSentence } from "./../lib/text";
 import { Card } from "./card";
 import { Badge } from "./badge";
-import { Combobox, ComboboxOption } from "./combobox";
+import { ComboboxOption } from "./combobox";
 
 const meta: Meta<typeof NavTab> = {
   title: "Stage/NavTab",
@@ -650,9 +650,9 @@ export const Mobile: Story = {
         id: "1",
         title: "Home",
         content: "This is home content",
-        badge: {
+        icon: {
           image: RiHome3Line,
-          notification: { content: "99+", fontSize: "8px" },
+          notificationBadge: { content: "99+", fontSize: "8px" },
         },
         onClick: () => {
           console.log("test tab 1");
@@ -661,7 +661,7 @@ export const Mobile: Story = {
       {
         id: "2",
         title: "Account",
-        badge: {
+        icon: {
           image: RiWallet2Line,
         },
         content: "This is account content",
@@ -673,7 +673,7 @@ export const Mobile: Story = {
         id: "3",
         title: "Transfer",
         content: "This is transfer content",
-        badge: {
+        icon: {
           image: RiExchangeDollarLine,
         },
         onClick: () => {
@@ -685,9 +685,9 @@ export const Mobile: Story = {
         id: "4",
         title: "Household",
         content: "This is household content",
-        badge: {
+        icon: {
           image: RiPieChartLine,
-          notification: { content: "99+", fontSize: "8px" },
+          notificationBadge: { content: "99+", fontSize: "8px" },
         },
         onClick: () => {
           console.log("test tab 1");
@@ -697,7 +697,7 @@ export const Mobile: Story = {
         id: "5",
         title: "Menu",
         content: "This is setting content",
-        badge: {
+        icon: {
           image: RiMenuLine,
         },
         onClick: () => {

--- a/components/nav-tab.stories.tsx
+++ b/components/nav-tab.stories.tsx
@@ -652,7 +652,6 @@ export const Mobile: Story = {
         content: "This is home content",
         icon: {
           image: RiHome3Line,
-          notificationBadge: { content: "99+", fontSize: "8px" },
         },
         onClick: () => {
           console.log("test tab 1");
@@ -663,6 +662,7 @@ export const Mobile: Story = {
         title: "Account",
         icon: {
           image: RiWallet2Line,
+          notificationBadge: { content: "" },
         },
         content: "This is account content",
         onClick: () => {
@@ -675,6 +675,7 @@ export const Mobile: Story = {
         content: "This is transfer content",
         icon: {
           image: RiExchangeDollarLine,
+          notificationBadge: { content: "5" },
         },
         onClick: () => {
           console.log("test tab 1");
@@ -687,7 +688,6 @@ export const Mobile: Story = {
         content: "This is household content",
         icon: {
           image: RiPieChartLine,
-          notificationBadge: { content: "99+", fontSize: "8px" },
         },
         onClick: () => {
           console.log("test tab 1");

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -41,6 +41,9 @@ export interface NavTabStyles {
   tabStyle?: CSSProp;
   barStyle?: CSSProp;
   underscoreStyle?: CSSProp;
+  iconStyle?: CSSProp;
+  badgeStyle?: CSSProp;
+  labelStyle?: CSSProp;
 }
 
 export interface NavTabAction extends ActionButtonProps {
@@ -61,7 +64,7 @@ export interface NavTabTab {
   onClick?: () => void;
   actions?: NavTabTabAction[];
   subItems?: NavTabSubItem[];
-  badge?: NavTabTabBadge;
+  icon?: NavTabTabBadge;
   hidden?: boolean;
   className?: string;
   withCircle?: boolean;
@@ -478,11 +481,22 @@ function NavTab({
                   $tabsLength={visibleTabs?.length}
                   $withCircle={tab?.withCircle}
                 >
-                  {tab.badge &&
+                  {tab.icon &&
                     (() => {
-                      const finalBadge: FigureProps = {
-                        ...tab.badge,
-                        size: mobile ? (tab.badge.size ?? 24) : tab.badge.size,
+                      const finalIcon: FigureProps = {
+                        ...tab?.icon,
+                        size: mobile ? (tab.icon.size ?? 24) : tab.icon.size,
+                        styles: {
+                          ...tab?.icon?.styles,
+                          notificationBadgeStyle: css`
+                            ${styles?.badgeStyle};
+                            ${tab?.icon?.styles?.notificationBadgeStyle};
+                          `,
+                          self: css`
+                            ${styles?.iconStyle};
+                            ${tab?.icon?.styles?.self};
+                          `,
+                        },
                       };
 
                       if (mobile && tab.withCircle) {
@@ -493,15 +507,23 @@ function NavTab({
                             $activeColor={activeColor}
                             $theme={navTheme}
                           >
-                            <Figure {...finalBadge} />
-                            {tab.title}
+                            <Figure {...finalIcon} />
+                            <NavTabLabel $style={styles?.labelStyle}>
+                              {tab.title}
+                            </NavTabLabel>
                           </CircleBadge>
                         );
                       }
 
-                      return <Figure {...finalBadge} />;
+                      return <Figure {...finalIcon} />;
                     })()}
-                  {!(mobile && tab.withCircle) && tab.title}
+
+                  {!(mobile && tab.withCircle) && (
+                    <NavTabLabel $style={styles?.labelStyle}>
+                      {tab.title}
+                    </NavTabLabel>
+                  )}
+
                   {!mobile &&
                     tab.actions &&
                     (() => {
@@ -648,6 +670,10 @@ const NavTabContainer = styled.div<{
   font-size: 14px;
   top: 0;
 
+  ${({ $style }) => $style}
+`;
+
+const NavTabLabel = styled.span<{ $style?: CSSProp }>`
   ${({ $style }) => $style}
 `;
 

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -165,7 +165,7 @@ function NavTab({
 
   const visibleTabs = useMemo(
     () =>
-      (mobile ? [...mobileActions, ...tabs] : tabs)?.filter(
+      (mobile ? [...tabs, ...mobileActions] : tabs)?.filter(
         (tab) => !tab.hidden
       ),
     [tabs, mobileActions]

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -493,6 +493,10 @@ function NavTab({
                             ${tab?.icon?.styles?.notificationBadgeStyle};
                           `,
                           self: css`
+                            ${tab?.withCircle &&
+                            css`
+                              transform: translateY(10%);
+                            `};
                             ${styles?.iconStyle};
                             ${tab?.icon?.styles?.self};
                           `,
@@ -508,7 +512,15 @@ function NavTab({
                             $theme={navTheme}
                           >
                             <Figure {...finalIcon} />
-                            <NavTabLabel $style={styles?.labelStyle}>
+                            <NavTabLabel
+                              $style={css`
+                                ${tab?.withCircle &&
+                                css`
+                                  transform: translateY(10%);
+                                `};
+                                ${styles?.labelStyle}
+                              `}
+                            >
                               {tab.title}
                             </NavTabLabel>
                           </CircleBadge>
@@ -875,7 +887,8 @@ const NavTabTab = styled.div<{
       display: flex;
       flex-direction: column;
       justify-content: center;
-      padding-top: 20px;
+      padding-top: 10px;
+      padding-bottom: 16px;
       font-size: 12px;
     `};
 
@@ -909,7 +922,7 @@ const CircleBadge = styled.span<{
   transform: translateX(-50%);
   width: 80px;
   height: 80px;
-  bottom: 8px;
+  bottom: 4px;
   border-radius: 9999px;
   display: flex;
   flex-direction: column;
@@ -917,16 +930,16 @@ const CircleBadge = styled.span<{
   justify-content: center;
   gap: 7px;
   background-color: ${({ $theme, $activeColor }) =>
-    $activeColor ?? $theme?.indicatorColor};
+    $activeColor ?? $theme?.circleInactiveColor};
 
   &:active {
-    background-color: ${({ $theme }) => $theme?.indicatorActiveColor};
+    background-color: ${({ $theme }) => $theme?.indicatorColor};
   }
 
   ${({ $pressed, $theme }) =>
     $pressed &&
     css`
-      background-color: ${$theme?.indicatorActiveColor};
+      background-color: ${$theme?.indicatorColor};
     `};
 
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -329,7 +329,7 @@ function NavTab({
 
                     ${mobile &&
                     css`
-                      width: 96dvw;
+                      width: 99dvw;
                       left: 50%;
                       transform: translateX(-50%);
                     `};
@@ -342,6 +342,8 @@ function NavTab({
                       tab.subItems
                         ?.filter((subItem) => !subItem?.hidden)
                         ?.map((subItem, idx) => {
+                          console.log(subItem);
+
                           return (
                             <NavTabTab
                               key={idx}
@@ -364,7 +366,7 @@ function NavTab({
                                 if (subItem.content) {
                                   setSelectedLocal(subItem.id);
                                 }
-                                if (onChange) {
+                                if (onChange && subItem.content) {
                                   onChange(subItem.id);
                                 }
                                 tooltipRefs.current.forEach((ref) => {

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -27,6 +27,8 @@ export interface NavTabProps {
   styles?: NavTabStyles;
   size?: NavTabSize;
   onChange?: (activeTab: string) => void;
+  underlineable?: boolean;
+  mobile?: boolean;
   className?: string;
   id?: string;
 }
@@ -91,6 +93,8 @@ function NavTab({
   size = "md",
   onChange,
   className,
+  underlineable = true,
+  mobile,
   id,
 }: NavTabProps) {
   const { currentTheme } = useTheme();
@@ -101,6 +105,17 @@ function NavTab({
   const [selectedLocal, setSelectedLocal] = useState<string>(activeTab);
   const [isHovered, setIsHovered] = useState<string | null>(null);
   const [isTipMenuOpen, setIsTipMenuOpen] = useState<string | null>(null);
+
+  const [openSubMenuId, setOpenSubMenuId] = useState<string | null>(null);
+  const subMenuTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const longPressTriggeredRef = useRef<boolean>(null);
+
+  const clearSubMenuTimer = () => {
+    if (subMenuTimeoutRef.current) {
+      clearTimeout(subMenuTimeoutRef.current);
+      subMenuTimeoutRef.current = null;
+    }
+  };
 
   const tabRefs = useRef<Array<HTMLDivElement | null>>([]);
   const [tabSizes, setTabSizes] = useState<{ width: number; left: number }[]>(
@@ -194,46 +209,60 @@ function NavTab({
       className={applyClassName("nav-tab", className)}
       $style={styles?.containerStyle}
       $theme={navTheme}
+      $mobile={mobile}
     >
-      <NavTabBar $theme={navTheme} $style={styles?.barStyle}>
+      <NavTabBar $mobile={mobile} $theme={navTheme} $style={styles?.barStyle}>
         <NavTabTabsSection
           aria-label="nav-tab-tabs-sections"
           $style={styles?.containerBoxStyle}
+          $mobile={mobile}
           ref={containerRef}
           $theme={navTheme}
         >
-          <NavTabUnderscore
-            aria-label="nav-tab-underscore"
-            $activeColor={activeColor}
-            $theme={navTheme}
-            $style={styles?.underscoreStyle}
-            initial={{
-              left: 0,
-              width: 0,
-              opacity: 0,
-            }}
-            animate={{
-              left: hoverPosition.left,
-              width: hoverPosition.width,
-              opacity: hoverPosition.opacity,
-            }}
-            transition={{
-              type: "spring",
-              stiffness: 300,
-              damping: 30,
-              opacity: { duration: 0.2 },
-            }}
-          />
+          {underlineable && (
+            <NavTabUnderscore
+              aria-label="nav-tab-underscore"
+              $mobile={mobile}
+              $activeColor={activeColor}
+              $theme={navTheme}
+              $style={styles?.underscoreStyle}
+              initial={{
+                left: 0,
+                width: 0,
+                opacity: 0,
+              }}
+              animate={{
+                left: hoverPosition.left,
+                width: hoverPosition.width,
+                opacity: hoverPosition.opacity,
+              }}
+              transition={{
+                type: "spring",
+                stiffness: 300,
+                damping: 30,
+                opacity: { duration: 0.2 },
+              }}
+            />
+          )}
 
           {visibleTabs.map((tab, index) => {
             return (
               <Tooltip
+                open={mobile ? openSubMenuId === tab.id : undefined}
                 ref={(el) => {
                   tooltipRefs.current[index] = el;
                 }}
+                onVisibilityChange={(next) => {
+                  if (!next) {
+                    setOpenSubMenuId((prev) => (prev === tab.id ? null : prev));
+                  }
+                }}
+                anchorRef={containerRef}
                 id={tab.id}
                 className={applyClassName("nav-tab-tab", tab?.className)}
                 key={index}
+                hideDialogOn={mobile ? "click" : "hover"}
+                showDialogOn={mobile ? "click" : "hover"}
                 styles={{
                   arrowStyle: css`
                     opacity: 0;
@@ -263,9 +292,16 @@ function NavTab({
                     css`
                       opacity: 1;
                     `}
+
+                    ${mobile &&
+                    css`
+                      width: 96dvw;
+                      left: 50%;
+                      transform: translateX(-50%);
+                    `};
                   `,
                 }}
-                dialogPlacement="bottom-left"
+                dialogPlacement={mobile ? "top-center" : "bottom-left"}
                 dialog={
                   <>
                     {tab.subItems &&
@@ -281,7 +317,15 @@ function NavTab({
                                 item?.className
                               )}
                               $theme={navTheme}
-                              $style={item?.styles?.self}
+                              $style={css`
+                                ${mobile &&
+                                css`
+                                  height: 80px;
+                                  font-size: 16px;
+                                `}
+
+                                ${item?.styles?.self}
+                              `}
                               onClick={() => {
                                 if (item.content) {
                                   setSelectedLocal(item.id);
@@ -292,6 +336,10 @@ function NavTab({
                                 tooltipRefs.current.forEach((ref) => {
                                   ref?.close();
                                 });
+
+                                if (mobile) {
+                                  setOpenSubMenuId(null);
+                                }
                                 if (item.onClick) {
                                   item.onClick();
                                 }
@@ -314,8 +362,24 @@ function NavTab({
                   $style={styles?.tabStyle}
                   ref={setTabRef(index)}
                   role="tab"
+                  onPointerDown={(e) => {
+                    longPressTriggeredRef.current = false;
+                    subMenuTimeoutRef.current = setTimeout(() => {
+                      longPressTriggeredRef.current = true;
+                      setOpenSubMenuId(tab.id);
+                    }, 400);
+                  }}
+                  onPointerUp={clearSubMenuTimer}
+                  onPointerLeave={clearSubMenuTimer}
+                  onPointerCancel={clearSubMenuTimer}
                   onClick={(e) => {
                     e.stopPropagation();
+                    if (longPressTriggeredRef.current) {
+                      longPressTriggeredRef.current = false;
+                      return;
+                    }
+
+                    setOpenSubMenuId(null);
                     setSelectedLocal(tab.id);
                     if (tab.onClick) {
                       tab.onClick();
@@ -456,6 +520,7 @@ function NavTab({
         })}
         {children}
       </NavContent>
+      {mobile && <NavTabSpacer />}
     </NavTabContainer>
   );
 }
@@ -463,6 +528,7 @@ function NavTab({
 const NavTabContainer = styled.div<{
   $style?: CSSProp;
   $theme: NavTabThemeConfig;
+  $mobile?: boolean;
 }>`
   *,
   ::before,
@@ -486,6 +552,7 @@ const NavTabTabsSection = styled.div<{
   $style?: CSSProp;
   $actions?: boolean;
   $theme: NavTabThemeConfig;
+  $mobile?: boolean;
 }>`
   width: 100%;
   height: auto;
@@ -499,14 +566,34 @@ const NavTabTabsSection = styled.div<{
     css`
       justify-content: end;
       margin-right: 10px;
-    `}
+    `};
+
+  ${({ $mobile }) =>
+    $mobile &&
+    css`
+      justify-content: center;
+    `};
 
   ${({ $style }) => $style}
+`;
+
+const NavTabSpacer = styled.div<{
+  $height?: string;
+}>`
+  display: flex;
+  background-color: transparent;
+  width: 100%;
+
+  @media (min-width: 768px) {
+    display: block;
+    min-width: ${({ $height }) => ($height ? `${$height}` : "48px")};
+  }
 `;
 
 const NavTabBar = styled.div<{
   $style?: CSSProp;
   $theme?: NavTabThemeConfig;
+  $mobile?: boolean;
 }>`
   width: 100%;
   height: auto;
@@ -520,6 +607,14 @@ const NavTabBar = styled.div<{
   border-bottom: 1px solid ${({ $theme }) => $theme.borderColor};
   box-shadow: ${({ $theme }) => $theme.boxShadow};
 
+  ${({ $mobile }) =>
+    $mobile &&
+    css`
+      position: fixed;
+      bottom: 0;
+      z-index: 20;
+    `}
+
   ${({ $style }) => $style}
 `;
 
@@ -527,15 +622,23 @@ const NavTabUnderscore = styled(motion.div)<{
   $activeColor?: string;
   $theme?: NavTabThemeConfig;
   $style?: CSSProp;
+  $mobile?: boolean;
 }>`
   position: absolute;
-  bottom: 0;
   z-index: 1;
   height: 2px;
   border-radius: 1px;
   pointer-events: none;
   background-color: ${({ $activeColor, $theme }) =>
     $activeColor ?? $theme?.indicatorColor};
+  ${({ $mobile }) =>
+    $mobile
+      ? css`
+          top: 0;
+        `
+      : css`
+          bottom: 0;
+        `}
 
   ${({ $style }) => $style}
 `;

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -483,6 +483,7 @@ function NavTab({
                       if (mobile && tab.withCircle) {
                         return (
                           <CircleBadge
+                            $pressed={selected === tab.id}
                             $activeColor={activeColor}
                             $theme={navTheme}
                           >
@@ -862,13 +863,14 @@ const NavTabTab = styled.div<{
 const CircleBadge = styled.span<{
   $theme?: NavTabThemeConfig;
   $activeColor?: string;
+  $pressed?: boolean;
 }>`
   position: absolute;
-  bottom: 4px;
   left: 50%;
   transform: translateX(-50%);
-  width: 80px;
-  height: 80px;
+  width: 70px;
+  height: 70px;
+  bottom: 8px;
   border-radius: 9999px;
   display: flex;
   flex-direction: column;
@@ -877,13 +879,24 @@ const CircleBadge = styled.span<{
   gap: 7px;
   background-color: ${({ $theme, $activeColor }) =>
     $activeColor ?? $theme?.indicatorColor};
+
+  &:active {
+    background-color: ${({ $theme }) => $theme?.indicatorActiveColor};
+  }
+
+  ${({ $pressed, $theme }) =>
+    $pressed &&
+    css`
+      background-color: ${$theme?.indicatorActiveColor};
+    `};
+
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
   color: white;
 
-  @media (max-width: 450px) {
-    width: 75px;
-    height: 75px;
-    bottom: 8px;
+  @media (min-width: 450px) {
+    width: 80px;
+    height: 80px;
+    bottom: 4px;
   }
 `;
 

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -502,7 +502,8 @@ function NavTab({
                       return <Figure {...finalBadge} />;
                     })()}
                   {!(mobile && tab.withCircle) && tab.title}
-                  {tab.actions &&
+                  {!mobile &&
+                    tab.actions &&
                     (() => {
                       const listActions = tab.actions;
                       const actionsWithIcons = listActions

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -890,6 +890,12 @@ const NavTabTab = styled.div<{
           width: ${$width}px;
         `};
 
+  ${({ $withCircle }) =>
+    $withCircle &&
+    css`
+      min-width: 85px;
+    `}
+
   ${({ $style }) => $style};
 `;
 
@@ -901,8 +907,8 @@ const CircleBadge = styled.span<{
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  width: 70px;
-  height: 70px;
+  width: 80px;
+  height: 80px;
   bottom: 8px;
   border-radius: 9999px;
   display: flex;
@@ -927,8 +933,8 @@ const CircleBadge = styled.span<{
   color: white;
 
   @media (min-width: 450px) {
-    width: 80px;
-    height: 80px;
+    width: 85px;
+    height: 85px;
     bottom: 4px;
   }
 `;

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -430,7 +430,7 @@ function NavTab({
                   onMouseEnter={() => setIsHovered(tab.id)}
                   onMouseLeave={() => setIsHovered(null)}
                   $isHovered={isHovered === tab.id || isTipMenuOpen === tab.id}
-                  $selected={selected === tab.id}
+                  $selected={selected === tab.id || openSubMenuId === tab.id}
                   $isAction={!!tab.actions}
                   $mobile={mobile}
                   $width={mobile ? maxTabWidth : undefined}

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -64,6 +64,7 @@ export interface NavTabTab {
   badge?: NavTabTabBadge;
   hidden?: boolean;
   className?: string;
+  withCircle?: boolean;
 }
 
 interface NavTabTabBadge extends FigureProps {}
@@ -152,7 +153,23 @@ function NavTab({
   const isControlled = activeTab !== undefined && onChange;
   const selected = isControlled ? activeTab : selectedLocal;
 
-  const visibleTabs = useMemo(() => tabs?.filter((tab) => !tab.hidden), [tabs]);
+  const mobileActions: NavTabTab[] =
+    actions?.map((action) => ({
+      id: action?.id,
+      title: action?.caption,
+      badge: action?.icon,
+      className: action?.className,
+      onClick: action?.onClick,
+      hidden: action?.hidden,
+    })) ?? [];
+
+  const visibleTabs = useMemo(
+    () =>
+      (mobile ? [...mobileActions, ...tabs] : tabs)?.filter(
+        (tab) => !tab.hidden
+      ),
+    [tabs, mobileActions]
+  );
 
   const getHoverPosition = () => {
     if (!isInitialized || tabSizes.length === 0) {
@@ -169,6 +186,19 @@ function NavTab({
 
     if (targetIndex === -1 || !tabSizes[targetIndex]) {
       return { left: 0, width: 0, opacity: 0 };
+    }
+
+    const targetTab = visibleTabs[targetIndex];
+
+    // Hide the underline instead of
+    // moving it there — keep the position so it fades out in place rather
+    // than sliding to (0,0) first.
+    if (mobile && targetTab.withCircle) {
+      return {
+        left: tabSizes[targetIndex].left,
+        width: tabSizes[targetIndex].width,
+        opacity: 0,
+      };
     }
 
     return {
@@ -281,7 +311,7 @@ function NavTab({
                     setOpenSubMenuId((prev) => (prev === tab.id ? null : prev));
                   }
                 }}
-                anchorRef={containerRef}
+                anchorRef={mobile ? containerRef : null}
                 id={tab.id}
                 className={applyClassName("nav-tab-tab", tab?.className)}
                 key={index}
@@ -332,6 +362,10 @@ function NavTab({
                       width: 99dvw;
                       left: 50%;
                       transform: translateX(-50%);
+                      ${tab.withCircle &&
+                      css`
+                        bottom: 10px;
+                      `};
                     `};
                   `,
                 }}
@@ -342,8 +376,6 @@ function NavTab({
                       tab.subItems
                         ?.filter((subItem) => !subItem?.hidden)
                         ?.map((subItem, idx) => {
-                          console.log(subItem);
-
                           return (
                             <NavTabTab
                               key={idx}
@@ -352,6 +384,7 @@ function NavTab({
                                 "nav-tab-sub-item",
                                 subItem?.className
                               )}
+                              $mobile={mobile}
                               $theme={navTheme}
                               $style={css`
                                 ${mobile &&
@@ -398,7 +431,8 @@ function NavTab({
                   $style={styles?.tabStyle}
                   ref={setTabRef(index)}
                   role="tab"
-                  onPointerDown={(e) => {
+                  onPointerDown={() => {
+                    if (!tab.subItems) return;
                     longPressTriggeredRef.current = false;
                     subMenuTimeoutRef.current = setTimeout(() => {
                       longPressTriggeredRef.current = true;
@@ -437,6 +471,7 @@ function NavTab({
                   $mobile={mobile}
                   $width={mobile ? maxTabWidth : undefined}
                   $tabsLength={visibleTabs?.length}
+                  $withCircle={tab?.withCircle}
                 >
                   {tab.badge &&
                     (() => {
@@ -445,10 +480,21 @@ function NavTab({
                         size: mobile ? (tab.badge.size ?? 24) : tab.badge.size,
                       };
 
+                      if (mobile && tab.withCircle) {
+                        return (
+                          <CircleBadge
+                            $activeColor={activeColor}
+                            $theme={navTheme}
+                          >
+                            <Figure {...finalBadge} />
+                            {tab.title}
+                          </CircleBadge>
+                        );
+                      }
+
                       return <Figure {...finalBadge} />;
                     })()}
-
-                  {tab.title}
+                  {!(mobile && tab.withCircle) && tab.title}
                   {tab.actions &&
                     (() => {
                       const listActions = tab.actions;
@@ -621,6 +667,7 @@ const NavTabTabsSection = styled.div<{
     $mobile &&
     css`
       justify-content: center;
+      align-items: end;
     `};
 
   ${({ $style }) => $style}
@@ -703,6 +750,7 @@ const NavTabTab = styled.div<{
   $mobile?: boolean;
   $width?: number;
   $tabsLength?: number;
+  $withCircle?: boolean;
 }>`
   color: ${({ $theme }) => $theme.textColor};
   display: flex;
@@ -719,8 +767,9 @@ const NavTabTab = styled.div<{
   user-select: none;
   padding: ${({ $size }) => ($size === "md" ? "12px 12px" : "7px 12px")};
 
-  ${({ $selected, $theme }) =>
+  ${({ $selected, $theme, $withCircle }) =>
     $selected &&
+    !$withCircle &&
     css`
       background-color: ${$theme?.selectedBackgroundColor};
     `}
@@ -766,38 +815,76 @@ const NavTabTab = styled.div<{
               width: 8px;
             }
           `}
+    `};
+
+  ${({ $theme, $withCircle, $mobile }) => css`
+    ${!$mobile &&
+    css`
+      &:hover {
+        background-color: ${$theme.hoverBackgroundColor};
+      }
     `}
 
-  &:hover {
-    background-color: ${({ $theme }) => $theme.hoverBackgroundColor};
-  }
+    ${!$withCircle &&
+    css`
+      &:active:not(:has([aria-label="action-button"]:active)) {
+        background-color: ${$theme.activeBackgroundColor};
+        box-shadow: ${$theme.activeInsetShadow};
+      }
+    `}
+  `}
 
-  &:active:not(:has([aria-label="action-button"]:active)) {
-    background-color: ${({ $theme }) => $theme.activeBackgroundColor};
-    box-shadow: ${({ $theme }) => $theme.activeInsetShadow};
-  }
-
-  ${({ $mobile }) =>
+  ${({ $mobile, $subMenu }) =>
     $mobile &&
+    !$subMenu &&
     css`
       display: flex;
       flex-direction: column;
+      justify-content: center;
+      padding-top: 20px;
+      font-size: 12px;
     `};
 
   ${({ $mobile, $width, $tabsLength }) =>
     $mobile && $tabsLength >= 4
       ? css`
           width: 100%;
-          justify-content: center;
         `
       : $mobile &&
         !!$width &&
         css`
           width: ${$width}px;
-          justify-content: center;
         `};
 
   ${({ $style }) => $style};
+`;
+
+const CircleBadge = styled.span<{
+  $theme?: NavTabThemeConfig;
+  $activeColor?: string;
+}>`
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 80px;
+  height: 80px;
+  border-radius: 9999px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  background-color: ${({ $theme, $activeColor }) =>
+    $activeColor ?? $theme?.indicatorColor};
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  color: white;
+
+  @media (max-width: 450px) {
+    width: 75px;
+    height: 75px;
+    bottom: 8px;
+  }
 `;
 
 const NavContent = styled.div<{ $contentStyle?: CSSProp }>`

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -260,6 +260,9 @@ function NavTab({
         .some((item) => item.id === selected)
   );
 
+  // apply the hasCircleTab spacing to all tab drawers when any tab uses withCircle.
+  const hasCircleTab = visibleTabs.some((tab) => tab.withCircle);
+
   return (
     <NavTabContainer
       id={id}
@@ -370,9 +373,9 @@ function NavTab({
                       width: 99dvw;
                       left: 50%;
                       transform: translateX(-50%);
-                      ${tab.withCircle &&
+                      ${hasCircleTab &&
                       css`
-                        bottom: 10px;
+                        bottom: 12px;
                       `};
                     `};
                   `,

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -125,6 +125,27 @@ function NavTab({
     []
   );
 
+  // mobile appearance
+  const [maxTabWidth, setMaxTabWidth] = useState<number>(0);
+
+  useEffect(() => {
+    if (!mobile || !tabRefs.current.length) return;
+
+    const calculateMaxWidth = () => {
+      if (!mobile || !tabRefs.current.length) return;
+
+      const widths: number[] = tabRefs.current.map(
+        (el) => el?.getBoundingClientRect().width ?? 0
+      );
+
+      const largest: number = widths.length ? Math.max(...widths) : 0;
+
+      setMaxTabWidth((prev) => (prev !== largest ? largest : prev));
+    };
+
+    calculateMaxWidth();
+  }, [tabs, mobile]);
+
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
 
@@ -206,32 +227,6 @@ function NavTab({
         .some((item) => item.id === selected)
   );
 
-  const contentActions =
-    actions &&
-    actions
-      .filter((action) => !action?.hidden)
-      .map((action, index) => {
-        return (
-          <ActionButton
-            key={index}
-            {...action}
-            styles={{
-              ...action?.styles,
-              self: css`
-                height: ${size === "sm" && "27px"};
-                border-bottom-width: 2px;
-
-                ${action.active &&
-                css`
-                  border-bottom: 2px solid ${navTheme?.indicatorColor};
-                `}
-                ${action?.styles?.self}
-              `,
-            }}
-          />
-        );
-      });
-
   return (
     <NavTabContainer
       id={id}
@@ -299,6 +294,16 @@ function NavTab({
                   `,
                   containerStyle: css`
                     width: fit-content;
+                    ${mobile &&
+                    css`
+                      width: 100%;
+                    `};
+                  `,
+                  triggerStyle: css`
+                    ${mobile &&
+                    css`
+                      width: 100%;
+                    `};
                   `,
                   drawerStyle: (placement) => css`
                     border-radius: 0px;
@@ -428,6 +433,8 @@ function NavTab({
                   $selected={selected === tab.id}
                   $isAction={!!tab.actions}
                   $mobile={mobile}
+                  $width={mobile ? maxTabWidth : undefined}
+                  $tabsLength={visibleTabs?.length}
                 >
                   {tab.badge &&
                     (() => {
@@ -507,8 +514,6 @@ function NavTab({
               </Tooltip>
             );
           })}
-
-          {actions && mobile && contentActions}
         </NavTabTabsSection>
 
         {actions && !mobile && (
@@ -522,7 +527,29 @@ function NavTab({
               ${styles?.containerActionsStyle}
             `}
           >
-            {contentActions}
+            {actions
+              .filter((action) => !action?.hidden)
+              .map((action, index) => {
+                return (
+                  <ActionButton
+                    key={index}
+                    {...action}
+                    styles={{
+                      ...action?.styles,
+                      self: css`
+                        height: ${size === "sm" && "27px"};
+                        border-bottom-width: 2px;
+
+                        ${action.active &&
+                        css`
+                          border-bottom: 2px solid ${navTheme?.indicatorColor};
+                        `}
+                        ${action?.styles?.self}
+                      `,
+                    }}
+                  />
+                );
+              })}
           </NavTabTabsSection>
         )}
       </NavTabBar>
@@ -672,6 +699,8 @@ const NavTabTab = styled.div<{
   $size?: NavTabSize;
   $theme?: NavTabThemeConfig;
   $mobile?: boolean;
+  $width?: number;
+  $tabsLength?: number;
 }>`
   color: ${({ $theme }) => $theme.textColor};
   display: flex;
@@ -752,6 +781,19 @@ const NavTabTab = styled.div<{
       display: flex;
       flex-direction: column;
     `};
+
+  ${({ $mobile, $width, $tabsLength }) =>
+    $mobile && $tabsLength >= 4
+      ? css`
+          width: 100%;
+          justify-content: center;
+        `
+      : $mobile &&
+        !!$width &&
+        css`
+          width: ${$width}px;
+          justify-content: center;
+        `};
 
   ${({ $style }) => $style};
 `;

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -265,7 +265,12 @@ function NavTab({
       $theme={navTheme}
       $mobile={mobile}
     >
-      <NavTabBar $mobile={mobile} $theme={navTheme} $style={styles?.barStyle}>
+      <NavTabBar
+        aria-label="nav-tab-bar"
+        $mobile={mobile}
+        $theme={navTheme}
+        $style={styles?.barStyle}
+      >
         <NavTabTabsSection
           aria-label="nav-tab-tabs-sections"
           $style={styles?.containerBoxStyle}

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -832,7 +832,8 @@ const NavTabTab = styled.div<{
       padding-right: 40px;
     `}
 
-  ${({ $isAction, $isHovered }) =>
+  ${({ $isAction, $isHovered, $mobile }) =>
+    !$mobile &&
     $isAction &&
     css`
       &::before,

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -488,6 +488,7 @@ function NavTab({
                       if (mobile && tab.withCircle) {
                         return (
                           <CircleBadge
+                            aria-label="nav-tab-circle"
                             $pressed={selected === tab.id}
                             $activeColor={activeColor}
                             $theme={navTheme}

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -61,9 +61,12 @@ export interface NavTabTab {
   onClick?: () => void;
   actions?: NavTabTabAction[];
   subItems?: NavTabSubItem[];
+  badge?: NavTabTabBadge;
   hidden?: boolean;
   className?: string;
 }
+
+interface NavTabTabBadge extends FigureProps {}
 
 export interface NavTabSubItem {
   id: string;
@@ -128,7 +131,7 @@ function NavTab({
   const isControlled = activeTab !== undefined && onChange;
   const selected = isControlled ? activeTab : selectedLocal;
 
-  const visibleTabs = useMemo(() => tabs.filter((tab) => !tab.hidden), [tabs]);
+  const visibleTabs = useMemo(() => tabs?.filter((tab) => !tab.hidden), [tabs]);
 
   const getHoverPosition = () => {
     if (!isInitialized || tabSizes.length === 0) {
@@ -195,13 +198,39 @@ function NavTab({
   };
 
   const hoverPosition = getHoverPosition();
-  const filteredTabs = tabs.filter(
+  const filteredTabs = tabs?.filter(
     (tab) =>
       tab.id === selected ||
       tab.subItems
         ?.filter((item) => !item?.hidden)
         .some((item) => item.id === selected)
   );
+
+  const contentActions =
+    actions &&
+    actions
+      .filter((action) => !action?.hidden)
+      .map((action, index) => {
+        return (
+          <ActionButton
+            key={index}
+            {...action}
+            styles={{
+              ...action?.styles,
+              self: css`
+                height: ${size === "sm" && "27px"};
+                border-bottom-width: 2px;
+
+                ${action.active &&
+                css`
+                  border-bottom: 2px solid ${navTheme?.indicatorColor};
+                `}
+                ${action?.styles?.self}
+              `,
+            }}
+          />
+        );
+      });
 
   return (
     <NavTabContainer
@@ -306,15 +335,15 @@ function NavTab({
                   <>
                     {tab.subItems &&
                       tab.subItems
-                        ?.filter((item) => !item?.hidden)
-                        ?.map((item, idx) => {
+                        ?.filter((subItem) => !subItem?.hidden)
+                        ?.map((subItem, idx) => {
                           return (
                             <NavTabTab
                               key={idx}
-                              id={item?.id}
+                              id={subItem?.id}
                               className={applyClassName(
                                 "nav-tab-sub-item",
-                                item?.className
+                                subItem?.className
                               )}
                               $theme={navTheme}
                               $style={css`
@@ -324,14 +353,14 @@ function NavTab({
                                   font-size: 16px;
                                 `}
 
-                                ${item?.styles?.self}
+                                ${subItem?.styles?.self}
                               `}
                               onClick={() => {
-                                if (item.content) {
-                                  setSelectedLocal(item.id);
+                                if (subItem.content) {
+                                  setSelectedLocal(subItem.id);
                                 }
                                 if (onChange) {
-                                  onChange(item.id);
+                                  onChange(subItem.id);
                                 }
                                 tooltipRefs.current.forEach((ref) => {
                                   ref?.close();
@@ -340,14 +369,14 @@ function NavTab({
                                 if (mobile) {
                                   setOpenSubMenuId(null);
                                 }
-                                if (item.onClick) {
-                                  item.onClick();
+                                if (subItem.onClick) {
+                                  subItem.onClick();
                                 }
                               }}
                               $subMenu={true}
                             >
-                              {item.icon && <Figure {...item.icon} />}
-                              {item.caption}
+                              {subItem.icon && <Figure {...subItem.icon} />}
+                              {subItem.caption}
                             </NavTabTab>
                           );
                         })}
@@ -398,7 +427,18 @@ function NavTab({
                   $isHovered={isHovered === tab.id || isTipMenuOpen === tab.id}
                   $selected={selected === tab.id}
                   $isAction={!!tab.actions}
+                  $mobile={mobile}
                 >
+                  {tab.badge &&
+                    (() => {
+                      const finalBadge: FigureProps = {
+                        ...tab.badge,
+                        size: mobile ? (tab.badge.size ?? 24) : tab.badge.size,
+                      };
+
+                      return <Figure {...finalBadge} />;
+                    })()}
+
                   {tab.title}
                   {tab.actions &&
                     (() => {
@@ -467,9 +507,11 @@ function NavTab({
               </Tooltip>
             );
           })}
+
+          {actions && mobile && contentActions}
         </NavTabTabsSection>
 
-        {actions && (
+        {actions && !mobile && (
           <NavTabTabsSection
             aria-label="nav-tab-actions-wrapper"
             $actions={!!actions}
@@ -480,29 +522,7 @@ function NavTab({
               ${styles?.containerActionsStyle}
             `}
           >
-            {actions
-              .filter((action) => !action?.hidden)
-              .map((action, index) => {
-                return (
-                  <ActionButton
-                    key={index}
-                    {...action}
-                    styles={{
-                      ...action?.styles,
-                      self: css`
-                        height: ${size === "sm" && "27px"};
-                        border-bottom-width: 2px;
-
-                        ${action.active &&
-                        css`
-                          border-bottom: 2px solid ${navTheme?.indicatorColor};
-                        `}
-                        ${action?.styles?.self}
-                      `,
-                    }}
-                  />
-                );
-              })}
+            {contentActions}
           </NavTabTabsSection>
         )}
       </NavTabBar>
@@ -510,7 +530,7 @@ function NavTab({
       <NavContent $contentStyle={styles?.contentStyle}>
         {filteredTabs.map((tab, index) => {
           const selectedSubItem = tab.subItems
-            ?.filter((item) => !item?.hidden)
+            ?.filter((subItem) => !subItem?.hidden)
             ?.find((subItem) => subItem.id === selected);
           if (selectedSubItem) {
             return <Fragment key={index}>{selectedSubItem.content}</Fragment>;
@@ -651,6 +671,7 @@ const NavTabTab = styled.div<{
   $subMenu?: boolean;
   $size?: NavTabSize;
   $theme?: NavTabThemeConfig;
+  $mobile?: boolean;
 }>`
   color: ${({ $theme }) => $theme.textColor};
   display: flex;
@@ -724,6 +745,13 @@ const NavTabTab = styled.div<{
     background-color: ${({ $theme }) => $theme.activeBackgroundColor};
     box-shadow: ${({ $theme }) => $theme.activeInsetShadow};
   }
+
+  ${({ $mobile }) =>
+    $mobile &&
+    css`
+      display: flex;
+      flex-direction: column;
+    `};
 
   ${({ $style }) => $style};
 `;

--- a/components/tooltip.tsx
+++ b/components/tooltip.tsx
@@ -7,6 +7,7 @@ import {
   flip,
   offset,
   Placement,
+  size,
   useFloating,
 } from "@floating-ui/react";
 import React, {
@@ -45,6 +46,7 @@ export type TooltipProps = {
   showDelayPeriod?: number;
   styles?: TooltipStyles;
   onClick?: (e: React.MouseEvent) => void;
+  anchorRef?: React.RefObject<HTMLElement>;
   id?: string;
   className?: string;
 };
@@ -77,6 +79,7 @@ const TooltipBase = forwardRef<TooltipRef, TooltipProps>(
       onClick,
       open,
       id,
+      anchorRef,
       className,
     },
     ref
@@ -106,9 +109,29 @@ const TooltipBase = forwardRef<TooltipRef, TooltipProps>(
       placement: getFloatingPlacement(dialogPlacement),
       open: open,
       onOpenChange: setIsOpenLocal,
-      middleware: [offset(8), flip()],
+      middleware: [
+        offset(8),
+        flip(),
+        ...(anchorRef
+          ? [
+              size({
+                apply({ rects, elements }) {
+                  Object.assign(elements.floating.style, {
+                    width: `${rects.reference.width}px`,
+                  });
+                },
+              }),
+            ]
+          : []),
+      ],
       whileElementsMounted: autoUpdate,
     });
+
+    useEffect(() => {
+      if (anchorRef) {
+        refs.setReference(anchorRef.current);
+      }
+    }, []);
 
     const safeAreaAriaLabelsLocal: string[] = [
       "combobox-drawer-month",
@@ -182,7 +205,7 @@ const TooltipBase = forwardRef<TooltipRef, TooltipProps>(
             }
           }
         }}
-        ref={refs.setReference}
+        ref={anchorRef ? undefined : refs.setReference}
       >
         <ContentTrigger
           id={id}

--- a/test/component/nav-tab.cy.tsx
+++ b/test/component/nav-tab.cy.tsx
@@ -50,6 +50,15 @@ describe("NavTab", () => {
           onClick: () => {
             console.log("test tab 1");
           },
+          actions: [
+            {
+              caption: "Discover",
+              onClick: () => {
+                console.log("Discover clicked");
+              },
+              icon: { image: RiSearchLine },
+            },
+          ],
         },
         {
           id: "2",
@@ -141,20 +150,57 @@ describe("NavTab", () => {
     });
 
     context("when given actions", () => {
-      it("should render as a Tab", () => {
-        cy.mount(
-          <MobileNavTabProduct
-            actions={[
-              {
-                icon: { image: RiSettings5Line },
-                onClick: () => {},
-                caption: "Test",
-              },
-            ]}
-          />
-        );
+      context("when given in parent level", () => {
+        it("should render as a Tab", () => {
+          cy.mount(
+            <MobileNavTabProduct
+              actions={[
+                {
+                  icon: { image: RiSettings5Line },
+                  onClick: () => {},
+                  caption: "Test",
+                },
+              ]}
+            />
+          );
 
-        cy.findAllByLabelText("nav-tab-tab").should("have.length", 6);
+          cy.findAllByLabelText("nav-tab-tab").should("have.length", 6);
+        });
+      });
+
+      context("when given inside of the tab", () => {
+        it("should not render the action item", () => {
+          cy.mount(
+            <MobileNavTabProduct
+              tabs={[
+                {
+                  id: "1",
+                  title: "Home",
+                  content: "This is home content",
+                  icon: {
+                    image: RiHome3Line,
+                    notificationBadge: { content: "99+", fontSize: "8px" },
+                  },
+                  onClick: () => {
+                    console.log("test tab 1");
+                  },
+                  actions: [
+                    {
+                      caption: "Discover",
+                      onClick: () => {
+                        console.log("Discover clicked");
+                      },
+                      icon: { image: RiSearchLine },
+                    },
+                  ],
+                },
+              ]}
+            />
+          );
+
+          cy.findByText("Home").realHover();
+          cy.findByLabelText("action-button").should("not.exist");
+        });
       });
     });
 
@@ -198,10 +244,28 @@ describe("NavTab", () => {
     });
 
     context("when given withCircle", () => {
+      it("should renders a bit striking upwards from bottom", () => {
+        cy.mount(<MobileNavTabProduct />);
+
+        cy.findAllByLabelText("nav-tab-circle").should(
+          "have.css",
+          "bottom",
+          "4px"
+        );
+      });
+
       it("should with circle in a Tab", () => {
         cy.mount(<MobileNavTabProduct />);
 
         cy.findAllByLabelText("nav-tab-circle").should("have.length", 1);
+      });
+
+      it("should renders the circle with darker color (rgb(60, 73, 95))", () => {
+        cy.mount(<MobileNavTabProduct />);
+
+        cy.findAllByLabelText("nav-tab-circle")
+          .eq(0)
+          .should("have.css", "background-color", "rgb(60, 73, 95)");
       });
 
       context("when selected the tab withCircle", () => {
@@ -221,6 +285,15 @@ describe("NavTab", () => {
             "opacity",
             "0"
           );
+        });
+
+        it("should renders the circle with the lighter color (rgb(59, 130, 246))", () => {
+          cy.mount(<MobileNavTabProduct />);
+
+          cy.findAllByLabelText("nav-tab-circle")
+            .eq(0)
+            .click()
+            .should("have.css", "background-color", "rgb(59, 130, 246)");
         });
       });
     });

--- a/test/component/nav-tab.cy.tsx
+++ b/test/component/nav-tab.cy.tsx
@@ -43,9 +43,9 @@ describe("NavTab", () => {
           id: "1",
           title: "Home",
           content: "This is home content",
-          badge: {
+          icon: {
             image: RiHome3Line,
-            notification: { content: "99+", fontSize: "8px" },
+            notificationBadge: { content: "99+", fontSize: "8px" },
           },
           onClick: () => {
             console.log("test tab 1");
@@ -54,7 +54,7 @@ describe("NavTab", () => {
         {
           id: "2",
           title: "Account",
-          badge: {
+          icon: {
             image: RiWallet2Line,
           },
           content: "This is account content",
@@ -66,7 +66,7 @@ describe("NavTab", () => {
           id: "3",
           title: "Transfer",
           content: "This is transfer content",
-          badge: {
+          icon: {
             image: RiExchangeDollarLine,
           },
           onClick: () => {
@@ -78,9 +78,9 @@ describe("NavTab", () => {
           id: "4",
           title: "Household",
           content: "This is household content",
-          badge: {
+          icon: {
             image: RiPieChartLine,
-            notification: { content: "99+", fontSize: "8px" },
+            notificationBadge: { content: "99+", fontSize: "8px" },
           },
           onClick: () => {
             console.log("test tab 1");
@@ -90,7 +90,7 @@ describe("NavTab", () => {
           id: "5",
           title: "Menu",
           content: "This is setting content",
-          badge: {
+          icon: {
             image: RiMenuLine,
           },
           onClick: () => {

--- a/test/component/nav-tab.cy.tsx
+++ b/test/component/nav-tab.cy.tsx
@@ -35,100 +35,100 @@ describe("NavTab", () => {
   ];
 
   context("mobile", () => {
+    const TABS_ITEMS: NavTabTab[] = [
+      {
+        id: "1",
+        title: "Home",
+        content: "This is home content",
+        icon: {
+          image: RiHome3Line,
+          notificationBadge: { content: "99+", fontSize: "8px" },
+        },
+        onClick: () => {
+          console.log("test tab 1");
+        },
+        actions: [
+          {
+            caption: "Discover",
+            onClick: () => {
+              console.log("Discover clicked");
+            },
+            icon: { image: RiSearchLine },
+          },
+        ],
+      },
+      {
+        id: "2",
+        title: "Account",
+        icon: {
+          image: RiWallet2Line,
+        },
+        content: "This is account content",
+        onClick: () => {
+          console.log("test tab 2");
+        },
+      },
+      {
+        id: "3",
+        title: "Transfer",
+        content: "This is transfer content",
+        icon: {
+          image: RiExchangeDollarLine,
+        },
+        onClick: () => {
+          console.log("test tab 1");
+        },
+        withCircle: true,
+      },
+      {
+        id: "4",
+        title: "Household",
+        content: "This is household content",
+        icon: {
+          image: RiPieChartLine,
+          notificationBadge: { content: "99+", fontSize: "8px" },
+        },
+        onClick: () => {
+          console.log("test tab 1");
+        },
+      },
+      {
+        id: "5",
+        title: "Menu",
+        content: "This is setting content",
+        icon: {
+          image: RiMenuLine,
+        },
+        onClick: () => {
+          console.log("test tab 1");
+        },
+        subItems: [
+          {
+            id: "5-1",
+            icon: { image: RiUserLine },
+            caption: "Privacy & security settings",
+            content: "This is privacy and security settings content",
+          },
+          {
+            id: "5-2",
+            icon: { image: RiTranslate2 },
+            caption: "Language",
+            content: "This is language content",
+          },
+          {
+            id: "5-3",
+            icon: { image: RiLogoutBoxFill },
+            caption: "Logout",
+            onClick: () => {
+              console.log("logout");
+            },
+          },
+        ],
+      },
+    ];
+
     function MobileNavTabProduct(props: NavTabProps) {
       const [activeTab, setActiveTab] = useState("2");
-
-      const TABS_ITEMS: NavTabTab[] = [
-        {
-          id: "1",
-          title: "Home",
-          content: "This is home content",
-          icon: {
-            image: RiHome3Line,
-            notificationBadge: { content: "99+", fontSize: "8px" },
-          },
-          onClick: () => {
-            console.log("test tab 1");
-          },
-          actions: [
-            {
-              caption: "Discover",
-              onClick: () => {
-                console.log("Discover clicked");
-              },
-              icon: { image: RiSearchLine },
-            },
-          ],
-        },
-        {
-          id: "2",
-          title: "Account",
-          icon: {
-            image: RiWallet2Line,
-          },
-          content: "This is account content",
-          onClick: () => {
-            console.log("test tab 2");
-          },
-        },
-        {
-          id: "3",
-          title: "Transfer",
-          content: "This is transfer content",
-          icon: {
-            image: RiExchangeDollarLine,
-          },
-          onClick: () => {
-            console.log("test tab 1");
-          },
-          withCircle: true,
-        },
-        {
-          id: "4",
-          title: "Household",
-          content: "This is household content",
-          icon: {
-            image: RiPieChartLine,
-            notificationBadge: { content: "99+", fontSize: "8px" },
-          },
-          onClick: () => {
-            console.log("test tab 1");
-          },
-        },
-        {
-          id: "5",
-          title: "Menu",
-          content: "This is setting content",
-          icon: {
-            image: RiMenuLine,
-          },
-          onClick: () => {
-            console.log("test tab 1");
-          },
-          subItems: [
-            {
-              id: "5-1",
-              icon: { image: RiUserLine },
-              caption: "Privacy & security settings",
-              content: "This is privacy and security settings content",
-            },
-            {
-              id: "5-2",
-              icon: { image: RiTranslate2 },
-              caption: "Language",
-              content: "This is language content",
-            },
-            {
-              id: "5-3",
-              icon: { image: RiLogoutBoxFill },
-              caption: "Logout",
-              onClick: () => {
-                console.log("logout");
-              },
-            },
-          ],
-        },
-      ];
 
       return (
         <NavTab
@@ -226,8 +226,13 @@ describe("NavTab", () => {
           });
         });
 
-        it("renders in the bottom of screen", () => {
-          cy.mount(<MobileNavTabProduct />);
+        it("renders in the bottom of screen with -4px", () => {
+          const TABS_ITEMS_WITHOUT_CIRCLE = TABS_ITEMS.map((tabs) => ({
+            ...tabs,
+            withCircle: false,
+          }));
+
+          cy.mount(<MobileNavTabProduct tabs={TABS_ITEMS_WITHOUT_CIRCLE} />);
 
           cy.findAllByLabelText("nav-tab-tab").eq(4).trigger("pointerdown");
 
@@ -239,6 +244,23 @@ describe("NavTab", () => {
             "bottom",
             "-4px"
           );
+        });
+
+        context("when one tabs using circle", () => {
+          it("renders in the bottom of screen with 12px", () => {
+            cy.mount(<MobileNavTabProduct />);
+
+            cy.findAllByLabelText("nav-tab-tab").eq(4).trigger("pointerdown");
+
+            cy.wait(500);
+
+            cy.findAllByLabelText("nav-tab-tab").eq(4).trigger("pointerup");
+            cy.findByLabelText("tooltip-drawer").should(
+              "have.css",
+              "bottom",
+              "12px"
+            );
+          });
         });
       });
     });

--- a/test/component/nav-tab.cy.tsx
+++ b/test/component/nav-tab.cy.tsx
@@ -2,16 +2,24 @@ import {
   ReviewTabContent,
   WriteTabContent,
 } from "./../../components/nav-tab.stories";
-import { NavTab, NavTabTab } from "./../../components/nav-tab";
+import { NavTab, NavTabProps, NavTabTab } from "./../../components/nav-tab";
 import { Button } from "./../../components/button";
 import { css } from "styled-components";
 import {
   RiAddBoxLine,
   RiAtLine,
   RiCharacterRecognitionLine,
+  RiExchangeDollarLine,
+  RiHome3Line,
+  RiLogoutBoxFill,
+  RiMenuLine,
+  RiPieChartLine,
   RiProfileFill,
   RiSearchLine,
   RiSettings5Line,
+  RiTranslate2,
+  RiUserLine,
+  RiWallet2Line,
 } from "@remixicon/react";
 import { useState } from "react";
 
@@ -25,6 +33,198 @@ describe("NavTab", () => {
       },
     },
   ];
+
+  context("mobile", () => {
+    function MobileNavTabProduct(props: NavTabProps) {
+      const [activeTab, setActiveTab] = useState("2");
+
+      const TABS_ITEMS: NavTabTab[] = [
+        {
+          id: "1",
+          title: "Home",
+          content: "This is home content",
+          badge: {
+            image: RiHome3Line,
+            notification: { content: "99+", fontSize: "8px" },
+          },
+          onClick: () => {
+            console.log("test tab 1");
+          },
+        },
+        {
+          id: "2",
+          title: "Account",
+          badge: {
+            image: RiWallet2Line,
+          },
+          content: "This is account content",
+          onClick: () => {
+            console.log("test tab 2");
+          },
+        },
+        {
+          id: "3",
+          title: "Transfer",
+          content: "This is transfer content",
+          badge: {
+            image: RiExchangeDollarLine,
+          },
+          onClick: () => {
+            console.log("test tab 1");
+          },
+          withCircle: true,
+        },
+        {
+          id: "4",
+          title: "Household",
+          content: "This is household content",
+          badge: {
+            image: RiPieChartLine,
+            notification: { content: "99+", fontSize: "8px" },
+          },
+          onClick: () => {
+            console.log("test tab 1");
+          },
+        },
+        {
+          id: "5",
+          title: "Menu",
+          content: "This is setting content",
+          badge: {
+            image: RiMenuLine,
+          },
+          onClick: () => {
+            console.log("test tab 1");
+          },
+          subItems: [
+            {
+              id: "5-1",
+              icon: { image: RiUserLine },
+              caption: "Privacy & security settings",
+              content: "This is privacy and security settings content",
+            },
+            {
+              id: "5-2",
+              icon: { image: RiTranslate2 },
+              caption: "Language",
+              content: "This is language content",
+            },
+            {
+              id: "5-3",
+              icon: { image: RiLogoutBoxFill },
+              caption: "Logout",
+              onClick: () => {
+                console.log("logout");
+              },
+            },
+          ],
+        },
+      ];
+
+      return (
+        <NavTab
+          mobile
+          tabs={TABS_ITEMS}
+          activeTab={activeTab}
+          onChange={(activeTab) => setActiveTab(activeTab)}
+          {...props}
+        />
+      );
+    }
+
+    it("render in the bottom of content", () => {
+      cy.mount(<MobileNavTabProduct />);
+
+      cy.findByLabelText("nav-tab-bar")
+        .should("have.css", "position", "fixed")
+        .and("have.css", "bottom", "0px");
+    });
+
+    context("when given actions", () => {
+      it("should render as a Tab", () => {
+        cy.mount(
+          <MobileNavTabProduct
+            actions={[
+              {
+                icon: { image: RiSettings5Line },
+                onClick: () => {},
+                caption: "Test",
+              },
+            ]}
+          />
+        );
+
+        cy.findAllByLabelText("nav-tab-tab").should("have.length", 6);
+      });
+    });
+
+    context("when given subItems", () => {
+      context("when when clicking", () => {
+        it("renders all submenu", () => {
+          cy.mount(<MobileNavTabProduct />);
+
+          const TEXTS = ["Logout", "Language", "Privacy & security settings"];
+
+          TEXTS.map((text) => {
+            cy.findByText(text).should("not.exist");
+          });
+
+          cy.findAllByLabelText("nav-tab-tab").eq(4).trigger("pointerdown");
+
+          cy.wait(500);
+
+          cy.findAllByLabelText("nav-tab-tab").eq(4).trigger("pointerup");
+
+          TEXTS.map((text) => {
+            cy.findByText(text).should("exist");
+          });
+        });
+
+        it("renders in the bottom of screen", () => {
+          cy.mount(<MobileNavTabProduct />);
+
+          cy.findAllByLabelText("nav-tab-tab").eq(4).trigger("pointerdown");
+
+          cy.wait(500);
+
+          cy.findAllByLabelText("nav-tab-tab").eq(4).trigger("pointerup");
+          cy.findByLabelText("tooltip-drawer").should(
+            "have.css",
+            "bottom",
+            "-4px"
+          );
+        });
+      });
+    });
+
+    context("when given withCircle", () => {
+      it("should with circle in a Tab", () => {
+        cy.mount(<MobileNavTabProduct />);
+
+        cy.findAllByLabelText("nav-tab-circle").should("have.length", 1);
+      });
+
+      context("when selected the tab withCircle", () => {
+        it("underline would be transparent", () => {
+          cy.mount(<MobileNavTabProduct />);
+
+          cy.findByLabelText("nav-tab-underscore").should(
+            "have.css",
+            "opacity",
+            "1"
+          );
+
+          cy.findAllByLabelText("nav-tab-circle").eq(0).click();
+
+          cy.findByLabelText("nav-tab-underscore").should(
+            "have.css",
+            "opacity",
+            "0"
+          );
+        });
+      });
+    });
+  });
 
   context("tabs", () => {
     context("when given hidden", () => {

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -426,8 +426,9 @@ export interface NavTabThemeConfig extends BodyThemeConfig {
   selectedBackgroundColor?: string;
 
   indicatorColor?: string;
-  indicatorActiveColor?: string;
   boxShadow?: string;
+
+  circleInactiveColor?: string;
 
   activeInsetShadow?: string;
 }

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -426,6 +426,7 @@ export interface NavTabThemeConfig extends BodyThemeConfig {
   selectedBackgroundColor?: string;
 
   indicatorColor?: string;
+  indicatorActiveColor?: string;
   boxShadow?: string;
 
   activeInsetShadow?: string;

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1058,6 +1058,7 @@ export function createNavTabTheme(
       selectedBackgroundColor: "rgb(243 244 246 / 50%)",
 
       indicatorColor: "rgb(59, 130, 246)",
+      indicatorActiveColor: "rgb(54, 122, 232)",
       boxShadow: "0 1px 4px -3px rgba(0,0,0,0.2)",
 
       activeInsetShadow:

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1058,7 +1058,7 @@ export function createNavTabTheme(
       selectedBackgroundColor: "rgb(243 244 246 / 50%)",
 
       indicatorColor: "rgb(59, 130, 246)",
-      indicatorActiveColor: "rgb(54, 122, 232)",
+      circleInactiveColor: "rgb(60, 73, 95)",
       boxShadow: "0 1px 4px -3px rgba(0,0,0,0.2)",
 
       activeInsetShadow:

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -531,7 +531,7 @@ const darkNavTab = createNavTabTheme(darkBody, {
   selectedBackgroundColor: "rgba(52, 52, 52, 0.5)",
 
   indicatorColor: "rgb(85, 65, 160)",
-  indicatorActiveColor: "rgb(76, 58, 141)",
+  circleInactiveColor: "rgb(58, 59, 61)",
   boxShadow: "0 1px 4px -3px rgba(0,0,0,0.8)",
 
   activeInsetShadow: `

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -531,6 +531,7 @@ const darkNavTab = createNavTabTheme(darkBody, {
   selectedBackgroundColor: "rgba(52, 52, 52, 0.5)",
 
   indicatorColor: "rgb(85, 65, 160)",
+  indicatorActiveColor: "rgb(76, 58, 141)",
   boxShadow: "0 1px 4px -3px rgba(0,0,0,0.8)",
 
   activeInsetShadow: `


### PR DESCRIPTION
Description:
This pull request introduces a `mobile` appearance of the `NavTab` component, it would be renders at the bottom of screen, can shows the `badge` and `circle` if needed.

Source:
[[Mobile] SYST-610: Add `mobile`, `styles` props to `NavTab`](https://linear.app/systatum/issue/SYST-610/add-mobile-styles-props-to-navtab)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself