### PR TITLE
[Improvement] SYST-599: Allow setting icon, background color and text color for NavTab tab

### DIFF
--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -17,6 +17,7 @@ import { Figure, FigureProps } from "./figure";
 import { useTheme } from "../theme/provider";
 import { NavTabThemeConfig } from "./../theme";
 import { applyClassName } from "./../constants/classname";
+import { lightenColor } from "./../lib/color";
 
 export interface NavTabProps {
   tabs?: NavTabTab[];
@@ -68,6 +69,12 @@ export interface NavTabTab {
   hidden?: boolean;
   className?: string;
   withCircle?: boolean;
+  textColor?: string;
+  backgroundColor?: string;
+  hoverBackgroundColor?: string;
+  hoverTextColor?: string;
+  selectedBackgroundColor?: string;
+  activeBackgroundColor?: string;
 }
 
 interface NavTabTabBadge extends FigureProps {}
@@ -454,6 +461,12 @@ function NavTab({
                   $theme={navTheme}
                   key={index}
                   $size={size}
+                  $backgroundColor={tab?.backgroundColor}
+                  $textColor={tab?.textColor}
+                  $hoverBackgroundColor={tab?.hoverBackgroundColor}
+                  $hoverTextColor={tab?.hoverTextColor}
+                  $selectedBackgroundColor={tab?.selectedBackgroundColor}
+                  $activeBackgroundColor={tab?.activeBackgroundColor}
                   aria-label="nav-tab-tab"
                   $style={styles?.tabStyle}
                   ref={setTabRef(index)}
@@ -529,6 +542,12 @@ function NavTab({
                             $pressed={selected === tab.id}
                             $activeColor={activeColor}
                             $theme={navTheme}
+                            $activeBackgroundColor={tab?.activeBackgroundColor}
+                            $backgroundColor={tab?.backgroundColor}
+                            $selectedBackgroundColor={
+                              tab?.selectedBackgroundColor
+                            }
+                            $textColor={tab?.textColor}
                           >
                             <Figure {...finalIcon} />
                             <NavTabLabel
@@ -816,8 +835,13 @@ const NavTabTab = styled.div<{
   $width?: number;
   $tabsLength?: number;
   $withCircle?: boolean;
+  $backgroundColor?: string;
+  $hoverBackgroundColor?: string;
+  $textColor?: string;
+  $hoverTextColor?: string;
+  $selectedBackgroundColor?: string;
+  $activeBackgroundColor?: string;
 }>`
-  color: ${({ $theme }) => $theme.textColor};
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -832,12 +856,24 @@ const NavTabTab = styled.div<{
   user-select: none;
   padding: ${({ $size }) => ($size === "md" ? "12px 12px" : "7px 12px")};
 
-  ${({ $selected, $theme, $withCircle }) =>
-    $selected &&
-    !$withCircle &&
-    css`
-      background-color: ${$theme?.selectedBackgroundColor};
-    `}
+  ${({
+    $selected,
+    $theme,
+    $withCircle,
+    $backgroundColor,
+    $textColor,
+    $selectedBackgroundColor,
+  }) =>
+    $selected && !$withCircle
+      ? css`
+          background-color: ${$selectedBackgroundColor ??
+          $theme?.selectedBackgroundColor};
+        `
+      : !$withCircle &&
+        css`
+          background-color: ${$backgroundColor ?? $theme.backgroundColor};
+          color: ${$textColor ?? $theme.textColor};
+        `}
 
   ${({ $subMenu, $theme }) =>
     $subMenu &&
@@ -846,8 +882,7 @@ const NavTabTab = styled.div<{
       width: 100%;
       min-width: 150px;
       border: 1px solid ${$theme?.borderColor};
-      background-color: 1px solid ${$theme?.hoverBackgroundColor};
-      color: 1px solid ${$theme?.textColor};
+      color: ${$theme?.textColor};
       padding-right: 40px;
     `}
 
@@ -883,18 +918,34 @@ const NavTabTab = styled.div<{
           `}
     `};
 
-  ${({ $theme, $withCircle, $mobile }) => css`
+  ${({
+    $theme,
+    $withCircle,
+    $mobile,
+    $hoverBackgroundColor,
+    $backgroundColor,
+    $selectedBackgroundColor,
+    $activeBackgroundColor,
+    $selected,
+  }) => css`
     ${!$mobile &&
+    !$selected &&
     css`
       &:hover {
-        background-color: ${$theme.hoverBackgroundColor};
+        background-color: ${$hoverBackgroundColor ??
+        ($backgroundColor ? lightenColor($backgroundColor, 0.4) : undefined) ??
+        $theme.hoverBackgroundColor};
       }
     `}
 
     ${!$withCircle &&
     css`
       &:active:not(:has([aria-label="action-button"]:active)) {
-        background-color: ${$theme.activeBackgroundColor};
+        background-color: ${$activeBackgroundColor ??
+        ($selectedBackgroundColor
+          ? lightenColor($selectedBackgroundColor, 0.4)
+          : undefined) ??
+        $theme.activeBackgroundColor};
         box-shadow: ${$theme.activeInsetShadow};
       }
     `}
@@ -956,10 +1007,16 @@ const getTabWidth = ({
   return "";
 };
 
+// Active color represents the indicator color of the currently selected screen/tab.
+// Active background color is used for the temporary pressed/click interaction state.
 const CircleBadge = styled.span<{
   $theme?: NavTabThemeConfig;
   $activeColor?: string;
   $pressed?: boolean;
+  $backgroundColor: string;
+  $textColor: string;
+  $selectedBackgroundColor: string;
+  $activeBackgroundColor: string;
 }>`
   position: absolute;
   left: 50%;
@@ -973,21 +1030,26 @@ const CircleBadge = styled.span<{
   align-items: center;
   justify-content: center;
   gap: 7px;
-  background-color: ${({ $theme, $activeColor }) =>
-    $activeColor ?? $theme?.circleInactiveColor};
+  background-color: ${({ $theme, $backgroundColor }) =>
+    $backgroundColor ?? $theme?.circleInactiveColor};
 
   &:active {
-    background-color: ${({ $theme }) => $theme?.indicatorColor};
+    background-color: ${({ $theme, $activeColor, $activeBackgroundColor }) =>
+      ($activeBackgroundColor && lightenColor($activeBackgroundColor, 0.05)) ??
+      ($activeColor && lightenColor($activeColor, 0.05)) ??
+      lightenColor($theme?.indicatorColor, 0.05)};
   }
 
-  ${({ $pressed, $theme }) =>
+  ${({ $pressed, $theme, $activeColor, $selectedBackgroundColor }) =>
     $pressed &&
     css`
-      background-color: ${$theme?.indicatorColor};
+      background-color: ${$selectedBackgroundColor ??
+      $activeColor ??
+      $theme?.indicatorColor};
     `};
 
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
-  color: white;
+  color: ${({ $textColor }) => $textColor ?? "white"};
 
   @media (min-width: 450px) {
     width: 85px;

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -926,6 +926,7 @@ const NavTabTab = styled.div<{
     $backgroundColor,
     $selectedBackgroundColor,
     $activeBackgroundColor,
+    $hoverTextColor,
     $selected,
   }) => css`
     ${!$mobile &&
@@ -935,6 +936,7 @@ const NavTabTab = styled.div<{
         background-color: ${$hoverBackgroundColor ??
         ($backgroundColor ? lightenColor($backgroundColor, 0.4) : undefined) ??
         $theme.hoverBackgroundColor};
+        color: ${$hoverTextColor};
       }
     `}
 

--- a/components/nav-tab.tsx
+++ b/components/nav-tab.tsx
@@ -941,6 +941,7 @@ const NavTabTab = styled.div<{
     `}
 
     ${!$withCircle &&
+    !$selected &&
     css`
       &:active:not(:has([aria-label="action-button"]:active)) {
         background-color: ${$activeBackgroundColor ??

--- a/test/component/nav-tab.cy.tsx
+++ b/test/component/nav-tab.cy.tsx
@@ -34,8 +34,72 @@ describe("NavTab", () => {
     },
   ];
 
+  const TABS_ITEMS: NavTabTab[] = [
+    {
+      id: "1",
+      title: "Write",
+      content: <WriteTabContent />,
+      onClick: () => {
+        console.log("test tab 1");
+      },
+      actions: [
+        {
+          caption: "Discover",
+          onClick: () => {
+            console.log("Discover clicked");
+          },
+          icon: { image: RiSearchLine },
+        },
+      ],
+    },
+    {
+      id: "2",
+      title: "Review",
+      content: <ReviewTabContent />,
+      onClick: () => {
+        console.log("test tab 2");
+      },
+      actions: [
+        {
+          caption: "Discover",
+          onClick: () => {
+            console.log("Discover clicked");
+          },
+          icon: { image: RiSearchLine },
+        },
+        {
+          caption: "Mention",
+          onClick: () => {
+            console.log("Mention clicked");
+          },
+          icon: { image: RiAtLine },
+        },
+      ],
+    },
+    {
+      hidden: true,
+      id: "3",
+      title: "Empty",
+      content: "Empty",
+      onClick: () => {},
+    },
+  ];
+
+  function ProductNavTab(props: NavTabProps) {
+    const [activeTab, setActiveTab] = useState("2");
+
+    return (
+      <NavTab
+        tabs={TABS_ITEMS}
+        activeTab={activeTab}
+        onChange={(activeTab) => setActiveTab(activeTab)}
+        {...props}
+      />
+    );
+  }
+
   context("mobile", () => {
-    const TABS_ITEMS: NavTabTab[] = [
+    const MOBILE_TABS_ITEMS: NavTabTab[] = [
       {
         id: "1",
         title: "Home",
@@ -127,23 +191,13 @@ describe("NavTab", () => {
       },
     ];
 
-    function MobileNavTabProduct(props: NavTabProps) {
-      const [activeTab, setActiveTab] = useState("2");
-
-      return (
-        <NavTab
-          mobile
-          tabs={TABS_ITEMS}
-          activeTab={activeTab}
-          onChange={(activeTab) => setActiveTab(activeTab)}
-          {...props}
-        />
-      );
+    function ProductMobileNavTab(props: NavTabProps) {
+      return <ProductNavTab mobile tabs={MOBILE_TABS_ITEMS} {...props} />;
     }
 
     context("general style", () => {
       it("render in the bottom of content", () => {
-        cy.mount(<MobileNavTabProduct />);
+        cy.mount(<ProductMobileNavTab />);
 
         cy.findByLabelText("nav-tab-bar")
           .should("have.css", "position", "fixed")
@@ -151,7 +205,7 @@ describe("NavTab", () => {
       });
 
       it("render with justify-between and align-stretch", () => {
-        cy.mount(<MobileNavTabProduct />);
+        cy.mount(<ProductMobileNavTab />);
 
         cy.findByLabelText("nav-tab-tabs-sections")
           .should("have.css", "justify-content", "space-between")
@@ -161,7 +215,7 @@ describe("NavTab", () => {
       context("when given untitle tab", () => {
         it("should render all tabs with equal height", () => {
           cy.mount(
-            <MobileNavTabProduct
+            <ProductMobileNavTab
               tabs={[
                 {
                   id: "1",
@@ -203,7 +257,7 @@ describe("NavTab", () => {
       context("when given content less than four", () => {
         it("should render all tabs with equal width", () => {
           cy.mount(
-            <MobileNavTabProduct
+            <ProductMobileNavTab
               tabs={[
                 {
                   id: "1",
@@ -284,7 +338,7 @@ describe("NavTab", () => {
       context("when given in parent level", () => {
         it("should render as a Tab", () => {
           cy.mount(
-            <MobileNavTabProduct
+            <ProductMobileNavTab
               actions={[
                 {
                   icon: { image: RiSettings5Line },
@@ -302,7 +356,7 @@ describe("NavTab", () => {
       context("when given inside of the tab", () => {
         it("should not render the action item", () => {
           cy.mount(
-            <MobileNavTabProduct
+            <ProductMobileNavTab
               tabs={[
                 {
                   id: "1",
@@ -338,7 +392,7 @@ describe("NavTab", () => {
     context("when given subItems", () => {
       context("when when clicking", () => {
         it("renders all submenu", () => {
-          cy.mount(<MobileNavTabProduct />);
+          cy.mount(<ProductMobileNavTab />);
 
           const TEXTS = ["Logout", "Language", "Privacy & security settings"];
 
@@ -358,12 +412,16 @@ describe("NavTab", () => {
         });
 
         it("renders in the bottom of screen with -4px", () => {
-          const TABS_ITEMS_WITHOUT_CIRCLE = TABS_ITEMS.map((tabs) => ({
-            ...tabs,
-            withCircle: false,
-          }));
+          const MOBILE_TABS_ITEMS_WITHOUT_CIRCLE = MOBILE_TABS_ITEMS.map(
+            (tabs) => ({
+              ...tabs,
+              withCircle: false,
+            })
+          );
 
-          cy.mount(<MobileNavTabProduct tabs={TABS_ITEMS_WITHOUT_CIRCLE} />);
+          cy.mount(
+            <ProductMobileNavTab tabs={MOBILE_TABS_ITEMS_WITHOUT_CIRCLE} />
+          );
 
           cy.findAllByLabelText("nav-tab-tab").eq(4).trigger("pointerdown");
 
@@ -379,7 +437,7 @@ describe("NavTab", () => {
 
         context("when one tabs using circle", () => {
           it("renders in the bottom of screen with 12px", () => {
-            cy.mount(<MobileNavTabProduct />);
+            cy.mount(<ProductMobileNavTab />);
 
             cy.findAllByLabelText("nav-tab-tab").eq(4).trigger("pointerdown");
 
@@ -398,7 +456,7 @@ describe("NavTab", () => {
 
     context("when given withCircle", () => {
       it("should render a bit striking upwards from bottom", () => {
-        cy.mount(<MobileNavTabProduct />);
+        cy.mount(<ProductMobileNavTab />);
 
         cy.findAllByLabelText("nav-tab-circle").should(
           "have.css",
@@ -408,13 +466,13 @@ describe("NavTab", () => {
       });
 
       it("should with circle in a Tab", () => {
-        cy.mount(<MobileNavTabProduct />);
+        cy.mount(<ProductMobileNavTab />);
 
         cy.findAllByLabelText("nav-tab-circle").should("have.length", 1);
       });
 
       it("should render the circle with darker color (rgb(60, 73, 95))", () => {
-        cy.mount(<MobileNavTabProduct />);
+        cy.mount(<ProductMobileNavTab />);
 
         cy.findAllByLabelText("nav-tab-circle")
           .eq(0)
@@ -423,7 +481,7 @@ describe("NavTab", () => {
 
       context("when selected the tab withCircle", () => {
         it("underline would be transparent", () => {
-          cy.mount(<MobileNavTabProduct />);
+          cy.mount(<ProductMobileNavTab />);
 
           cy.findByLabelText("nav-tab-underscore").should(
             "have.css",
@@ -441,7 +499,7 @@ describe("NavTab", () => {
         });
 
         it("should render the circle with the lighter color (rgb(59, 130, 246))", () => {
-          cy.mount(<MobileNavTabProduct />);
+          cy.mount(<ProductMobileNavTab />);
 
           cy.findAllByLabelText("nav-tab-circle")
             .eq(0)
@@ -460,6 +518,297 @@ describe("NavTab", () => {
         cy.findByText("Write").should("exist");
         cy.findByText("Review").should("exist");
         cy.findByText("Empty").should("not.exist");
+      });
+    });
+
+    context("coloring", () => {
+      context("textColor", () => {
+        context("when given red color", () => {
+          const TABS_WITH_TEXT_COLOR = TABS_ITEMS.map((tab, index) => ({
+            ...tab,
+            textColor: index === 0 && "red",
+          }));
+
+          it("render the color with rgb(255, 0, 0)", () => {
+            cy.mount(<ProductNavTab tabs={TABS_WITH_TEXT_COLOR} />);
+            cy.findAllByLabelText("nav-tab-tab")
+              .eq(0)
+              .should("have.css", "color", "rgb(255, 0, 0)");
+            cy.findAllByLabelText("nav-tab-tab")
+              .eq(1)
+              .should("not.have.css", "color", "rgb(255, 0, 0)");
+          });
+
+          context("when hovering the tab", () => {
+            it("still render the color with rgb(255, 0, 0)", () => {
+              cy.mount(<ProductNavTab tabs={TABS_WITH_TEXT_COLOR} />);
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "color", "rgb(255, 0, 0)");
+
+              cy.findAllByLabelText("nav-tab-tab").eq(0).realHover();
+
+              cy.wait(200);
+
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "color", "rgb(255, 0, 0)");
+            });
+          });
+        });
+      });
+
+      context("hoverTextColor", () => {
+        context("when given blue color", () => {
+          const TABS_WITH_HOVER_TEXT_COLOR = TABS_ITEMS.map((tab, index) => ({
+            ...tab,
+            hoverTextColor: index === 0 && "blue",
+          }));
+
+          it("render the color with inherit color (black)", () => {
+            cy.mount(<ProductNavTab tabs={TABS_WITH_HOVER_TEXT_COLOR} />);
+            cy.findAllByLabelText("nav-tab-tab")
+              .eq(0)
+              .should("have.css", "color", "rgb(0, 0, 0)");
+          });
+
+          context("when hovering the tab", () => {
+            it("still render the color with rgb(0, 0, 255)", () => {
+              cy.mount(<ProductNavTab tabs={TABS_WITH_HOVER_TEXT_COLOR} />);
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "color", "rgb(0, 0, 0)");
+
+              cy.findAllByLabelText("nav-tab-tab").eq(0).realHover();
+
+              cy.wait(200);
+
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "color", "rgb(0, 0, 255)");
+            });
+          });
+        });
+      });
+
+      context("backgroundColor", () => {
+        context("when given red color", () => {
+          const TABS_WITH_BACKGROUND_COLOR = TABS_ITEMS.map((tab, index) => ({
+            ...tab,
+            backgroundColor: index === 0 && "red",
+          }));
+
+          it("render the background color with rgb(255, 0, 0)", () => {
+            cy.mount(<ProductNavTab tabs={TABS_WITH_BACKGROUND_COLOR} />);
+            cy.findAllByLabelText("nav-tab-tab")
+              .eq(0)
+              .should("have.css", "background-color", "rgb(255, 0, 0)");
+          });
+
+          context("when selecting the red background color", () => {
+            it("render the background color with selected color (rgba(243, 244, 246, 0.5))", () => {
+              cy.mount(<ProductNavTab tabs={TABS_WITH_BACKGROUND_COLOR} />);
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "background-color", "rgb(255, 0, 0)");
+
+              cy.findAllByLabelText("nav-tab-tab").eq(0).click();
+
+              cy.wait(200);
+
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should(
+                  "have.css",
+                  "background-color",
+                  "rgba(243, 244, 246, 0.5)"
+                );
+            });
+          });
+
+          context("when hovering the tab", () => {
+            it("render the background color lighter than rgb(255, 102, 102)", () => {
+              cy.mount(<ProductNavTab tabs={TABS_WITH_BACKGROUND_COLOR} />);
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "background-color", "rgb(255, 0, 0)");
+
+              cy.findAllByLabelText("nav-tab-tab").eq(0).realHover();
+
+              cy.wait(200);
+
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "background-color", "rgb(255, 102, 102)");
+            });
+          });
+        });
+      });
+
+      context("hoverBackgroundColor", () => {
+        context("when given red color", () => {
+          const TABS_WITH_TEXT_COLOR = TABS_ITEMS.map((tab, index) => ({
+            ...tab,
+            hoverBackgroundColor: index === 0 && "red",
+          }));
+
+          it("render the background with default color (rgb(255, 255, 255))", () => {
+            cy.mount(<ProductNavTab tabs={TABS_WITH_TEXT_COLOR} />);
+            cy.findAllByLabelText("nav-tab-tab")
+              .eq(0)
+              .should("have.css", "background-color", "rgb(255, 255, 255)");
+          });
+
+          context("when hovering the tab", () => {
+            it("render the background color with rgb(255, 0, 0)", () => {
+              cy.mount(<ProductNavTab tabs={TABS_WITH_TEXT_COLOR} />);
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "background-color", "rgb(255, 255, 255)");
+
+              cy.findAllByLabelText("nav-tab-tab").eq(0).realHover();
+
+              cy.wait(200);
+
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "background-color", "rgb(255, 0, 0)");
+            });
+          });
+
+          context("when selecting the hover color", () => {
+            context("when hover the selected tab with hover color", () => {
+              it("render the background color with inherit selected color (rgba(243, 244, 246, 0.5))", () => {
+                cy.mount(<ProductNavTab tabs={TABS_WITH_TEXT_COLOR} />);
+                cy.findAllByLabelText("nav-tab-tab")
+                  .eq(0)
+                  .should("have.css", "background-color", "rgb(255, 255, 255)");
+
+                cy.findAllByLabelText("nav-tab-tab").eq(0).click();
+
+                cy.findAllByLabelText("nav-tab-tab").eq(0).realHover();
+                cy.wait(200);
+
+                cy.findAllByLabelText("nav-tab-tab")
+                  .eq(0)
+                  .should(
+                    "have.css",
+                    "background-color",
+                    "rgba(243, 244, 246, 0.5)"
+                  );
+              });
+            });
+          });
+        });
+      });
+
+      context("selectedBackgroundColor", () => {
+        context("when given red color", () => {
+          const TABS_WITH_SELECTED_BACKGROUND_COLOR = TABS_ITEMS.map(
+            (tab, index) => ({
+              ...tab,
+              selectedBackgroundColor: index === 0 && "red",
+            })
+          );
+
+          it("render the background with default color (rgb(255, 255, 255))", () => {
+            cy.mount(
+              <ProductNavTab tabs={TABS_WITH_SELECTED_BACKGROUND_COLOR} />
+            );
+            cy.findAllByLabelText("nav-tab-tab")
+              .eq(0)
+              .should("have.css", "background-color", "rgb(255, 255, 255)");
+          });
+
+          context("when hovering the tab", () => {
+            it("render the background color with default color (rgba(243, 244, 246, 0.5))", () => {
+              cy.mount(
+                <ProductNavTab tabs={TABS_WITH_SELECTED_BACKGROUND_COLOR} />
+              );
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "background-color", "rgb(255, 255, 255)");
+
+              cy.findAllByLabelText("nav-tab-tab").eq(0).realHover();
+
+              cy.wait(200);
+
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should(
+                  "have.css",
+                  "background-color",
+                  "rgba(243, 244, 246, 0.5)"
+                );
+            });
+          });
+
+          context("when selecting the tab", () => {
+            it("render the background color with rgb(255, 0, 0)", () => {
+              cy.mount(
+                <ProductNavTab tabs={TABS_WITH_SELECTED_BACKGROUND_COLOR} />
+              );
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "background-color", "rgb(255, 255, 255)");
+
+              cy.findAllByLabelText("nav-tab-tab").eq(0).click();
+
+              cy.wait(200);
+
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "background-color", "rgb(255, 0, 0)");
+            });
+          });
+        });
+      });
+
+      context("activeBackgroundColor", () => {
+        context("when given blue color", () => {
+          const TABS_WITH_ACTIVE_BACKGROUND_COLOR = TABS_ITEMS.map(
+            (tab, index) => ({
+              ...tab,
+              activeBackgroundColor: index === 0 && "blue",
+            })
+          );
+
+          it("render the background with default color (rgb(255, 255, 255))", () => {
+            cy.mount(
+              <ProductNavTab tabs={TABS_WITH_ACTIVE_BACKGROUND_COLOR} />
+            );
+            cy.findAllByLabelText("nav-tab-tab")
+              .eq(0)
+              .should("have.css", "background-color", "rgb(255, 255, 255)");
+          });
+
+          context("when selecting the tab", () => {
+            it("render the active background color with rgb(0, 0, 255)", () => {
+              cy.mount(
+                <ProductNavTab tabs={TABS_WITH_ACTIVE_BACKGROUND_COLOR} />
+              );
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should("have.css", "background-color", "rgb(255, 255, 255)");
+
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .realMouseDown()
+                .should("have.css", "background-color", "rgb(0, 0, 255)");
+              cy.wait(200);
+
+              cy.findAllByLabelText("nav-tab-tab").eq(0).realClick();
+
+              cy.findAllByLabelText("nav-tab-tab")
+                .eq(0)
+                .should(
+                  "have.css",
+                  "background-color",
+                  "rgba(243, 244, 246, 0.5)"
+                );
+            });
+          });
+        });
       });
     });
   });
@@ -975,54 +1324,3 @@ describe("NavTab", () => {
     });
   });
 });
-
-const TABS_ITEMS: NavTabTab[] = [
-  {
-    id: "1",
-    title: "Write",
-    content: <WriteTabContent />,
-    onClick: () => {
-      console.log("test tab 1");
-    },
-    actions: [
-      {
-        caption: "Discover",
-        onClick: () => {
-          console.log("Discover clicked");
-        },
-        icon: { image: RiSearchLine },
-      },
-    ],
-  },
-  {
-    id: "2",
-    title: "Review",
-    content: <ReviewTabContent />,
-    onClick: () => {
-      console.log("test tab 2");
-    },
-    actions: [
-      {
-        caption: "Discover",
-        onClick: () => {
-          console.log("Discover clicked");
-        },
-        icon: { image: RiSearchLine },
-      },
-      {
-        caption: "Mention",
-        onClick: () => {
-          console.log("Mention clicked");
-        },
-        icon: { image: RiAtLine },
-      },
-    ],
-  },
-  {
-    hidden: true,
-    id: "3",
-    title: "Empty",
-    content: "Empty",
-    onClick: () => {},
-  },
-];


### PR DESCRIPTION
Description:
This pull request introduces a `backgroundColor`, `hoverBackgroundColor`, `textColor`, `hoverTextColor`, `activeBackgroundColor`, and `selectedBackgroundColor` inside of the `NavTabTab` interface, which would enrich flexibility of styling per tab.

It also improves the styling behavior across all tab interaction states by:

* Ensuring the hover style is applied only when `backgroundColor` is provided, using a lighter shade of the background color.
* Preventing the hover style from affecting the selected tab, so the selected appearance remains consistent.
* Preventing the active (pressed) style from being displayed when clicking an already selected tab.
* Ensuring each tab state (`default`, `hover`, `selected`, and `active`) is applied correctly without overriding one another.

Source:
[[Improvement] SYST-599: Allow setting icon, background color and text color for NavTab tab](https://linear.app/systatum/issue/SYST-599/allow-setting-icon-background-color-and-text-color-for-navtab-tab)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself