### PR TITLE
[Mobile] SYST-805: Support `bottom sheet` appearance for `ScreenTransition`

### DIFF
--- a/components/paper-dialog.stories.tsx
+++ b/components/paper-dialog.stories.tsx
@@ -154,8 +154,9 @@ Each icon accepts:
       description: "Custom styles for the dialog, tabs, and close button",
       control: false,
     },
-    onClosed: {
-      description: "Callback fired after the dialog closes",
+    onChange: {
+      description:
+        "Callback fired after the dialog for closed, minimized, and restored condition",
       action: "closed",
     },
   },

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -45,7 +45,7 @@ export interface PaperDialogProps {
   children?: ReactNode;
   closable?: boolean;
   styles?: PaperDialogStyles;
-  onClosed?: () => void;
+  onChange?: (state: PaperDialogState) => void;
   icons?: PaperDialogIcons;
   id?: string;
   className?: string;
@@ -114,7 +114,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
       position = "right",
       children,
       styles,
-      onClosed,
+      onChange,
       icons,
       className,
       title,
@@ -320,7 +320,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
           window.removeEventListener("pointerup", onUp);
 
           if (velocityRef.current > 0.5) {
-            setDialogState("minimized");
+            handleChangeDialog("minimized");
             setShowTitlebar(true);
             setTimeout(() => {
               // Clear inline styles so Framer Motion takes back control
@@ -394,15 +394,25 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
     const resolvedWidth = resizeWidth != null ? `${resizeWidth}px` : width;
     const resolvedHeight = resizeHeight != null ? `${resizeHeight}px` : height;
 
+    const handleChangeDialog = useCallback(
+      (state: PaperDialogState) => {
+        setDialogState(state);
+        if (onChange) {
+          onChange(state);
+        }
+      },
+      [setDialogState, onChange]
+    );
+
     const closeDialog = useCallback(
       async (withTimeout: boolean = true) => {
-        const close = async () => await setDialogState("closed");
+        const close = async () => await handleChangeDialog("closed");
 
         await setResizeHeight(null);
         await setResizeWidth(null);
 
         if (mobile) {
-          await setDialogState("minimized");
+          await handleChangeDialog("minimized");
 
           if (withTimeout) {
             setTimeout(close, 400);
@@ -412,21 +422,17 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         } else {
           await close();
         }
-
-        if (onClosed) {
-          await onClosed();
-        }
       },
-      [mobile, onClosed]
+      [mobile, handleChangeDialog]
     );
 
     useImperativeHandle(ref, () => ({
       openDialog: async () => {
-        await setDialogState("restored");
+        await handleChangeDialog("restored");
       },
       closeDialog: (withTimeout?: boolean) => closeDialog(withTimeout),
       minimizeDialog: async () => {
-        await setDialogState("minimized");
+        await handleChangeDialog("minimized");
       },
     }));
 
@@ -439,12 +445,9 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         ) {
           closeDialog();
           setShowTitlebar(false);
-          if (onClosed) {
-            onClosed();
-          }
         }
       },
-      [setDialogState, dialogState]
+      [dialogState]
     );
 
     useEffect(() => {
@@ -478,7 +481,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             <MiniTitleBar
               $theme={paperDialogTheme}
               onClick={() => {
-                setDialogState("restored");
+                handleChangeDialog("restored");
                 setShowTitlebar(false);
               }}
               initial={{ y: "100%" }}
@@ -520,7 +523,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                           size: icons?.closeIcon?.size ?? 18,
                         },
                         onClick: () => {
-                          setDialogState("closed");
+                          handleChangeDialog("closed");
                         },
                       },
                     ],
@@ -570,7 +573,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             dragElastic={{ top: 0, bottom: 0.6 }}
             onDragEnd={(_, info) => {
               if (info.offset.y > 120 || info.velocity.y > 500) {
-                setDialogState("minimized");
+                handleChangeDialog("minimized");
                 setShowTitlebar(true);
               }
             }}
@@ -615,7 +618,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 aria-label="paper-dialog-toggle-restore"
                 $style={styles?.minimizeButtonStyle}
                 onClick={() => {
-                  setDialogState(
+                  handleChangeDialog(
                     dialogState === "minimized" ? "restored" : "minimized"
                   );
                   setShowTitlebar(true);
@@ -962,7 +965,6 @@ const DragIndicatorWrapper = styled(motion.div)<{
   cursor: ${({ $resizable }) => ($resizable ? "ns-resize" : "grab")};
   width: 100dvw;
   height: 60px;
-  z-index: 9992999;
   align-items: center;
   border-radius: 1.2rem 1.2rem 0 0;
   background-color: ${({ $theme }) => $theme?.backgroundColor};

--- a/components/screen-transition.stories.tsx
+++ b/components/screen-transition.stories.tsx
@@ -161,6 +161,59 @@ Each dialog maintains its own animation while remaining synchronized with the na
 
 ---
 
+---
+
+#### Sheet Presentation
+
+By default, every screen is presented as a full-screen \`PaperDialog\`. Alternatively, a screen can be configured to appear as a sheet by providing a configuration object instead of a component.
+
+\`\`\`tsx
+const screens = {
+  home: HomeScreen,
+  profile: ProfileScreen,
+  filter: {
+    component: FilterScreen,
+    sheet: true,
+  },
+};
+\`\`\`
+
+The \`sheet\` option controls how the screen is presented.
+
+\`\`\`ts
+type ScreenConfig = {
+  component: ComponentType<Partial<ScreenProps>>;
+  sheet?: boolean | PaperDialogResizable;
+};
+\`\`\`
+
+Setting \`sheet: true\` displays the screen using the default sheet appearance.
+
+\`\`\`tsx
+const screens = {
+  filter: {
+    component: FilterScreen,
+    sheet: true,
+  },
+};
+\`\`\`
+
+A custom sheet configuration can also be provided by passing \`PaperDialogResizable\`.
+
+\`\`\`tsx
+const screens = {
+  filter: {
+    component: FilterScreen,
+    sheet: {
+      minHeight: "50dvh",
+      maxHeight: "90dvh",
+    },
+  },
+};
+\`\`\`
+
+This allows \`ScreenTransition\` to present a mixture of full-screen pages and sheets while using the same navigation API.
+
 #### Initial Screen Restoration
 
 If a screen already exists inside the initial \`activeScreens\` array, it opens immediately without replaying its opening animation.

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -29,7 +29,7 @@ type ScreenSheetConfig =
   | boolean
   | Omit<PaperDialogResizable, "minWidth" | "maxWidth">;
 
-type ScreenEntry = ScreensComponent | ScreenConfig;
+export type ScreenEntry = ScreensComponent | ScreenConfig;
 
 export type ScreensMap = Record<string, ScreenEntry>;
 

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -25,7 +25,9 @@ type ScreenConfig = {
   sheet?: ScreenSheetConfig;
 };
 
-type ScreenSheetConfig = boolean | PaperDialogResizable;
+type ScreenSheetConfig =
+  | boolean
+  | Omit<PaperDialogResizable, "minWidth" | "maxWidth">;
 
 type ScreenEntry = ScreensComponent | ScreenConfig;
 

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -5,7 +5,12 @@ import React, {
   useEffect,
   useRef,
 } from "react";
-import { PaperDialog, PaperDialogRef } from "./paper-dialog";
+import {
+  PaperDialog,
+  PaperDialogRef,
+  PaperDialogResizable,
+  PaperDialogState,
+} from "./paper-dialog";
 import { css } from "styled-components";
 
 export interface ScreenProps<TScreenKey extends string = string> {
@@ -13,7 +18,18 @@ export interface ScreenProps<TScreenKey extends string = string> {
   goBack: (() => void) | null;
 }
 
-type ScreensMap = Record<string, ComponentType<Partial<ScreenProps>>>;
+type ScreensComponent = ComponentType<Partial<ScreenProps>>;
+
+type ScreenConfig = {
+  component: ScreensComponent;
+  sheet?: ScreenSheetConfig;
+};
+
+type ScreenSheetConfig = boolean | PaperDialogResizable;
+
+type ScreenEntry = ScreensComponent | ScreenConfig;
+
+export type ScreensMap = Record<string, ScreenEntry>;
 
 export interface ScreenTransitionProps<TScreens extends ScreensMap> {
   /** Registry of every screen this transition can render, keyed by id */
@@ -67,25 +83,48 @@ function ScreenTransition<TScreens extends ScreensMap>({
     [screens, activeScreens, onScreenChange]
   );
 
-  const goBack = useCallback(() => {
-    if (activeScreens.length === 0) return;
+  // Tracks dialog indices currently being closed via goBack(), so that
+  // re-entrant onChange("minimized") events fired internally by
+  // minimizeDialog()/closeDialog() don't call onClosed -> goBack() again
+  // and cause an infinite/duplicate close loop.
+  const closingIndicesRef = useRef<Set<number>>(new Set());
 
-    const topIndex = activeScreens.length - 1; // the dialog wrapping the top screen
-    const ref = dialogRefsRef.current.get(topIndex);
+  const goBack = useCallback(
+    (mobile?: boolean) => {
+      if (activeScreens.length === 0) return;
 
-    ref?.current?.minimizeDialog();
-    setTimeout(() => {
-      ref?.current?.closeDialog();
-      onScreenChange(activeScreens.slice(0, -1));
-      mountedIndicesRef.current!.delete(topIndex);
-    }, 300);
-  }, [activeScreens, onScreenChange]);
+      const topIndex = activeScreens.length - 1; // the dialog wrapping the top screen
+      const ref = dialogRefsRef.current.get(topIndex);
+
+      // this preventing the condition mobile case for onChanges
+      // so we don't use this, because would be re-render minimize state
+      // and if closed with drag indicator still enough not trigger ref
+      // for minimizing
+      closingIndicesRef.current.add(topIndex);
+      if (!mobile) {
+        ref?.current?.minimizeDialog();
+      }
+
+      setTimeout(async () => {
+        await ref?.current?.closeDialog();
+        if (closingIndicesRef.current.has(topIndex)) {
+          await onScreenChange(activeScreens.slice(0, -1));
+        }
+        closingIndicesRef.current!.delete(topIndex);
+        mountedIndicesRef.current!.delete(topIndex);
+      }, 300);
+    },
+    [activeScreens, onScreenChange]
+  );
 
   const renderStack = (index: number): ReactNode => {
     const key = activeScreens[index];
     if (!key) return null;
+    const screen = screens[key];
 
-    const ScreenComponent = screens[key] as ComponentType<Partial<ScreenProps>>;
+    const config = getScreenConfig(screen);
+
+    const ScreenComponent: ScreensComponent = config.component;
     if (!ScreenComponent) {
       console.warn(
         `ScreenTransition: screen "${String(key)}" is not registered`
@@ -102,8 +141,11 @@ function ScreenTransition<TScreens extends ScreensMap>({
 
     return (
       <DialogLevel
+        key={index}
         dialogRef={getDialogRef(index)}
         skipInitialAnimation={skipInitialAnimation}
+        onClosed={config?.sheet ? () => goBack?.(!!config?.sheet) : undefined}
+        sheet={config?.sheet}
       >
         <ScreenComponent {...screenProps} />
         {index < activeScreens.length - 1 && renderStack(index + 1)}
@@ -116,14 +158,28 @@ function ScreenTransition<TScreens extends ScreensMap>({
   return renderStack(0);
 }
 
+function getScreenConfig(screen: ScreenEntry): ScreenConfig {
+  if (typeof screen === "function") {
+    return {
+      component: screen,
+    };
+  }
+
+  return screen;
+}
+
 function DialogLevel({
   dialogRef,
   children,
   skipInitialAnimation,
+  sheet,
+  onClosed,
 }: {
   dialogRef: React.RefObject<PaperDialogRef | null>;
   children: ReactNode;
   skipInitialAnimation?: boolean;
+  sheet?: ScreenSheetConfig;
+  onClosed?: () => void;
 }) {
   useEffect(() => {
     // Only animate-open if this dialog wasn't pre-existing/already mounted.
@@ -143,9 +199,18 @@ function DialogLevel({
       closable={false}
       controls={[]}
       width={"100dvw"}
-      height={"100dvh"}
+      height={sheet ? "80dvh" : "100dvh"}
+      mobile={!!sheet}
+      resizable={sheet}
       initialDialogState={skipInitialAnimation ? "restored" : "closed"}
       skipInitialAnimation={skipInitialAnimation}
+      onChange={
+        sheet
+          ? (state: PaperDialogState) => {
+              if (state === "minimized") onClosed?.();
+            }
+          : undefined
+      }
     >
       {children}
     </PaperDialog>

--- a/test/component/paper-dialog.cy.tsx
+++ b/test/component/paper-dialog.cy.tsx
@@ -817,7 +817,7 @@ describe("PaperDialog", () => {
         it("should renders with arrow icon (default)", () => {
           cy.mount(
             <ProductPaperDialog
-              onClosed={() => {
+              onChange={() => {
                 console.log("the modal is closed");
               }}
             />
@@ -837,8 +837,8 @@ describe("PaperDialog", () => {
         it("should changes with customize icon", () => {
           cy.mount(
             <ProductPaperDialog
-              onClosed={() => {
-                console.log("the modal is closed");
+              onChange={(state) => {
+                console.log(`the modal is ${state}`);
               }}
               icons={{
                 restoreIcon: {
@@ -864,8 +864,8 @@ describe("PaperDialog", () => {
         it("should renders with close icon (default)", () => {
           cy.mount(
             <ProductPaperDialog
-              onClosed={() => {
-                console.log("the modal is closed");
+              onChange={(state) => {
+                console.log(`the modal is ${state}`);
               }}
             />
           );
@@ -883,8 +883,8 @@ describe("PaperDialog", () => {
         it("should changes with customize icon", () => {
           cy.mount(
             <ProductPaperDialog
-              onClosed={() => {
-                console.log("the modal is closed");
+              onChange={(state) => {
+                console.log(`the modal is ${state}`);
               }}
               icons={{
                 closeIcon: {
@@ -906,13 +906,13 @@ describe("PaperDialog", () => {
     });
   });
 
-  context("onClosed", () => {
+  context("onChange", () => {
     context("when pressing escape", () => {
       it("should give the callback", () => {
         cy.mount(
           <ProductPaperDialog
-            onClosed={() => {
-              console.log("the modal is closed");
+            onChange={(state) => {
+              console.log(`the modal is ${state}`);
             }}
           />
         );
@@ -943,8 +943,8 @@ describe("PaperDialog", () => {
       it("should give the callback", () => {
         cy.mount(
           <ProductPaperDialog
-            onClosed={() => {
-              console.log("the modal is closed");
+            onChange={(state) => {
+              console.log(`the modal is ${state}`);
             }}
           />
         );
@@ -975,8 +975,8 @@ describe("PaperDialog", () => {
       it("should give the callback", () => {
         cy.mount(
           <ProductPaperDialog
-            onClosed={() => {
-              console.log("the modal is closed");
+            onChange={(state) => {
+              console.log(`the modal is ${state}`);
             }}
           />
         );
@@ -1005,12 +1005,12 @@ describe("PaperDialog", () => {
 
     context("when given closable false", () => {
       context("when pressing escape", () => {
-        it("should not give the callback", () => {
+        it("should give the callback only for minimized", () => {
           cy.mount(
             <ProductPaperDialog
               closable={false}
-              onClosed={() => {
-                console.log("the modal is closed");
+              onChange={(state) => {
+                console.log(`the modal is ${state}`);
               }}
             />
           );
@@ -1042,8 +1042,8 @@ describe("PaperDialog", () => {
           cy.mount(
             <ProductPaperDialog
               closable={false}
-              onClosed={() => {
-                console.log("the modal is closed");
+              onChange={(state) => {
+                console.log(`the modal is ${state}`);
               }}
             />
           );

--- a/test/component/screen-transition.cy.tsx
+++ b/test/component/screen-transition.cy.tsx
@@ -1,7 +1,9 @@
 import { useTheme } from "./../../theme";
 import {
   ScreenProps,
+  ScreensMap,
   ScreenTransition,
+  ScreenTransitionProps,
 } from "./../../components/screen-transition";
 import styled, { css } from "styled-components";
 import { RiArrowLeftSLine } from "@remixicon/react";
@@ -10,114 +12,120 @@ import { Button } from "./../../components/button";
 import { useState } from "react";
 
 describe("Screen Transition", () => {
-  function ProductTransition({
-    initializeScreen = [],
-    onScreenChange,
-  }: {
-    initializeScreen?: ("a" | "b" | "c")[];
-    onScreenChange?: (screens: ("a" | "b" | "c")[]) => void;
-  }) {
-    const { currentTheme } = useTheme();
-    const screens = {
-      a: PageA,
-      b: PageB,
-      c: PageC,
-    };
+  const productScreen = {
+    a: PageA,
+    b: PageB,
+    c: PageC,
+  };
 
-    type ScreenKey = keyof typeof screens;
+  type ScreenKey = keyof typeof productScreen;
+
+  function PageTitle({
+    text,
+    goBack = null,
+  }: {
+    text?: string;
+  } & Partial<ScreenProps>) {
+    const { currentTheme } = useTheme();
+
     const bodyTheme = currentTheme?.body;
 
-    const [activeScreens, setActiveScreens] =
-      useState<ScreenKey[]>(initializeScreen);
-
-    function PageTitle({
-      text,
-      goBack = null,
-    }: {
-      text?: string;
-    } & Partial<ScreenProps>) {
-      return (
-        <Title
-          size="md"
-          leftSection={
-            goBack
-              ? [
-                  {
-                    styles: {
-                      toggleActionStyle: css`
-                        padding: 4px;
-                        height: 30px;
-                        width: 30px;
-                        border-radius: 4px;
-                      `,
-                    },
-                    type: "actions",
-                    actions: [
-                      {
-                        caption: "back",
-                        icon: { image: RiArrowLeftSLine },
-                        onClick: () => {
-                          goBack();
-                        },
-                      },
-                    ],
+    return (
+      <Title
+        size="md"
+        leftSection={
+          goBack
+            ? [
+                {
+                  styles: {
+                    toggleActionStyle: css`
+                      padding: 4px;
+                      height: 30px;
+                      width: 30px;
+                      border-radius: 4px;
+                    `,
                   },
-                ]
-              : []
-          }
-          text={text}
-          styles={{
-            containerStyle: css`
-              border-bottom: 1px solid ${bodyTheme?.borderColor || "#ececec"};
-              height: 53px;
-              justify-content: center;
-              align-items: center;
-              padding: 0 6px;
-            `,
-            textContainerStyle: css`
-              align-items: center;
-            `,
-            titleStyle: css`
-              justify-content: center;
-              font-size: 20px;
+                  type: "actions",
+                  actions: [
+                    {
+                      caption: "back",
+                      icon: { image: RiArrowLeftSLine },
+                      onClick: () => {
+                        goBack();
+                      },
+                    },
+                  ],
+                },
+              ]
+            : []
+        }
+        text={text}
+        styles={{
+          containerStyle: css`
+            border-bottom: 1px solid ${bodyTheme?.borderColor || "#ececec"};
+            height: 53px;
+            justify-content: center;
+            align-items: center;
+            padding: 0 6px;
+          `,
+          textContainerStyle: css`
+            align-items: center;
+          `,
+          titleStyle: css`
+            justify-content: center;
+            font-size: 20px;
 
-              ${goBack &&
-              css`
-                padding-right: 40px;
-              `}
-              align-items: center;
-            `,
-          }}
-        />
-      );
-    }
+            ${goBack &&
+            css`
+              padding-right: 40px;
+            `}
+            align-items: center;
+          `,
+        }}
+      />
+    );
+  }
 
-    function PageC({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
-      return (
-        <Wrapper>
-          <PageTitle text="Page C" goBack={goBack} />
-          <Button onClick={() => goToScreen("a")}>Go to Page A</Button>
-        </Wrapper>
-      );
-    }
+  function PageC({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
+    return (
+      <Wrapper>
+        <PageTitle text="Page C" goBack={goBack} />
+        <Button onClick={() => goToScreen("a")}>Go to Page A</Button>
+      </Wrapper>
+    );
+  }
 
-    function PageB({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
-      return (
-        <Wrapper>
-          <PageTitle text="Page B" goBack={goBack} />
-          <Button onClick={() => goToScreen("c")}>Go to Page C</Button>
-        </Wrapper>
-      );
-    }
+  function PageB({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
+    return (
+      <Wrapper>
+        <PageTitle text="Page B" goBack={goBack} />
+        <Button onClick={() => goToScreen("c")}>Go to Page C</Button>
+      </Wrapper>
+    );
+  }
 
-    function PageA({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
-      return (
-        <Wrapper>
-          <PageTitle text="Page A" goBack={goBack} />
-          <Button onClick={() => goToScreen("b")}>Go to Page B</Button>
-        </Wrapper>
-      );
-    }
+  function PageA({ goBack, goToScreen }: ScreenProps<ScreenKey>) {
+    return (
+      <Wrapper>
+        <PageTitle text="Page A" goBack={goBack} />
+        <Button onClick={() => goToScreen("b")}>Go to Page B</Button>
+      </Wrapper>
+    );
+  }
+
+  type ProductTransitionProps<TScreens extends ScreensMap> = {
+    screens: TScreens;
+    initializeScreen?: (keyof TScreens)[];
+    onScreenChange?: (screens: (keyof TScreens)[]) => void;
+  } & Partial<ScreenTransitionProps<TScreens>>;
+
+  function ProductTransition<TScreens extends ScreensMap>({
+    initializeScreen = [],
+    onScreenChange,
+    screens,
+  }: Partial<ProductTransitionProps<TScreens>>) {
+    const [activeScreens, setActiveScreens] =
+      useState<(keyof TScreens)[]>(initializeScreen);
 
     return (
       <>
@@ -141,9 +149,82 @@ describe("Screen Transition", () => {
   }
 
   context("screens", () => {
+    context("when given sheet", () => {
+      const productWithSheetScreens: ScreensMap = {
+        a: PageA,
+        b: PageB,
+        c: { component: PageC, sheet: true },
+      };
+
+      context("when initialize with C in screen", () => {
+        it("renders the PaperDialog mobile", () => {
+          cy.viewport(500, 700);
+
+          cy.mount(
+            <ProductTransition
+              screens={productWithSheetScreens}
+              initializeScreen={["c"]}
+            />
+          );
+
+          cy.findByLabelText("paper-dialog-drag-indicator").should("exist");
+
+          cy.wait(500);
+        });
+
+        context("when drag to the bottom with indicator", () => {
+          it("should close the PaperDialog", () => {
+            cy.viewport(500, 700);
+
+            cy.mount(
+              <ProductTransition
+                screens={productWithSheetScreens}
+                initializeScreen={["c"]}
+              />
+            );
+            cy.findByLabelText("paper-dialog-drag-indicator")
+              .realMouseDown({ position: "center" })
+              .realMouseMove(0, 30)
+              .wait(100)
+              .realMouseMove(0, 60)
+              .wait(100)
+              .realMouseMove(0, 100)
+              .realMouseUp();
+
+            cy.findByLabelText("paper-dialog-drag-indicator").should(
+              "not.exist"
+            );
+          });
+
+          it("should given onScreenChange callback as usual", () => {
+            cy.viewport(500, 700);
+            const onScreenChangeSpy = cy.stub().as("onScreenChange");
+
+            cy.mount(
+              <ProductTransition
+                screens={productWithSheetScreens}
+                initializeScreen={["c"]}
+                onScreenChange={onScreenChangeSpy}
+              />
+            );
+            cy.findByLabelText("paper-dialog-drag-indicator")
+              .realMouseDown({ position: "center" })
+              .realMouseMove(0, 30)
+              .wait(100)
+              .realMouseMove(0, 60)
+              .wait(100)
+              .realMouseMove(0, 100)
+              .realMouseUp();
+
+            cy.get("@onScreenChange").should("have.been.calledWith", []);
+          });
+        });
+      });
+    });
+
     context("when clicking next button", () => {
       it("should move to the page A", () => {
-        cy.mount(<ProductTransition />);
+        cy.mount(<ProductTransition screens={productScreen} />);
         cy.findByLabelText("title-title").should("have.text", "Index Screen");
 
         cy.findByText("Go to Page A").should("be.visible").click();
@@ -156,7 +237,7 @@ describe("Screen Transition", () => {
 
       context("when clicking next button", () => {
         it("should move to the page C", () => {
-          cy.mount(<ProductTransition />);
+          cy.mount(<ProductTransition screens={productScreen} />);
           cy.findByLabelText("title-title").should("have.text", "Index Screen");
 
           cy.findByText("Go to Page A").should("be.visible").click();
@@ -177,7 +258,7 @@ describe("Screen Transition", () => {
 
       context("when clicking chevron icon", () => {
         it("should move to the initial screen", () => {
-          cy.mount(<ProductTransition />);
+          cy.mount(<ProductTransition screens={productScreen} />);
           cy.findByLabelText("title-title").should("have.text", "Index Screen");
 
           cy.findByText("Go to Page A").should("be.visible").click();
@@ -196,13 +277,23 @@ describe("Screen Transition", () => {
   context("activeScreens", () => {
     context("when initialize 3 screen", () => {
       it("should render 3 screen", () => {
-        cy.mount(<ProductTransition initializeScreen={["b", "c", "a"]} />);
+        cy.mount(
+          <ProductTransition
+            screens={productScreen}
+            initializeScreen={["b", "c", "a"]}
+          />
+        );
         cy.findAllByLabelText("paper-dialog-wrapper").should("have.length", 3);
       });
 
       context("when move to back", () => {
         it("closes screens in reverse order", () => {
-          cy.mount(<ProductTransition initializeScreen={["b", "c", "a"]} />);
+          cy.mount(
+            <ProductTransition
+              screens={productScreen}
+              initializeScreen={["b", "c", "a"]}
+            />
+          );
           cy.findAllByLabelText("title-title")
             .eq(3)
             .should("have.text", "Page A");
@@ -234,6 +325,7 @@ describe("Screen Transition", () => {
 
         cy.mount(
           <ProductTransition
+            screens={productScreen}
             initializeScreen={["a"]}
             onScreenChange={onScreenChangeSpy}
           />
@@ -250,6 +342,7 @@ describe("Screen Transition", () => {
 
           cy.mount(
             <ProductTransition
+              screens={productScreen}
               initializeScreen={["a"]}
               onScreenChange={onScreenChangeSpy}
             />


### PR DESCRIPTION
Description:
This pull request adds support for rendering screens as a `sheet` within `ScreenTransition`, allowing screens to be displayed using `PaperDialog` instead of the default full-screen transition.

Previously, every screen registered in `ScreenTransition` was rendered as a standard page. With this change, a screen can now specify whether it should be presented as a sheet by providing additional configuration.

```tsx
type ScreensComponent = ComponentType<Partial<ScreenProps>>;

type ScreenConfig = {
  component: ScreensComponent;
  sheet?: ScreenSheetConfig;
};

type ScreenSheetConfig = boolean | PaperDialogResizable;

type ScreenEntry = ScreensComponent | ScreenConfig;

export type ScreensMap = Record<string, ScreenEntry>;
```

This enables both simple and configurable screen definitions:

```tsx
const screens: ScreensMap = {
   a: PageA,
   b: PageB,
   c: {
     component: PageC,
     sheet: true,
   },
 };
```

if we provides the name with `mobile` to shows `PaperDialog.Mobile` in that case it's not really good name, because the `ScreenTransition` pursuing for `mobile`.

This approach keeps the API simple while making it easy to choose between a default `ScreenTransition` and a `Sheet` presentation on a per-screen basis.

Source:
[[Mobile] SYST-805: Support `bottom sheet` appearance for `ScreenTransition`
](https://linear.app/systatum/issue/SYST-805/support-bottom-sheet-appearance-for-screentransition)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself