### PR TITLE
Fix sluggish table horizontal scrolling

### DIFF
--- a/components/table.tsx
+++ b/components/table.tsx
@@ -1,6 +1,5 @@
 import React, {
   Children,
-  cloneElement,
   createContext,
   isValidElement,
   ReactElement,
@@ -603,87 +602,90 @@ function Table({
                             />
                           </CheckboxWrapper>
                         )}
-                        {columns.map((col, i) => {
-                          const columnAction =
-                            typeof col.actions === "function" &&
-                            col.actions(col.id);
+                        <IndexedCells lastGetsPadding={!!withRowActions}>
+                          {columns.map((col, i) => {
+                            const columnAction =
+                              typeof col.actions === "function" &&
+                              col.actions(col.id);
 
-                          const variant = columnAction?.variant ?? "ghost";
-                          const finalColumnAction: ButtonProps = columnAction &&
-                            !columnAction.hidden && {
-                              ...columnAction,
-                              icon: {
-                                ...columnAction?.icon,
-                                image:
-                                  columnAction?.icon?.image ??
-                                  RiArrowUpDownLine,
-                                size: columnAction?.icon?.size ?? 20,
-                              },
-                              showSubMenuOn: "self",
-                              tipMenuSize: columnAction?.tipMenuSize ?? "md",
-                              styles: {
-                                ...columnAction?.styles,
-                                self: css`
-                                  padding: 0px;
-                                  height: 34px;
-                                  width: 34px;
-                                  border-radius: 6px;
-                                  &:not(:focus-visible):not(:active):not(
-                                      :hover
-                                    ):not(:focus) {
-                                    background-color: transparent;
-                                  }
-                                  ${columnAction?.styles?.self};
-                                `,
-                              },
-                              hoverBackgroundColor:
-                                variant === "ghost" &&
-                                tableTheme?.headerActionHoverBackgroundColor,
-                              variant,
-                              "aria-label": "table-column-action",
-                            };
+                            const variant = columnAction?.variant ?? "ghost";
+                            const finalColumnAction: ButtonProps =
+                              columnAction &&
+                                !columnAction.hidden && {
+                                  ...columnAction,
+                                  icon: {
+                                    ...columnAction?.icon,
+                                    image:
+                                      columnAction?.icon?.image ??
+                                      RiArrowUpDownLine,
+                                    size: columnAction?.icon?.size ?? 20,
+                                  },
+                                  showSubMenuOn: "self",
+                                  tipMenuSize:
+                                    columnAction?.tipMenuSize ?? "md",
+                                  styles: {
+                                    ...columnAction?.styles,
+                                    self: css`
+                                      padding: 0px;
+                                      height: 34px;
+                                      width: 34px;
+                                      border-radius: 6px;
+                                      &:not(:focus-visible):not(:active):not(
+                                          :hover
+                                        ):not(:focus) {
+                                        background-color: transparent;
+                                      }
+                                      ${columnAction?.styles?.self};
+                                    `,
+                                  },
+                                  hoverBackgroundColor:
+                                    variant === "ghost" &&
+                                    tableTheme?.headerActionHoverBackgroundColor,
+                                  variant,
+                                  "aria-label": "table-column-action",
+                                };
 
-                          return (
-                            <TableRowCell
-                              key={i}
-                              _index={i}
-                              width={col.width}
-                              contentStyle={css`
-                                display: flex;
-                                align-items: center;
+                            return (
+                              <TableRowCell
+                                key={i}
+                                width={col.width}
+                                contentStyle={css`
+                                  display: flex;
+                                  align-items: center;
 
-                                background: ${tableTheme?.headerBackgroundColor ||
-                                "linear-gradient(to bottom, #f0f0f0, #e4e4e4)"};
+                                  background: ${tableTheme?.headerBackgroundColor ||
+                                  "linear-gradient(to bottom, #f0f0f0, #e4e4e4)"};
 
-                                ${col.width
-                                  ? css`
-                                      width: ${col.width};
-                                      flex-direction: row;
-                                    `
-                                  : css`
-                                      flex: 1;
-                                    `}
+                                  ${col.width
+                                    ? css`
+                                        width: ${col.width};
+                                        flex-direction: row;
+                                      `
+                                    : css`
+                                        flex: 1;
+                                      `}
 
-                                ${finalColumnAction &&
-                                css`
-                                  padding: 4px 19.2px;
+                                  ${finalColumnAction &&
+                                  css`
+                                    padding: 4px 19.2px;
+                                  `}
+
+                                  ${col?.styles?.containerStyle}
                                 `}
-
-                          ${col?.styles?.containerStyle}
-                              `}
-                            >
-                              <Label
-                                aria-label="table-column-label"
-                                $style={col?.styles?.labelStyle}
                               >
-                                {col.caption}
-                              </Label>
-                              {finalColumnAction && (
-                                <Button {...finalColumnAction} />
-                              )}
-                            </TableRowCell>
-                          );
-                        })}
+                                <Label
+                                  aria-label="table-column-label"
+                                  $style={col?.styles?.labelStyle}
+                                >
+                                  {col.caption}
+                                </Label>
+                                {finalColumnAction && (
+                                  <Button {...finalColumnAction} />
+                                )}
+                              </TableRowCell>
+                            );
+                          })}
+                        </IndexedCells>
 
                         {loose && withRowActions && (
                           <StickyRowActions
@@ -773,83 +775,85 @@ function Table({
                               }
                             />
                           )}
-                          {(() => {
-                            const cells: ReactNode[] = [];
-                            let colPointer = 0;
+                          <IndexedCells lastGetsPadding={!!withRowActions}>
+                            {(() => {
+                              const cells: ReactNode[] = [];
+                              let colPointer = 0;
 
-                            const totalCells = sumRow.reduce(
-                              (acc, col) => acc + (col.span ?? 1),
-                              0
-                            );
+                              const totalCells = sumRow.reduce(
+                                (acc, col) => acc + (col.span ?? 1),
+                                0
+                              );
 
-                            sumRow.map((col, i) => {
-                              const span = col.span ?? 1;
+                              sumRow.map((col, i) => {
+                                const span = col.span ?? 1;
 
-                              for (let s = 0; s < span; s++) {
-                                const columnWidth = columns[colPointer]?.width;
+                                for (let s = 0; s < span; s++) {
+                                  const columnWidth =
+                                    columns[colPointer]?.width;
 
-                                const isLast =
-                                  rowActions && colPointer === totalCells - 1;
+                                  const isLast =
+                                    rowActions && colPointer === totalCells - 1;
 
-                                const isFirst = i === 0;
+                                  const isFirst = i === 0;
 
-                                cells.push(
-                                  <TableRowCell
-                                    _index={i}
-                                    key={`${colPointer}-${s}`}
-                                    width={columnWidth}
-                                    bold={col.bold}
-                                    contentStyle={css`
-                                      display: flex;
-                                      align-items: center;
+                                  cells.push(
+                                    <TableRowCell
+                                      key={`${colPointer}-${s}`}
+                                      width={columnWidth}
+                                      bold={col.bold}
+                                      contentStyle={css`
+                                        display: flex;
+                                        align-items: center;
 
-                                      ${columnWidth
-                                        ? css`
-                                            width: ${columnWidth};
-                                            flex-direction: row;
-                                          `
-                                        : css`
-                                            flex: 1;
-                                          `};
+                                        ${columnWidth
+                                          ? css`
+                                              width: ${columnWidth};
+                                              flex-direction: row;
+                                            `
+                                          : css`
+                                              flex: 1;
+                                            `};
 
-                                      ${isLast &&
-                                      css`
-                                        padding-right: 36px;
-                                      `};
-
-                                      ${loose &&
-                                      css`
-                                        ${isFirst &&
+                                        ${isLast &&
                                         css`
-                                          z-index: 40;
-                                          background: ${tableTheme?.summaryBackgroundColor ??
-                                          "#e4e4e4"};
-                                        `}
-                                      `};
+                                          padding-right: 36px;
+                                        `};
 
-                                      ${col.styles?.self}
-                                    `}
-                                  >
-                                    {s === 0 ? col.content : ""}
-                                  </TableRowCell>
-                                );
+                                        ${loose &&
+                                        css`
+                                          ${isFirst &&
+                                          css`
+                                            z-index: 40;
+                                            background: ${tableTheme?.summaryBackgroundColor ??
+                                            "#e4e4e4"};
+                                          `}
+                                        `};
 
-                                colPointer++;
-                              }
-                            });
+                                        ${col.styles?.self}
+                                      `}
+                                    >
+                                      {s === 0 ? col.content : ""}
+                                    </TableRowCell>
+                                  );
 
-                            return cells;
-                          })()}
+                                  colPointer++;
+                                }
+                              });
 
-                          {loose && withRowActions && (
-                            <StickyRowActions
-                              aria-label="summary-row-loose-action"
-                              $theme={tableTheme}
-                              $loose={loose}
-                              $position={"summary"}
-                              $isScrolledRight={isScrolledRight}
-                            />
-                          )}
+                              return cells;
+                            })()}
+
+                            {loose && withRowActions && (
+                              <StickyRowActions
+                                aria-label="summary-row-loose-action"
+                                $theme={tableTheme}
+                                $loose={loose}
+                                $position={"summary"}
+                                $isScrolledRight={isScrolledRight}
+                              />
+                            )}
+                          </IndexedCells>
                         </TableSummary>
                       </ScrollWrapper>
                     )}
@@ -1438,6 +1442,22 @@ export interface TableRowStyles {
   rowCellStyle?: CSSProp;
 }
 
+/*
+ * Set by IndexedCells, one level per cell, so a cell resolves its own
+ * position (for the sticky first column) and width without a parent
+ * cloning props onto it.
+ */
+const TableRowCellPositionContext = createContext<{
+  index?: number;
+  width?: string;
+  isLastCol?: boolean;
+} | null>({
+  index: 0,
+  width: undefined,
+  isLastCol: false,
+});
+const useTableRowCellPosition = () => useContext(TableRowCellPositionContext);
+
 function TableRow({
   content,
   styles,
@@ -1655,52 +1675,39 @@ function TableRow({
             />
           </CheckboxWrapper>
         )}
-        {content
-          ? content.map((col, i) => {
-              const column = columns[i];
-              const isLast = actions && i === childArray.length - 1;
+        <IndexedCells lastGetsPadding={!!actions}>
+          {content
+            ? content.map((col, i) => {
+                const column = columns[i];
+                const isLastCol = actions && i === childArray.length - 1;
 
-              return (
-                <TableRowCell
-                  key={i}
-                  _index={i}
-                  width={column?.width}
-                  contentStyle={
-                    isLast
-                      ? css`
-                          padding-right: 36px;
-                          ${styles?.rowCellStyle}
-                        `
-                      : styles?.rowCellStyle
-                  }
-                >
-                  {col}
-                </TableRowCell>
-              );
-            })
-          : childArray.map((child, i) => {
-              if (!isValidElement<TableRowCellProps>(child)) return child;
-
-              const widthColumn = columns[i].width;
-              const isLast = actions && i === childArray.length - 1;
-
-              const isTableRowCell = child.type === Table.Row.Cell;
-
-              return cloneElement(child, {
-                ...(isTableRowCell
-                  ? {
-                      _index: i,
-                      width: child.props.width ?? widthColumn,
-                      contentStyle: isLast
+                return (
+                  <TableRowCell
+                    key={i}
+                    width={column?.width}
+                    contentStyle={
+                      isLastCol
                         ? css`
                             padding-right: 36px;
-                            ${child.props.contentStyle};
+                            ${styles?.rowCellStyle}
                           `
-                        : child.props.contentStyle,
+                        : styles?.rowCellStyle
                     }
-                  : {}),
-              });
-            })}
+                  >
+                    {col}
+                  </TableRowCell>
+                );
+              })
+            : /* width/padding for a caller-provided Table.Row.Cell now come from IndexedCells via position context, not a clone. */
+              childArray.map((child) => {
+                if (!isValidElement<TableRowCellProps>(child)) return child;
+
+                const isTableRowCell = child.type === Table.Row.Cell;
+                if (!isTableRowCell) return child;
+
+                return child;
+              })}
+        </IndexedCells>
 
         {isOver && dropPosition && <DragLine position={dropPosition} />}
 
@@ -1828,6 +1835,35 @@ function TableRow({
       </AnimatePresence>
     </RowWrapper>
   );
+}
+
+/**
+ * Wraps a list of cells and assigns each one its position via context.
+ * Callers never compute or pass an index themselves: they just render
+ * whatever children they have, in order, and this does the counting.
+ */
+function IndexedCells({
+  children,
+  lastGetsPadding = false,
+}: {
+  children: ReactNode;
+  lastGetsPadding?: boolean;
+}) {
+  const columns = useTableColumns();
+  const items = Children.toArray(children).filter(isValidElement);
+
+  return items.map((child, index) => (
+    <TableRowCellPositionContext.Provider
+      key={child.key ?? index}
+      value={{
+        index,
+        isLastCol: lastGetsPadding && index === items.length - 1,
+        width: columns[index]?.width,
+      }}
+    >
+      {child}
+    </TableRowCellPositionContext.Provider>
+  ));
 }
 
 const EXPAND_COLLAPSE_VARIANTS = {
@@ -1971,24 +2007,28 @@ const DraggableRequest = styled.div<{
     `}
 `;
 
-function TableRowCell({
+const TableRowCell = React.memo(function TableRowCell({
   children,
   contentStyle,
-  width,
   onClick,
-  bold,
   id,
+  width,
   className,
-  _index,
-}: TableRowCellProps &
-  Partial<{
-    bold?: boolean;
-    _index?: number;
-  }>) {
+  bold,
+}: TableRowCellProps & Partial<{ bold?: boolean }>) {
+  const {
+    index,
+    isLastCol,
+    width: widthFromPosition,
+  } = useTableRowCellPosition();
+
   const { loose, selectable, isScrolledLeft } = useTableLoose();
-  const isFirst = _index === 0;
+  const isFirst = index === 0;
   const { currentTheme } = useTheme();
   const tableTheme = currentTheme?.table;
+
+  // An explicit width prop always wins over the column width IndexedCells resolved.
+  const resolvedWidth = width ? width : widthFromPosition;
 
   return (
     <CellContent
@@ -2005,9 +2045,14 @@ function TableRowCell({
           onClick();
         }
       }}
-      $width={width}
+      $width={resolvedWidth}
       $bold={bold}
       $contentStyle={css`
+        ${isLastCol &&
+        css`
+          padding-right: 36px;
+          ${contentStyle}
+        `};
         ${contentStyle};
         ${onClick &&
         css`
@@ -2018,7 +2063,7 @@ function TableRowCell({
       {children}
     </CellContent>
   );
-}
+});
 
 /*
  * use the provided `width` as the flex-basis while allowing the column to shrink.

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -145,25 +145,9 @@ export interface TableSummaryRowColumnStyles {
 export type TableResultMenuProps = SearchboxResultMenu;
 
 const DnDContext = createContext<{
-  dragItem: {
-    oldGroupId: string;
-    oldPosition: number;
-    newGroupId?: string;
-    newPosition?: number;
-    id: string;
-  } | null;
-  setDragItem: (props: {
-    oldGroupId: string;
-    oldPosition: number;
-    newGroupId?: string;
-    newPosition?: number;
-    id: string;
-  }) => void;
   onDragged?: TableProps["onDragged"];
-}>({
-  dragItem: null,
-  setDragItem: () => {},
-});
+}>(null);
+const useTableDND = () => useContext(DnDContext);
 
 const TableColumnContext = createContext<TableColumn[]>([]);
 const useTableColumns = () => useContext(TableColumnContext);
@@ -183,6 +167,58 @@ const TableLooseContext = createContext<{
   isScrolledRight: false,
 });
 const useTableLoose = () => useContext(TableLooseContext);
+
+// Selection state, often changes, isolated from static config
+const TableSelectionContext = createContext<{
+  selectedData: string[];
+  handleSelect: (id: string) => void;
+}>({
+  selectedData: [],
+  handleSelect: () => {},
+});
+const useTableSelection = () => useContext(TableSelectionContext);
+
+// Which row's context-menu/expanded-content is open, changes often
+const TableOpenRowContext = createContext<{
+  openRowId: string | null;
+  setOpenRowId: (id: string | null) => void;
+}>({
+  openRowId: null,
+  setOpenRowId: () => {},
+});
+const useTableOpenRow = () => useContext(TableOpenRowContext);
+
+interface RowPosition {
+  /** Index of this row among its siblings within the same group. */
+  localIndex: number;
+  /** Total row count in this row's group. */
+  groupLength: number;
+}
+
+/*
+ * Per-row metadata a row used to receive via cloneElement props;
+ * centralized here so a row looks itself up instead of being cloned into.
+ */
+const TableRowMetaContext = createContext<{
+  /** Flat, document-order row ids. Used to detect the very last row. */
+  rowIds: string[];
+  /** Each row's position within its own group. Used for drag-and-drop reordering. */
+  rowPositions: Map<string, RowPosition>;
+  onLastRowReached?: () => void;
+  draggable?: boolean;
+  alwaysShowDragIcon?: boolean;
+}>({
+  rowIds: [],
+  rowPositions: new Map(),
+});
+const useTableRowMeta = () => useContext(TableRowMetaContext);
+
+/*
+ * Provided by a row's enclosing group so it can resolve its own groupId
+ * without prop cloning. A row outside any group has no provider above it,
+ * so it falls back to its own groupId prop.
+ */
+const TableRowGroupIdContext = createContext<string | undefined>(undefined);
 
 function Table({
   selectable = false,
@@ -213,14 +249,6 @@ function Table({
 }: TableProps & TableAlwaysShowDragIcon) {
   const { currentTheme } = useTheme();
   const tableTheme = currentTheme.table;
-
-  const [dragItem, setDragItem] = useState<{
-    oldGroupId: string;
-    oldPosition: number;
-    newGroupId?: string;
-    newPosition?: number;
-    id: string;
-  } | null>(null);
 
   const [selectedData, setSelectedData] = useState<string[]>(selectedItems);
   const [allRowsLocal, setAllRowsLocal] = useState<string[]>([]);
@@ -282,83 +310,19 @@ function Table({
     setSelectedData(newData);
     onItemsSelected?.(newData);
   };
-  const flatChildren = resolveChildren(children);
+  /* No more cloning: flatten wrapper components into real elements. */
+  const flatChildren = useMemo(() => resolveChildren(children), [children]);
 
-  const rowChildren = useMemo(
-    () =>
-      flatChildren.map((child, index) => {
-        const hasRowGroup = child.type === TableRowGroup;
-        const hasRow = child.type === TableRow;
+  /** Flat, document-order row ids, replacing the `index`/`isLast` props a row used to receive via cloneElement. */
+  const rowIds = useMemo(
+    () => getAllRowContentsFromChildren(children),
+    [children]
+  );
 
-        if (hasRowGroup) {
-          return cloneElement(child, {
-            selectable,
-            selectedData,
-            handleSelect,
-            draggable,
-            openRowId,
-            setOpenRowId,
-            alwaysShowDragIcon,
-          } as TableRowGroupProps &
-            TableAlwaysShowDragIcon & {
-              selectedData?: string[];
-              handleSelect?: (data: string) => void;
-              draggable?: boolean;
-              isSelected?: boolean;
-            });
-        }
-
-        if (hasRow) {
-          const props = child.props as TableRowProps;
-
-          const isSelected = selectedData.some(
-            (d) => JSON.stringify(d) === JSON.stringify(props.rowId)
-          );
-
-          const isLast = index === Children.count(children) - 1;
-
-          return cloneElement(child, {
-            selectable,
-            isSelected,
-            handleSelect,
-            isLast,
-            onLastRowReached,
-            draggable,
-            openRowId,
-            setOpenRowId,
-            groupLength: Children?.count(children),
-            index: index,
-            alwaysShowDragIcon,
-            onDropItem: (newPosition: number) => {
-              if (dragItem) {
-                const { oldGroupId, newGroupId, oldPosition, id } = dragItem;
-                onDragged?.({
-                  oldGroupId: oldGroupId || "",
-                  newGroupId: newGroupId || "",
-                  oldPosition,
-                  newPosition,
-                  id: id,
-                });
-
-                setDragItem(null);
-              }
-            },
-          } as TableRowProps & TableAlwaysShowDragIcon);
-        }
-
-        return null;
-      }),
-    [
-      flatChildren,
-      selectable,
-      selectedData,
-      handleSelect,
-      draggable,
-      openRowId,
-      alwaysShowDragIcon,
-      dragItem,
-      onDragged,
-    ]
+  /** Each row's index and size within its own group, replacing the `index`/`groupLength` props a row used to receive via cloneElement. */
+  const rowPositions = useMemo(
+    () => getRowPositionsFromChildren(children),
+    [children]
   );
 
   const tableBodyRef = useRef<ScrollbarRef>(null);
@@ -370,7 +334,7 @@ function Table({
   // element may not be available on the initial mount.
   useEffect(() => {
     setScrollElement(getViewport() ?? null);
-  }, [rowChildren.length > 0]);
+  }, [flatChildren.length > 0]);
 
   useEffect(() => {
     const viewport = getViewport();
@@ -441,445 +405,492 @@ function Table({
   };
 
   const rowVirtualizer = useVirtualizer({
-    count: rowChildren?.length,
+    count: flatChildren?.length,
     getScrollElement: () => scrollElement,
     estimateSize: () => 48,
     overscan: 20,
   });
 
+  /* Memoized so identity only changes when the underlying values change, to prevent unnecessary consumer re-renders. */
+  const selectionContextValue = useMemo(
+    () => ({ selectedData, handleSelect }),
+    [selectedData, handleSelect]
+  );
+
+  const openRowContextValue = useMemo(
+    () => ({ openRowId, setOpenRowId }),
+    [openRowId]
+  );
+
+  const rowMetaContextValue = useMemo(
+    () => ({
+      rowIds,
+      rowPositions,
+      onLastRowReached,
+      draggable,
+      alwaysShowDragIcon,
+    }),
+    [rowIds, rowPositions, onLastRowReached, draggable, alwaysShowDragIcon]
+  );
+
+  const dndContextValue = useMemo(() => ({ onDragged }), [onDragged]);
+
   return (
-    <DnDContext.Provider value={{ dragItem, setDragItem, onDragged }}>
-      <TableLooseContext.Provider
-        value={{
-          loose,
-          selectable,
-          withRowActions,
-          setWithRowActions,
-          isScrolledLeft,
-          isScrolledRight,
-        }}
-      >
-        <TableColumnContext.Provider value={columns}>
-          <Wrapper
-            id={id}
-            $theme={tableTheme}
-            className={applyClassName("table", className)}
-            $style={styles?.containerStyle}
-          >
-            {((selectedData.length > 0 &&
-              labels?.totalSelectedItemText !== null) ||
-              showPagination ||
-              actions ||
-              searchable) && (
-              <HeaderActions $theme={tableTheme} aria-label="header-wrapper">
-                {(actions || showPagination) && (
-                  <ActionsWrapper>
-                    {showPagination && (
-                      <>
-                        <PaginationButton
-                          $theme={tableTheme}
-                          disabled={disablePreviousPageButton}
-                          aria-label="previous-button-pagination"
-                          onClick={onPreviousPageRequested}
-                        >
-                          <RiArrowLeftSLine size={16} />
-                        </PaginationButton>
-                        <PaginationButton
-                          $theme={tableTheme}
-                          disabled={disableNextPageButton}
-                          aria-label="next-button-pagination"
-                          onClick={onNextPageRequested}
-                        >
-                          <RiArrowRightSLine size={16} />
-                        </PaginationButton>
-                      </>
-                    )}
-                    {hasActions &&
-                      filteredActions.map((action, index) => {
-                        const { capsuleProps, type, ...rest } = action;
-
-                        if (type === "capsule") {
-                          return (
-                            <ActionCapsule key={index} {...capsuleProps} />
-                          );
-                        }
-
-                        return <ActionButton key={index} {...rest} forTable />;
-                      })}
-                  </ActionsWrapper>
-                )}
-                {searchable && (
-                  <Searchbox
-                    autoComplete="off"
-                    name="search"
-                    {...searchbox}
-                    styles={{
-                      ...searchbox?.styles,
-                      containerStyle: css`
-                        ${actions &&
-                        css`
-                          margin-left: 34px;
-                        `};
-                        ${(showPagination || selectable) &&
-                        css`
-                          margin-right: 34px;
-                        `};
-                        max-height: 33px;
-                        ${searchbox?.styles?.containerStyle}
-                      `,
-                      self: css`
-                        background-color: transparent;
-
-                        ${searchbox?.styles?.self}
-                      `,
-                    }}
-                  />
-                )}
-                {(selectable || showPagination) && (
-                  <PaginationInfo
-                    aria-label="pagination-wrapper"
-                    $style={styles?.paginationWrapperStyle}
-                  >
-                    {showPagination && (
-                      <PaginationNumber
-                        aria-label="pagination-number"
-                        $style={styles?.paginationNumberStyle}
-                      >
-                        {typeof labels.pageNumberText === "number"
-                          ? `Pg. ${labels.pageNumberText}`
-                          : labels.pageNumberText}
-                      </PaginationNumber>
-                    )}
-                    {selectable && (
-                      <PaginationSelectedItem
-                        aria-label="pagination-selected-item"
-                        $style={styles?.totalSelectedItemTextStyle}
-                      >
-                        {labels?.totalSelectedItemText
-                          ? labels?.totalSelectedItemText(selectedData.length)
-                          : `${selectedData.length} items selected`}
-                      </PaginationSelectedItem>
-                    )}
-                  </PaginationInfo>
-                )}
-              </HeaderActions>
-            )}
-
-            <TableContainer
-              $theme={tableTheme}
-              $loose={loose}
-              $hasSelected={selectedData.length > 0}
+    <DnDContext.Provider value={dndContextValue}>
+      <TableSelectionContext.Provider value={selectionContextValue}>
+        <TableOpenRowContext.Provider value={openRowContextValue}>
+          <TableRowMetaContext.Provider value={rowMetaContextValue}>
+            <TableLooseContext.Provider
+              value={{
+                loose,
+                selectable,
+                withRowActions,
+                setWithRowActions,
+                isScrolledLeft,
+                isScrolledRight,
+              }}
             >
-              <ScrollWrapper
-                ref={headerScrollRef}
-                onScroll={loose ? handleSummaryScroll : undefined}
-                $loose={loose}
-              >
-                <TableHeader
+              <TableColumnContext.Provider value={columns}>
+                <Wrapper
+                  id={id}
                   $theme={tableTheme}
-                  $loose={loose}
-                  aria-label="table-header"
-                  $style={styles?.tableHeaderStyle}
+                  className={applyClassName("table", className)}
+                  $style={styles?.containerStyle}
                 >
-                  {selectable && (
-                    <CheckboxWrapper
-                      $position="header"
+                  {((selectedData.length > 0 &&
+                    labels?.totalSelectedItemText !== null) ||
+                    showPagination ||
+                    actions ||
+                    searchable) && (
+                    <HeaderActions
                       $theme={tableTheme}
+                      aria-label="header-wrapper"
+                    >
+                      {(actions || showPagination) && (
+                        <ActionsWrapper>
+                          {showPagination && (
+                            <>
+                              <PaginationButton
+                                $theme={tableTheme}
+                                disabled={disablePreviousPageButton}
+                                aria-label="previous-button-pagination"
+                                onClick={onPreviousPageRequested}
+                              >
+                                <RiArrowLeftSLine size={16} />
+                              </PaginationButton>
+                              <PaginationButton
+                                $theme={tableTheme}
+                                disabled={disableNextPageButton}
+                                aria-label="next-button-pagination"
+                                onClick={onNextPageRequested}
+                              >
+                                <RiArrowRightSLine size={16} />
+                              </PaginationButton>
+                            </>
+                          )}
+                          {hasActions &&
+                            filteredActions.map((action, index) => {
+                              const { capsuleProps, type, ...rest } = action;
+
+                              if (type === "capsule") {
+                                return (
+                                  <ActionCapsule
+                                    key={index}
+                                    {...capsuleProps}
+                                  />
+                                );
+                              }
+
+                              return (
+                                <ActionButton key={index} {...rest} forTable />
+                              );
+                            })}
+                        </ActionsWrapper>
+                      )}
+                      {searchable && (
+                        <Searchbox
+                          autoComplete="off"
+                          name="search"
+                          {...searchbox}
+                          styles={{
+                            ...searchbox?.styles,
+                            containerStyle: css`
+                              ${actions &&
+                              css`
+                                margin-left: 34px;
+                              `};
+                              ${(showPagination || selectable) &&
+                              css`
+                                margin-right: 34px;
+                              `};
+                              max-height: 33px;
+                              ${searchbox?.styles?.containerStyle}
+                            `,
+                            self: css`
+                              background-color: transparent;
+
+                              ${searchbox?.styles?.self}
+                            `,
+                          }}
+                        />
+                      )}
+                      {(selectable || showPagination) && (
+                        <PaginationInfo
+                          aria-label="pagination-wrapper"
+                          $style={styles?.paginationWrapperStyle}
+                        >
+                          {showPagination && (
+                            <PaginationNumber
+                              aria-label="pagination-number"
+                              $style={styles?.paginationNumberStyle}
+                            >
+                              {typeof labels.pageNumberText === "number"
+                                ? `Pg. ${labels.pageNumberText}`
+                                : labels.pageNumberText}
+                            </PaginationNumber>
+                          )}
+                          {selectable && (
+                            <PaginationSelectedItem
+                              aria-label="pagination-selected-item"
+                              $style={styles?.totalSelectedItemTextStyle}
+                            >
+                              {labels?.totalSelectedItemText
+                                ? labels?.totalSelectedItemText(
+                                    selectedData.length
+                                  )
+                                : `${selectedData.length} items selected`}
+                            </PaginationSelectedItem>
+                          )}
+                        </PaginationInfo>
+                      )}
+                    </HeaderActions>
+                  )}
+
+                  <TableContainer
+                    $theme={tableTheme}
+                    $loose={loose}
+                    $hasSelected={selectedData.length > 0}
+                  >
+                    <ScrollWrapper
+                      ref={headerScrollRef}
+                      onScroll={loose ? handleSummaryScroll : undefined}
                       $loose={loose}
                     >
-                      <Checkbox
-                        styles={{
-                          controlStyle: css`
-                            height: 100%;
-                          `,
-                          boxStyle: css`
-                            width: 100%;
-                          `,
-                        }}
-                        onChange={handleSelectAll}
-                        checked={allRowSelectedLocal}
-                        indeterminate={someSelectedLocal}
-                      />
-                    </CheckboxWrapper>
-                  )}
-                  {columns.map((col, i) => {
-                    const columnAction =
-                      typeof col.actions === "function" && col.actions(col.id);
-
-                    const variant = columnAction?.variant ?? "ghost";
-                    const finalColumnAction: ButtonProps = columnAction &&
-                      !columnAction.hidden && {
-                        ...columnAction,
-                        icon: {
-                          ...columnAction?.icon,
-                          image: columnAction?.icon?.image ?? RiArrowUpDownLine,
-                          size: columnAction?.icon?.size ?? 20,
-                        },
-                        showSubMenuOn: "self",
-                        tipMenuSize: columnAction?.tipMenuSize ?? "md",
-                        styles: {
-                          ...columnAction?.styles,
-                          self: css`
-                            padding: 0px;
-                            height: 34px;
-                            width: 34px;
-                            border-radius: 6px;
-                            &:not(:focus-visible):not(:active):not(:hover):not(
-                                :focus
-                              ) {
-                              background-color: transparent;
-                            }
-                            ${columnAction?.styles?.self};
-                          `,
-                        },
-                        hoverBackgroundColor:
-                          variant === "ghost" &&
-                          tableTheme?.headerActionHoverBackgroundColor,
-                        variant,
-                        "aria-label": "table-column-action",
-                      };
-
-                    return (
-                      <TableRowCell
-                        key={i}
-                        _index={i}
-                        width={col.width}
-                        contentStyle={css`
-                          display: flex;
-                          align-items: center;
-
-                          background: ${tableTheme?.headerBackgroundColor ||
-                          "linear-gradient(to bottom, #f0f0f0, #e4e4e4)"};
-
-                          ${col.width
-                            ? css`
-                                width: ${col.width};
-                                flex-direction: row;
-                              `
-                            : css`
-                                flex: 1;
-                              `}
-
-                          ${finalColumnAction &&
-                          css`
-                            padding: 4px 19.2px;
-                          `}
-
-                          ${col?.styles?.containerStyle}
-                        `}
-                      >
-                        <Label
-                          aria-label="table-column-label"
-                          $style={col?.styles?.labelStyle}
-                        >
-                          {col.caption}
-                        </Label>
-                        {finalColumnAction && <Button {...finalColumnAction} />}
-                      </TableRowCell>
-                    );
-                  })}
-
-                  {loose && withRowActions && (
-                    <StickyRowActions
-                      aria-label="header-row-loose-action"
-                      $theme={tableTheme}
-                      $loose={loose}
-                      $isScrolledRight={isScrolledRight}
-                    />
-                  )}
-                </TableHeader>
-              </ScrollWrapper>
-
-              {rowChildren.length > 0 ? (
-                <Scrollbar
-                  style={{ height: "100%", width: "100%" }}
-                  overflowX={loose ? "scroll" : "hidden"}
-                  overflowY="scroll"
-                  autoHideDelay={800}
-                  onScroll={loose ? handleWrapperScroll : undefined}
-                  ref={tableBodyRef}
-                  totalSize={rowVirtualizer.getTotalSize()}
-                  scrollOffset={rowVirtualizer.scrollOffset ?? 0}
-                >
-                  <TableBody
-                    $theme={tableTheme}
-                    aria-label="table-body"
-                    $loose={loose}
-                    $style={styles?.tableBodyStyle}
-                    // Reserve the full virtualized height so rows can be positioned correctly.
-                    style={{
-                      position: "relative",
-                      height: `${rowVirtualizer.getTotalSize()}px`,
-                    }}
-                  >
-                    {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-                      return (
-                        <div
-                          key={virtualRow.key}
-                          data-index={virtualRow.index}
-                          ref={rowVirtualizer.measureElement}
-                          style={{
-                            position: "absolute",
-                            top: 0,
-                            left: 0,
-                            width: "100%",
-                            display: "flex",
-                            flexDirection: "column",
-                            transform: `translateY(${virtualRow.start}px)`,
-                          }}
-                        >
-                          {rowChildren[virtualRow.index]}
-                        </div>
-                      );
-                    })}
-                  </TableBody>
-                </Scrollbar>
-              ) : (
-                <EmptyState $theme={tableTheme}>{emptySlate}</EmptyState>
-              )}
-
-              {sumRow && (
-                <ScrollWrapper
-                  ref={summaryScrollRef}
-                  $loose={loose}
-                  onScroll={loose ? handleSummaryScroll : undefined}
-                >
-                  <TableSummary
-                    $loose={loose}
-                    $theme={tableTheme}
-                    $selectable={selectable}
-                    aria-label="table-summary-wrapper"
-                  >
-                    {selectable && (
-                      <CheckboxWrapper
-                        aria-label="empty-checkbox"
-                        $position="summary"
+                      <TableHeader
                         $theme={tableTheme}
                         $loose={loose}
-                        $style={
-                          loose &&
-                          css`
-                            width: 36px;
-                            height: 49px;
-                          `
-                        }
-                      />
-                    )}
-                    {(() => {
-                      const cells: ReactNode[] = [];
-                      let colPointer = 0;
+                        aria-label="table-header"
+                        $style={styles?.tableHeaderStyle}
+                      >
+                        {selectable && (
+                          <CheckboxWrapper
+                            $position="header"
+                            $theme={tableTheme}
+                            $loose={loose}
+                          >
+                            <Checkbox
+                              styles={{
+                                controlStyle: css`
+                                  height: 100%;
+                                `,
+                                boxStyle: css`
+                                  width: 100%;
+                                `,
+                              }}
+                              onChange={handleSelectAll}
+                              checked={allRowSelectedLocal}
+                              indeterminate={someSelectedLocal}
+                            />
+                          </CheckboxWrapper>
+                        )}
+                        {columns.map((col, i) => {
+                          const columnAction =
+                            typeof col.actions === "function" &&
+                            col.actions(col.id);
 
-                      const totalCells = sumRow.reduce(
-                        (acc, col) => acc + (col.span ?? 1),
-                        0
-                      );
+                          const variant = columnAction?.variant ?? "ghost";
+                          const finalColumnAction: ButtonProps = columnAction &&
+                            !columnAction.hidden && {
+                              ...columnAction,
+                              icon: {
+                                ...columnAction?.icon,
+                                image:
+                                  columnAction?.icon?.image ??
+                                  RiArrowUpDownLine,
+                                size: columnAction?.icon?.size ?? 20,
+                              },
+                              showSubMenuOn: "self",
+                              tipMenuSize: columnAction?.tipMenuSize ?? "md",
+                              styles: {
+                                ...columnAction?.styles,
+                                self: css`
+                                  padding: 0px;
+                                  height: 34px;
+                                  width: 34px;
+                                  border-radius: 6px;
+                                  &:not(:focus-visible):not(:active):not(
+                                      :hover
+                                    ):not(:focus) {
+                                    background-color: transparent;
+                                  }
+                                  ${columnAction?.styles?.self};
+                                `,
+                              },
+                              hoverBackgroundColor:
+                                variant === "ghost" &&
+                                tableTheme?.headerActionHoverBackgroundColor,
+                              variant,
+                              "aria-label": "table-column-action",
+                            };
 
-                      sumRow.map((col, i) => {
-                        const span = col.span ?? 1;
-
-                        for (let s = 0; s < span; s++) {
-                          const columnWidth = columns[colPointer]?.width;
-
-                          const isLast =
-                            rowActions && colPointer === totalCells - 1;
-
-                          const isFirst = i === 0;
-
-                          cells.push(
+                          return (
                             <TableRowCell
+                              key={i}
                               _index={i}
-                              key={`${colPointer}-${s}`}
-                              width={columnWidth}
-                              bold={col.bold}
+                              width={col.width}
                               contentStyle={css`
                                 display: flex;
                                 align-items: center;
 
-                                ${columnWidth
+                                background: ${tableTheme?.headerBackgroundColor ||
+                                "linear-gradient(to bottom, #f0f0f0, #e4e4e4)"};
+
+                                ${col.width
                                   ? css`
-                                      width: ${columnWidth};
+                                      width: ${col.width};
                                       flex-direction: row;
                                     `
                                   : css`
                                       flex: 1;
-                                    `};
+                                    `}
 
-                                ${isLast &&
+                                ${finalColumnAction &&
                                 css`
-                                  padding-right: 36px;
-                                `};
+                                  padding: 4px 19.2px;
+                                `}
 
-                                ${loose &&
-                                css`
-                                  ${isFirst &&
-                                  css`
-                                    z-index: 40;
-                                    background: ${tableTheme?.summaryBackgroundColor ??
-                                    "#e4e4e4"};
-                                  `}
-                                `};
-
-                                ${col.styles?.self}
+                          ${col?.styles?.containerStyle}
                               `}
                             >
-                              {s === 0 ? col.content : ""}
+                              <Label
+                                aria-label="table-column-label"
+                                $style={col?.styles?.labelStyle}
+                              >
+                                {col.caption}
+                              </Label>
+                              {finalColumnAction && (
+                                <Button {...finalColumnAction} />
+                              )}
                             </TableRowCell>
                           );
+                        })}
 
-                          colPointer++;
-                        }
-                      });
+                        {loose && withRowActions && (
+                          <StickyRowActions
+                            aria-label="header-row-loose-action"
+                            $theme={tableTheme}
+                            $loose={loose}
+                            $isScrolledRight={isScrolledRight}
+                          />
+                        )}
+                      </TableHeader>
+                    </ScrollWrapper>
 
-                      return cells;
-                    })()}
-
-                    {loose && withRowActions && (
-                      <StickyRowActions
-                        aria-label="summary-row-loose-action"
-                        $theme={tableTheme}
-                        $loose={loose}
-                        $position={"summary"}
-                        $isScrolledRight={isScrolledRight}
-                      />
+                    {flatChildren.length > 0 ? (
+                      <Scrollbar
+                        style={{ height: "100%", width: "100%" }}
+                        overflowX={loose ? "scroll" : "hidden"}
+                        overflowY="scroll"
+                        autoHideDelay={800}
+                        onScroll={loose ? handleWrapperScroll : undefined}
+                        ref={tableBodyRef}
+                        totalSize={rowVirtualizer.getTotalSize()}
+                        scrollOffset={rowVirtualizer.scrollOffset ?? 0}
+                      >
+                        <TableBody
+                          $theme={tableTheme}
+                          aria-label="table-body"
+                          $loose={loose}
+                          $style={styles?.tableBodyStyle}
+                          // Reserve the full virtualized height so rows can be positioned correctly.
+                          style={{
+                            position: "relative",
+                            height: `${rowVirtualizer.getTotalSize()}px`,
+                          }}
+                        >
+                          {rowVirtualizer
+                            .getVirtualItems()
+                            .map((virtualRow) => {
+                              return (
+                                <div
+                                  key={virtualRow.key}
+                                  data-index={virtualRow.index}
+                                  ref={rowVirtualizer.measureElement}
+                                  style={{
+                                    position: "absolute",
+                                    top: 0,
+                                    left: 0,
+                                    width: "100%",
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    transform: `translateY(${virtualRow.start}px)`,
+                                  }}
+                                >
+                                  {flatChildren[virtualRow.index]}
+                                </div>
+                              );
+                            })}
+                        </TableBody>
+                      </Scrollbar>
+                    ) : (
+                      <EmptyState $theme={tableTheme}>{emptySlate}</EmptyState>
                     )}
-                  </TableSummary>
-                </ScrollWrapper>
-              )}
-            </TableContainer>
 
-            {isLoading && (
-              <OverlayBlocker
-                styles={{
-                  self: css`
-                    display: flex;
-                    align-items: start;
-                    padding-left: 10px;
-                    padding-top: 10px;
-                  `,
-                }}
-                show={isLoading}
-                onClick="preventDefault"
-              >
-                <LoadingSpinner
-                  styles={{
-                    containerStyle: css`
-                      background-color: black;
-                      border-radius: 20px;
-                      opacity: 0.8;
-                      color: white;
-                      padding: 4px;
-                      padding-right: 8px;
-                    `,
-                  }}
-                  label="Loading"
-                  gap={10}
-                  iconSize={24}
-                />
-              </OverlayBlocker>
-            )}
-          </Wrapper>
-        </TableColumnContext.Provider>
-      </TableLooseContext.Provider>
+                    {sumRow && (
+                      <ScrollWrapper
+                        ref={summaryScrollRef}
+                        $loose={loose}
+                        onScroll={loose ? handleSummaryScroll : undefined}
+                      >
+                        <TableSummary
+                          $loose={loose}
+                          $theme={tableTheme}
+                          $selectable={selectable}
+                          aria-label="table-summary-wrapper"
+                        >
+                          {selectable && (
+                            <CheckboxWrapper
+                              aria-label="empty-checkbox"
+                              $position="summary"
+                              $theme={tableTheme}
+                              $loose={loose}
+                              $style={
+                                loose &&
+                                css`
+                                  width: 36px;
+                                  height: 49px;
+                                `
+                              }
+                            />
+                          )}
+                          {(() => {
+                            const cells: ReactNode[] = [];
+                            let colPointer = 0;
+
+                            const totalCells = sumRow.reduce(
+                              (acc, col) => acc + (col.span ?? 1),
+                              0
+                            );
+
+                            sumRow.map((col, i) => {
+                              const span = col.span ?? 1;
+
+                              for (let s = 0; s < span; s++) {
+                                const columnWidth = columns[colPointer]?.width;
+
+                                const isLast =
+                                  rowActions && colPointer === totalCells - 1;
+
+                                const isFirst = i === 0;
+
+                                cells.push(
+                                  <TableRowCell
+                                    _index={i}
+                                    key={`${colPointer}-${s}`}
+                                    width={columnWidth}
+                                    bold={col.bold}
+                                    contentStyle={css`
+                                      display: flex;
+                                      align-items: center;
+
+                                      ${columnWidth
+                                        ? css`
+                                            width: ${columnWidth};
+                                            flex-direction: row;
+                                          `
+                                        : css`
+                                            flex: 1;
+                                          `};
+
+                                      ${isLast &&
+                                      css`
+                                        padding-right: 36px;
+                                      `};
+
+                                      ${loose &&
+                                      css`
+                                        ${isFirst &&
+                                        css`
+                                          z-index: 40;
+                                          background: ${tableTheme?.summaryBackgroundColor ??
+                                          "#e4e4e4"};
+                                        `}
+                                      `};
+
+                                      ${col.styles?.self}
+                                    `}
+                                  >
+                                    {s === 0 ? col.content : ""}
+                                  </TableRowCell>
+                                );
+
+                                colPointer++;
+                              }
+                            });
+
+                            return cells;
+                          })()}
+
+                          {loose && withRowActions && (
+                            <StickyRowActions
+                              aria-label="summary-row-loose-action"
+                              $theme={tableTheme}
+                              $loose={loose}
+                              $position={"summary"}
+                              $isScrolledRight={isScrolledRight}
+                            />
+                          )}
+                        </TableSummary>
+                      </ScrollWrapper>
+                    )}
+                  </TableContainer>
+
+                  {isLoading && (
+                    <OverlayBlocker
+                      styles={{
+                        self: css`
+                          display: flex;
+                          align-items: start;
+                          padding-left: 10px;
+                          padding-top: 10px;
+                        `,
+                      }}
+                      show={isLoading}
+                      onClick="preventDefault"
+                    >
+                      <LoadingSpinner
+                        styles={{
+                          containerStyle: css`
+                            background-color: black;
+                            border-radius: 20px;
+                            opacity: 0.8;
+                            color: white;
+                            padding: 4px;
+                            padding-right: 8px;
+                          `,
+                        }}
+                        label="Loading"
+                        gap={10}
+                        iconSize={24}
+                      />
+                    </OverlayBlocker>
+                  )}
+                </Wrapper>
+              </TableColumnContext.Provider>
+            </TableLooseContext.Provider>
+          </TableRowMetaContext.Provider>
+        </TableOpenRowContext.Provider>
+      </TableSelectionContext.Provider>
     </DnDContext.Provider>
   );
 }
@@ -1222,7 +1233,6 @@ export interface TableRowGroupProps {
   children?: ReactNode;
   title?: string;
   subtitle?: string;
-  selectable?: boolean;
   className?: string;
   styles?: TableRowGroupStyles;
 }
@@ -1251,75 +1261,11 @@ function TableRowGroup({
   children,
   title,
   subtitle,
-  selectable = false,
-  handleSelect,
-  selectedData,
-  isLast,
-  onLastRowReached,
-  draggable,
   className,
   styles,
-  ...props
-}: TableRowGroupProps & {
-  selectedData?: string[];
-  handleSelect?: (data: string) => void;
-  onLastRowReached?: () => void;
-  isLast?: boolean;
-  draggable?: boolean;
-}) {
+}: TableRowGroupProps) {
   const { currentTheme } = useTheme();
   const tableTheme = currentTheme.table;
-
-  const { openRowId, setOpenRowId, alwaysShowDragIcon } =
-    props as TableAlwaysShowDragIcon & TableRowOpenWithId;
-
-  const { dragItem, setDragItem, onDragged } = useContext(DnDContext);
-
-  const rowChildren = resolveRowChildren(children).map((child, index) => {
-    if (!isValidElement<TableRowProps & TableRowOpenWithId>(child)) return null;
-    if (child.type === TableRow) {
-      const props = child.props as TableRowProps & TableRowOpenWithId;
-
-      const isSelected = selectedData.some(
-        (d) => JSON.stringify(d) === JSON.stringify(props.rowId)
-      );
-
-      return cloneElement(child, {
-        selectable,
-        isSelected,
-        handleSelect,
-        isLast,
-        onLastRowReached,
-        index: index,
-        groupLength: Children?.count(children),
-        draggable: draggable,
-        groupId: id,
-        openRowId,
-        setOpenRowId,
-        alwaysShowDragIcon,
-        onDropItem: (newPosition: number) => {
-          if (dragItem) {
-            const { oldGroupId, oldPosition, id: rowId } = dragItem;
-            onDragged?.({
-              oldGroupId,
-              newGroupId: id,
-              oldPosition,
-              newPosition: newPosition,
-              id: rowId,
-            });
-
-            setDragItem(null);
-          }
-        },
-      } as TableRowProps &
-        TableAlwaysShowDragIcon & {
-          index?: number;
-          onDropItem?: (position: number) => void;
-          groupLength?: number;
-          draggable?: boolean;
-        });
-    }
-  });
 
   const [isOpen, setIsOpen] = useState(true);
 
@@ -1386,7 +1332,9 @@ function TableRowGroup({
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.3, ease: "easeInOut" }}
           >
-            {rowChildren}
+            <TableRowGroupIdContext.Provider value={id ?? "default"}>
+              {children}
+            </TableRowGroupIdContext.Provider>
           </TableRowGroupBody>
         )}
       </AnimatePresence>
@@ -1490,54 +1438,51 @@ export interface TableRowStyles {
   rowCellStyle?: CSSProp;
 }
 
-interface TableRowOpenWithId {
-  openRowId?: string | null;
-  setOpenRowId?: (prop: string | null) => void;
-}
-
 function TableRow({
   content,
-  selectable = false,
-  handleSelect,
   styles,
   rowId,
   children,
   actions,
-  onLastRowReached,
   onClick,
-  groupLength,
-  groupId = "default",
-  onDropItem,
-  draggable,
+  groupId: groupIdProp = "default",
   className,
   id,
-  ...props
-}: TableRowProps &
-  Partial<{
-    onLastRowReached?: () => void;
-    onDropItem?: (position: number) => void;
-    groupLength?: number;
-    draggable?: boolean;
-  }>) {
+}: TableRowProps) {
   const { currentTheme } = useTheme();
   const tableTheme = currentTheme.table;
 
-  const { setDragItem, dragItem } = useContext(DnDContext);
+  const { onDragged } = useTableDND();
+  const { openRowId, setOpenRowId } = useTableOpenRow();
+  const { selectedData, handleSelect } = useTableSelection();
   const {
-    openRowId,
-    setOpenRowId,
+    rowIds,
+    rowPositions,
     alwaysShowDragIcon,
-    isSelected = false,
-    isLast,
-    index,
-  } = props as TableRowOpenWithId &
-    TableAlwaysShowDragIcon & {
-      index?: number;
-      isSelected?: boolean;
-      isLast?: boolean;
-    };
+    draggable,
+    onLastRowReached,
+  } = useTableRowMeta();
+  const { loose, selectable, setWithRowActions, isScrolledRight } =
+    useTableLoose();
 
-  const { loose, setWithRowActions, isScrolledRight } = useTableLoose();
+  /*
+   * A row inside a Table.Row.Group always takes that group's id, the same
+   * way TableRowGroup used to unconditionally inject `groupId`. A row
+   * outside any group has no provider above it, so it falls back to its
+   * own prop.
+   */
+  const contextGroupId = useContext(TableRowGroupIdContext);
+  const groupId = contextGroupId ?? groupIdProp;
+
+  const isSelected = !!rowId && selectedData.includes(rowId);
+  /** Position among all rows in the table, used only to detect the very last row (see the effect below). */
+  const index = rowId ? rowIds.indexOf(rowId) : -1;
+  const isLast = index === rowIds.length - 1;
+
+  const rowPosition = rowId ? rowPositions.get(rowId) : undefined;
+  /** Position within this row's own group, used for drag-and-drop reordering below. */
+  const localIndex = rowPosition?.localIndex ?? 0;
+  const groupLength = rowPosition?.groupLength ?? 0;
 
   const rowActions = actions?.(rowId ?? "").filter((action) => !action.hidden);
   const hasRowActions = (rowActions?.length ?? 0) > 0;
@@ -1617,12 +1562,15 @@ function TableRow({
           `}
         `}
         draggable={draggable}
-        onDragStart={() =>
-          setDragItem({
-            oldGroupId: groupId!,
-            oldPosition: index,
-            id: rowId ?? "",
-          })
+        onDragStart={(e) =>
+          e.dataTransfer.setData(
+            "application/json",
+            JSON.stringify({
+              id: rowId,
+              oldGroupId: groupId,
+              oldPosition: localIndex,
+            })
+          )
         }
         onDragOver={(e) => {
           e.preventDefault();
@@ -1646,13 +1594,21 @@ function TableRow({
           e.preventDefault();
           setIsOver(false);
 
+          const dragItem = JSON.parse(
+            e.dataTransfer.getData("application/json")
+          ) as {
+            id: string;
+            oldGroupId: string;
+            oldPosition: number;
+          };
+
           let position = 0;
           const isSameGroup = dragItem?.oldGroupId === groupId;
 
           if (dropPosition === "top") {
-            position = index;
+            position = localIndex;
           } else {
-            position = index + 1;
+            position = localIndex + 1;
           }
 
           if (isSameGroup && dragItem?.oldPosition < position) {
@@ -1662,14 +1618,14 @@ function TableRow({
           const clampedPosition = Math.min(position, groupLength ?? 0);
 
           if (dragItem) {
-            setDragItem({
-              ...dragItem,
-              id: rowId,
-              newGroupId: groupId || "default",
+            onDragged?.({
+              id: dragItem.id,
+              oldGroupId: dragItem.oldGroupId || "",
+              oldPosition: dragItem.oldPosition,
+              newGroupId: groupId || "",
+              newPosition: clampedPosition,
             });
           }
-
-          onDropItem?.(clampedPosition);
         }}
       >
         {selectable && (
@@ -2225,23 +2181,51 @@ function resolveChildren(
   return result;
 }
 
-function resolveRowChildren(
+/**
+ * For each row, finds its index among its own group's rows and that
+ * group's total row count. Mirrors getAllRowContentsFromChildren's
+ * traversal, but a nested Table.Row.Group starts a new counting scope
+ * instead of contributing to its parent's.
+ */
+function getRowPositionsFromChildren(
   children: ReactNode
-): ReactElement<TableRowProps>[] {
-  const result: ReactElement<TableRowProps>[] = [];
+): Map<string, RowPosition> {
+  const result = new Map<string, RowPosition>();
 
-  Children.forEach(children, (child) => {
-    if (!isValidElement(child)) return;
+  // Returns the row ids found directly at this level (not inside a nested
+  // group), and records their positions into `result` once the full count
+  // for this level is known.
+  function walk(nodes: ReactNode): string[] {
+    const ownRowIds: string[] = [];
 
-    if (child.type === TableRow) {
-      result.push(child as ReactElement<TableRowProps>);
-    } else if (typeof child.type === "function") {
-      // Unwrap wrapper components recursively until we find TableRow elements
-      const rendered = (child.type as Function)(child.props);
-      result.push(...resolveRowChildren(rendered));
-    }
-  });
+    Children.forEach(nodes, (child) => {
+      if (!isValidElement(child)) return;
 
+      if (child.type === TableRowGroup) {
+        const groupChildren = (child.props as TableRowGroupProps).children;
+        walk(groupChildren);
+        return;
+      }
+
+      if (child.type === TableRow) {
+        const rowId = (child.props as TableRowProps).rowId;
+        if (rowId) ownRowIds.push(rowId);
+        return;
+      }
+
+      if (typeof child.type === "function") {
+        ownRowIds.push(...walk((child.type as Function)(child.props)));
+      }
+    });
+
+    ownRowIds.forEach((rowId, localIndex) => {
+      result.set(rowId, { localIndex, groupLength: ownRowIds.length });
+    });
+
+    return ownRowIds;
+  }
+
+  walk(children);
   return result;
 }
 

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -4,6 +4,7 @@ import React, {
   isValidElement,
   ReactElement,
   ReactNode,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -358,30 +359,77 @@ function Table({
 
   const hasActions = filteredActions.length > 0;
 
-  // Scroll sync for loose mode.
-  // Header and summary don't scroll on their own — their scrollLeft is driven
-  // by TableBody (the only real scroll container).
-
+  // Scroll sync for loose mode. Header and summary don't scroll on their own,
+  // their scrollLeft is driven by TableBody (the only real scroll container).
   const headerScrollRef = useRef<HTMLDivElement>(null);
   const summaryScrollRef = useRef<HTMLDivElement>(null);
 
-  // Sync horizontal scroll: body → header & summary
-  const handleWrapperScroll = () => {
-    const viewport = getViewport();
-    if (!viewport) return;
+  // Normalizes access across the three scroll containers: body is wrapped
+  // in Scrollbar (needs getViewport()), header/summary are plain divs.
+  const scrollTargets = useRef([
+    {
+      key: "body" as const,
+      getEl: () => tableBodyRef.current?.getViewport() ?? null,
+    },
+    { key: "header" as const, getEl: () => headerScrollRef.current },
+    { key: "summary" as const, getEl: () => summaryScrollRef.current },
+  ]).current;
 
-    const scrollLeft = viewport.scrollLeft;
-    const scrollRight =
-      viewport.scrollWidth - viewport.clientWidth - scrollLeft;
+  /*
+   * Guards against the echo below: assigning `el.scrollLeft` on header/summary
+   * queues a native "scroll" event on them, which re-enters this function
+   * during the same frame. Without this flag every real scroll tick did 3x
+   * the work (3 separate scrollWidth/clientWidth reads, each forcing a sticky
+   * layout recalc on `loose` tables) even though the two echoed calls always
+   * find nothing left to do. That redundant thrash is what shows up as
+   * horizontal-scroll jitter on wide `loose` tables.
+   */
+  const isSyncingScrollRef = useRef(false);
 
-    setIsScrolledLeft(scrollLeft > 5);
-    setIsScrolledRight(scrollRight > 5);
+  // Any of the three can be the source. Propagates to the other two, guarded
+  // by value-equality so the chain self-terminates instead of ping-ponging.
+  const syncScroll = useCallback(
+    (sourceKey: "body" | "header" | "summary") => {
+      if (isSyncingScrollRef.current) return;
 
-    if (headerScrollRef.current)
-      headerScrollRef.current.scrollLeft = scrollLeft;
-    if (summaryScrollRef.current)
-      summaryScrollRef.current.scrollLeft = scrollLeft;
-  };
+      const source = scrollTargets.find((t) => t.key === sourceKey)?.getEl();
+      if (!source) return;
+
+      const scrollLeft = source.scrollLeft;
+
+      // Shadow indicators depend on scroll position + total scrollWidth.
+      const scrollRight = source.scrollWidth - source.clientWidth - scrollLeft;
+      setIsScrolledLeft(scrollLeft > 5);
+      setIsScrolledRight(scrollRight > 5);
+
+      isSyncingScrollRef.current = true;
+      for (const target of scrollTargets) {
+        if (target.key === sourceKey) continue;
+        const el = target.getEl();
+        if (el && el.scrollLeft !== scrollLeft) {
+          el.scrollLeft = scrollLeft;
+        }
+      }
+      // Native "scroll" events queued by the assignments above fire before
+      // the next paint, in the same batch as rAF callbacks. Releasing here
+      // still lets this frame's echoes hit the early-return, while leaving
+      // the guard clear in time for the next real user scroll tick.
+      requestAnimationFrame(() => {
+        isSyncingScrollRef.current = false;
+      });
+    },
+    [scrollTargets]
+  );
+
+  const handleHeaderScroll = useCallback(
+    () => syncScroll("header"),
+    [syncScroll]
+  );
+  const handleBodyScroll = useCallback(() => syncScroll("body"), [syncScroll]);
+  const handleSummaryScroll = useCallback(
+    () => syncScroll("summary"),
+    [syncScroll]
+  );
 
   // On mount, check if the table body already overflows horizontally.
   // This ensures the right shadow appears immediately without needing to scroll first.
@@ -391,17 +439,6 @@ function Table({
     const scrollRight = viewport.scrollWidth - viewport.clientWidth;
     setIsScrolledRight(scrollRight > 5);
   }, []);
-
-  // Sync horizontal scroll: summary → body & header
-  const handleSummaryScroll = (e: React.UIEvent<HTMLDivElement>) => {
-    const scrollLeft = e.currentTarget.scrollLeft;
-    const viewport = getViewport();
-    if (viewport) viewport.scrollLeft = scrollLeft;
-    if (headerScrollRef.current)
-      headerScrollRef.current.scrollLeft = scrollLeft;
-    if (summaryScrollRef.current)
-      summaryScrollRef.current.scrollLeft = scrollLeft;
-  };
 
   const rowVirtualizer = useVirtualizer({
     count: flatChildren?.length,
@@ -572,7 +609,7 @@ function Table({
                   >
                     <ScrollWrapper
                       ref={headerScrollRef}
-                      onScroll={loose ? handleSummaryScroll : undefined}
+                      onScroll={loose ? handleHeaderScroll : undefined}
                       $loose={loose}
                     >
                       <TableHeader
@@ -704,7 +741,7 @@ function Table({
                         overflowX={loose ? "scroll" : "hidden"}
                         overflowY="scroll"
                         autoHideDelay={800}
-                        onScroll={loose ? handleWrapperScroll : undefined}
+                        onScroll={loose ? handleBodyScroll : undefined}
                         ref={tableBodyRef}
                         totalSize={rowVirtualizer.getTotalSize()}
                         scrollOffset={rowVirtualizer.scrollOffset ?? 0}

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -780,12 +780,16 @@ function Table({
                                   ref={rowVirtualizer.measureElement}
                                   style={{
                                     position: "absolute",
-                                    top: 0,
+                                    // Not transform: translateY() here. A
+                                    // transform on this ancestor would create
+                                    // a new containing block, which breaks
+                                    // TableRowGroupHeader's `position: sticky`
+                                    // for grouped rows.
+                                    top: virtualRow.start,
                                     left: 0,
                                     width: "100%",
                                     display: "flex",
                                     flexDirection: "column",
-                                    transform: `translateY(${virtualRow.start}px)`,
                                   }}
                                 >
                                   {flatChildren[virtualRow.index]}

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -157,14 +157,10 @@ const TableLooseContext = createContext<{
   selectable?: boolean;
   withRowActions?: boolean;
   setWithRowActions?: (value: boolean) => void;
-  isScrolledLeft?: boolean;
-  isScrolledRight?: boolean;
 }>({
   loose: false,
   selectable: false,
   withRowActions: false,
-  isScrolledLeft: false,
-  isScrolledRight: false,
 });
 const useTableLoose = () => useContext(TableLooseContext);
 
@@ -258,11 +254,23 @@ function Table({
 
   const [withRowActions, setWithRowActions] = useState(false);
 
-  // Tracks whether the table body has been scrolled horizontally.
-  // isScrolledLeft: activates the shadow effect on sticky left columns (e.g. first cell).
-  // isScrolledRight: activates the shadow effect on sticky right actions — true when there's still content to scroll right.
-  const [isScrolledLeft, setIsScrolledLeft] = useState(false);
-  const [isScrolledRight, setIsScrolledRight] = useState(false);
+  /*
+   * Drives the shadow effect on sticky left columns / sticky row actions as
+   * the table scrolls horizontally. This used to be React state, but
+   * crossing the shadow threshold (leaving either edge) flipped it and
+   * re-rendered every TableRowCell across every visible + overscanned
+   * row/column through TableLooseContext, which is what showed up as
+   * jitter right at the scroll edges. Writing CSS custom properties
+   * directly on tableContainerRef instead costs a style recalc scoped to
+   * the handful of pseudo-elements that read the variable, not a re-render.
+   */
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+  const applyScrollShadow = useCallback((isLeft: boolean, isRight: boolean) => {
+    const el = tableContainerRef.current;
+    if (!el) return;
+    el.style.setProperty("--table-scrolled-left", isLeft ? "1" : "0");
+    el.style.setProperty("--table-scrolled-right", isRight ? "1" : "0");
+  }, []);
 
   const handleSelectAll = () => {
     const currentPageIds = getAllRowContentsFromChildren(children);
@@ -399,8 +407,7 @@ function Table({
 
       // Shadow indicators depend on scroll position + total scrollWidth.
       const scrollRight = source.scrollWidth - source.clientWidth - scrollLeft;
-      setIsScrolledLeft(scrollLeft > 5);
-      setIsScrolledRight(scrollRight > 5);
+      applyScrollShadow(scrollLeft > 5, scrollRight > 5);
 
       isSyncingScrollRef.current = true;
       for (const target of scrollTargets) {
@@ -418,7 +425,7 @@ function Table({
         isSyncingScrollRef.current = false;
       });
     },
-    [scrollTargets]
+    [scrollTargets, applyScrollShadow]
   );
 
   const handleHeaderScroll = useCallback(
@@ -431,14 +438,18 @@ function Table({
     [syncScroll]
   );
 
-  // On mount, check if the table body already overflows horizontally.
-  // This ensures the right shadow appears immediately without needing to scroll first.
+  // Re-derive the shadows whenever the body's overflow could have changed
+  // (initial mount, and whenever the sticky row-actions column appears or
+  // disappears and shifts how much content overflows), not just on scroll.
   useEffect(() => {
-    const viewport = getViewport();
+    const viewport = tableBodyRef.current?.getViewport();
     if (!viewport) return;
-    const scrollRight = viewport.scrollWidth - viewport.clientWidth;
-    setIsScrolledRight(scrollRight > 5);
-  }, []);
+    const { scrollLeft, scrollWidth, clientWidth } = viewport;
+    applyScrollShadow(
+      scrollLeft > 5,
+      scrollWidth - clientWidth - scrollLeft > 5
+    );
+  }, [rowActions, applyScrollShadow]);
 
   const rowVirtualizer = useVirtualizer({
     count: flatChildren?.length,
@@ -471,21 +482,17 @@ function Table({
 
   const dndContextValue = useMemo(() => ({ onDragged }), [onDragged]);
 
+  const looseContextValue = useMemo(
+    () => ({ loose, selectable, withRowActions, setWithRowActions }),
+    [loose, selectable, withRowActions]
+  );
+
   return (
     <DnDContext.Provider value={dndContextValue}>
       <TableSelectionContext.Provider value={selectionContextValue}>
         <TableOpenRowContext.Provider value={openRowContextValue}>
           <TableRowMetaContext.Provider value={rowMetaContextValue}>
-            <TableLooseContext.Provider
-              value={{
-                loose,
-                selectable,
-                withRowActions,
-                setWithRowActions,
-                isScrolledLeft,
-                isScrolledRight,
-              }}
-            >
+            <TableLooseContext.Provider value={looseContextValue}>
               <TableColumnContext.Provider value={columns}>
                 <Wrapper
                   id={id}
@@ -603,6 +610,7 @@ function Table({
                   )}
 
                   <TableContainer
+                    ref={tableContainerRef}
                     $theme={tableTheme}
                     $loose={loose}
                     $hasSelected={selectedData.length > 0}
@@ -729,7 +737,6 @@ function Table({
                             aria-label="header-row-loose-action"
                             $theme={tableTheme}
                             $loose={loose}
-                            $isScrolledRight={isScrolledRight}
                           />
                         )}
                       </TableHeader>
@@ -887,7 +894,6 @@ function Table({
                                 $theme={tableTheme}
                                 $loose={loose}
                                 $position={"summary"}
-                                $isScrolledRight={isScrolledRight}
                               />
                             )}
                           </IndexedCells>
@@ -1007,7 +1013,6 @@ const StickyRowActions = styled.div<{
   $loose?: boolean;
   $theme?: TableThemeConfig;
   $position?: "header" | "summary";
-  $isScrolledRight?: boolean;
   $isFirefox?: boolean;
 }>`
   position: sticky;
@@ -1031,8 +1036,9 @@ const StickyRowActions = styled.div<{
     left: -6px;
     bottom: 0;
     width: 6px;
-    background: ${({ $isScrolledRight, $theme }) =>
-      $isScrolledRight ? $theme?.rightLooseEffectColor : "transparent"};
+    /* toggled via CSS var rather than a React prop, to minimize re-rendering. */
+    background: ${({ $theme }) => $theme?.rightLooseEffectColor};
+    opacity: var(--table-scrolled-right, 0);
     pointer-events: none;
   }
 `;
@@ -1519,8 +1525,7 @@ function TableRow({
     draggable,
     onLastRowReached,
   } = useTableRowMeta();
-  const { loose, selectable, setWithRowActions, isScrolledRight } =
-    useTableLoose();
+  const { loose, selectable, setWithRowActions } = useTableLoose();
 
   /*
    * A row inside a Table.Row.Group always takes that group's id, the same
@@ -1822,9 +1827,9 @@ function TableRow({
                         left: -6px;
                         bottom: 0;
                         width: 6px;
-                        background: ${isScrolledRight
-                          ? tableTheme?.rightLooseEffectColor
-                          : "transparent"};
+                        /* CSS var toggled imperatively by syncScroll. */
+                        background: ${tableTheme?.rightLooseEffectColor};
+                        opacity: var(--table-scrolled-right, 0);
                         pointer-events: none;
                       }
                     `};
@@ -2059,7 +2064,7 @@ const TableRowCell = React.memo(function TableRowCell({
     width: widthFromPosition,
   } = useTableRowCellPosition();
 
-  const { loose, selectable, isScrolledLeft } = useTableLoose();
+  const { loose, selectable } = useTableLoose();
   const isFirst = index === 0;
   const { currentTheme } = useTheme();
   const tableTheme = currentTheme?.table;
@@ -2073,7 +2078,6 @@ const TableRowCell = React.memo(function TableRowCell({
       id={id}
       $loose={loose}
       $selectable={selectable}
-      $isScrolledLeft={isScrolledLeft}
       $sticky={isFirst}
       className={applyClassName("table-row-cell", className)}
       aria-label="table-row-cell"
@@ -2114,7 +2118,6 @@ const CellContent = styled.div<{
   $sticky: boolean;
   $selectable?: boolean;
   $theme: TableThemeConfig;
-  $isScrolledLeft?: boolean;
 }>`
   *,
   ::before,
@@ -2146,7 +2149,7 @@ const CellContent = styled.div<{
           `
         : ""};
 
-  ${({ $loose, $sticky, $selectable, $theme, $isScrolledLeft }) =>
+  ${({ $loose, $sticky, $selectable, $theme }) =>
     $sticky &&
     $loose &&
     css`
@@ -2165,9 +2168,9 @@ const CellContent = styled.div<{
         right: -6px;
         bottom: 0;
         width: 6px;
-        background: ${$isScrolledLeft
-          ? $theme?.leftLooseEffectColor
-          : "var(--row-bg, transparent)"};
+        /* toggled imperatively by syncScroll; previously every cell in every row re-rendered whenever this flipped. */
+        background: ${$theme?.leftLooseEffectColor};
+        opacity: var(--table-scrolled-left, 0);
         pointer-events: none;
       }
     `};


### PR DESCRIPTION
 ## Root causes & fixes

1. Header/body/summary scroll sync echoed through all three containers every tick, redoing scrollWidth/clientWidth reads (forcing sticky-layout recalcs) 3x per scroll. Added a re-entrancy guard so echoed events short-circuit.

2. The scroll-shadow flags lived in React context, so crossing either edge re-rendered every cell in every row/column. Replaced with CSS custom properties written directly on the container ref.


Tick what you have done:

[ ] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself