### PR TITLE
[Bug] SYST-724: Fix button without title but with just icon

### DIFF
--- a/test/component/button.cy.tsx
+++ b/test/component/button.cy.tsx
@@ -19,7 +19,6 @@ import { Calendar } from "./../../components/calendar";
 import { TipMenuItemProps } from "./../../components/tip-menu";
 import { useState } from "react";
 import { FigureProps } from "./../../components/figure";
-import { m } from "framer-motion";
 
 interface ButtonWithIconOptions {
   icon?: FigureProps;

--- a/test/component/button.cy.tsx
+++ b/test/component/button.cy.tsx
@@ -19,6 +19,7 @@ import { Calendar } from "./../../components/calendar";
 import { TipMenuItemProps } from "./../../components/tip-menu";
 import { useState } from "react";
 import { FigureProps } from "./../../components/figure";
+import { m } from "framer-motion";
 
 interface ButtonWithIconOptions {
   icon?: FigureProps;
@@ -112,6 +113,20 @@ describe("Button", () => {
       </div>
     );
   }
+
+  context("when only given icons", () => {
+    it("still renders always in center with flex: 0 1 auto", () => {
+      cy.mount(
+        <Button>
+          <RiAddLine />
+        </Button>
+      );
+
+      cy.findAllByLabelText("button-label")
+        .eq(0)
+        .should("have.css", "flex", "0 1 auto");
+    });
+  });
 
   context("mobile", () => {
     it("renders taller than the default button", () => {

--- a/test/component/button.cy.tsx
+++ b/test/component/button.cy.tsx
@@ -125,6 +125,29 @@ describe("Button", () => {
         .eq(0)
         .should("have.css", "flex", "0 1 auto");
     });
+
+    it("renders the SVG with equal left and right spacing", () => {
+      cy.mount(
+        <Button>
+          <RiAddLine />
+        </Button>
+      );
+
+      cy.get(".coneto-button").then(($button) => {
+        const buttonRect = $button[0].getBoundingClientRect();
+
+        cy.wrap($button)
+          .find("svg")
+          .then(($svg) => {
+            const svgRect = $svg[0].getBoundingClientRect();
+
+            const leftGap = svgRect.left - buttonRect.left;
+            const rightGap = buttonRect.right - svgRect.right;
+
+            expect(leftGap).to.equal(rightGap);
+          });
+      });
+    });
   });
 
   context("mobile", () => {


### PR DESCRIPTION
Description:
This pull request only ensures the `icon` if given inside on the  `Button`, the icon previously not shows properly and have some empty space, but it was cleared from another PR was related to this PR.

Source:
[[Bug] SYST-724: Fix button without title but with just icon](https://linear.app/systatum/issue/SYST-724/fix-button-without-title-but-with-just-icon)

Related Task:
[[Bug] SYST-722: Fix button with just icon rendering visual bug](https://github.com/systatum/coneto/pull/420)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself