### PR TITLE
[Improvement] SYST-819: Extends the some `HTMLDivElement` inside of `ThumbField`

### DIFF
--- a/components/thumb-field.tsx
+++ b/components/thumb-field.tsx
@@ -25,6 +25,10 @@ interface BaseThumbFieldProps
   id?: string;
   showError?: boolean;
   thumbText?: ThumbFieldThumbText;
+  onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onMouseDown?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onMouseEnter?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onMouseLeave?: (event: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 export interface ThumbFieldThumbText {

--- a/components/thumb-field.tsx
+++ b/components/thumb-field.tsx
@@ -5,7 +5,7 @@ import {
   RiThumbUpFill,
   RiThumbUpLine,
 } from "@remixicon/react";
-import { ChangeEvent, ReactNode, useRef, useState } from "react";
+import { ChangeEvent, HTMLAttributes, ReactNode, useRef } from "react";
 import styled, { css, CSSProp } from "styled-components";
 import { StatefulForm } from "./stateful-form";
 import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
@@ -13,7 +13,8 @@ import { useTheme } from "./../theme/provider";
 import { ThumbFieldThemeConfig } from "./../theme";
 import { applyClassName } from "./../constants/classname";
 
-interface BaseThumbFieldProps {
+interface BaseThumbFieldProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
   value?: boolean | null;
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
   thumbsUpBackgroundColor?: string;
@@ -58,6 +59,7 @@ function BaseThumbField({
   thumbText,
   styles,
   id,
+  ...props
 }: BaseThumbFieldProps) {
   const { currentTheme } = useTheme();
   const thumbFieldTheme = currentTheme.thumbField;
@@ -98,7 +100,11 @@ function BaseThumbField({
   };
 
   return (
-    <InputGroup aria-label="thumb-field" $style={styles?.triggerWrapperStyle}>
+    <InputGroup
+      {...props}
+      aria-label="thumb-field"
+      $style={styles?.triggerWrapperStyle}
+    >
       <input
         aria-label="thumbfield-input"
         ref={thumbInputRef}
@@ -179,8 +185,7 @@ function BaseThumbField({
 export type ThumbFieldStyles = BaseThumbFieldStyles & FieldLaneStyles;
 
 export interface ThumbFieldProps
-  extends
-    Omit<BaseThumbFieldProps, "styles">,
+  extends Omit<BaseThumbFieldProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
   styles?: ThumbFieldStyles;
 }
@@ -198,7 +203,7 @@ function ThumbField({
   labelWidth,
   labelPosition,
   className,
-  ...rest
+  ...props
 }: ThumbFieldProps) {
   const inputId = StatefulForm.sanitizeId({
     prefix: "ThumbField",
@@ -227,7 +232,7 @@ function ThumbField({
       label={label}
       errorIconPosition="none"
       className={applyClassName("thumb-field", className)}
-      required={rest.required}
+      required={props.required}
       styles={{
         bodyStyle,
         controlStyle,
@@ -236,7 +241,7 @@ function ThumbField({
       }}
     >
       <BaseThumbField
-        {...rest}
+        {...props}
         disabled={disabled}
         name={name}
         id={inputId}

--- a/test/component/thumb-field.cy.tsx
+++ b/test/component/thumb-field.cy.tsx
@@ -2,7 +2,89 @@ import { css } from "styled-components";
 import { ThumbField } from "./../../components/thumb-field";
 
 describe("ThumbField", () => {
-  describe("thumbText", () => {
+  context("events", () => {
+    context("onClick", () => {
+      context("when clicking the thumb field", () => {
+        it("should call the click handler", () => {
+          const onClick = cy.stub().as("onClick");
+
+          cy.mount(<ThumbField aria-label="thumb-field" onClick={onClick} />);
+
+          cy.findByLabelText("thumb-field").click();
+
+          cy.get("@onClick").should("have.been.calledOnce");
+        });
+      });
+    });
+
+    context("onMouseDown", () => {
+      context("when pressing the mouse button on the thumb field", () => {
+        it("should call the mouse down handler", () => {
+          const onMouseDown = cy.stub().as("onMouseDown");
+
+          cy.mount(
+            <ThumbField aria-label="thumb-field" onMouseDown={onMouseDown} />
+          );
+
+          cy.findByLabelText("thumb-field").trigger("mousedown");
+          cy.wait(200);
+
+          cy.get("@onMouseDown").should("have.been.calledOnce");
+        });
+      });
+    });
+
+    context("onMouseUp", () => {
+      context("when releasing the mouse button on the thumb field", () => {
+        it("should call the mouse up handler", () => {
+          const onMouseUp = cy.stub().as("onMouseUp");
+
+          cy.mount(
+            <ThumbField aria-label="thumb-field" onMouseUp={onMouseUp} />
+          );
+
+          cy.findByLabelText("thumb-field").trigger("mouseup");
+
+          cy.get("@onMouseUp").should("have.been.calledOnce");
+        });
+      });
+    });
+
+    context("onMouseEnter", () => {
+      context("when hovering over the thumb field", () => {
+        it("should call the mouse enter handler", () => {
+          const onMouseEnter = cy.stub().as("onMouseEnter");
+
+          cy.mount(
+            <ThumbField aria-label="thumb-field" onMouseEnter={onMouseEnter} />
+          );
+
+          cy.findByLabelText("thumb-field").realHover();
+
+          cy.get("@onMouseEnter").should("have.been.calledOnce");
+        });
+      });
+    });
+
+    context("onMouseLeave", () => {
+      context("when moving the cursor away from the thumb field", () => {
+        it("should call the mouse leave handler", () => {
+          const onMouseLeave = cy.stub().as("onMouseLeave");
+
+          cy.mount(
+            <ThumbField aria-label="thumb-field" onMouseLeave={onMouseLeave} />
+          );
+
+          cy.findByLabelText("thumb-field").realHover();
+          cy.findByLabelText("thumb-field").trigger("mouseleave");
+
+          cy.get("@onMouseLeave").should("have.been.calledOnce");
+        });
+      });
+    });
+  });
+
+  context("thumbText", () => {
     context("when given text for both thumbs", () => {
       it("renders the up and down text", () => {
         cy.mount(

--- a/test/component/thumb-field.cy.tsx
+++ b/test/component/thumb-field.cy.tsx
@@ -8,7 +8,7 @@ describe("ThumbField", () => {
         it("should call the click handler", () => {
           const onClick = cy.stub().as("onClick");
 
-          cy.mount(<ThumbField aria-label="thumb-field" onClick={onClick} />);
+          cy.mount(<ThumbField onClick={onClick} />);
 
           cy.findByLabelText("thumb-field").click();
 
@@ -22,9 +22,7 @@ describe("ThumbField", () => {
         it("should call the mouse down handler", () => {
           const onMouseDown = cy.stub().as("onMouseDown");
 
-          cy.mount(
-            <ThumbField aria-label="thumb-field" onMouseDown={onMouseDown} />
-          );
+          cy.mount(<ThumbField onMouseDown={onMouseDown} />);
 
           cy.findByLabelText("thumb-field").trigger("mousedown");
           cy.wait(200);
@@ -39,9 +37,7 @@ describe("ThumbField", () => {
         it("should call the mouse up handler", () => {
           const onMouseUp = cy.stub().as("onMouseUp");
 
-          cy.mount(
-            <ThumbField aria-label="thumb-field" onMouseUp={onMouseUp} />
-          );
+          cy.mount(<ThumbField onMouseUp={onMouseUp} />);
 
           cy.findByLabelText("thumb-field").trigger("mouseup");
 
@@ -55,9 +51,7 @@ describe("ThumbField", () => {
         it("should call the mouse enter handler", () => {
           const onMouseEnter = cy.stub().as("onMouseEnter");
 
-          cy.mount(
-            <ThumbField aria-label="thumb-field" onMouseEnter={onMouseEnter} />
-          );
+          cy.mount(<ThumbField onMouseEnter={onMouseEnter} />);
 
           cy.findByLabelText("thumb-field").realHover();
 
@@ -71,9 +65,7 @@ describe("ThumbField", () => {
         it("should call the mouse leave handler", () => {
           const onMouseLeave = cy.stub().as("onMouseLeave");
 
-          cy.mount(
-            <ThumbField aria-label="thumb-field" onMouseLeave={onMouseLeave} />
-          );
+          cy.mount(<ThumbField onMouseLeave={onMouseLeave} />);
 
           cy.findByLabelText("thumb-field").realHover();
           cy.findByLabelText("thumb-field").trigger("mouseleave");


### PR DESCRIPTION
Description:
This ticket adds a `HTMLDivElement` props to `ThumbField`. Would it be better to expose them at the `InputGroup` level for more flexibility handle events, such as `onClick`, `onMouseEnter`, and others.

Source:
[[Improvement] SYST-819: Extends the `HTMLDivElement` inside of `ThumbField`](https://linear.app/systatum/issue/SYST-819/extends-the-htmldivelement-inside-of-thumbfield)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself