### PR TITLE
[Bug] SYST-739: Do not render title right section if there's no right section

### DIFF
--- a/components/card.stories.tsx
+++ b/components/card.stories.tsx
@@ -1122,7 +1122,7 @@ export const Toggleable: Story = {
 
       const sortableColumns: TableColumn[] = columns.map((column) => ({
         ...column,
-        actions: {
+        actions: () => ({
           title: "Sort",
           icon: { image: RiArrowUpDownLine },
           subMenu: ({ list }) =>
@@ -1155,7 +1155,7 @@ export const Toggleable: Story = {
                   }),
               },
             ]),
-        },
+        }),
       }));
 
       return (

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -147,6 +147,8 @@ function Card({
       : []),
   ];
 
+  const finalIcon = icon ? { ...icon, size: icon.size ?? 20 } : undefined;
+
   return (
     <CardContainer
       aria-label="card-container"
@@ -163,7 +165,7 @@ function Card({
         <Title
           size="sm"
           text={title}
-          icon={icon}
+          icon={finalIcon}
           pretitle={pretitle}
           subtitle={subtitle}
           styles={{

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -13,6 +13,7 @@ import { useTheme } from "./../theme/provider";
 import { CardThemeConfig } from "./../theme";
 import { applyClassName } from "./../constants/classname";
 import { Title, TitleSection } from "./title";
+import { FigureProps } from "./figure";
 
 export const CardShadow = {
   None: "none",
@@ -52,14 +53,12 @@ export const CardPadding = {
 
 export type CardPadding = (typeof CardPadding)[keyof typeof CardPadding];
 
-export interface CardProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  "title" | "style"
-> {
+export interface CardProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "title" | "style"> {
   shadow?: CardShadow;
   radius?: CardBorderRadius;
   padding?: CardPadding;
-  children: ReactNode;
+  children?: ReactNode;
   title?: ReactNode;
   pretitle?: ReactNode;
   subtitle?: ReactNode;
@@ -71,6 +70,7 @@ export interface CardProps extends Omit<
   toggleable?: boolean;
   onToggleChange?: (isOpen?: boolean) => void;
   open?: boolean;
+  icon?: FigureProps;
 }
 
 export interface CardStyles {
@@ -103,6 +103,7 @@ function Card({
   id,
   className,
   pretitle,
+  icon,
   ...props
 }: CardProps) {
   const { currentTheme } = useTheme();
@@ -115,14 +116,16 @@ function Card({
   const hasActions = filteredHeaderActions.length > 0;
 
   const renderHeaderActions: TitleSection[] = [
-    {
-      type: "custom",
-      render: hasActions
-        ? filteredHeaderActions.map((action, index) => (
-            <ActionButton key={index} {...action} />
-          ))
-        : undefined,
-    },
+    ...(hasActions
+      ? [
+          {
+            type: "custom",
+            render: filteredHeaderActions.map((action, index) => (
+              <ActionButton key={index} {...action} />
+            )),
+          } satisfies TitleSection,
+        ]
+      : []),
     ...(toggleable
       ? [
           {
@@ -156,10 +159,11 @@ function Card({
       $containerStyle={styles?.containerStyle}
       $theme={cardTheme}
     >
-      {(title || subtitle || pretitle || headerActions) && (
+      {(title || subtitle || pretitle || headerActions || icon) && (
         <Title
           size="sm"
           text={title}
+          icon={icon}
           pretitle={pretitle}
           subtitle={subtitle}
           styles={{

--- a/test/component/card.cy.tsx
+++ b/test/component/card.cy.tsx
@@ -1,4 +1,4 @@
-import { RiDeleteBack2Fill, RiEdit2Line } from "@remixicon/react";
+import { RiAddBoxLine, RiDeleteBack2Fill, RiEdit2Line } from "@remixicon/react";
 import { Card, CardProps } from "./../../components/card";
 import { Button } from "./../../components/button";
 import { DormantText } from "./../../components/dormant-text";
@@ -35,6 +35,59 @@ describe("Card", () => {
       </Card>
     );
   }
+
+  context("content", () => {
+    context("title", () => {
+      context("when given only with title", () => {
+        it("still can renders the card with title", () => {
+          cy.mount(<Card title="Test" />);
+          cy.findByLabelText("title-title")
+            .should("have.text", "Test")
+            .and("exist");
+        });
+      });
+    });
+
+    context("subtitle", () => {
+      context("when given only with subtitle", () => {
+        it("still can renders the card with subtitle", () => {
+          cy.mount(<Card subtitle="Test Subtitle" />);
+          cy.findByLabelText("title-subtitle")
+            .should("have.text", "Test Subtitle")
+            .and("exist");
+        });
+      });
+    });
+
+    context("pretitle", () => {
+      context("when given only with pretitle", () => {
+        it("still can renders the card with pretitle", () => {
+          cy.mount(<Card pretitle="Test Pretitle" />);
+          cy.findByLabelText("title-pretitle")
+            .should("have.text", "Test Pretitle")
+            .and("exist");
+        });
+      });
+    });
+
+    context("icon", () => {
+      context("when given only with icon", () => {
+        it("still can renders the card with icon 30px", () => {
+          cy.mount(
+            <Card
+              pretitle="Test Pretitle"
+              icon={{
+                image: RiAddBoxLine,
+              }}
+            />
+          );
+          cy.get(".coneto-figure svg")
+            .should("have.attr", "width", "20")
+            .and("have.attr", "height", "20");
+        });
+      });
+    });
+  });
 
   context("styles", () => {
     context("containerStyle", () => {
@@ -523,6 +576,18 @@ describe("Card", () => {
       );
 
       cy.findByLabelText("action-button-icon").should("not.exist");
+    });
+
+    context("when not given action", () => {
+      it("not renders right section", () => {
+        cy.mount(<Card title="Test" />);
+
+        cy.findByLabelText("title-title")
+          .should("have.text", "Test")
+          .and("exist");
+
+        cy.findByLabelText("title-right-section").should("not.exist");
+      });
     });
 
     context("when given hidden action", () => {


### PR DESCRIPTION
Description:
This pull request fixes an issue where the `rightSection` was rendered even when no `headerActions` were provided, caused by incorrect logic when handling the actions array.

Additionally, it introduces support for an `icon` in the `Card` component using the `Figure` component, and makes the card content optional. This provides greater flexibility, allowing consumers to render only a `Title`, `Pretitle`, or even just an `icon` without requiring card content.

It also ensures that the `rightSection` is not rendered unless header actions are explicitly provided.

Source:
[[Bug] SYST-739: Do not render title right section if there's no right section](https://linear.app/systatum/issue/SYST-739/do-not-render-title-right-section-if-theres-no-right-section)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself