### PR TITLE
[Improvement] SYST-810: Optional uses for `children` and `title` on `Messagebox`

### DIFF
--- a/components/messagebox.tsx
+++ b/components/messagebox.tsx
@@ -19,9 +19,9 @@ export type MessageboxVariant =
 
 export interface MessageboxProps {
   variant?: MessageboxVariant;
-  title: string;
+  title?: ReactNode;
   icon?: FigureProps;
-  children: ReactNode;
+  children?: ReactNode;
   actionLinks?: MessageActionLinks[];
   closable?: boolean;
   onCloseRequest?: () => void;
@@ -76,7 +76,6 @@ function Messagebox({
       $variant={variant}
       $style={styles?.containerStyle}
     >
-      <BorderAccent $theme={messageboxTheme} $variant={variant} />
       <Figure
         {...icon}
         styles={{
@@ -191,6 +190,7 @@ const Wrapper = styled.div<{
     $theme[$variant].backgroundColor};
 
   color: ${({ $variant, $theme }) => $theme[$variant].textColor};
+  border-top: 2px solid ${({ $variant, $theme }) => $theme[$variant].textColor};
 
   ${({ $style }) => $style};
 `;
@@ -214,17 +214,6 @@ const Children = styled.span<{ $style?: CSSProp }>`
   line-height: 1.4;
   color: inherit;
   ${({ $style }) => $style};
-`;
-
-const BorderAccent = styled.div<{
-  $variant: MessageboxVariant;
-  $theme: MessageboxThemeConfig;
-}>`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  border-top: 2px solid ${({ $variant, $theme }) => $theme[$variant].textColor};
 `;
 
 const ActionList = styled.div`

--- a/components/messagebox.tsx
+++ b/components/messagebox.tsx
@@ -92,12 +92,19 @@ function Messagebox({
         aria-label="messagebox-content-wrapper"
         $style={styles?.contentWrapperStyle}
       >
-        <Title aria-label="messagebox-title" $style={styles?.titleStyle}>
-          {title}
-        </Title>
-        <Children aria-label="messagebox-content" $style={styles?.contentStyle}>
-          {children}
-        </Children>
+        {title && (
+          <Title aria-label="messagebox-title" $style={styles?.titleStyle}>
+            {title}
+          </Title>
+        )}
+        {children && (
+          <Children
+            aria-label="messagebox-content"
+            $style={styles?.contentStyle}
+          >
+            {children}
+          </Children>
+        )}
         {actionLinks && (
           <ActionList>
             {actionLinks.map((action, index) =>

--- a/test/component/messagebox.cy.tsx
+++ b/test/component/messagebox.cy.tsx
@@ -11,6 +11,24 @@ describe("Messagebox", () => {
     );
   }
 
+  context("content", () => {
+    context("when only given the title", () => {
+      it("renders only the title", () => {
+        cy.mount(<Messagebox title="This is title" />);
+        cy.findByLabelText("messagebox-title").should("exist");
+        cy.findByLabelText("messagebox-content").should("not.exist");
+      });
+    });
+
+    context("when only given the children", () => {
+      it("renders only the content", () => {
+        cy.mount(<Messagebox>Test</Messagebox>);
+        cy.findByLabelText("messagebox-title").should("not.exist");
+        cy.findByLabelText("messagebox-content").should("exist");
+      });
+    });
+  });
+
   context("title", () => {
     context("when given string", () => {
       it("renders the title with string", () => {

--- a/test/component/messagebox.cy.tsx
+++ b/test/component/messagebox.cy.tsx
@@ -11,13 +11,33 @@ describe("Messagebox", () => {
     );
   }
 
+  context("title", () => {
+    context("when given string", () => {
+      it("renders the title with string", () => {
+        cy.mount(<ProductMessagebox />);
+        cy.findByText("This is title").should("exist");
+      });
+    });
+
+    context("when given react node", () => {
+      it("renders the title with element", () => {
+        cy.mount(
+          <ProductMessagebox
+            title={<div aria-label="label-with-react-node">Hi john doe</div>}
+          />
+        );
+        cy.findByLabelText("label-with-react-node").should("exist");
+      });
+    });
+  });
+
   context("height", () => {
     it("renders with fit-content (by default)", () => {
       cy.mount(<ProductMessagebox />);
       cy.findByLabelText("messagebox-container").should(
         "have.css",
         "height",
-        "78.59375px"
+        "80.59375px"
       );
     });
 
@@ -33,7 +53,7 @@ describe("Messagebox", () => {
         cy.findByLabelText("messagebox-container").should(
           "have.css",
           "height",
-          "294.125px"
+          "296.125px"
         );
       });
     });
@@ -69,7 +89,7 @@ describe("Messagebox", () => {
         cy.findByLabelText("messagebox-container").should(
           "have.css",
           "height",
-          "78.59375px"
+          "80.59375px"
         );
       });
     });


### PR DESCRIPTION
Description:
This ticket improves the flexibility of the `Messagebox` component by allowing it to be rendered with only a `title`, only `children`, or both. The `title` and `children` props have been changed from required to optional.

It also ensures that each rendering scenario behaves as expected.

Source:
[[Improvement] SYST-810: Optional uses for `Children` and `Title` on `Messagebox`
](https://linear.app/systatum/issue/SYST-810/optional-uses-for-children-and-title-on-messagebox)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself