### PR TITLE
[Mobile] SYST-808: Add `width`, `height`, and changes the `closable` behavior in `ScreenTransition`

### DIFF
--- a/components/overlay-blocker.tsx
+++ b/components/overlay-blocker.tsx
@@ -60,6 +60,7 @@ export const OverlayBlocker = forwardRef<
       ".coneto-paper-dialog",
       ".coneto-dialog",
       ".coneto-sidebar",
+      "#combo-list",
       ...(_exemptRegions ?? []),
     ];
 

--- a/components/paper-dialog.stories.tsx
+++ b/components/paper-dialog.stories.tsx
@@ -132,7 +132,6 @@ The \`trigger\` indicates what caused the state change:
 | \`overlay\` | User clicked the overlay to close the dialog. |
 | \`escape\` | User pressed the Escape key. |
 | \`drag\` | User swiped the mobile drag indicator to minimize the dialog. |
-| \`resize\` | Dialog state changed as part of a resize interaction (for example, resizing to the minimized state). |
 | \`control\` | User clicked one of the dialog controls (close, minimize, or restore). |
 
 ### 📝 Notes

--- a/components/paper-dialog.stories.tsx
+++ b/components/paper-dialog.stories.tsx
@@ -462,7 +462,7 @@ export const Mobile: Story = {
             onClick={() => {
               PAPER_DIALOGS.forEach((item) => {
                 if (item.ref !== dialog.ref) {
-                  item.ref.current?.closeDialog(false);
+                  item.ref.current?.closeDialog();
                 }
               });
 

--- a/components/paper-dialog.stories.tsx
+++ b/components/paper-dialog.stories.tsx
@@ -109,6 +109,32 @@ Use \`onResize\` to react to size changes while dragging and \`onResizeComplete\
 />
 \`\`\`
 
+### 🔄 State Changes
+
+Use \`onChange\` to listen for dialog state changes. The callback receives both the current dialog state and the trigger that caused the change.
+
+\`\`\`tsx
+<PaperDialog
+  onChange={state: PaperDialogState, trigger: PaperDialogTrigger) => {
+    console.log(state);   // "restored" | "minimized" | "closed"
+    console.log(trigger); // "api" | "overlay" | "escape" | "drag" | "resize" | "control"
+  }}
+/>
+\`\`\`
+
+#### Triggers
+
+The \`trigger\` indicates what caused the state change:
+
+| Trigger | Description |
+| -------- | ----------- |
+| \`api\` | Changed programmatically via the dialog ref (\`openDialog\`, \`closeDialog\`, \`restoreDialog\`, etc.). |
+| \`overlay\` | User clicked the overlay to close the dialog. |
+| \`escape\` | User pressed the Escape key. |
+| \`drag\` | User swiped the mobile drag indicator to minimize the dialog. |
+| \`resize\` | Dialog state changed as part of a resize interaction (for example, resizing to the minimized state). |
+| \`control\` | User clicked one of the dialog controls (close, minimize, or restore). |
+
 ### 📝 Notes
 - Use \`styles\` prop to override default styles.
 - Use the \`icons\` prop to override default icons.

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -445,7 +445,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
     );
 
     const closeDialog = useCallback(
-      async (withTimeout: boolean = true, trigger: PaperDialogTrigger) => {
+      async (withTimeout: boolean, trigger: PaperDialogTrigger) => {
         const close = async () =>
           await handleChangeDialog(PaperDialogState.Closed, trigger);
 
@@ -491,7 +491,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
           canCloseWithEscape &&
           (dialogState === "restored" || dialogState === "minimized")
         ) {
-          closeDialog(true, PaperDialogTrigger.Escape);
+          closeDialog(false, PaperDialogTrigger.Escape);
           setShowTitlebar(false);
         }
       },

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -33,7 +33,7 @@ export type PaperDialogState =
   (typeof PaperDialogState)[keyof typeof PaperDialogState];
 
 export const PaperDialogTrigger = {
-  Api: "api",
+  API: "api",
   Overlay: "overlay",
   Escape: "escape",
   Drag: "drag",
@@ -78,6 +78,7 @@ export interface PaperDialogClosable {
   withOverlay?: boolean;
   withEscape?: boolean;
   withButton?: boolean;
+  withIndicator?: boolean;
 }
 
 export interface PaperDialogResizable {
@@ -122,8 +123,12 @@ export interface PaperDialogContentStyles {
 
 export interface PaperDialogRef {
   openDialog: () => void;
-  closeDialog: (withTimeout?: boolean) => void;
+  closeDialog: (props?: PaperDialogCloseOption) => void;
   minimizeDialog: () => void;
+}
+export interface PaperDialogCloseOption {
+  withMinimize?: boolean;
+  withTimeout?: boolean;
 }
 
 const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
@@ -164,6 +169,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
       withEscape = true,
       withOverlay = true,
       withButton = true,
+      withIndicator = true,
     } = typeof closable === "object" ? closable : {};
 
     const canCloseWithEscape =
@@ -172,6 +178,8 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
       closable !== false && (typeof closable !== "object" || withOverlay);
     const canCloseWithButton =
       closable !== false && (typeof closable !== "object" || withButton);
+    const canCloseWithIndicator =
+      closable !== false && (typeof closable !== "object" || withIndicator);
 
     const contentRef = useRef<HTMLDivElement>(null);
 
@@ -357,24 +365,26 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
           window.removeEventListener("pointerup", onUp);
 
           if (velocityRef.current > 0.5) {
-            handleChangeDialog(
-              PaperDialogState.Minimized,
-              PaperDialogTrigger.Resize
-            );
-            setShowTitlebar(true);
-            setTimeout(() => {
-              // Clear inline styles so Framer Motion takes back control
-              if (dialogRef.current) {
-                dialogRef.current.style.minHeight = "";
-                dialogRef.current.style.maxHeight = "";
-              }
+            if (canCloseWithIndicator) {
+              handleChangeDialog(
+                PaperDialogState.Minimized,
+                PaperDialogTrigger.Resize
+              );
+              setShowTitlebar(true);
+              setTimeout(() => {
+                // Clear inline styles so Framer Motion takes back control
+                if (dialogRef.current) {
+                  dialogRef.current.style.minHeight = "";
+                  dialogRef.current.style.maxHeight = "";
+                }
 
-              if (contentRef.current) {
-                contentRef.current.style.height = "";
-                contentRef.current.style.maxHeight = "";
-              }
-              setResizeHeight(null);
-            }, 300);
+                if (contentRef.current) {
+                  contentRef.current.style.height = "";
+                  contentRef.current.style.maxHeight = "";
+                }
+                setResizeHeight(null);
+              }, 300);
+            }
 
             // Fast flick upward → animate smoothly to max height
           } else if (velocityRef.current < -0.5) {
@@ -445,14 +455,17 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
     );
 
     const closeDialog = useCallback(
-      async (withTimeout: boolean, trigger: PaperDialogTrigger) => {
+      async (
+        { withMinimize, withTimeout }: PaperDialogCloseOption,
+        trigger: PaperDialogTrigger
+      ) => {
         const close = async () =>
           await handleChangeDialog(PaperDialogState.Closed, trigger);
 
         await setResizeHeight(null);
         await setResizeWidth(null);
 
-        if (withTimeout) {
+        if (withMinimize) {
           await handleChangeDialog(PaperDialogState.Minimized, trigger);
 
           if (withTimeout) {
@@ -468,19 +481,19 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
     );
 
     useImperativeHandle(ref, () => ({
-      openDialog: async () => {
-        await handleChangeDialog(
-          PaperDialogState.Restored,
-          PaperDialogTrigger.Api
-        );
+      openDialog: () => {
+        handleChangeDialog(PaperDialogState.Restored, PaperDialogTrigger.API);
       },
-      closeDialog: (withTimeout?: boolean) =>
-        closeDialog(withTimeout, PaperDialogTrigger.Api),
-      minimizeDialog: async () => {
-        await handleChangeDialog(
-          PaperDialogState.Minimized,
-          PaperDialogTrigger.Api
-        );
+      closeDialog: ({ withMinimize, withTimeout }: PaperDialogCloseOption) =>
+        closeDialog(
+          {
+            withMinimize,
+            withTimeout,
+          },
+          PaperDialogTrigger.API
+        ),
+      minimizeDialog: () => {
+        handleChangeDialog(PaperDialogState.Minimized, PaperDialogTrigger.API);
       },
     }));
 
@@ -491,7 +504,10 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
           canCloseWithEscape &&
           (dialogState === "restored" || dialogState === "minimized")
         ) {
-          closeDialog(false, PaperDialogTrigger.Escape);
+          closeDialog(
+            { withMinimize: false, withTimeout: false },
+            PaperDialogTrigger.Escape
+          );
           setShowTitlebar(false);
         }
       },
@@ -516,7 +532,10 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 await preventDefault();
                 if (canCloseWithOverlay) {
                   await setShowTitlebar(false);
-                  await closeDialog(true, PaperDialogTrigger.Overlay);
+                  await closeDialog(
+                    { withMinimize: true, withTimeout: true },
+                    PaperDialogTrigger.Overlay
+                  );
                   await close();
                 }
               }}
@@ -574,7 +593,10 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                           size: icons?.closeIcon?.size ?? 18,
                         },
                         onClick: () => {
-                          closeDialog(false, PaperDialogTrigger.Control);
+                          closeDialog(
+                            { withMinimize: false, withTimeout: false },
+                            PaperDialogTrigger.Control
+                          );
                         },
                       },
                     ],
@@ -622,15 +644,6 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             dragControls={dragControls}
             dragConstraints={{ top: 0, bottom: 0 }}
             dragElastic={{ top: 0, bottom: 0.6 }}
-            onDragEnd={(_, info) => {
-              if (info.offset.y > 120 || info.velocity.y > 500) {
-                handleChangeDialog(
-                  PaperDialogState.Minimized,
-                  PaperDialogTrigger.Drag
-                );
-                setShowTitlebar(true);
-              }
-            }}
             whileDrag={{ cursor: "grabbing", userSelect: "none" }}
           >
             {resizable && !mobile && (
@@ -650,7 +663,10 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 $isLeft={isLeft}
                 $theme={paperDialogTheme}
                 onClick={() => {
-                  closeDialog(false, PaperDialogTrigger.Control);
+                  closeDialog(
+                    { withMinimize: false, withTimeout: false },
+                    PaperDialogTrigger.Control
+                  );
                 }}
                 $style={styles?.closeButtonStyle}
                 aria-label="paper-dialog-toggle-close"
@@ -718,7 +734,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 onPointerDown={(e) => {
                   if (resizable) {
                     handleMobileResizePointerDown(e);
-                  } else if (closable) {
+                  } else if (!!closable) {
                     dragControls.start(e);
                   }
                 }}

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -607,6 +607,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             {resizable && !mobile && (
               <DesktopResizeHandle
                 $isLeft={isLeft}
+                $style={styles?.indicatorStyle}
                 onPointerDown={handleDesktopResizePointerDown}
                 aria-label="paper-dialog-resize-handle"
               />
@@ -681,6 +682,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
               <DragIndicatorWrapper
                 aria-label="paper-dialog-drag-indicator"
                 $resizable={!!resizable}
+                $style={styles?.indicatorStyle}
                 onPointerDown={(e) => {
                   if (resizable) {
                     handleMobileResizePointerDown(e);
@@ -837,7 +839,7 @@ const MotionDialog = styled(motion.div)<{
   ${({ $style }) => $style};
 `;
 
-const DesktopResizeHandle = styled.div<{ $isLeft: boolean }>`
+const DesktopResizeHandle = styled.div<{ $isLeft: boolean; $style?: CSSProp }>`
   touch-action: none;
   position: absolute;
   top: 0;
@@ -862,6 +864,8 @@ const DesktopResizeHandle = styled.div<{ $isLeft: boolean }>`
   &:active {
     background-color: rgba(128, 128, 128, 0.18);
   }
+
+  ${({ $style }) => $style}
 `;
 
 const ActionButtonWrapper = styled.div<{
@@ -998,7 +1002,7 @@ const DragIndicatorWrapper = styled(motion.div)<{
     cursor: ${({ $resizable }) => ($resizable ? "ns-resize" : "grabbing")};
   }
 
-  ${({ $style }) => $style}
+  ${({ $style }) => $style};
 `;
 
 const DragIndicator = styled(motion.div)<{

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -32,6 +32,18 @@ export const PaperDialogState = {
 export type PaperDialogState =
   (typeof PaperDialogState)[keyof typeof PaperDialogState];
 
+export const PaperDialogTrigger = {
+  Api: "api",
+  Overlay: "overlay",
+  Escape: "escape",
+  Drag: "drag",
+  Resize: "resize",
+  Control: "control",
+} as const;
+
+export type PaperDialogTrigger =
+  (typeof PaperDialogTrigger)[keyof typeof PaperDialogTrigger];
+
 export const PaperDialogPosition = {
   Left: "left",
   Right: "right",
@@ -45,7 +57,7 @@ export interface PaperDialogProps {
   children?: ReactNode;
   closable?: boolean | PaperDialogClosable;
   styles?: PaperDialogStyles;
-  onChange?: (state: PaperDialogState) => void;
+  onChange?: (state: PaperDialogState, trigger?: PaperDialogTrigger) => void;
   icons?: PaperDialogIcons;
   id?: string;
   className?: string;
@@ -345,7 +357,10 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
           window.removeEventListener("pointerup", onUp);
 
           if (velocityRef.current > 0.5) {
-            handleChangeDialog("minimized");
+            handleChangeDialog(
+              PaperDialogState.Minimized,
+              PaperDialogTrigger.Resize
+            );
             setShowTitlebar(true);
             setTimeout(() => {
               // Clear inline styles so Framer Motion takes back control
@@ -420,24 +435,25 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
     const resolvedHeight = resizeHeight != null ? `${resizeHeight}px` : height;
 
     const handleChangeDialog = useCallback(
-      (state: PaperDialogState) => {
+      (state: PaperDialogState, trigger: PaperDialogTrigger) => {
         setDialogState(state);
         if (onChange) {
-          onChange(state);
+          onChange(state, trigger);
         }
       },
       [setDialogState, onChange]
     );
 
     const closeDialog = useCallback(
-      async (withTimeout: boolean = true) => {
-        const close = async () => await handleChangeDialog("closed");
+      async (withTimeout: boolean = true, trigger: PaperDialogTrigger) => {
+        const close = async () =>
+          await handleChangeDialog(PaperDialogState.Closed, trigger);
 
         await setResizeHeight(null);
         await setResizeWidth(null);
 
         if (withTimeout) {
-          await handleChangeDialog("minimized");
+          await handleChangeDialog(PaperDialogState.Minimized, trigger);
 
           if (withTimeout) {
             setTimeout(close, 400);
@@ -453,11 +469,18 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
 
     useImperativeHandle(ref, () => ({
       openDialog: async () => {
-        await handleChangeDialog("restored");
+        await handleChangeDialog(
+          PaperDialogState.Restored,
+          PaperDialogTrigger.Api
+        );
       },
-      closeDialog: (withTimeout?: boolean) => closeDialog(withTimeout),
+      closeDialog: (withTimeout?: boolean) =>
+        closeDialog(withTimeout, PaperDialogTrigger.Api),
       minimizeDialog: async () => {
-        await handleChangeDialog("minimized");
+        await handleChangeDialog(
+          PaperDialogState.Minimized,
+          PaperDialogTrigger.Api
+        );
       },
     }));
 
@@ -468,7 +491,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
           canCloseWithEscape &&
           (dialogState === "restored" || dialogState === "minimized")
         ) {
-          closeDialog();
+          closeDialog(true, PaperDialogTrigger.Escape);
           setShowTitlebar(false);
         }
       },
@@ -493,12 +516,12 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 await preventDefault();
                 if (canCloseWithOverlay) {
                   await setShowTitlebar(false);
-                  await closeDialog();
+                  await closeDialog(true, PaperDialogTrigger.Overlay);
                   await close();
                 }
               }}
               styles={{ self: styles?.overlayStyle }}
-              show={dialogState === "restored"}
+              show={dialogState === PaperDialogState.Restored}
             />
           )}
 
@@ -506,7 +529,10 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             <MiniTitleBar
               $theme={paperDialogTheme}
               onClick={() => {
-                handleChangeDialog("restored");
+                handleChangeDialog(
+                  PaperDialogState.Restored,
+                  PaperDialogTrigger.Control
+                );
                 setShowTitlebar(false);
               }}
               initial={{ y: "100%" }}
@@ -548,7 +574,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                           size: icons?.closeIcon?.size ?? 18,
                         },
                         onClick: () => {
-                          handleChangeDialog("closed");
+                          closeDialog(false, PaperDialogTrigger.Control);
                         },
                       },
                     ],
@@ -598,7 +624,10 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             dragElastic={{ top: 0, bottom: 0.6 }}
             onDragEnd={(_, info) => {
               if (info.offset.y > 120 || info.velocity.y > 500) {
-                handleChangeDialog("minimized");
+                handleChangeDialog(
+                  PaperDialogState.Minimized,
+                  PaperDialogTrigger.Drag
+                );
                 setShowTitlebar(true);
               }
             }}
@@ -621,7 +650,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 $isLeft={isLeft}
                 $theme={paperDialogTheme}
                 onClick={() => {
-                  closeDialog();
+                  closeDialog(true, PaperDialogTrigger.Control);
                 }}
                 $style={styles?.closeButtonStyle}
                 aria-label="paper-dialog-toggle-close"
@@ -645,7 +674,8 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 $style={styles?.minimizeButtonStyle}
                 onClick={() => {
                   handleChangeDialog(
-                    dialogState === "minimized" ? "restored" : "minimized"
+                    dialogState === "minimized" ? "restored" : "minimized",
+                    PaperDialogTrigger.Control
                   );
                   setShowTitlebar(true);
                 }}

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -38,8 +38,7 @@ export type PaperDialogState =
  * - API     — called programmatically via PaperDialogRef (openDialog/closeDialog/minimizeDialog)
  * - Overlay — clicked the backdrop behind the dialog
  * - Escape  — pressed the Escape key
- * - Drag    — swiped the mobile drag-indicator to dismiss (with resizable false)
- * - Resize  — fast flick while resizing (mobile) that snapped to minimized instead of resizing
+ * - Drag    — swiped the mobile drag-indicator to dismiss
  * - Control — used an in-dialog control (close button, minimize/restore button, mini title bar tap)
  */
 export const PaperDialogTrigger = {
@@ -47,7 +46,6 @@ export const PaperDialogTrigger = {
   Overlay: "overlay",
   Escape: "escape",
   Drag: "drag",
-  Resize: "resize",
   Control: "control",
 } as const;
 
@@ -378,7 +376,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             if (canCloseWithIndicator) {
               handleChangeDialog(
                 PaperDialogState.Minimized,
-                PaperDialogTrigger.Resize
+                PaperDialogTrigger.Drag
               );
               setShowTitlebar(true);
               setTimeout(() => {
@@ -759,7 +757,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 onPointerDown={(e) => {
                   if (resizable) {
                     handleMobileResizePointerDown(e);
-                  } else if (canCloseWithButton) {
+                  } else if (canCloseWithIndicator) {
                     dragControls.start(e);
                   }
                 }}

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -32,6 +32,16 @@ export const PaperDialogState = {
 export type PaperDialogState =
   (typeof PaperDialogState)[keyof typeof PaperDialogState];
 
+/**
+ * PaperDialogTrigger — identifies what caused a dialog state change (passed to onChange).
+ *
+ * - API     — called programmatically via PaperDialogRef (openDialog/closeDialog/minimizeDialog)
+ * - Overlay — clicked the backdrop behind the dialog
+ * - Escape  — pressed the Escape key
+ * - Drag    — swiped the mobile drag-indicator to dismiss (with resizable false)
+ * - Resize  — fast flick while resizing (mobile) that snapped to minimized instead of resizing
+ * - Control — used an in-dialog control (close button, minimize/restore button, mini title bar tap)
+ */
 export const PaperDialogTrigger = {
   API: "api",
   Overlay: "overlay",

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -755,6 +755,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 aria-label="paper-dialog-drag-indicator"
                 $resizable={!!resizable}
                 $style={styles?.indicatorStyle}
+                $width={resolvedWidth}
                 onPointerDown={(e) => {
                   if (resizable) {
                     handleMobileResizePointerDown(e);
@@ -1048,6 +1049,7 @@ const DragIndicatorWrapper = styled(motion.div)<{
   $theme?: PaperDialogThemeConfig;
   $style?: CSSProp;
   $resizable?: boolean;
+  $width?: string;
 }>`
   *,
   ::before,
@@ -1064,11 +1066,17 @@ const DragIndicatorWrapper = styled(motion.div)<{
   touch-action: none;
 
   cursor: ${({ $resizable }) => ($resizable ? "ns-resize" : "grab")};
-  width: 100dvw;
   height: 60px;
   align-items: center;
   border-radius: 1.2rem 1.2rem 0 0;
   background-color: ${({ $theme }) => $theme?.backgroundColor};
+
+  ${({ $width }) =>
+    $width &&
+    css`
+      min-width: ${$width ?? "100dvw"};
+      max-width: ${$width ?? "100dvw"};
+    `}
 
   &:active {
     cursor: ${({ $resizable }) => ($resizable ? "ns-resize" : "grabbing")};

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -645,6 +645,20 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             dragConstraints={{ top: 0, bottom: 0 }}
             dragElastic={{ top: 0, bottom: 0.6 }}
             whileDrag={{ cursor: "grabbing", userSelect: "none" }}
+            onDragEnd={(_, info) => {
+              // For non-resizable dialogs, only allow swipe-to-minimize
+              // when the indicator is enabled.
+              if (
+                (info.offset.y > 120 || info.velocity.y > 500) &&
+                canCloseWithIndicator
+              ) {
+                handleChangeDialog(
+                  PaperDialogState.Minimized,
+                  PaperDialogTrigger.Drag
+                );
+                setShowTitlebar(true);
+              }
+            }}
           >
             {resizable && !mobile && (
               <DesktopResizeHandle
@@ -734,7 +748,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 onPointerDown={(e) => {
                   if (resizable) {
                     handleMobileResizePointerDown(e);
-                  } else if (!!closable) {
+                  } else if (canCloseWithButton) {
                     dragControls.start(e);
                   }
                 }}

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -650,7 +650,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 $isLeft={isLeft}
                 $theme={paperDialogTheme}
                 onClick={() => {
-                  closeDialog(true, PaperDialogTrigger.Control);
+                  closeDialog(false, PaperDialogTrigger.Control);
                 }}
                 $style={styles?.closeButtonStyle}
                 aria-label="paper-dialog-toggle-close"
@@ -674,7 +674,9 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
                 $style={styles?.minimizeButtonStyle}
                 onClick={() => {
                   handleChangeDialog(
-                    dialogState === "minimized" ? "restored" : "minimized",
+                    dialogState === PaperDialogState.Minimized
+                      ? PaperDialogState.Restored
+                      : PaperDialogState.Minimized,
                     PaperDialogTrigger.Control
                   );
                   setShowTitlebar(true);

--- a/components/paper-dialog.tsx
+++ b/components/paper-dialog.tsx
@@ -43,7 +43,7 @@ export type PaperDialogPosition =
 export interface PaperDialogProps {
   position?: PaperDialogPosition;
   children?: ReactNode;
-  closable?: boolean;
+  closable?: boolean | PaperDialogClosable;
   styles?: PaperDialogStyles;
   onChange?: (state: PaperDialogState) => void;
   icons?: PaperDialogIcons;
@@ -60,6 +60,12 @@ export interface PaperDialogProps {
   onResizeComplete?: (size: { width?: number; height?: number }) => void;
   initialDialogState?: PaperDialogState;
   skipInitialAnimation?: boolean;
+}
+
+export interface PaperDialogClosable {
+  withOverlay?: boolean;
+  withEscape?: boolean;
+  withButton?: boolean;
 }
 
 export interface PaperDialogResizable {
@@ -135,6 +141,25 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
   ) => {
     const { currentTheme } = useTheme();
     const paperDialogTheme = currentTheme.paperDialog;
+
+    // `closable` supports:
+    // - `false`: disable all closing behaviors.
+    // - `true` or `undefined`: enable all closing behaviors.
+    // - `{ withEscape, withOverlay, withButton }`: configure each behavior individually.
+    // withTimeout meaning can close without animation, if true, it would
+    // use animation inside of close behavior
+    const {
+      withEscape = true,
+      withOverlay = true,
+      withButton = true,
+    } = typeof closable === "object" ? closable : {};
+
+    const canCloseWithEscape =
+      closable !== false && (typeof closable !== "object" || withEscape);
+    const canCloseWithOverlay =
+      closable !== false && (typeof closable !== "object" || withOverlay);
+    const canCloseWithButton =
+      closable !== false && (typeof closable !== "object" || withButton);
 
     const contentRef = useRef<HTMLDivElement>(null);
 
@@ -411,7 +436,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
         await setResizeHeight(null);
         await setResizeWidth(null);
 
-        if (mobile) {
+        if (withTimeout) {
           await handleChangeDialog("minimized");
 
           if (withTimeout) {
@@ -440,7 +465,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
       (e: KeyboardEvent) => {
         if (
           e.key === "Escape" &&
-          closable &&
+          canCloseWithEscape &&
           (dialogState === "restored" || dialogState === "minimized")
         ) {
           closeDialog();
@@ -466,7 +491,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
             <OverlayBlocker
               onClick={async ({ preventDefault, close }) => {
                 await preventDefault();
-                if (closable) {
+                if (canCloseWithOverlay) {
                   await setShowTitlebar(false);
                   await closeDialog();
                   await close();
@@ -587,7 +612,7 @@ const PaperDialog = forwardRef<PaperDialogRef, PaperDialogProps>(
               />
             )}
 
-            {closable && controls?.includes("close") && (
+            {canCloseWithButton && controls?.includes("close") && (
               <ActionButtonWrapper
                 $indexAction={0}
                 $mobile={mobile}

--- a/components/screen-transition.stories.tsx
+++ b/components/screen-transition.stories.tsx
@@ -29,6 +29,8 @@ Each screen automatically receives \`goToScreen\` and \`goBack\` callbacks, allo
 - ⬅️ Built-in back navigation
 - 🎬 Smooth open and close dialog animations
 - 🔄 Restores previously mounted screens without replaying opening animations
+- 📐 Per-screen width and height customization
+- 🎨 Customizable dialog indicator and content styles
 - 🧩 Fully controlled navigation state
 - 🛡️ Warns when navigating to unregistered screens
 
@@ -60,11 +62,26 @@ Every screen that can be displayed must be registered through the \`screens\` pr
 
 Each key acts as the unique identifier used during navigation.
 
+A screen may be registered directly as a component or as a configuration object.
+
 \`\`\`tsx
 const screens = {
   home: HomeScreen,
   profile: ProfileScreen,
-  settings: SettingsScreen,
+  settings: {
+    component: SettingsScreen,
+  },
+};
+\`\`\`
+
+The configuration object supports additional presentation options.
+
+\`\`\`ts
+type ScreenConfig = {
+  component: ComponentType<Partial<ScreenProps>>;
+  sheet?: boolean | Omit<PaperDialogResizable, "minWidth" | "maxWidth">;
+  width?: string;
+  height?: string;
 };
 \`\`\`
 
@@ -161,8 +178,6 @@ Each dialog maintains its own animation while remaining synchronized with the na
 
 ---
 
----
-
 #### Sheet Presentation
 
 By default, every screen is presented as a full-screen \`PaperDialog\`. Alternatively, a screen can be configured to appear as a sheet by providing a configuration object instead of a component.
@@ -213,6 +228,63 @@ const screens = {
 \`\`\`
 
 This allows \`ScreenTransition\` to present a mixture of full-screen pages and sheets while using the same navigation API.
+
+---
+
+#### Screen Dimensions
+
+Individual screens can customize their dialog size using the \`width\` and \`height\` properties.
+
+\`\`\`tsx
+const screens = {
+  detail: {
+    component: DetailScreen,
+    width: "480px",
+    height: "600px",
+  },
+};
+\`\`\`
+
+If omitted:
+
+- \`width\` defaults to \`100dvw\`
+- Full-screen dialogs default to \`100dvh\`
+- Sheet dialogs default to \`80dvh\`
+
+These options allow desktop-style dialogs while keeping other screens full-screen or presented as sheets.
+
+---
+
+#### Custom Styles
+
+Additional styles can be applied to the underlying \`PaperDialog\` without introducing wrapper elements.
+
+\`\`\`tsx
+<ScreenTransition
+  screens={screens}
+  activeScreens={activeScreens}
+  onScreenChange={setActiveScreens}
+  styles={{
+    indicatorStyle: css\`
+      height: 40px;
+    \`,
+    contentStyle: css\`
+      padding: 0;
+      min-width: 350px;
+      max-width: 400px;
+    \`,
+  }}
+/>
+\`\`\`
+
+The \`styles\` prop supports:
+
+- \`indicatorStyle\` — styles applied to the dialog indicator.
+- \`contentStyle\` — styles applied to the dialog content container.
+
+This provides additional flexibility while preserving the default dialog structure.
+
+---
 
 #### Initial Screen Restoration
 
@@ -274,11 +346,13 @@ ScreenTransition: screen "profile" is not registered
 - Use for mobile-style navigation within a single page.
 - Keep the navigation stack in parent state.
 - Register every available screen inside the \`screens\` prop.
+- Use a configuration object when customizing presentation, dimensions, or sheet behavior.
 - Navigate using \`goToScreen\` instead of mutating \`activeScreens\` directly.
 - Use \`goBack\` so closing animations always play correctly.
 - Restore navigation state by initializing \`activeScreens\` with multiple screen keys.
+- Use the \`styles\` prop to customize the dialog appearance without additional wrapper elements.
 - Keep individual screen components focused on UI and navigation only, leaving state management to the parent component.
-        `,
+`,
       },
     },
   },

--- a/components/screen-transition.stories.tsx
+++ b/components/screen-transition.stories.tsx
@@ -82,6 +82,7 @@ type ScreenConfig = {
   sheet?: boolean | Omit<PaperDialogResizable, "minWidth" | "maxWidth">;
   width?: string;
   height?: string;
+  closable?: boolean
 };
 \`\`\`
 

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -11,6 +11,7 @@ import {
   PaperDialogResizable,
   PaperDialogState,
   PaperDialogStyles,
+  PaperDialogTrigger,
 } from "./paper-dialog";
 import { css } from "styled-components";
 
@@ -116,14 +117,11 @@ function ScreenTransition<TScreens extends ScreensMap>({
       // for minimizing
       closingIndicesRef.current.add(topIndex);
       if (!withTimeout) {
-        ref?.current?.minimizeDialog();
+        ref?.current?.closeDialog(true);
       }
 
-      setTimeout(async () => {
-        await ref?.current?.closeDialog();
-        if (closingIndicesRef.current.has(topIndex)) {
-          await onScreenChange(activeScreens.slice(0, -1));
-        }
+      setTimeout(() => {
+        onScreenChange(activeScreens.slice(0, -1));
         closingIndicesRef.current!.delete(topIndex);
         mountedIndicesRef.current!.delete(topIndex);
       }, 300);
@@ -159,11 +157,7 @@ function ScreenTransition<TScreens extends ScreensMap>({
         styles={styles}
         dialogRef={getDialogRef(index)}
         skipInitialAnimation={skipInitialAnimation}
-        onClosed={
-          config?.sheet || config?.width
-            ? () => goBack?.(!!config?.sheet || !!config?.width)
-            : undefined
-        }
+        onClosed={() => goBack?.(true)}
         sheet={config?.sheet}
         width={config?.width}
         height={config?.height}
@@ -241,13 +235,15 @@ function DialogLevel({
       resizable={sheet}
       initialDialogState={skipInitialAnimation ? "restored" : "closed"}
       skipInitialAnimation={skipInitialAnimation}
-      onChange={
-        sheet || width
-          ? (state: PaperDialogState) => {
-              if (state === "minimized") onClosed?.();
-            }
-          : undefined
-      }
+      onChange={(state: PaperDialogState, trigger: PaperDialogTrigger) => {
+        if (
+          (state === PaperDialogState.Minimized &&
+            trigger === PaperDialogTrigger.Overlay) ||
+          (state === PaperDialogState.Minimized &&
+            trigger === PaperDialogTrigger.Resize)
+        )
+          onClosed?.();
+      }}
     >
       {children}
     </PaperDialog>

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -111,7 +111,7 @@ function ScreenTransition<TScreens extends ScreensMap>({
       // and resetting the minimized state. When the dialog is closed via the
       // drag indicator, the required close behavior is already handled.
       if (!skipCloseDialog) {
-        ref?.current?.closeDialog(true);
+        ref?.current?.closeDialog({ withMinimize: true, withTimeout: true });
       }
 
       setTimeout(() => {

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -50,7 +50,7 @@ export interface ScreenTransitionProps<TScreens extends ScreensMap> {
 
 export type ScreenTransitionStyles = Pick<
   PaperDialogStyles,
-  "indicatorStyle" | "contentStyle"
+  "indicatorStyle" | "contentStyle" | "containerStyle"
 >;
 
 function ScreenTransition<TScreens extends ScreensMap>({
@@ -221,6 +221,7 @@ function DialogLevel({
   return (
     <PaperDialog
       styles={{
+        containerStyle: styles?.containerStyle,
         indicatorStyle: styles?.indicatorStyle,
         contentStyle: css`
           gap: 0px;

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -159,11 +159,7 @@ function ScreenTransition<TScreens extends ScreensMap>({
         styles={styles}
         dialogRef={getDialogRef(index)}
         skipInitialAnimation={skipInitialAnimation}
-        onClosed={
-          config?.sheet || config?.width
-            ? () => goBack?.(!!config?.sheet || !!config?.width)
-            : undefined
-        }
+        onClosed={() => goBack?.(true)}
         sheet={config?.sheet}
         width={config?.width}
         height={config?.height}

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -99,31 +99,23 @@ function ScreenTransition<TScreens extends ScreensMap>({
     [screens, activeScreens, onScreenChange]
   );
 
-  // Tracks dialog indices currently being closed via goBack(), so that
-  // re-entrant onChange("minimized") events fired internally by
-  // minimizeDialog()/closeDialog() don't call onClosed -> goBack() again
-  // and cause an infinite/duplicate close loop.
-  const closingIndicesRef = useRef<Set<number>>(new Set());
-
   const goBack = useCallback(
-    (withTimeout?: boolean) => {
+    (skipCloseDialog?: boolean) => {
       if (activeScreens.length === 0) return;
 
       const topIndex = activeScreens.length - 1; // the dialog wrapping the top screen
       const ref = dialogRefsRef.current.get(topIndex);
 
-      // this preventing the condition mobile case for onChanges
-      // so we don't use this, because would be re-render minimize state
-      // and if closed with drag indicator still enough not trigger ref
-      // for minimizing
-      closingIndicesRef.current.add(topIndex);
-      if (!withTimeout) {
+      // Prevent triggering `closeDialog` on mobile.
+      // Calling it would fire `onChange`, causing an unnecessary re-render
+      // and resetting the minimized state. When the dialog is closed via the
+      // drag indicator, the required close behavior is already handled.
+      if (!skipCloseDialog) {
         ref?.current?.closeDialog(true);
       }
 
       setTimeout(() => {
         onScreenChange(activeScreens.slice(0, -1));
-        closingIndicesRef.current!.delete(topIndex);
         mountedIndicesRef.current!.delete(topIndex);
       }, 300);
     },

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -159,7 +159,11 @@ function ScreenTransition<TScreens extends ScreensMap>({
         styles={styles}
         dialogRef={getDialogRef(index)}
         skipInitialAnimation={skipInitialAnimation}
-        onClosed={() => goBack?.(true)}
+        onClosed={
+          config?.sheet || config?.width
+            ? () => goBack?.(!!config?.sheet || !!config?.width)
+            : undefined
+        }
         sheet={config?.sheet}
         width={config?.width}
         height={config?.height}

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -25,6 +25,7 @@ type ScreensComponent = ComponentType<Partial<ScreenProps>>;
 type ScreenConfig = {
   component: ScreensComponent;
   sheet?: ScreenSheetConfig;
+  closable?: boolean;
   width?: string;
   height?: string;
 };
@@ -161,6 +162,7 @@ function ScreenTransition<TScreens extends ScreensMap>({
         sheet={config?.sheet}
         width={config?.width}
         height={config?.height}
+        closable={config?.closable}
       >
         <ScreenComponent {...screenProps} />
         {index < activeScreens.length - 1 && renderStack(index + 1)}
@@ -192,6 +194,7 @@ function DialogLevel({
   styles,
   height,
   width,
+  closable,
 }: {
   dialogRef: React.RefObject<PaperDialogRef | null>;
   children: ReactNode;
@@ -201,6 +204,7 @@ function DialogLevel({
   styles?: ScreenTransitionStyles;
   height?: string;
   width?: string;
+  closable?: boolean;
 }) {
   useEffect(() => {
     // Only animate-open if this dialog wasn't pre-existing/already mounted.
@@ -226,7 +230,7 @@ function DialogLevel({
       closable={{
         withButton: false,
         withEscape: false,
-        withOverlay: true,
+        withOverlay: (sheet ? true : closable) ?? false,
       }}
       controls={[]}
       width={finalWidth}

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -229,7 +229,7 @@ function DialogLevel({
       width={finalWidth}
       height={finalHeight}
       mobile={!!sheet}
-      resizable={sheet}
+      resizable={!!sheet}
       initialDialogState={skipInitialAnimation ? "restored" : "closed"}
       skipInitialAnimation={skipInitialAnimation}
       onChange={(state: PaperDialogState, trigger: PaperDialogTrigger) => {
@@ -237,7 +237,7 @@ function DialogLevel({
           (state === PaperDialogState.Minimized &&
             trigger === PaperDialogTrigger.Overlay) ||
           (state === PaperDialogState.Minimized &&
-            trigger === PaperDialogTrigger.Resize)
+            trigger === PaperDialogTrigger.Drag)
         )
           onClosed?.();
       }}

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -10,6 +10,7 @@ import {
   PaperDialogRef,
   PaperDialogResizable,
   PaperDialogState,
+  PaperDialogStyles,
 } from "./paper-dialog";
 import { css } from "styled-components";
 
@@ -23,6 +24,8 @@ type ScreensComponent = ComponentType<Partial<ScreenProps>>;
 type ScreenConfig = {
   component: ScreensComponent;
   sheet?: ScreenSheetConfig;
+  width?: string;
+  height?: string;
 };
 
 type ScreenSheetConfig =
@@ -40,12 +43,21 @@ export interface ScreenTransitionProps<TScreens extends ScreensMap> {
   activeScreens: (keyof TScreens)[] | string[];
   /** Called with the next stack whenever navigation happens */
   onScreenChange: (screens: (keyof TScreens)[]) => void;
+  /** styles for screen transition*/
+  styles?: ScreenTransitionStyles;
+  /** initial size when needed, for sheet and normal appearance */
 }
+
+export type ScreenTransitionStyles = Pick<
+  PaperDialogStyles,
+  "indicatorStyle" | "contentStyle"
+>;
 
 function ScreenTransition<TScreens extends ScreensMap>({
   screens,
   activeScreens = [],
   onScreenChange,
+  styles,
 }: ScreenTransitionProps<TScreens>) {
   const dialogRefsRef = useRef<
     Map<number, React.RefObject<PaperDialogRef | null>>
@@ -92,7 +104,7 @@ function ScreenTransition<TScreens extends ScreensMap>({
   const closingIndicesRef = useRef<Set<number>>(new Set());
 
   const goBack = useCallback(
-    (mobile?: boolean) => {
+    (withTimeout?: boolean) => {
       if (activeScreens.length === 0) return;
 
       const topIndex = activeScreens.length - 1; // the dialog wrapping the top screen
@@ -103,7 +115,7 @@ function ScreenTransition<TScreens extends ScreensMap>({
       // and if closed with drag indicator still enough not trigger ref
       // for minimizing
       closingIndicesRef.current.add(topIndex);
-      if (!mobile) {
+      if (!withTimeout) {
         ref?.current?.minimizeDialog();
       }
 
@@ -144,10 +156,17 @@ function ScreenTransition<TScreens extends ScreensMap>({
     return (
       <DialogLevel
         key={index}
+        styles={styles}
         dialogRef={getDialogRef(index)}
         skipInitialAnimation={skipInitialAnimation}
-        onClosed={config?.sheet ? () => goBack?.(!!config?.sheet) : undefined}
+        onClosed={
+          config?.sheet || config?.width
+            ? () => goBack?.(!!config?.sheet || !!config?.width)
+            : undefined
+        }
         sheet={config?.sheet}
+        width={config?.width}
+        height={config?.height}
       >
         <ScreenComponent {...screenProps} />
         {index < activeScreens.length - 1 && renderStack(index + 1)}
@@ -176,12 +195,18 @@ function DialogLevel({
   skipInitialAnimation,
   sheet,
   onClosed,
+  styles,
+  height,
+  width,
 }: {
   dialogRef: React.RefObject<PaperDialogRef | null>;
   children: ReactNode;
   skipInitialAnimation?: boolean;
   sheet?: ScreenSheetConfig;
   onClosed?: () => void;
+  styles?: ScreenTransitionStyles;
+  height?: string;
+  width?: string;
 }) {
   useEffect(() => {
     // Only animate-open if this dialog wasn't pre-existing/already mounted.
@@ -190,24 +215,33 @@ function DialogLevel({
     }
   }, [dialogRef, skipInitialAnimation]);
 
+  const finalWidth = width ? width : "100dvw";
+  const finalHeight = height ? height : sheet ? "80dvh" : "100dvh";
+
   return (
     <PaperDialog
       styles={{
+        indicatorStyle: styles?.indicatorStyle,
         contentStyle: css`
           gap: 0px;
+          ${styles?.contentStyle}
         `,
       }}
       ref={dialogRef}
-      closable={false}
+      closable={{
+        withButton: false,
+        withEscape: false,
+        withOverlay: true,
+      }}
       controls={[]}
-      width={"100dvw"}
-      height={sheet ? "80dvh" : "100dvh"}
+      width={finalWidth}
+      height={finalHeight}
       mobile={!!sheet}
       resizable={sheet}
       initialDialogState={skipInitialAnimation ? "restored" : "closed"}
       skipInitialAnimation={skipInitialAnimation}
       onChange={
-        sheet
+        sheet || width
           ? (state: PaperDialogState) => {
               if (state === "minimized") onClosed?.();
             }

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -230,7 +230,7 @@ function DialogLevel({
       closable={{
         withButton: false,
         withEscape: false,
-        withOverlay: (sheet ? true : closable) ?? false,
+        withOverlay: closable ?? (sheet ? true : false),
       }}
       controls={[]}
       width={finalWidth}

--- a/components/screen-transition.tsx
+++ b/components/screen-transition.tsx
@@ -223,6 +223,7 @@ function DialogLevel({
         withButton: false,
         withEscape: false,
         withOverlay: closable ?? (sheet ? true : false),
+        withIndicator: closable,
       }}
       controls={[]}
       width={finalWidth}

--- a/test/component/screen-transition.cy.tsx
+++ b/test/component/screen-transition.cy.tsx
@@ -212,7 +212,7 @@ describe("Screen Transition", () => {
   context("screen config", () => {
     context("with sheet", () => {
       context("closable", () => {
-        context("when not given", () => {
+        context("when not given (by default is true)", () => {
           context("when clicking the overlay", () => {
             it("should close the screen", () => {
               cy.viewport(500, 700);
@@ -236,6 +236,44 @@ describe("Screen Transition", () => {
               );
 
               cy.findByLabelText("overlay-blocker").click({ force: true });
+
+              cy.findByLabelText("paper-dialog-wrapper").should("not.exist");
+            });
+          });
+
+          context("when drag the indicator", () => {
+            it("should close the screen", () => {
+              cy.viewport(500, 700);
+
+              const productWithSheetScreens: ScreensMap = {
+                a: PageA,
+                b: PageB,
+                c: { component: PageC, sheet: true },
+              };
+
+              cy.mount(
+                <ProductTransition
+                  screens={productWithSheetScreens}
+                  initializeScreen={["c"]}
+                />
+              );
+
+              cy.findByLabelText("paper-dialog-wrapper").should(
+                "have.css",
+                "height",
+                "560px"
+              );
+
+              cy.findByLabelText("paper-dialog-drag-indicator")
+                .realMouseDown({ position: "center" })
+                .realMouseMove(0, 50)
+                .wait(200)
+                .realMouseMove(0, 100)
+                .wait(200)
+                .realMouseMove(0, 150)
+                .wait(200)
+                .realMouseMove(0, 250)
+                .realMouseUp();
 
               cy.findByLabelText("paper-dialog-wrapper").should("not.exist");
             });
@@ -268,6 +306,49 @@ describe("Screen Transition", () => {
               cy.findByLabelText("overlay-blocker").click({ force: true });
 
               cy.findByLabelText("paper-dialog-wrapper").should("exist");
+            });
+          });
+
+          context("when drag the indicator", () => {
+            it("should not close the screen", () => {
+              cy.viewport(500, 700);
+
+              const productWithSheetScreens: ScreensMap = {
+                a: PageA,
+                b: PageB,
+                c: { component: PageC, sheet: true, closable: false },
+              };
+
+              cy.mount(
+                <ProductTransition
+                  screens={productWithSheetScreens}
+                  initializeScreen={["c"]}
+                />
+              );
+
+              cy.findByLabelText("paper-dialog-wrapper").should(
+                "have.css",
+                "height",
+                "560px"
+              );
+
+              cy.findByLabelText("paper-dialog-drag-indicator")
+                .realMouseDown({ position: "center" })
+                .realMouseMove(0, 50)
+                .wait(200)
+                .realMouseMove(0, 100)
+                .wait(200)
+                .realMouseMove(0, 150)
+                .wait(200)
+                .realMouseMove(0, 250)
+                .realMouseUp();
+
+              cy.findByLabelText("paper-dialog-wrapper").should("exist");
+              cy.findByLabelText("paper-dialog-wrapper").should(
+                "not.have.css",
+                "height",
+                "560px"
+              );
             });
           });
         });
@@ -322,7 +403,7 @@ describe("Screen Transition", () => {
 
     context("without sheet", () => {
       context("closable", () => {
-        context("when not given", () => {
+        context("when not given (by default is false)", () => {
           context("when clicking the overlay", () => {
             it("should not close the screen", () => {
               cy.viewport(500, 700);

--- a/test/component/screen-transition.cy.tsx
+++ b/test/component/screen-transition.cy.tsx
@@ -123,6 +123,7 @@ describe("Screen Transition", () => {
     initializeScreen = [],
     onScreenChange,
     screens,
+    styles,
   }: Partial<ProductTransitionProps<TScreens>>) {
     const [activeScreens, setActiveScreens] =
       useState<(keyof TScreens)[]>(initializeScreen);
@@ -143,10 +144,167 @@ describe("Screen Transition", () => {
             setActiveScreens(screens);
             onScreenChange?.(screens as ("a" | "b" | "c")[]);
           }}
+          styles={styles}
         />
       </>
     );
   }
+
+  context("styles", () => {
+    context("indicatorStyle", () => {
+      context("when given red color", () => {
+        it("renders the background with red color", () => {
+          cy.viewport(500, 700);
+
+          const productWithSheetScreens: ScreensMap = {
+            a: PageA,
+            b: PageB,
+            c: { component: PageC, sheet: true },
+          };
+
+          cy.mount(
+            <ProductTransition
+              screens={productWithSheetScreens}
+              initializeScreen={["c"]}
+              styles={{
+                indicatorStyle: css`
+                  background-color: red;
+                `,
+              }}
+            />
+          );
+
+          cy.findByLabelText("paper-dialog-drag-indicator").should(
+            "have.css",
+            "background-color",
+            "rgb(255, 0, 0)"
+          );
+        });
+      });
+    });
+
+    context("contentStyle", () => {
+      context("when given padding 20px", () => {
+        it("renders the content with padding 20px", () => {
+          cy.viewport(500, 700);
+
+          cy.mount(
+            <ProductTransition
+              screens={productScreen}
+              initializeScreen={["c"]}
+              styles={{
+                contentStyle: css`
+                  padding: 20px;
+                `,
+              }}
+            />
+          );
+          cy.findByLabelText("paper-dialog-content").should(
+            "have.css",
+            "padding",
+            "20px"
+          );
+        });
+      });
+    });
+  });
+
+  context("screen config", () => {
+    context("with sheet", () => {
+      it("renders with height 80dvh", () => {
+        cy.viewport(500, 700);
+
+        const productWithSheetScreens: ScreensMap = {
+          a: PageA,
+          b: PageB,
+          c: { component: PageC, sheet: true },
+        };
+
+        cy.mount(
+          <ProductTransition
+            screens={productWithSheetScreens}
+            initializeScreen={["c"]}
+          />
+        );
+        cy.findByLabelText("paper-dialog-wrapper").should(
+          "have.css",
+          "height",
+          "560px"
+        );
+      });
+      context("when given height 300px", () => {
+        it("renders the element with 300px", () => {
+          cy.viewport(500, 700);
+
+          const productWithSheetScreens: ScreensMap = {
+            a: PageA,
+            b: PageB,
+            c: { component: PageC, sheet: true, height: "300px" },
+          };
+
+          cy.mount(
+            <ProductTransition
+              screens={productWithSheetScreens}
+              initializeScreen={["c"]}
+            />
+          );
+          cy.findByLabelText("paper-dialog-wrapper").should(
+            "have.css",
+            "height",
+            "300px"
+          );
+        });
+      });
+    });
+
+    context("without sheet", () => {
+      it("renders with full width (100dvw)", () => {
+        cy.viewport(500, 700);
+
+        const productWithSheetScreens: ScreensMap = {
+          a: PageA,
+          b: PageB,
+          c: { component: PageC },
+        };
+
+        cy.mount(
+          <ProductTransition
+            screens={productWithSheetScreens}
+            initializeScreen={["c"]}
+          />
+        );
+        cy.findByLabelText("paper-dialog-wrapper").should(
+          "have.css",
+          "width",
+          "500px"
+        );
+      });
+
+      context("when given width 300px", () => {
+        it("renders the element with 300px", () => {
+          cy.viewport(500, 700);
+
+          const productWithSheetScreens: ScreensMap = {
+            a: PageA,
+            b: PageB,
+            c: { component: PageC, width: "300px" },
+          };
+
+          cy.mount(
+            <ProductTransition
+              screens={productWithSheetScreens}
+              initializeScreen={["c"]}
+            />
+          );
+          cy.findByLabelText("paper-dialog-wrapper").should(
+            "have.css",
+            "width",
+            "300px"
+          );
+        });
+      });
+    });
+  });
 
   context("screens", () => {
     context("when given sheet", () => {

--- a/test/component/screen-transition.cy.tsx
+++ b/test/component/screen-transition.cy.tsx
@@ -211,6 +211,68 @@ describe("Screen Transition", () => {
 
   context("screen config", () => {
     context("with sheet", () => {
+      context("closable", () => {
+        context("when not given", () => {
+          context("when clicking the overlay", () => {
+            it("should close the screen", () => {
+              cy.viewport(500, 700);
+
+              const productWithSheetScreens: ScreensMap = {
+                a: PageA,
+                b: PageB,
+                c: { component: PageC, sheet: true },
+              };
+
+              cy.mount(
+                <ProductTransition
+                  screens={productWithSheetScreens}
+                  initializeScreen={["c"]}
+                />
+              );
+              cy.findByLabelText("paper-dialog-wrapper").should(
+                "have.css",
+                "height",
+                "560px"
+              );
+
+              cy.findByLabelText("overlay-blocker").click({ force: true });
+
+              cy.findByLabelText("paper-dialog-wrapper").should("not.exist");
+            });
+          });
+        });
+
+        context("when given false", () => {
+          context("when clicking the overlay", () => {
+            it("should not close the screen", () => {
+              cy.viewport(500, 700);
+
+              const productWithSheetScreens: ScreensMap = {
+                a: PageA,
+                b: PageB,
+                c: { component: PageC, sheet: true, closable: false },
+              };
+
+              cy.mount(
+                <ProductTransition
+                  screens={productWithSheetScreens}
+                  initializeScreen={["c"]}
+                />
+              );
+              cy.findByLabelText("paper-dialog-wrapper").should(
+                "have.css",
+                "height",
+                "560px"
+              );
+
+              cy.findByLabelText("overlay-blocker").click({ force: true });
+
+              cy.findByLabelText("paper-dialog-wrapper").should("exist");
+            });
+          });
+        });
+      });
+
       it("renders with height 80dvh", () => {
         cy.viewport(500, 700);
 
@@ -232,6 +294,7 @@ describe("Screen Transition", () => {
           "560px"
         );
       });
+
       context("when given height 300px", () => {
         it("renders the element with 300px", () => {
           cy.viewport(500, 700);
@@ -258,6 +321,67 @@ describe("Screen Transition", () => {
     });
 
     context("without sheet", () => {
+      context("closable", () => {
+        context("when not given", () => {
+          context("when clicking the overlay", () => {
+            it("should not close the screen", () => {
+              cy.viewport(500, 700);
+
+              const productWithSheetScreens: ScreensMap = {
+                a: PageA,
+                b: PageB,
+                c: { component: PageC, width: "300px" },
+              };
+
+              cy.mount(
+                <ProductTransition
+                  screens={productWithSheetScreens}
+                  initializeScreen={["c"]}
+                />
+              );
+
+              cy.findByLabelText("paper-dialog-wrapper")
+                .should("have.css", "height", "700px")
+                .and("have.css", "width", "300px");
+
+              cy.findByLabelText("overlay-blocker").click({ force: true });
+
+              cy.findByLabelText("paper-dialog-wrapper").should("exist");
+            });
+          });
+        });
+
+        context("when given true", () => {
+          context("when clicking the overlay", () => {
+            it("should close the screen", () => {
+              cy.viewport(500, 700);
+
+              const productWithSheetScreens: ScreensMap = {
+                a: PageA,
+                b: PageB,
+                c: { component: PageC, sheet: true, closable: true },
+              };
+
+              cy.mount(
+                <ProductTransition
+                  screens={productWithSheetScreens}
+                  initializeScreen={["c"]}
+                />
+              );
+              cy.findByLabelText("paper-dialog-wrapper").should(
+                "have.css",
+                "height",
+                "560px"
+              );
+
+              cy.findByLabelText("overlay-blocker").click({ force: true });
+
+              cy.findByLabelText("paper-dialog-wrapper").should("not.exist");
+            });
+          });
+        });
+      });
+
       it("renders with full width (100dvw)", () => {
         cy.viewport(500, 700);
 

--- a/test/component/screen-transition.cy.tsx
+++ b/test/component/screen-transition.cy.tsx
@@ -296,7 +296,7 @@ describe("Screen Transition", () => {
       });
 
       context("when given height 300px", () => {
-        it("renders the element with 300px", () => {
+        it("renders the element with height 300px", () => {
           cy.viewport(500, 700);
 
           const productWithSheetScreens: ScreensMap = {
@@ -405,7 +405,7 @@ describe("Screen Transition", () => {
       });
 
       context("when given width 300px", () => {
-        it("renders the element with 300px", () => {
+        it("renders the element with width 300px", () => {
           cy.viewport(500, 700);
 
           const productWithSheetScreens: ScreensMap = {


### PR DESCRIPTION
Description:
This pull request enhances the `ScreenTransition` component by allowing each screen to define its own initial `width`, `height`, and `closable` behavior.

```ts
type ScreenConfig = {
  component: ScreensComponent;
  sheet?: ScreenSheetConfig;
  width?: string;
  height?: string;
  closable?: boolean;
};
```

It also introduces customizable `indicatorStyle`, `contentStyle`, and `containerStyle` properties, providing greater flexibility when styling the underlying `PaperDialog`. These style props allow consumers to customize the dialog directly without introducing additional wrapper elements.

```ts
export interface ScreenTransitionProps<TScreens extends ScreensMap> {
  /** Registry of every screen this transition can render, keyed by id */
  screens: TScreens;
  /** Ordered stack of active screen keys. First = base, rest = nested dialogs */
  activeScreens: (keyof TScreens)[] | string[];
  /** Called with the next stack whenever navigation happens */
  onScreenChange: (screens: (keyof TScreens)[]) => void;
  /** Styles applied to the underlying PaperDialog */
  styles?: ScreenTransitionStyles;
}

export type ScreenTransitionStyles = Pick<
  PaperDialogStyles,
  "indicatorStyle" | "contentStyle" | "containerStyle"
>;
```

When a screen is presented as a mobile sheet, the Escape key is no longer enabled by default. Since sheet presentation is intended for mobile interactions, supporting desktop-specific dismissal via the Escape key is unnecessary. The `withEscape` option remains available and continues to default to `true` when using `PaperDialog` directly.

```ts
export interface PaperDialogClosable {
  withOverlay?: boolean;
  withEscape?: boolean;
  withButton?: boolean;
  withIndicator?: boolean;
}
```

The `PaperDialog` `onChange` callback has also been enhanced to include a trigger parameter that identifies what caused the state transition. This allows consumers to distinguish between programmatic changes and user interactions such as clicking the overlay, pressing the Escape key, dragging, resizing, or interacting with dialog controls.

```ts
export const PaperDialogTrigger = {
  API: "api",
  Overlay: "overlay",
  Escape: "escape",
  Drag: "drag",
  Control: "control",
} as const;

export type PaperDialogTrigger =
  (typeof PaperDialogTrigger)[keyof typeof PaperDialogTrigger];

onChange?: (
  state: PaperDialogState,
  trigger: PaperDialogTrigger
) => void;
```

Consumers can use this trigger to determine what initiated a dialog state change, enabling more granular control over dialog behavior.


Source:
[[Mobile] SYST-808: Add `width`, `height`, and changes the `closable` behavior in `ScreenTransition`](https://linear.app/systatum/issue/SYST-808/add-width-height-and-changes-the-closable-behavior-in-screentransition)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself