### PR TITLE
[Bug] SYST-801: Fix `Combobox.drawer` bug in Coneto

### DIFF
--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -877,7 +877,7 @@ function ComboboxDrawer({
 
   const searchboxProps = typeof searchbox === "object" && searchbox;
 
-  const hasFewOptions = finalOptions?.length < 5;
+  const hasFewOptions = finalOptions?.length <= 5;
 
   const mainCombobox = (
     <DrawerWrapper

--- a/test/component/combobox.cy.tsx
+++ b/test/component/combobox.cy.tsx
@@ -143,6 +143,33 @@ describe("Combobox", () => {
     );
   }
 
+  context("when content is less than or equal 5", () => {
+    it("should render drawer with fit content", () => {
+      cy.viewport(500, 700);
+
+      const FEWER_OPTIONS = FRUIT_OPTIONS.slice(0, 4);
+
+      cy.mount(<ProductCombobox options={FEWER_OPTIONS} />);
+
+      cy.findByRole("textbox").click();
+
+      cy.findByLabelText("combobox-drawer").then(($drawer) => {
+        const drawerHeight = $drawer.innerHeight();
+
+        cy.findAllByLabelText("tree-list-group-title").then(($items) => {
+          const contentHeight = [...$items].reduce(
+            (sum, el) => sum + Cypress.$(el).outerHeight(true),
+            0
+          );
+
+          expect(drawerHeight).to.be.closeTo(contentHeight, 1);
+        });
+      });
+
+      cy.findByRole("textbox").click();
+    });
+  });
+
   context("drawerHeight", () => {
     context("when given 60dvh", () => {
       it("should render with 420px", () => {


### PR DESCRIPTION
Description:
This pull request fixes an issue on the `Combobox` component if `options` where providing 5 `options` resulted in an incorrect appearance with extra empty space. This issue was caused by the height calculation logic, which only handled cases where the number of options was `less than 5`

The fix updates the condition to `use less than or equal 5`, instead of just `less than 5`.

```tsx
const hasFewOptions = finalOptions?.length <= 5
```

This ensures the `Combobox` uses the correct height for 5 or fewer options, preventing the extra empty space and avoiding the same issue in the future.

Source:
[[Bug] SYST-801: Fix dropdown bug in Coneto](https://linear.app/systatum/issue/SYST-801/fix-dropdown-bug-in-coneto)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself