### PR TITLE
[Bug] SYST-809: Fix hidden condition on `Table.Loose`

### DIFF
--- a/components/table.tsx
+++ b/components/table.tsx
@@ -1539,7 +1539,7 @@ function TableRow({
 
   const { loose, setWithRowActions, isScrolledRight } = useTableLoose();
 
-  const rowActions = actions?.(rowId ?? "");
+  const rowActions = actions?.(rowId ?? "").filter((action) => !action.hidden);
   const hasRowActions = (rowActions?.length ?? 0) > 0;
 
   useEffect(() => {
@@ -1753,6 +1753,7 @@ function TableRow({
             const listActions = actions(`${rowId}`);
             const actionsWithIcons = listActions
               ?.filter((action): action is TableRowAction => Boolean(action))
+              ?.filter((action) => !action.hidden)
               .map((action) => ({
                 ...action,
                 icon: {

--- a/test/component/table.cy.tsx
+++ b/test/component/table.cy.tsx
@@ -865,15 +865,131 @@ describe("Table", () => {
                   });
               });
 
-              context("when given empty action", () => {
+              context("when given hidden action", () => {
                 it("not renders header loose", () => {
-                  cy.mount(<ProductTableLoose loose actions={() => []} />);
+                  cy.mount(
+                    <ProductTableLoose
+                      loose
+                      actions={() => [
+                        {
+                          caption: "Edit",
+                          icon: { image: RiArrowUpSLine },
+                          hidden: true,
+                        },
+                      ]}
+                    />
+                  );
+
+                  cy.findAllByLabelText("action-button").eq(1).click();
+                  cy.findAllByLabelText("action-button").eq(2).click();
 
                   cy.wait(300);
 
                   cy.findByLabelText("header-row-loose-action").should(
                     "not.exist"
                   );
+                });
+
+                context("when scrolling to the right side", () => {
+                  it("still not renders header loose", () => {
+                    cy.mount(
+                      <ProductTableLoose
+                        loose
+                        actions={() => [
+                          {
+                            caption: "Edit",
+                            icon: { image: RiArrowUpSLine },
+                            hidden: true,
+                          },
+                        ]}
+                      />
+                    );
+
+                    cy.wait(300);
+                    cy.findAllByLabelText("action-button").eq(1).click();
+                    cy.findAllByLabelText("action-button").eq(2).click();
+
+                    cy.findByLabelText("header-row-loose-action").should(
+                      "not.exist"
+                    );
+
+                    cy.findByLabelText("table-body")
+                      .parent()
+                      .then(($el) => {
+                        const el = $el[0];
+
+                        const scrollToEnd = () => {
+                          const maxScroll = el.scrollWidth - el.clientWidth;
+                          el.scrollLeft = maxScroll;
+                          el.dispatchEvent(
+                            new Event("scroll", { bubbles: true })
+                          );
+
+                          if (el.scrollLeft < maxScroll) {
+                            scrollToEnd();
+                          }
+                        };
+
+                        scrollToEnd();
+                      });
+
+                    cy.findByLabelText("header-row-loose-action").should(
+                      "not.exist"
+                    );
+                  });
+                });
+              });
+
+              context("when given empty action", () => {
+                it("not renders header loose", () => {
+                  cy.mount(<ProductTableLoose loose actions={() => []} />);
+
+                  cy.wait(300);
+
+                  cy.findAllByLabelText("action-button").eq(1).click();
+                  cy.findAllByLabelText("action-button").eq(2).click();
+
+                  cy.findByLabelText("header-row-loose-action").should(
+                    "not.exist"
+                  );
+                });
+
+                context("when scrolling to the right side", () => {
+                  it("still not renders header loose", () => {
+                    cy.mount(<ProductTableLoose loose actions={() => []} />);
+
+                    cy.wait(300);
+                    cy.findAllByLabelText("action-button").eq(1).click();
+                    cy.findAllByLabelText("action-button").eq(2).click();
+
+                    cy.findByLabelText("header-row-loose-action").should(
+                      "not.exist"
+                    );
+
+                    cy.findByLabelText("table-body")
+                      .parent()
+                      .then(($el) => {
+                        const el = $el[0];
+
+                        const scrollToEnd = () => {
+                          const maxScroll = el.scrollWidth - el.clientWidth;
+                          el.scrollLeft = maxScroll;
+                          el.dispatchEvent(
+                            new Event("scroll", { bubbles: true })
+                          );
+
+                          if (el.scrollLeft < maxScroll) {
+                            scrollToEnd();
+                          }
+                        };
+
+                        scrollToEnd();
+                      });
+
+                    cy.findByLabelText("header-row-loose-action").should(
+                      "not.exist"
+                    );
+                  });
                 });
               });
             });


### PR DESCRIPTION
Description:
This ticket fixes the `Table.Loose` header condition when row actions are marked with `hidden: true`, which was previously not handled correctly. It also ensures the test to prevents the `loose.effect` with `hidden: true` not being applied incorrectly again.

Source:
[[Bug] SYST-809: Fix hidden condition on`Table.Loose`](https://linear.app/systatum/issue/SYST-809/fix-hidden-condition-ontableloose)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself