### PR TITLE
[Bug] SYST-812: Fix toast jittery progress bar

### DIFF
--- a/components/toast.stories.tsx
+++ b/components/toast.stories.tsx
@@ -127,6 +127,7 @@ Each variant automatically provides its own icon and theme styling.
 - Enabled by default
 - Visualizes remaining display duration
 - Can be disabled using \`withLoadingBar={false}\`
+- The fill animation transition duration can be customized using \`transitionDuration\` (in milliseconds)
 
 #### Action Buttons
 - Rendered below the content area

--- a/components/toast.tsx
+++ b/components/toast.tsx
@@ -273,10 +273,8 @@ function ToastItem({ item, onClose }: ToastItemProps) {
                 bottom: 0;
                 left: 0;
               `,
-              valueBarStyle: css`
-                transition: width ${disappearAfterMs}ms linear;
-              `,
             }}
+            transitionDuration={disappearAfterMs}
             variant={variant}
             value={progress}
           />

--- a/components/toast.tsx
+++ b/components/toast.tsx
@@ -145,23 +145,9 @@ function ToastItem({ item, onClose }: ToastItemProps) {
   const [progress, setProgress] = useState(100);
 
   useEffect(() => {
-    const start = performance.now();
-    let raf: number;
-
-    const tick = (now: number) => {
-      const elapsed = now - start;
-      const next = Math.max(0, 100 - (elapsed / disappearAfterMs) * 100);
-      setProgress(next);
-
-      if (next > 0) {
-        raf = requestAnimationFrame(tick);
-      }
-    };
-
-    raf = requestAnimationFrame(tick);
-
+    const raf = requestAnimationFrame(() => setProgress(0));
     return () => cancelAnimationFrame(raf);
-  }, [disappearAfterMs]);
+  }, []);
 
   const {
     position: iconPosition = ToastIconPosition.LeftTop,
@@ -286,6 +272,9 @@ function ToastItem({ item, onClose }: ToastItemProps) {
                 position: absolute;
                 bottom: 0;
                 left: 0;
+              `,
+              valueBarStyle: css`
+                transition: width ${disappearAfterMs}ms linear;
               `,
             }}
             variant={variant}

--- a/components/trackbar.tsx
+++ b/components/trackbar.tsx
@@ -16,6 +16,11 @@ export interface TrackbarProps {
   containerColor?: string;
   onChange?: (value?: number) => void;
   labels?: TrackbarLabels;
+  /**
+   * Controls the duration of the fill width transition animation in milliseconds.
+   * Useful for synchronizing the visual progress animation with external timing.
+   */
+  transitionDuration?: number;
   className?: string;
   id?: string;
 }
@@ -78,6 +83,7 @@ function Trackbar({
   containerColor,
   onChange,
   labels,
+  transitionDuration,
   className,
   id,
 }: TrackbarProps) {
@@ -178,6 +184,7 @@ function Trackbar({
             $fillColor={fillColor}
             $indeterminate={indeterminate}
             $isDragging={isDragging}
+            $transitionDuration={transitionDuration}
             $directionTo={directionTo}
             $style={styles?.valueBarStyle}
           />
@@ -308,6 +315,7 @@ const Fill = styled.div<{
   $style?: CSSProp;
   $fillColor?: string;
   $isDragging: boolean;
+  $transitionDuration?: number;
 }>`
   position: absolute;
   top: 0;
@@ -316,8 +324,8 @@ const Fill = styled.div<{
   background-color: ${({ $theme, $variant, $fillColor }) =>
     $fillColor ?? $theme?.[$variant]?.barColor};
 
-  transition: ${({ $isDragging }) =>
-    $isDragging ? "none" : "width 0.1s linear"};
+  transition: ${({ $isDragging, $transitionDuration }) =>
+    $isDragging ? "none" : `width ${$transitionDuration ?? 100}ms linear`};
 
   ${({ $indeterminate, $directionTo, $maxValue, $value, $editable }) => {
     const widthPercent = $maxValue > 0 ? ($value / $maxValue) * 100 : 0;

--- a/components/trackbar.tsx
+++ b/components/trackbar.tsx
@@ -177,6 +177,7 @@ function Trackbar({
             $editable={editable}
             $fillColor={fillColor}
             $indeterminate={indeterminate}
+            $isDragging={isDragging}
             $directionTo={directionTo}
             $style={styles?.valueBarStyle}
           />
@@ -306,6 +307,7 @@ const Fill = styled.div<{
   $directionTo: TrackbarDirectionTo;
   $style?: CSSProp;
   $fillColor?: string;
+  $isDragging: boolean;
 }>`
   position: absolute;
   top: 0;
@@ -313,6 +315,9 @@ const Fill = styled.div<{
   height: 100%;
   background-color: ${({ $theme, $variant, $fillColor }) =>
     $fillColor ?? $theme?.[$variant]?.barColor};
+
+  transition: ${({ $isDragging }) =>
+    $isDragging ? "none" : "width 0.1s linear"};
 
   ${({ $indeterminate, $directionTo, $maxValue, $value, $editable }) => {
     const widthPercent = $maxValue > 0 ? ($value / $maxValue) * 100 : 0;


### PR DESCRIPTION
Description:
This pull request fixes an issue in the `Toast` component where the `ProgressBar` animation could become jittery due to frequent progress updates from `setInterval` conflicting with the `CSS` width transition.

Previously, `setInterval` combined with `useEffect` was used to drive the progress value. This caused inconsistent animation behavior on some devices with different refresh rates, as the updates were not synchronized with the browser rendering cycle. It also conflicted with `Fill`'s default transition (`transition: width 0.1s linear`), causing the bar to continuously re-target instead of animating smoothly.

This is fixed by overriding the transition duration via `transitionDuration` prop inside of the `Trackbar`.

In `Toast`:
```tsx
<Trackbar
  styles={{
    containerStyle: css`
      height: 2px;
      position: absolute;
      bottom: 0;
      left: 0;
    `,
  }}
  transitionDuration={disappearAfterMs}
  variant={variant}
  value={progress}
/>
```

In the `Trackbar` component:
```tsx
transition: ${({ $isDragging, $transitionDuration }) =>
    $isDragging ? "none" : `width ${$transitionDuration ?? 100}ms linear`};
```

Source:
[[Bug] SYST-812: Fix toast jittery progress bar](https://linear.app/systatum/issue/SYST-812/fix-toast-jittery-progress-bar)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[ ] I have created/updated any relevant test code
[x] I have tested it myself