### PR TITLE
[Bug] SYST-800: `NavTab` tab style issue

### DIFF
--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -336,16 +336,21 @@ function NavTab({
                   containerStyle: css`
                     width: fit-content;
                     ${mobile &&
-                    css`
-                      width: 100%;
-                    `};
+                    getTabWidth({
+                      mobile,
+                      tabsLength: visibleTabs?.length,
+                      width: maxTabWidth,
+                    })};
+
                     ${styles?.tabStyle}
                   `,
                   triggerStyle: css`
                     ${mobile &&
-                    css`
-                      width: 100%;
-                    `};
+                    getTabWidth({
+                      mobile,
+                      tabsLength: visibleTabs?.length,
+                      width: maxTabWidth,
+                    })};
 
                     ${styles?.tabStyle}
                   `,

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -335,6 +335,8 @@ function NavTab({
                   `,
                   containerStyle: css`
                     width: fit-content;
+                    height: auto;
+
                     ${mobile &&
                     getTabWidth({
                       mobile,
@@ -345,6 +347,8 @@ function NavTab({
                     ${styles?.tabStyle}
                   `,
                   triggerStyle: css`
+                    height: 100%;
+
                     ${mobile &&
                     getTabWidth({
                       mobile,
@@ -724,7 +728,7 @@ const NavTabTabsSection = styled.div<{
     $mobile &&
     css`
       justify-content: space-between;
-      align-items: end;
+      align-items: stretch;
     `};
 
   ${({ $style }) => $style}
@@ -905,12 +909,16 @@ const NavTabTab = styled.div<{
     `};
 
   ${({ $mobile, $width, $tabsLength }) =>
-    getTabWidth({
-      mobile: $mobile,
-      tabsLength: $tabsLength,
-      width: $width,
-    })};
+    $mobile &&
+    css`
+      height: 100%;
 
+      ${getTabWidth({
+        mobile: $mobile,
+        tabsLength: $tabsLength,
+        width: $width,
+      })}
+    `}
   ${({ $withCircle }) =>
     $withCircle &&
     css`

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -335,26 +335,30 @@ function NavTab({
                   `,
                   containerStyle: css`
                     width: fit-content;
-                    height: auto;
 
                     ${mobile &&
-                    getTabWidth({
-                      mobile,
-                      tabsLength: visibleTabs?.length,
-                      width: maxTabWidth,
-                    })};
+                    css`
+                      height: auto;
+
+                      ${getTabWidth({
+                        mobile,
+                        tabsLength: visibleTabs?.length,
+                        width: maxTabWidth,
+                      })}
+                    `};
 
                     ${styles?.tabStyle}
                   `,
                   triggerStyle: css`
-                    height: 100%;
-
                     ${mobile &&
-                    getTabWidth({
-                      mobile,
-                      tabsLength: visibleTabs?.length,
-                      width: maxTabWidth,
-                    })};
+                    css`
+                      height: 100%;
+                      ${getTabWidth({
+                        mobile,
+                        tabsLength: visibleTabs?.length,
+                        width: maxTabWidth,
+                      })};
+                    `}
 
                     ${styles?.tabStyle}
                   `,

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -59,7 +59,7 @@ export type NavTabSize = (typeof NavTabSize)[keyof typeof NavTabSize];
 
 export interface NavTabTab {
   id: string;
-  title: string;
+  title?: string;
   content?: ReactNode;
   onClick?: () => void;
   actions?: NavTabTabAction[];

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -339,12 +339,15 @@ function NavTab({
                     css`
                       width: 100%;
                     `};
+                    ${styles?.tabStyle}
                   `,
                   triggerStyle: css`
                     ${mobile &&
                     css`
                       width: 100%;
                     `};
+
+                    ${styles?.tabStyle}
                   `,
                   drawerStyle: (placement) => css`
                     border-radius: 0px;
@@ -715,7 +718,7 @@ const NavTabTabsSection = styled.div<{
   ${({ $mobile }) =>
     $mobile &&
     css`
-      justify-content: center;
+      justify-content: space-between;
       align-items: end;
     `};
 
@@ -897,15 +900,11 @@ const NavTabTab = styled.div<{
     `};
 
   ${({ $mobile, $width, $tabsLength }) =>
-    $mobile && $tabsLength >= 4
-      ? css`
-          width: 100%;
-        `
-      : $mobile &&
-        !!$width &&
-        css`
-          width: ${$width}px;
-        `};
+    getTabWidth({
+      mobile: $mobile,
+      tabsLength: $tabsLength,
+      width: $width,
+    })};
 
   ${({ $withCircle }) =>
     $withCircle &&
@@ -915,6 +914,30 @@ const NavTabTab = styled.div<{
 
   ${({ $style }) => $style};
 `;
+
+const getTabWidth = ({
+  mobile,
+  tabsLength,
+  width,
+}: {
+  mobile: boolean;
+  tabsLength: number;
+  width?: number;
+}) => {
+  if (mobile && tabsLength >= 4) {
+    return css`
+      width: 100%;
+    `;
+  }
+
+  if (mobile && width) {
+    return css`
+      width: ${width}px;
+    `;
+  }
+
+  return "";
+};
 
 const CircleBadge = styled.span<{
   $theme?: NavTabThemeConfig;

--- a/test/component/nav-tab.cy.tsx
+++ b/test/component/nav-tab.cy.tsx
@@ -141,12 +141,143 @@ describe("NavTab", () => {
       );
     }
 
-    it("render in the bottom of content", () => {
-      cy.mount(<MobileNavTabProduct />);
+    context("general style", () => {
+      it("render in the bottom of content", () => {
+        cy.mount(<MobileNavTabProduct />);
 
-      cy.findByLabelText("nav-tab-bar")
-        .should("have.css", "position", "fixed")
-        .and("have.css", "bottom", "0px");
+        cy.findByLabelText("nav-tab-bar")
+          .should("have.css", "position", "fixed")
+          .and("have.css", "bottom", "0px");
+      });
+
+      it("render with justify-between and align-stretch", () => {
+        cy.mount(<MobileNavTabProduct />);
+
+        cy.findByLabelText("nav-tab-tabs-sections")
+          .should("have.css", "justify-content", "space-between")
+          .and("have.css", "align-items", "stretch");
+      });
+
+      context("when given untitle tab", () => {
+        it("should render all tabs with equal height", () => {
+          cy.mount(
+            <MobileNavTabProduct
+              tabs={[
+                {
+                  id: "1",
+                  content: "This is home content",
+                  icon: {
+                    image: RiHome3Line,
+                  },
+                  onClick: () => {
+                    console.log("test tab 1");
+                  },
+                },
+                {
+                  id: "2",
+                  title: "Menu",
+                  content: "This is setting content",
+                  icon: {
+                    image: RiMenuLine,
+                  },
+                  onClick: () => {
+                    console.log("test tab 1");
+                  },
+                },
+              ]}
+            />
+          );
+
+          cy.findAllByLabelText("nav-tab-tab")
+            .should("have.length", 2)
+            .then(($tabs) => {
+              const heights = [...$tabs].map(
+                (el) => el.getBoundingClientRect().width
+              );
+
+              expect(heights[0]).to.equal(heights[1]);
+            });
+        });
+      });
+
+      context("when given content less than four", () => {
+        it("should render all tabs with equal width", () => {
+          cy.mount(
+            <MobileNavTabProduct
+              tabs={[
+                {
+                  id: "1",
+                  title: "Home",
+                  content: "This is home content",
+                  icon: {
+                    image: RiHome3Line,
+                  },
+                  onClick: () => {
+                    console.log("test tab 1");
+                  },
+                },
+                {
+                  id: "2",
+                  title: "Transfer",
+                  content: "This is transfer content",
+                  icon: {
+                    image: RiExchangeDollarLine,
+                    notificationBadge: { content: "5" },
+                  },
+                  onClick: () => {
+                    console.log("test tab 1");
+                  },
+                  withCircle: true,
+                },
+                {
+                  id: "3",
+                  title: "Menu",
+                  content: "This is setting content",
+                  icon: {
+                    image: RiMenuLine,
+                  },
+                  onClick: () => {
+                    console.log("test tab 1");
+                  },
+                  subItems: [
+                    {
+                      id: "5-1",
+                      icon: { image: RiUserLine },
+                      caption: "Privacy & security settings",
+                      content: "This is privacy and security settings content",
+                    },
+                    {
+                      id: "5-2",
+                      icon: { image: RiTranslate2 },
+                      caption: "Language",
+                      content: "This is language content",
+                    },
+                    {
+                      id: "5-3",
+                      icon: { image: RiLogoutBoxFill },
+                      caption: "Logout",
+                      onClick: () => {
+                        console.log("logout");
+                      },
+                    },
+                  ],
+                },
+              ]}
+            />
+          );
+
+          cy.findAllByLabelText("nav-tab-tab")
+            .should("have.length", 3)
+            .then(($tabs) => {
+              const widths = [...$tabs].map(
+                (el) => el.getBoundingClientRect().width
+              );
+
+              expect(widths[0]).to.equal(widths[1]);
+              expect(widths[1]).to.equal(widths[2]);
+            });
+        });
+      });
     });
 
     context("when given actions", () => {
@@ -266,7 +397,7 @@ describe("NavTab", () => {
     });
 
     context("when given withCircle", () => {
-      it("should renders a bit striking upwards from bottom", () => {
+      it("should render a bit striking upwards from bottom", () => {
         cy.mount(<MobileNavTabProduct />);
 
         cy.findAllByLabelText("nav-tab-circle").should(
@@ -282,7 +413,7 @@ describe("NavTab", () => {
         cy.findAllByLabelText("nav-tab-circle").should("have.length", 1);
       });
 
-      it("should renders the circle with darker color (rgb(60, 73, 95))", () => {
+      it("should render the circle with darker color (rgb(60, 73, 95))", () => {
         cy.mount(<MobileNavTabProduct />);
 
         cy.findAllByLabelText("nav-tab-circle")
@@ -309,7 +440,7 @@ describe("NavTab", () => {
           );
         });
 
-        it("should renders the circle with the lighter color (rgb(59, 130, 246))", () => {
+        it("should render the circle with the lighter color (rgb(59, 130, 246))", () => {
           cy.mount(<MobileNavTabProduct />);
 
           cy.findAllByLabelText("nav-tab-circle")


### PR DESCRIPTION
Description:
Previously, the `NavTab` would be `error` if we use the `tabs` less than 4 item, the `width` would be 100%, but not the item, so the content shows not correctly, especially in the `desktop` appearance, and the `tabStyle` now not added properly, which causes an issue like on below

<img width="782" height="241" alt="Screenshot 2026-07-14 at 10 52 14" src="https://github.com/user-attachments/assets/2c777e25-2760-4ea1-bbea-22a7250ec37d" />

And if not given the `title`, the `tab` it would be broken, because the `align-items` using `end`, so we should use by `stretch`, 

<img width="779" height="197" alt="Screenshot 2026-07-14 at 11 24 55" src="https://github.com/user-attachments/assets/2f265f7e-b8fd-4032-bbc3-def8319a0c0a" />

This pull request fixes several issues in the `NavTab` component and includes the following changes:
1. Refactored the placement of `tabStyle` by moving it out of `styles` for better organization.
2. Improved the width calculation for tabs on mobile. The same logic is now applied to the `Tooltip` to keep both components consistent:
   * Fewer than 4 tabs: each tab has an equal width.
   * 4 or more tabs: each tab uses `width: 100%`.
3. Updated the height layout by using `height: auto` and `height: 100%` where appropriate, and added `align-items: stretch` to ensure tabs without a `title` still have a clean and consistent appearance.
4. Set `justify-content: space-between` as the default for the wrapper while still allowing users to override it (for example, with `justify-content: center`) through custom styles.

<img width="642" height="564" alt="Screenshot 2026-07-14 at 11 06 59" src="https://github.com/user-attachments/assets/eb42a7b9-927f-4b6e-97a8-d59ee3402d57" />

Source:
[[Bug] SYST-800: `NavTab` tab style issue](https://linear.app/systatum/issue/SYST-800/navtab-tab-style-issue)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself