### PR TITLE
[Bug] SYST-803: Avoid using `useArgs` for controlled values in `Textarea` and `Textbox` stories

### DIFF
--- a/components/textarea.stories.tsx
+++ b/components/textarea.stories.tsx
@@ -1,5 +1,4 @@
 import * as RemixIcons from "@remixicon/react";
-import { useArgs } from "@storybook/preview-api";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { css } from "styled-components";
@@ -141,25 +140,17 @@ export const Default: Story = {
     name: "textarea",
     label: "Textarea",
     placeholder: "Type your message...",
-    value: "",
     rows: 3,
   },
   render: (args: TextareaProps) => {
-    const [, setUpdateArgs] = useArgs();
-
-    const handleChange = (e: StatefulOnChangeType) => {
-      if (e && "target" in e) {
-        const newValue = e.target.value;
-        setUpdateArgs({ value: newValue });
-      }
-    };
+    const [value, setValue] = useState("");
 
     return (
       <Textarea
         {...args}
         width={400}
-        value={args.value}
-        onChange={handleChange}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
       />
     );
   },
@@ -171,25 +162,17 @@ export const Autogrow: Story = {
     label: "Textarea Autogrow",
     autogrow: true,
     placeholder: "Type your message...",
-    value: "",
     rows: 3,
   },
   render: (args: TextareaProps) => {
-    const [, setUpdateArgs] = useArgs();
-
-    const handleChange = (e: StatefulOnChangeType) => {
-      if (e && "target" in e) {
-        const newValue = e.target.value;
-        setUpdateArgs({ value: newValue });
-      }
-    };
+    const [value, setValue] = useState("");
 
     return (
       <Textarea
         {...args}
         width={400}
-        value={args.value}
-        onChange={handleChange}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
       />
     );
   },
@@ -270,17 +253,16 @@ export const WithErrorMessage: Story = {
     label: "With Error",
     placeholder: "Type with error...",
     autogrow: true,
-    value: "",
     showError: true,
     errorMessage: "This field is required",
   },
   render: (args: TextareaProps) => {
-    const [, setUpdateArgs] = useArgs();
+    const [value, setValue] = useState("");
 
     const handleChange = (e: StatefulOnChangeType) => {
-      if (e && "target" in e) {
+      if (e && "currentTarget" in e) {
         const newValue = e.target.value;
-        setUpdateArgs({ value: newValue });
+        setValue(newValue);
       }
     };
 
@@ -288,8 +270,8 @@ export const WithErrorMessage: Story = {
       <Textarea
         {...args}
         width={400}
-        value={args.value}
-        onChange={handleChange}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
       />
     );
   },

--- a/components/textbox.stories.tsx
+++ b/components/textbox.stories.tsx
@@ -418,13 +418,12 @@ export const WithErrorMessage: Story = {
   render: (args: TextboxProps) => {
     const [value, setValue] = useState("");
 
-    const handleChange = (e: StatefulOnChangeType) => {
-      if (e && "currentTarget" in e) {
-        const newValue = e.target.value;
-        setValue(newValue);
-      }
-    };
-
-    return <Textbox {...args} value={value} onChange={handleChange} />;
+    return (
+      <Textbox
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
   },
 };

--- a/components/textbox.stories.tsx
+++ b/components/textbox.stories.tsx
@@ -1,8 +1,7 @@
 import * as RemixIcons from "@remixicon/react";
-import { useArgs } from "@storybook/preview-api";
 import type { Meta, StoryObj } from "@storybook/react";
-import { useEffect, useState, type ChangeEvent } from "react";
 import { css } from "styled-components";
+import { useState } from "react";
 import { Textbox, TextboxProps, TextboxDropdownOption } from "./textbox";
 
 const meta: Meta<typeof Textbox> = {
@@ -228,7 +227,6 @@ export const Input: Story = {
     name: "input",
     label: "Input",
     placeholder: "Type here...",
-    value: "",
     type: "text",
     styles: {
       self: css`
@@ -238,23 +236,15 @@ export const Input: Story = {
     },
   },
   render: (args: TextboxProps) => {
-    const [, setUpdateArgs] = useArgs();
+    const [value, setValue] = useState("");
 
-    useEffect(() => {
-      const timer = setTimeout(() => {
-        setUpdateArgs({ value: "" });
-      }, 100);
-      return () => clearTimeout(timer);
-    }, [setUpdateArgs]);
-
-    const handleChange = (
-      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-    ) => {
-      const newValue = e.target.value;
-      setUpdateArgs({ value: newValue });
-    };
-
-    return <Textbox {...args} value={args.value} onChange={handleChange} />;
+    return (
+      <Textbox
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
   },
 };
 
@@ -348,7 +338,6 @@ export const WithAction: Story = {
     name: "message",
     label: "With Action",
     placeholder: "Type a message...",
-    value: "",
     type: "text",
     styles: {
       self: css`
@@ -358,26 +347,12 @@ export const WithAction: Story = {
     },
   },
   render: (args: TextboxProps) => {
-    const [, setUpdateArgs] = useArgs();
-
-    useEffect(() => {
-      const timer = setTimeout(() => {
-        setUpdateArgs({ value: "" });
-      }, 100);
-      return () => clearTimeout(timer);
-    }, [setUpdateArgs]);
-
-    const handleChange = (
-      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-    ) => {
-      const newValue = e.target.value;
-      setUpdateArgs({ value: newValue });
-    };
+    const [value, setValue] = useState("");
 
     return (
       <Textbox
         {...args}
-        value={args.value}
+        value={value}
         actions={[
           {
             id: "send-message",
@@ -388,11 +363,11 @@ export const WithAction: Story = {
           {
             id: "delete-message",
             icon: { image: RemixIcons.RiCloseLine },
-            onClick: () => setUpdateArgs({ value: "" }),
+            onClick: () => setValue(""),
             title: "Delete message",
           },
         ].filter(Boolean)}
-        onChange={handleChange}
+        onChange={(e) => setValue(e.target.value)}
       />
     );
   },
@@ -403,7 +378,6 @@ export const Password: Story = {
     name: "password",
     label: "Password",
     placeholder: "Enter password...",
-    value: "",
     type: "password",
     styles: {
       self: css`
@@ -413,23 +387,15 @@ export const Password: Story = {
     },
   },
   render: (args: TextboxProps) => {
-    const [, setUpdateArgs] = useArgs();
+    const [value, setValue] = useState("");
 
-    useEffect(() => {
-      const timer = setTimeout(() => {
-        setUpdateArgs({ value: "" });
-      }, 100);
-      return () => clearTimeout(timer);
-    }, [setUpdateArgs]);
-
-    const handleChange = (
-      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-    ) => {
-      const newValue = e.target.value;
-      setUpdateArgs({ value: newValue });
-    };
-
-    return <Textbox {...args} value={args.value} onChange={handleChange} />;
+    return (
+      <Textbox
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
   },
 };
 
@@ -450,28 +416,15 @@ export const WithErrorMessage: Story = {
     },
   },
   render: (args: TextboxProps) => {
-    const [, setUpdateArgs] = useArgs();
+    const [value, setValue] = useState("");
 
-    useEffect(() => {
-      const timer = setTimeout(() => {
-        setUpdateArgs({ value: "" });
-      }, 100);
-      return () => clearTimeout(timer);
-    }, [setUpdateArgs]);
-
-    const handleChange = (
-      e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-    ) => {
-      const newValue = e.target.value;
-
-      setUpdateArgs({
-        value: newValue,
-        showError: newValue.length < 10,
-        errorMessage:
-          newValue.length < 10 ? "This field is required" : undefined,
-      });
+    const handleChange = (e: StatefulOnChangeType) => {
+      if (e && "currentTarget" in e) {
+        const newValue = e.target.value;
+        setValue(newValue);
+      }
     };
 
-    return <Textbox {...args} value={args.value} onChange={handleChange} />;
+    return <Textbox {...args} value={value} onChange={handleChange} />;
   },
 };


### PR DESCRIPTION
Description:
This pull request fixes the `textarea` and `textbox` story to not use `useArgs`, state from `storybook` for managing the input value. 

Using `useArgs` for controlled text inputs updates the value through Storybook's args store, causing the story to re-render after each value change. This can result in the browser losing the current caret position while editing.

```tsx
1. type
2. onChange fires
3. updateArgs({ value: newValue })
4. posted to Storybook's manager frame (async, postMessage) 
5. manager updates the args store 
6. updated args flow back as props
7. story re-renders with args.value
```

Source:
[[Bug] SYST-803: Changes the `Textarea` and `Textbox` useArgs re-render](https://linear.app/systatum/issue/SYST-803/changes-the-textarea-and-textbox-useargs-re-render)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself