### PR TITLE
[Research] SYST-820: Use `RHF` with `values`, instead of `defaultValues`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,10 @@
 {
-  "semi": true,
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": [],
+  "semi": false,
   "singleQuote": false,
-  "trailingComma": "es5",
-  "tabWidth": 2
+  "trailingComma": "all",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "endOfLine": "lf"
 }

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -1,25 +1,25 @@
-import { Meta, StoryObj } from "@storybook/react/";
-import { useMemo, useState } from "react";
-import styled, { css } from "styled-components";
-import { z } from "zod";
-import { COUNTRY_CODES } from "./../constants/countries";
-import { BadgeProps } from "./badge";
-import { Button } from "./button";
-import { CapsuleTab } from "./capsule";
-import { Card } from "./card";
+import { Meta, StoryObj } from "@storybook/react/"
+import { useMemo, useState } from "react"
+import styled, { css } from "styled-components"
+import { z } from "zod"
+import { COUNTRY_CODES } from "./../constants/countries"
+import { BadgeProps } from "./badge"
+import { Button } from "./button"
+import { CapsuleTab } from "./capsule"
+import { Card } from "./card"
 import {
   OnCompleteFunctionArgs,
   OnFileDroppedFunctionArgs,
-} from "./file-drop-box";
-import { Messagebox } from "./messagebox";
-import { MoneyboxCurrencyOption } from "./moneybox";
-import { PhoneboxCountryCode } from "./phonebox";
-import { PinboxParts } from "./pinbox";
-import { SelectboxOption } from "./selectbox";
-import { FormFieldGroup, StatefulForm } from "./stateful-form";
-import { BodyThemeConfig, ThemeMode } from "./../theme";
-import { useTheme } from "./../theme/provider";
-import { darkenColor, lightenColor } from "./../lib/color";
+} from "./file-drop-box"
+import { Messagebox } from "./messagebox"
+import { MoneyboxCurrencyOption } from "./moneybox"
+import { PhoneboxCountryCode } from "./phonebox"
+import { PinboxParts } from "./pinbox"
+import { SelectboxOption } from "./selectbox"
+import { FormFieldGroup, StatefulForm } from "./stateful-form"
+import { BodyThemeConfig, ThemeMode } from "./../theme"
+import { useTheme } from "./../theme/provider"
+import { darkenColor, lightenColor } from "./../lib/color"
 
 const meta: Meta<typeof StatefulForm> = {
   title: "Input Elements/StatefulForm",
@@ -29,12 +29,13 @@ const meta: Meta<typeof StatefulForm> = {
     docs: {
       description: {
         component: `
-**StatefulForm** is a form renderer capable to handle complex scenarios involving data validation,
-nested fields, custom input rendering, and state management. It works seamlessly with Zod.
+**StatefulForm** is a flexible form renderer designed to handle complex forms with data validation, 
+nested layouts, custom field rendering, and controlled state management. It integrates seamlessly with Zod.
 
 ---
 
 ### ✨ Features
+- 🎛 **Controlled by design**: The form is driven by the \`formValues\` prop, making it easy to synchronize with React state, Zustand, Redux, or any external store.
 - 🖊 **Flexible input types**: Supports text, email, password, textarea, checkbox, radio, phone, file, image, color, date, money, rating, toggle, pin, and fully custom fields.
 - 📦 **Nested/grouped fields**: Organize fields in groups or frames for complex layouts.
 - ⚠️ **Validation**: Integrates with Zod schemas, supporting \`onChange\`, \`onBlur\`, or \`onSubmit\` validation modes.
@@ -43,6 +44,20 @@ nested fields, custom input rendering, and state management. It works seamlessly
 - 🔍 **Error handling**: Automatically shows validation errors for touched fields.
 - 🖌 **Custom render**: For fields with \`type="custom"\`, you can render any JSX/component.
 - 🎯 **AutoFocus**: Focus on a specific field when the form mounts.
+
+---
+
+### 🔄 Controlled State
+
+\`StatefulForm\` follows the controlled component pattern.
+
+1. The parent owns the form state.
+2. The parent passes the latest state through \`formValues\`.
+3. User interactions trigger \`onChange\`.
+4. The parent updates its state.
+5. The updated \`formValues\` are passed back to \`StatefulForm\`.
+
+Because the component always renders from \`formValues\`, external updates (such as API responses, resetting a form, or loading draft data) are reflected automatically.
 
 ---
 
@@ -162,20 +177,18 @@ Custom styles for form components:
       table: { type: { summary: "StatefulFormStyles" } },
     },
   },
-};
+}
 
-export default meta;
+export default meta
 
-type Story = StoryObj<typeof StatefulForm>;
+type Story = StoryObj<typeof StatefulForm>
 
 export const Default: Story = {
   render: () => {
-    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-      (data) => data.id === "US"
-    );
+    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find((data) => data.id === "US")
 
     if (!DEFAULT_COUNTRY_CODES) {
-      throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
+      throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
     }
 
     const [value, setValue] = useState({
@@ -187,15 +200,15 @@ export const Default: Story = {
       note: "",
       access: false,
       country_code: DEFAULT_COUNTRY_CODES,
-    });
+    })
 
     const SALUTATION_OPTIONS: SelectboxOption[] = [
       { text: "Mr.", value: "1" },
       { text: "Mrs.", value: "2" },
       { text: "Ms.", value: "3" },
-    ];
+    ]
 
-    const [isFormValid, setIsFormValid] = useState(false);
+    const [isFormValid, setIsFormValid] = useState(false)
 
     const employeeSchema = z.object({
       salutation: z
@@ -204,9 +217,9 @@ export const Default: Story = {
         .refine(
           (arr) =>
             arr.every((val) =>
-              SALUTATION_OPTIONS.some((opt) => opt.value === val)
+              SALUTATION_OPTIONS.some((opt) => opt.value === val),
             ),
-          "Invalid value in combo"
+          "Invalid value in combo",
         ),
       first_name: z
         .string()
@@ -221,7 +234,7 @@ export const Default: Story = {
       access: z.boolean().refine((val) => val === true, {
         message: "Access must be true",
       }),
-    });
+    })
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
@@ -337,7 +350,7 @@ export const Default: Story = {
         placeholder: "Enter text",
         rowJustifyPosition: "end",
       },
-    ];
+    ]
 
     return (
       <div
@@ -355,7 +368,7 @@ export const Default: Story = {
       >
         <StatefulForm
           onChange={({ currentState }) => {
-            setValue((prev) => ({ ...prev, ...currentState }));
+            setValue((prev) => ({ ...prev, ...currentState }))
           }}
           fields={EMPLOYEE_FIELDS}
           formValues={value}
@@ -365,13 +378,13 @@ export const Default: Story = {
           mode="onChange"
         />
       </div>
-    );
+    )
   },
-};
+}
 
 export const WithFrame: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false);
+    const [isFormValid, setIsFormValid] = useState(false)
     const [value, setValue] = useState({
       name: "",
       department: "",
@@ -379,13 +392,13 @@ export const WithFrame: Story = {
       start_date: [""],
       end_date: [""],
       purpose: "",
-    });
+    })
 
     const dateArraySchema = z
       .array(
-        z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date")
+        z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date"),
       )
-      .min(1, "At least one date is required");
+      .min(1, "At least one date is required")
 
     const employeeSchema = z.object({
       name: z.string().min(3, "Name is required"),
@@ -394,17 +407,17 @@ export const WithFrame: Story = {
       start_date: dateArraySchema,
       end_date: dateArraySchema,
       purpose: z.string().min(10, "Business purpose is required"),
-    });
+    })
 
     const MANAGER_NAME_OPTIONS: SelectboxOption[] = [
       { text: "Alim Naufal", value: "1" },
       { text: "Soekarno", value: "2" },
-    ];
+    ]
 
     const DEPARTMENT_OPTIONS: SelectboxOption[] = [
       { text: "HR", value: "1" },
       { text: "IT", value: "2" },
-    ];
+    ]
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       {
@@ -473,7 +486,7 @@ export const WithFrame: Story = {
         disabled: !isFormValid,
         rowJustifyPosition: "end",
       },
-    ];
+    ]
 
     return (
       <div
@@ -491,7 +504,7 @@ export const WithFrame: Story = {
       >
         <StatefulForm
           onChange={({ currentState }) => {
-            setValue((prev) => ({ ...prev, ...currentState }));
+            setValue((prev) => ({ ...prev, ...currentState }))
           }}
           validationSchema={employeeSchema}
           onValidityChange={setIsFormValid}
@@ -500,20 +513,20 @@ export const WithFrame: Story = {
           mode="onChange"
         />
       </div>
-    );
+    )
   },
-};
+}
 
 export const ConditionalElement: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false);
+    const [isFormValid, setIsFormValid] = useState(false)
     const [formFields, setFormFields] = useState({
       quantType: "",
       compEffort: "",
       scheIterations: "",
       target: "",
       hostArch: "",
-    });
+    })
 
     const schema = z.object({
       quantType: z.string().optional(),
@@ -524,46 +537,46 @@ export const ConditionalElement: Story = {
         .optional(),
       target: z.string().min(1, "Target is required"),
       hostArch: z.string().optional(),
-    });
+    })
 
     const HostArchitecture = {
       x86: 0,
       x64: 1,
       ARM: 2,
       ARM64: 3,
-    } as const;
+    } as const
 
     const CompilationTarget = {
       Interpreter: 0,
       Simulator: 1,
       IP: 2,
-    } as const;
+    } as const
 
     const CompilationEffort = {
       SimpleScheduling: 0,
       Performance: 1,
       Aggressive: 2,
-    } as const;
+    } as const
 
     const Quantization = {
       Int8: 0,
       Bf16: 1,
       Fp16: 2,
       Fp32: 3,
-    } as const;
+    } as const
 
     const HOST_ARCHITECTURE_OPTIONS: SelectboxOption[] = [
       { value: String(HostArchitecture.x86), text: "x86" },
       { value: String(HostArchitecture.x64), text: "x64" },
       { value: String(HostArchitecture.ARM), text: "ARM" },
       { value: String(HostArchitecture.ARM64), text: "ARM64" },
-    ];
+    ]
 
     const COMPILATION_TARGET_OPTIONS: SelectboxOption[] = [
       { value: String(CompilationTarget.Interpreter), text: "Interpreter" },
       { value: String(CompilationTarget.Simulator), text: "Simulator" },
       { value: String(CompilationTarget.IP), text: "IP" },
-    ];
+    ]
 
     const COMPILATION_EFFORT_OPTIONS: SelectboxOption[] = [
       {
@@ -578,21 +591,21 @@ export const ConditionalElement: Story = {
         value: String(CompilationEffort.Aggressive),
         text: "Aggressive",
       },
-    ];
+    ]
 
     const QUANTIZATION_TYPE_OPTIONS: SelectboxOption[] = [
       { value: String(Quantization.Int8), text: "INT8" },
       { value: String(Quantization.Bf16), text: "BF16" },
       { value: String(Quantization.Fp16), text: "FP16" },
       { value: String(Quantization.Fp32), text: "FP32" },
-    ];
+    ]
 
     const COMPILATION_FIELDS: FormFieldGroup[] = useMemo(() => {
       const isInt8Quantization =
-        formFields.quantType === String(Quantization.Int8);
+        formFields.quantType === String(Quantization.Int8)
 
       const isPerfCompilation =
-        formFields.compEffort === String(CompilationEffort.Performance);
+        formFields.compEffort === String(CompilationEffort.Performance)
 
       return [
         {
@@ -653,13 +666,13 @@ export const ConditionalElement: Story = {
           disabled: !isFormValid,
           rowJustifyPosition: "end",
         },
-      ] as FormFieldGroup[];
-    }, [formFields.compEffort, formFields.quantType, isFormValid]);
+      ] as FormFieldGroup[]
+    }, [formFields.compEffort, formFields.quantType, isFormValid])
 
     return (
       <StatefulForm
         onChange={({ currentState }) => {
-          setFormFields((prev) => ({ ...prev, ...currentState }));
+          setFormFields((prev) => ({ ...prev, ...currentState }))
         }}
         onValidityChange={setIsFormValid}
         validationSchema={schema}
@@ -667,33 +680,33 @@ export const ConditionalElement: Story = {
         formValues={formFields}
         mode="onChange"
       />
-    );
+    )
   },
-};
+}
 
 export const LeftLabeled: Story = {
   render: () => {
-    const { currentTheme, mode } = useTheme();
-    const bodyTheme = currentTheme?.body;
+    const { currentTheme, mode } = useTheme()
+    const bodyTheme = currentTheme?.body
 
     const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-      (country) => country.id === "US"
-    );
+      (country) => country.id === "US",
+    )
 
-    const [isFormValid, setIsFormValid] = useState(false);
+    const [isFormValid, setIsFormValid] = useState(false)
     const [value, setValue] = useState<{
-      name: string;
-      email: string;
-      phone: string;
-      country_code: PhoneboxCountryCode;
-      password: string;
+      name: string
+      email: string
+      phone: string
+      country_code: PhoneboxCountryCode
+      password: string
     }>({
       name: "",
       email: "",
       phone: "",
       country_code: DEFAULT_COUNTRY_CODES,
       password: "",
-    });
+    })
 
     const SIGN_UP_FIELDS: FormFieldGroup[] = [
       {
@@ -731,14 +744,14 @@ export const LeftLabeled: Story = {
         required: true,
         labelPosition: "left",
       },
-    ];
+    ]
 
     const signUpSchema = z.object({
       name: z.string().min(3, "Name must be at least 3 characters"),
       phone: z.string().min(8, "Phone number must be 8 digits"),
       email: z.string().email("Please enter a valid email"),
       password: z.string().min(8, "Password must be at least 8 characters"),
-    });
+    })
 
     return (
       <Card
@@ -789,14 +802,14 @@ export const LeftLabeled: Story = {
           </div>
         </Footer>
       </Card>
-    );
+    )
   },
-};
+}
 
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-`;
+`
 
 const Title = styled.h3`
   font-family: monospace;
@@ -808,7 +821,7 @@ const Title = styled.h3`
   @media (min-width: 768px) {
     font-size: 1.5rem;
   }
-`;
+`
 
 const Description = styled.span`
   font-size: 0.625rem;
@@ -817,18 +830,18 @@ const Description = styled.span`
   @media (min-width: 768px) {
     font-size: 0.75rem;
   }
-`;
+`
 
 const FormBody = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
   padding: 2rem;
-`;
+`
 
 const Footer = styled.div<{
-  $theme?: BodyThemeConfig;
-  $mode: ThemeMode | string;
+  $theme?: BodyThemeConfig
+  $mode: ThemeMode | string
 }>`
   display: flex;
   flex-direction: row;
@@ -856,7 +869,7 @@ const Footer = styled.div<{
   .loader {
     margin-left: 0.5rem;
   }
-`;
+`
 
 const ScrollBox = styled.div`
   max-height: 120px;
@@ -881,17 +894,17 @@ const ScrollBox = styled.div`
 
   scrollbar-width: thin;
   scrollbar-color: #ccc transparent;
-`;
+`
 
 export const Mobile: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false);
+    const [isFormValid, setIsFormValid] = useState(false)
     const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-      (data) => data.id === "US" || COUNTRY_CODES[206]
-    );
+      (data) => data.id === "US" || COUNTRY_CODES[206],
+    )
 
     if (!DEFAULT_COUNTRY_CODES) {
-      throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
+      throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
     }
 
     const FRUIT_OPTIONS: SelectboxOption[] = [
@@ -902,7 +915,7 @@ export const Mobile: Story = {
       { text: "Pineapple", value: "5" },
       { text: "Strawberry", value: "6" },
       { text: "Watermelon", value: "7" },
-    ];
+    ]
 
     const BADGE_OPTIONS: BadgeProps[] = [
       {
@@ -945,7 +958,7 @@ export const Mobile: Story = {
         id: "10",
         caption: "Webtoons",
       },
-    ];
+    ]
 
     const CURRENCY_OPTIONS: MoneyboxCurrencyOption[] = [
       { id: "IDR", name: "Indonesian Rupiah", symbol: "Rp" },
@@ -958,36 +971,36 @@ export const Mobile: Story = {
       { id: "MYR", name: "Malaysian Ringgit", symbol: "RM" },
       { id: "KRW", name: "South Korean Won", symbol: "₩" },
       { id: "CNY", name: "Chinese Yuan", symbol: "¥" },
-    ];
+    ]
 
     interface AllCaseValueProps {
-      text: string;
-      time: string;
-      email: string;
-      number: string;
-      password: string;
-      textarea: string;
-      rating: string;
-      check: boolean;
+      text: string
+      time: string
+      email: string
+      number: string
+      password: string
+      textarea: string
+      rating: string
+      check: boolean
       chips?: {
-        searchText: string;
-        selectedOptions: string[];
-      };
-      color: string;
-      combo: string[];
-      date: string[];
-      file_drop_box?: File[];
-      file: File[] | undefined;
-      image: File | undefined;
-      money: string;
-      phone: string;
-      thumb_field: boolean;
-      toggle: boolean;
-      signature: string;
-      capsule: string;
-      country_code?: PhoneboxCountryCode;
-      currency: string;
-      pin: string;
+        searchText: string
+        selectedOptions: string[]
+      }
+      color: string
+      combo: string[]
+      date: string[]
+      file_drop_box?: File[]
+      file: File[] | undefined
+      image: File | undefined
+      money: string
+      phone: string
+      thumb_field: boolean
+      toggle: boolean
+      signature: string
+      capsule: string
+      country_code?: PhoneboxCountryCode
+      currency: string
+      pin: string
     }
 
     const [value, setValue] = useState<AllCaseValueProps>({
@@ -1018,7 +1031,7 @@ export const Mobile: Story = {
       country_code: DEFAULT_COUNTRY_CODES,
       currency: "USD",
       pin: "",
-    });
+    })
 
     const CAPSULE_TABS: CapsuleTab[] = [
       {
@@ -1029,7 +1042,7 @@ export const Mobile: Story = {
         id: "unpaid",
         title: "Unpaid",
       },
-    ];
+    ]
 
     const PARTS_INPUT: PinboxParts[] = [
       {
@@ -1052,7 +1065,7 @@ export const Mobile: Story = {
       {
         type: "alphabet",
       },
-    ];
+    ]
 
     const schema = z.object({
       text: z.string().min(3, "Text must be at least 3 characters"),
@@ -1076,10 +1089,10 @@ export const Mobile: Story = {
           (arr) =>
             arr.every((val) =>
               FRUIT_OPTIONS.some((opt) => {
-                return opt.value === val;
-              })
+                return opt.value === val
+              }),
             ),
-          "Invalid value in combo"
+          "Invalid value in combo",
         ),
       date: z.array(
         z
@@ -1090,15 +1103,15 @@ export const Mobile: Story = {
               /^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/\d{4}$/.test(val),
             {
               message: "Invalid date",
-            }
-          )
+            },
+          ),
       ),
       file_drop_box: z.any().optional(),
       file: z
         .preprocess((value) => {
-          if (value instanceof FileList) return Array.from(value);
-          if (Array.isArray(value)) return value;
-          return [];
+          if (value instanceof FileList) return Array.from(value)
+          if (Array.isArray(value)) return value
+          return []
         }, z.array(z.any()))
         .refine((files) => files.length > 0, {
           message: "At least one file is required",
@@ -1110,17 +1123,17 @@ export const Mobile: Story = {
           (files) => files.every((file) => file.size <= 5 * 1024 * 1024),
           {
             message: "Each file must be 5MB or less",
-          }
+          },
         ),
       image: z
         .any()
         .refine(
           (file) => {
-            return file?.type === "image/jpeg";
+            return file?.type === "image/jpeg"
           },
           {
             message: "Only JPEG file are allowed",
-          }
+          },
         )
         .refine((file) => file?.size <= 5 * 1024 * 1024, {
           message: "File size must be 5MB or less",
@@ -1141,7 +1154,7 @@ export const Mobile: Story = {
           code: z.string(),
         })
         .optional(),
-    });
+    })
 
     const onFileDropped = async ({
       error,
@@ -1149,27 +1162,27 @@ export const Mobile: Story = {
       setProgressLabel,
       succeed,
     }: OnFileDroppedFunctionArgs) => {
-      const file = files[0];
-      setProgressLabel(`Uploading ${file.name}`);
+      const file = files[0]
+      setProgressLabel(`Uploading ${file.name}`)
 
       return new Promise<void>((resolve) => {
-        let progress = 0;
+        let progress = 0
         const interval = setInterval(() => {
-          progress += 20;
+          progress += 20
 
           if (progress >= 100) {
-            clearInterval(interval);
+            clearInterval(interval)
             if (file === null) {
-              error(file, `file ${files[0].name} is not uploaded`);
+              error(file, `file ${files[0].name} is not uploaded`)
             } else {
-              succeed(file);
+              succeed(file)
             }
-            setProgressLabel(`Uploaded ${files[0].name}`);
-            resolve();
+            setProgressLabel(`Uploaded ${files[0].name}`)
+            resolve()
           }
-        }, 300);
-      });
-    };
+        }, 300)
+      })
+    }
 
     const onComplete = ({
       failedFiles,
@@ -1179,13 +1192,13 @@ export const Mobile: Story = {
       setValue((prev) => ({
         ...prev,
         file_drop_box: succeedFiles,
-      }));
-      console.log(succeedFiles, "This is succeedFiles");
-      console.log(failedFiles, "This is failedFiles");
+      }))
+      console.log(succeedFiles, "This is succeedFiles")
+      console.log(failedFiles, "This is failedFiles")
       setProgressLabel(
-        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`
-      );
-    };
+        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`,
+      )
+    }
 
     const MONTH_NAMES = [
       { text: "JAN", value: "1" },
@@ -1200,7 +1213,7 @@ export const Mobile: Story = {
       { text: "OCT", value: "10" },
       { text: "NOV", value: "11" },
       { text: "DEC", value: "12" },
-    ];
+    ]
 
     const FIELDS: FormFieldGroup[] = [
       [
@@ -1404,7 +1417,7 @@ export const Mobile: Story = {
           },
         },
       ],
-    ];
+    ]
 
     return (
       <StatefulForm
@@ -1420,7 +1433,7 @@ export const Mobile: Story = {
           `,
         }}
         onChange={({ currentState }) => {
-          const [[key, value]] = Object.entries(currentState);
+          const [[key, value]] = Object.entries(currentState)
 
           setValue((prev) => ({
             ...prev,
@@ -1433,7 +1446,7 @@ export const Mobile: Story = {
                   },
                 }
               : currentState),
-          }));
+          }))
         }}
         onValidityChange={setIsFormValid}
         labelSize="14px"
@@ -1443,19 +1456,19 @@ export const Mobile: Story = {
         validationSchema={schema}
         mode="onChange"
       />
-    );
+    )
   },
-};
+}
 
 export const AllCase: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false);
+    const [isFormValid, setIsFormValid] = useState(false)
     const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-      (data) => data.id === "US" || COUNTRY_CODES[206]
-    );
+      (data) => data.id === "US" || COUNTRY_CODES[206],
+    )
 
     if (!DEFAULT_COUNTRY_CODES) {
-      throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
+      throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
     }
 
     const FRUIT_OPTIONS: SelectboxOption[] = [
@@ -1466,7 +1479,7 @@ export const AllCase: Story = {
       { text: "Pineapple", value: "5" },
       { text: "Strawberry", value: "6" },
       { text: "Watermelon", value: "7" },
-    ];
+    ]
 
     const BADGE_OPTIONS: BadgeProps[] = [
       {
@@ -1509,7 +1522,7 @@ export const AllCase: Story = {
         id: "10",
         caption: "Webtoons",
       },
-    ];
+    ]
 
     const CURRENCY_OPTIONS: MoneyboxCurrencyOption[] = [
       { id: "IDR", name: "Indonesian Rupiah", symbol: "Rp" },
@@ -1522,36 +1535,36 @@ export const AllCase: Story = {
       { id: "MYR", name: "Malaysian Ringgit", symbol: "RM" },
       { id: "KRW", name: "South Korean Won", symbol: "₩" },
       { id: "CNY", name: "Chinese Yuan", symbol: "¥" },
-    ];
+    ]
 
     interface AllCaseValueProps {
-      text: string;
-      time: string;
-      email: string;
-      number: string;
-      password: string;
-      textarea: string;
-      rating: string;
-      check: boolean;
+      text: string
+      time: string
+      email: string
+      number: string
+      password: string
+      textarea: string
+      rating: string
+      check: boolean
       chips?: {
-        searchText: string;
-        selectedOptions: string[];
-      };
-      color: string;
-      combo: string[];
-      date: string[];
-      file_drop_box?: File[];
-      file: File[] | undefined;
-      image: File | undefined;
-      money: string;
-      phone: string;
-      thumb_field: boolean;
-      toggle: boolean;
-      signature: string;
-      capsule: string;
-      country_code?: PhoneboxCountryCode;
-      currency: string;
-      pin: string;
+        searchText: string
+        selectedOptions: string[]
+      }
+      color: string
+      combo: string[]
+      date: string[]
+      file_drop_box?: File[]
+      file: File[] | undefined
+      image: File | undefined
+      money: string
+      phone: string
+      thumb_field: boolean
+      toggle: boolean
+      signature: string
+      capsule: string
+      country_code?: PhoneboxCountryCode
+      currency: string
+      pin: string
     }
 
     const [value, setValue] = useState<AllCaseValueProps>({
@@ -1582,7 +1595,7 @@ export const AllCase: Story = {
       country_code: DEFAULT_COUNTRY_CODES,
       currency: "USD",
       pin: "",
-    });
+    })
 
     const CAPSULE_TABS: CapsuleTab[] = [
       {
@@ -1593,7 +1606,7 @@ export const AllCase: Story = {
         id: "unpaid",
         title: "Unpaid",
       },
-    ];
+    ]
 
     const PARTS_INPUT: PinboxParts[] = [
       {
@@ -1616,7 +1629,7 @@ export const AllCase: Story = {
       {
         type: "alphabet",
       },
-    ];
+    ]
 
     const schema = z.object({
       text: z.string().min(3, "Text must be at least 3 characters"),
@@ -1640,10 +1653,10 @@ export const AllCase: Story = {
           (arr) =>
             arr.every((val) =>
               FRUIT_OPTIONS.some((opt) => {
-                return opt.value === val;
-              })
+                return opt.value === val
+              }),
             ),
-          "Invalid value in combo"
+          "Invalid value in combo",
         ),
       date: z.array(
         z
@@ -1654,15 +1667,15 @@ export const AllCase: Story = {
               /^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/\d{4}$/.test(val),
             {
               message: "Invalid date",
-            }
-          )
+            },
+          ),
       ),
       file_drop_box: z.any().optional(),
       file: z
         .preprocess((value) => {
-          if (value instanceof FileList) return Array.from(value);
-          if (Array.isArray(value)) return value;
-          return [];
+          if (value instanceof FileList) return Array.from(value)
+          if (Array.isArray(value)) return value
+          return []
         }, z.array(z.any()))
         .refine((files) => files.length > 0, {
           message: "At least one file is required",
@@ -1674,17 +1687,17 @@ export const AllCase: Story = {
           (files) => files.every((file) => file.size <= 5 * 1024 * 1024),
           {
             message: "Each file must be 5MB or less",
-          }
+          },
         ),
       image: z
         .any()
         .refine(
           (file) => {
-            return file?.type === "image/jpeg";
+            return file?.type === "image/jpeg"
           },
           {
             message: "Only JPEG file are allowed",
-          }
+          },
         )
         .refine((file) => file?.size <= 5 * 1024 * 1024, {
           message: "File size must be 5MB or less",
@@ -1705,7 +1718,7 @@ export const AllCase: Story = {
           code: z.string(),
         })
         .optional(),
-    });
+    })
 
     const onFileDropped = async ({
       error,
@@ -1713,27 +1726,27 @@ export const AllCase: Story = {
       setProgressLabel,
       succeed,
     }: OnFileDroppedFunctionArgs) => {
-      const file = files[0];
-      setProgressLabel(`Uploading ${file.name}`);
+      const file = files[0]
+      setProgressLabel(`Uploading ${file.name}`)
 
       return new Promise<void>((resolve) => {
-        let progress = 0;
+        let progress = 0
         const interval = setInterval(() => {
-          progress += 20;
+          progress += 20
 
           if (progress >= 100) {
-            clearInterval(interval);
+            clearInterval(interval)
             if (file === null) {
-              error(file, `file ${files[0].name} is not uploaded`);
+              error(file, `file ${files[0].name} is not uploaded`)
             } else {
-              succeed(file);
+              succeed(file)
             }
-            setProgressLabel(`Uploaded ${files[0].name}`);
-            resolve();
+            setProgressLabel(`Uploaded ${files[0].name}`)
+            resolve()
           }
-        }, 300);
-      });
-    };
+        }, 300)
+      })
+    }
 
     const onComplete = ({
       failedFiles,
@@ -1743,13 +1756,13 @@ export const AllCase: Story = {
       setValue((prev) => ({
         ...prev,
         file_drop_box: succeedFiles,
-      }));
-      console.log(succeedFiles, "This is succeedFiles");
-      console.log(failedFiles, "This is failedFiles");
+      }))
+      console.log(succeedFiles, "This is succeedFiles")
+      console.log(failedFiles, "This is failedFiles")
       setProgressLabel(
-        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`
-      );
-    };
+        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`,
+      )
+    }
 
     const MONTH_NAMES = [
       { text: "JAN", value: "1" },
@@ -1764,7 +1777,7 @@ export const AllCase: Story = {
       { text: "OCT", value: "10" },
       { text: "NOV", value: "11" },
       { text: "DEC", value: "12" },
-    ];
+    ]
 
     const FIELDS: FormFieldGroup[] = [
       {
@@ -1978,9 +1991,9 @@ export const AllCase: Story = {
         disabled: !isFormValid,
         rowJustifyPosition: "end",
       },
-    ];
+    ]
 
-    console.log(value.chips.searchText);
+    console.log(value.chips.searchText)
 
     return (
       <StatefulForm
@@ -1995,7 +2008,7 @@ export const AllCase: Story = {
           `,
         }}
         onChange={({ currentState }) => {
-          const [[key, value]] = Object.entries(currentState);
+          const [[key, value]] = Object.entries(currentState)
 
           setValue((prev) => ({
             ...prev,
@@ -2008,7 +2021,7 @@ export const AllCase: Story = {
                   },
                 }
               : currentState),
-          }));
+          }))
         }}
         onValidityChange={setIsFormValid}
         labelSize="14px"
@@ -2018,40 +2031,40 @@ export const AllCase: Story = {
         validationSchema={schema}
         mode="onChange"
       />
-    );
+    )
   },
-};
+}
 
 export const AllCaseDisabled: Story = {
   render: () => {
     interface AllCaseValueProps {
-      text: string;
-      time: string;
-      email: string;
-      number: string;
-      password: string;
-      textarea: string;
-      rating: string;
-      check: boolean;
+      text: string
+      time: string
+      email: string
+      number: string
+      password: string
+      textarea: string
+      rating: string
+      check: boolean
       chips?: {
-        searchText: string;
-        selectedOptions: string[];
-      };
-      color: string;
-      combo: string[];
-      date: string[];
-      file_drop_box?: File[];
-      file: File[] | undefined;
-      image: File | undefined;
-      money: string;
-      phone: string;
-      thumb_field: boolean;
-      togglebox: boolean;
-      signature: string;
-      capsule: string;
-      country_code?: PhoneboxCountryCode;
-      currency: string;
-      pin: string;
+        searchText: string
+        selectedOptions: string[]
+      }
+      color: string
+      combo: string[]
+      date: string[]
+      file_drop_box?: File[]
+      file: File[] | undefined
+      image: File | undefined
+      money: string
+      phone: string
+      thumb_field: boolean
+      togglebox: boolean
+      signature: string
+      capsule: string
+      country_code?: PhoneboxCountryCode
+      currency: string
+      pin: string
     }
 
     const [value, setValue] = useState<AllCaseValueProps>({
@@ -2082,7 +2095,7 @@ export const AllCaseDisabled: Story = {
       country_code: undefined,
       currency: "USD",
       pin: "",
-    });
+    })
 
     const CAPSULE_TABS: CapsuleTab[] = [
       {
@@ -2093,7 +2106,7 @@ export const AllCaseDisabled: Story = {
         id: "unpaid",
         title: "Unpaid",
       },
-    ];
+    ]
 
     const PARTS_INPUT: PinboxParts[] = [
       {
@@ -2116,7 +2129,7 @@ export const AllCaseDisabled: Story = {
       {
         type: "alphabet",
       },
-    ];
+    ]
 
     const FIELDS: FormFieldGroup[] = [
       {
@@ -2331,7 +2344,7 @@ export const AllCaseDisabled: Story = {
         required: true,
         rowJustifyPosition: "end",
       },
-    ];
+    ]
 
     return (
       <StatefulForm
@@ -2347,13 +2360,13 @@ export const AllCaseDisabled: Story = {
         }}
         disabled
         onChange={({ currentState }) => {
-          const { chips, ...rest } = currentState;
-          void chips;
+          const { chips, ...rest } = currentState
+          void chips
 
           setValue((prev) => ({
             ...prev,
             ...rest,
-          }));
+          }))
         }}
         labelSize="14px"
         fieldSize="14px"
@@ -2361,6 +2374,6 @@ export const AllCaseDisabled: Story = {
         formValues={value}
         mode="onChange"
       />
-    );
+    )
   },
-};
+}

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -1,6 +1,6 @@
-import { useForm, UseFormProps, UseFormSetValue } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import z, { ZodTypeAny, TypeOf, ZodObject } from "zod";
+import { useForm, UseFormProps, UseFormSetValue } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import z, { ZodTypeAny, TypeOf, ZodObject } from "zod"
 import React, {
   ChangeEvent,
   Fragment,
@@ -8,7 +8,7 @@ import React, {
   ReactNode,
   useEffect,
   useRef,
-} from "react";
+} from "react"
 import {
   Control,
   Controller,
@@ -16,44 +16,44 @@ import {
   FieldValues,
   Path,
   UseFormRegister,
-} from "react-hook-form";
-import { Phonebox, PhoneboxCountryCode, PhoneboxProps } from "./phonebox";
-import { Checkbox, CheckboxProps } from "./checkbox";
-import { Textbox, TextboxProps } from "./textbox";
-import { Colorbox, ColorboxProps } from "./colorbox";
-import { FileDropBox, FileDropBoxProps } from "./file-drop-box";
-import { FileInputBox, FileInputBoxProps } from "./file-input-box";
-import { Imagebox, ImageboxProps } from "./imagebox";
-import { Moneybox, MoneyboxProps } from "./moneybox";
-import { Datebox, DateboxProps } from "./datebox";
-import { Combobox, ComboboxProps } from "./combobox";
-import { Chips, ChipsProps } from "./chips";
-import { Signbox, SignboxProps } from "./signbox";
-import { Textarea, TextareaProps } from "./textarea";
-import styled, { css, CSSProp } from "styled-components";
-import { Rating, RatingProps } from "./rating";
-import { ThumbField, ThumbFieldProps } from "./thumb-field";
-import { Toggle, ToggleProps } from "./toggle";
-import { Capsule, CapsuleProps } from "./capsule";
-import { Timebox, TimeboxProps } from "./timebox";
-import { Button, ButtonProps } from "./button";
-import { Radio, RadioProps } from "./radio";
-import { Helper } from "./helper";
-import { FigureProps } from "./figure";
-import { Pinbox, PinboxProps } from "./pinbox";
-import { FieldLaneProps } from "./field-lane";
-import { Frame, FrameProps } from "./frame";
-import { applyClassName } from "./../constants/classname";
-import { useTheme, StatefulFormThemeConfig } from "./../theme";
+} from "react-hook-form"
+import { Phonebox, PhoneboxCountryCode, PhoneboxProps } from "./phonebox"
+import { Checkbox, CheckboxProps } from "./checkbox"
+import { Textbox, TextboxProps } from "./textbox"
+import { Colorbox, ColorboxProps } from "./colorbox"
+import { FileDropBox, FileDropBoxProps } from "./file-drop-box"
+import { FileInputBox, FileInputBoxProps } from "./file-input-box"
+import { Imagebox, ImageboxProps } from "./imagebox"
+import { Moneybox, MoneyboxProps } from "./moneybox"
+import { Datebox, DateboxProps } from "./datebox"
+import { Combobox, ComboboxProps } from "./combobox"
+import { Chips, ChipsProps } from "./chips"
+import { Signbox, SignboxProps } from "./signbox"
+import { Textarea, TextareaProps } from "./textarea"
+import styled, { css, CSSProp } from "styled-components"
+import { Rating, RatingProps } from "./rating"
+import { ThumbField, ThumbFieldProps } from "./thumb-field"
+import { Toggle, ToggleProps } from "./toggle"
+import { Capsule, CapsuleProps } from "./capsule"
+import { Timebox, TimeboxProps } from "./timebox"
+import { Button, ButtonProps } from "./button"
+import { Radio, RadioProps } from "./radio"
+import { Helper } from "./helper"
+import { FigureProps } from "./figure"
+import { Pinbox, PinboxProps } from "./pinbox"
+import { FieldLaneProps } from "./field-lane"
+import { Frame, FrameProps } from "./frame"
+import { applyClassName } from "./../constants/classname"
+import { useTheme, StatefulFormThemeConfig } from "./../theme"
 
 export type StatefulOnChangeType =
   | ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   | {
       target: {
-        name: string;
-        value: FormValueType;
-      };
-    };
+        name: string
+        value: FormValueType
+      }
+    }
 
 export type FormValueType =
   | string
@@ -66,7 +66,7 @@ export type FormValueType =
   | undefined
   | PhoneboxCountryCode
   | string[]
-  | number[];
+  | number[]
 
 export const FormFieldType = {
   Text: "text",
@@ -96,112 +96,112 @@ export const FormFieldType = {
   Pin: "pin",
   Frame: "frame",
   Custom: "custom",
-} as const;
+} as const
 
-export type FormFieldType = (typeof FormFieldType)[keyof typeof FormFieldType];
+export type FormFieldType = (typeof FormFieldType)[keyof typeof FormFieldType]
 
 export const StatefulFormMode = {
   OnChange: "onChange",
   OnBlur: "onBlur",
   OnSubmit: "onSubmit",
-} as const;
+} as const
 
 export type StatefulFormMode =
-  (typeof StatefulFormMode)[keyof typeof StatefulFormMode];
+  (typeof StatefulFormMode)[keyof typeof StatefulFormMode]
 
 export interface StatefulFormProps<Z extends ZodTypeAny> {
-  fields: FormFieldGroup[];
-  formValues: TypeOf<Z>;
-  validationSchema?: Z;
-  mode?: StatefulFormMode;
-  onValidityChange?: (e: boolean) => void;
-  labelSize?: string;
-  fieldSize?: string;
-  onChange?: (args: { currentState: any }) => void;
-  autoFocusField?: string;
-  styles?: StatefulFormStyles;
-  disabled?: boolean;
-  mobile?: boolean;
-  className?: string;
-  id?: string;
+  fields: FormFieldGroup[]
+  formValues: TypeOf<Z>
+  validationSchema?: Z
+  mode?: StatefulFormMode
+  onValidityChange?: (e: boolean) => void
+  labelSize?: string
+  fieldSize?: string
+  onChange?: (args: { currentState: any }) => void
+  autoFocusField?: string
+  styles?: StatefulFormStyles
+  disabled?: boolean
+  mobile?: boolean
+  className?: string
+  id?: string
 }
 
 export interface StatefulFormStyles {
-  containerStyle?: CSSProp;
-  frameContainerStyle?: CSSProp;
-  frameTitleStyle?: CSSProp;
-  mobileFieldGroupStyle?: CSSProp;
-  mobileFieldGroupRowDividerStyle?: CSSProp;
+  containerStyle?: CSSProp
+  frameContainerStyle?: CSSProp
+  frameTitleStyle?: CSSProp
+  mobileFieldGroupStyle?: CSSProp
+  mobileFieldGroupRowDividerStyle?: CSSProp
 }
 
-export type FormFieldGroup = FormFieldProps | FormFieldProps[];
+export type FormFieldGroup = FormFieldProps | FormFieldProps[]
 
 export const FormFieldRowJustifyPosition = {
   Center: "center",
   Start: "start",
   End: "end",
   SpaceBetween: "space-between",
-} as const;
+} as const
 
 export type FormFieldRowJustifyPosition =
-  (typeof FormFieldRowJustifyPosition)[keyof typeof FormFieldRowJustifyPosition];
+  (typeof FormFieldRowJustifyPosition)[keyof typeof FormFieldRowJustifyPosition]
 
 export const FormFieldRowItemsAligment = {
   Center: "center",
   Start: "start",
   End: "end",
   Stretch: "stretch",
-} as const;
+} as const
 
 export type FormFieldRowItemsAligment =
-  (typeof FormFieldRowItemsAligment)[keyof typeof FormFieldRowItemsAligment];
+  (typeof FormFieldRowItemsAligment)[keyof typeof FormFieldRowItemsAligment]
 
 export interface FormFieldProps {
-  name: string;
-  id?: string;
-  className?: string;
-  title?: string;
-  helper?: string;
-  required?: boolean;
-  type?: FormFieldType;
-  placeholder?: string;
-  render?: ReactNode;
-  hidden?: boolean;
-  rows?: number;
-  width?: string;
-  rowStyle?: CSSProp;
-  fields?: FormFieldGroup[];
-  icon?: FigureProps["image"];
-  labelPosition?: FieldLaneProps["labelPosition"];
-  labelGap?: FieldLaneProps["labelGap"];
-  labelWidth?: FieldLaneProps["labelWidth"];
-  disabled?: boolean;
-  rowJustifyPosition?: FormFieldRowJustifyPosition;
-  rowItemsAlignment?: FormFieldRowItemsAligment;
-  onChange?: (e?: StatefulOnChangeType) => void;
-  onClick?: (e?: React.MouseEvent) => void;
-  textbox?: TextboxProps;
-  textarea?: TextareaProps;
-  checkbox?: CheckboxProps;
-  radio?: RadioProps;
-  phonebox?: PhoneboxProps;
-  colorbox?: ColorboxProps;
-  money?: MoneyboxProps;
-  fileDropBox?: FileDropBoxProps;
-  fileInputBox?: FileInputBoxProps;
-  imagebox?: ImageboxProps;
-  signbox?: SignboxProps;
-  date?: DateboxProps;
-  combobox?: ComboboxProps;
-  chips?: ChipsProps;
-  rating?: RatingProps;
-  thumbField?: ThumbFieldProps;
-  toggle?: ToggleProps;
-  capsule?: CapsuleProps;
-  timebox?: TimeboxProps;
-  button?: ButtonProps;
-  pinbox?: PinboxProps;
-  frame?: FrameProps;
+  name: string
+  id?: string
+  className?: string
+  title?: string
+  helper?: string
+  required?: boolean
+  type?: FormFieldType
+  placeholder?: string
+  render?: ReactNode
+  hidden?: boolean
+  rows?: number
+  width?: string
+  rowStyle?: CSSProp
+  fields?: FormFieldGroup[]
+  icon?: FigureProps["image"]
+  labelPosition?: FieldLaneProps["labelPosition"]
+  labelGap?: FieldLaneProps["labelGap"]
+  labelWidth?: FieldLaneProps["labelWidth"]
+  disabled?: boolean
+  rowJustifyPosition?: FormFieldRowJustifyPosition
+  rowItemsAlignment?: FormFieldRowItemsAligment
+  onChange?: (e?: StatefulOnChangeType) => void
+  onClick?: (e?: React.MouseEvent) => void
+  textbox?: TextboxProps
+  textarea?: TextareaProps
+  checkbox?: CheckboxProps
+  radio?: RadioProps
+  phonebox?: PhoneboxProps
+  colorbox?: ColorboxProps
+  money?: MoneyboxProps
+  fileDropBox?: FileDropBoxProps
+  fileInputBox?: FileInputBoxProps
+  imagebox?: ImageboxProps
+  signbox?: SignboxProps
+  date?: DateboxProps
+  combobox?: ComboboxProps
+  chips?: ChipsProps
+  rating?: RatingProps
+  thumbField?: ThumbFieldProps
+  toggle?: ToggleProps
+  capsule?: CapsuleProps
+  timebox?: TimeboxProps
+  button?: ButtonProps
+  pinbox?: PinboxProps
+  frame?: FrameProps
 }
 
 function StatefulForm<Z extends ZodTypeAny>({
@@ -225,23 +225,23 @@ function StatefulForm<Z extends ZodTypeAny>({
   // register/Controller — NOT from an external formValues update.
   // RHF's own register/Controller already handles validate+touch for these,
   // so we don't need (and don't want) to force setValue on them again.
-  const internallyChangedFieldsRef = useRef<Set<string>>(new Set());
+  const internallyChangedFieldsRef = useRef<Set<string>>(new Set())
 
   const handleFieldChange = (name: keyof TypeOf<Z>, value: FormValueType) => {
-    if (disabled) return;
-    internallyChangedFieldsRef.current.add(name as string);
-    onChange?.({ currentState: { [name]: value } });
-  };
+    if (disabled) return
+    internallyChangedFieldsRef.current.add(name as string)
+    onChange?.({ currentState: { [name]: value } })
+  }
 
-  const finalSchema = getSchemaForVisibleFields(validationSchema, fields);
+  const finalSchema = getSchemaForVisibleFields(validationSchema, fields)
 
   const formConfig: UseFormProps<TypeOf<Z>> = {
     mode,
     values: formValues,
-  };
+  }
 
   if (validationSchema) {
-    formConfig.resolver = zodResolver(finalSchema);
+    formConfig.resolver = zodResolver(finalSchema)
   }
 
   const {
@@ -249,12 +249,12 @@ function StatefulForm<Z extends ZodTypeAny>({
     control,
     setValue,
     formState: { errors, touchedFields, isValid },
-  } = useForm(formConfig) as ReturnType<typeof useForm<TypeOf<Z>>>;
+  } = useForm(formConfig) as ReturnType<typeof useForm<TypeOf<Z>>>
 
-  const isFile = (val: unknown): val is File => val instanceof File;
+  const isFile = (val: unknown): val is File => val instanceof File
 
   const isFileArray = (val: unknown): val is File[] =>
-    Array.isArray(val) && val.every((v) => v instanceof File);
+    Array.isArray(val) && val.every((v) => v instanceof File)
 
   // Recursively collect ALL field names that hold a real form value —
   // including "custom" fields now, since they need the same touched/validate
@@ -263,35 +263,35 @@ function StatefulForm<Z extends ZodTypeAny>({
   function flattenAllFieldNames(fields: FormFieldGroup[]): string[] {
     return fields.flatMap((f) => {
       if (Array.isArray(f)) {
-        return flattenAllFieldNames(f);
+        return flattenAllFieldNames(f)
       }
 
       if (f.type === "frame" && f.fields) {
-        return flattenAllFieldNames(f.fields as FormFieldGroup[]);
+        return flattenAllFieldNames(f.fields as FormFieldGroup[])
       }
 
       // skip fields that don't hold a real, validatable form value
       if (f.type === "button" || f.type === "custom" || f.hidden) {
-        return [];
+        return []
       }
 
-      return [f.name];
-    });
+      return [f.name]
+    })
   }
 
   // Decide whether a value is "real" enough to be worth touching/validating.
   // Prevents empty/untouched fields from getting falsely marked as touched
   // on initial mount (which would make them show errors immediately).
   const hasMeaningfulValue = (value: unknown): boolean => {
-    if (typeof value === "string") return value.length > 1;
-    if (typeof value === "number" || typeof value === "boolean") return true;
-    if (isFile(value) || isFileArray(value)) return true;
-    return value != null;
-  };
+    if (typeof value === "string") return value.length > 1
+    if (typeof value === "number" || typeof value === "boolean") return true
+    if (isFile(value) || isFileArray(value)) return true
+    return value != null
+  }
 
-  const allFieldNames = flattenAllFieldNames(fields);
+  const allFieldNames = flattenAllFieldNames(fields)
 
-  const prevFormValuesRef = useRef<TypeOf<Z>>(formValues);
+  const prevFormValuesRef = useRef<TypeOf<Z>>(formValues)
 
   // Whenever `formValues` changes — whether from an external source (values
   // prop reactive sync) or a "custom" field's own render logic — RHF's
@@ -301,22 +301,22 @@ function StatefulForm<Z extends ZodTypeAny>({
   // with `shouldValidate` + `shouldTouch` only on fields that actually changed,
   // avoiding unnecessary re-validation on fields that didn't change.
   useEffect(() => {
-    const prevFormValues = prevFormValuesRef.current;
+    const prevFormValues = prevFormValuesRef.current
 
     allFieldNames.forEach((name) => {
-      const key = name as keyof TypeOf<Z>;
-      const value = formValues[key];
-      const prevValue = prevFormValues[key];
+      const key = name as keyof TypeOf<Z>
+      const value = formValues[key]
+      const prevValue = prevFormValues[key]
 
-      const changedInternally = internallyChangedFieldsRef.current.has(name);
+      const changedInternally = internallyChangedFieldsRef.current.has(name)
 
       // consume the flag either way, so it doesn't leak into future renders
-      internallyChangedFieldsRef.current.delete(name);
+      internallyChangedFieldsRef.current.delete(name)
 
       if (changedInternally) {
         // came from real user interaction via register/Controller —
         // RHF already validated + touched it, nothing to do here
-        return;
+        return
       }
 
       // only reaches here for changes NOT triggered by handleFieldChange,
@@ -326,21 +326,21 @@ function StatefulForm<Z extends ZodTypeAny>({
           shouldValidate: true,
           shouldTouch: true,
           shouldDirty: true,
-        });
+        })
       }
-    });
+    })
 
-    prevFormValuesRef.current = formValues;
-  }, [formValues, setValue]);
+    prevFormValuesRef.current = formValues
+  }, [formValues, setValue])
 
   useEffect(() => {
     if (onValidityChange) {
-      onValidityChange(isValid);
+      onValidityChange(isValid)
     }
-  }, [isValid, onValidityChange]);
+  }, [isValid, onValidityChange])
 
   const shouldShowError = (name: keyof TypeOf<Z>): boolean => {
-    const fieldConfig = findField(fields, name as string);
+    const fieldConfig = findField(fields, name as string)
 
     if (
       !fieldConfig ||
@@ -348,62 +348,62 @@ function StatefulForm<Z extends ZodTypeAny>({
       fieldConfig.type === "button" ||
       fieldConfig.hidden
     ) {
-      return false;
+      return false
     }
 
-    const value = formValues[name];
-    const touched = touchedFields[name];
-    const error = errors[name];
+    const value = formValues[name]
+    const touched = touchedFields[name]
+    const error = errors[name]
 
     const hasErrorMessage = (err: unknown): boolean => {
-      if (!err || typeof err !== "object") return false;
+      if (!err || typeof err !== "object") return false
 
-      if (typeof (err as any)?.message === "string") return true;
+      if (typeof (err as any)?.message === "string") return true
 
-      if (typeof (err as any)?.text?.message === "string") return true;
+      if (typeof (err as any)?.text?.message === "string") return true
 
       if (Array.isArray(err)) {
-        return err.some((item) => hasErrorMessage(item));
+        return err.some((item) => hasErrorMessage(item))
       }
 
-      return Object.values(err).some((v) => hasErrorMessage(v));
-    };
+      return Object.values(err).some((v) => hasErrorMessage(v))
+    }
 
     if (typeof value === "string") {
-      return value.length > 0 && !!touched && hasErrorMessage(error);
+      return value.length > 0 && !!touched && hasErrorMessage(error)
     }
 
     if (typeof value === "number" || typeof value === "boolean") {
-      return !!touched && hasErrorMessage(error);
+      return !!touched && hasErrorMessage(error)
     }
 
     if (isFile(value) || isFileArray(value)) {
-      return !!touched && hasErrorMessage(error);
+      return !!touched && hasErrorMessage(error)
     }
 
     if (typeof value === "object" && value !== null) {
-      return !!touched && hasErrorMessage(error);
+      return !!touched && hasErrorMessage(error)
     }
 
-    return !!touched && hasErrorMessage(error);
-  };
+    return !!touched && hasErrorMessage(error)
+  }
 
   function findField(
     fields: FormFieldGroup[],
-    name: string
+    name: string,
   ): FormFieldProps | undefined {
     for (const f of fields) {
       if (Array.isArray(f)) {
-        const found = findField(f, name);
-        if (found) return found;
+        const found = findField(f, name)
+        if (found) return found
       } else if (f.type === "frame" && f.fields) {
-        const found = findField(f.fields, name);
-        if (found) return found;
+        const found = findField(f.fields, name)
+        if (found) return found
       } else if (f.name === name) {
-        return f;
+        return f
       }
     }
-    return undefined;
+    return undefined
   }
 
   return (
@@ -425,80 +425,80 @@ function StatefulForm<Z extends ZodTypeAny>({
       styles={styles}
       shouldShowError={shouldShowError}
     />
-  );
+  )
 }
 
 function unwrapSchema(schema: ZodTypeAny): ZodTypeAny {
   if (schema._def.typeName === "ZodEffects") {
-    return unwrapSchema(schema._def.schema);
+    return unwrapSchema(schema._def.schema)
   }
-  return schema;
+  return schema
 }
 
 function getSchemaForVisibleFields<Z extends ZodTypeAny>(
   validationSchema?: Z,
-  fields?: FormFieldGroup[]
+  fields?: FormFieldGroup[],
 ) {
-  if (!validationSchema) return undefined;
+  if (!validationSchema) return undefined
 
-  const baseSchema = unwrapSchema(validationSchema);
+  const baseSchema = unwrapSchema(validationSchema)
 
   if (baseSchema._def.typeName !== "ZodObject") {
-    throw new Error("StatefulForm only supports Zod object schemas");
+    throw new Error("StatefulForm only supports Zod object schemas")
   }
 
-  const objSchema = baseSchema as ZodObject<any>;
+  const objSchema = baseSchema as ZodObject<any>
 
   function flattenFields(fields: FormFieldGroup[]): FormFieldProps[] {
     return fields.flatMap((f) => {
-      if (Array.isArray(f)) return flattenFields(f);
+      if (Array.isArray(f)) return flattenFields(f)
 
       if (f.type === "frame" && f.fields) {
-        return flattenFields(f.fields as FormFieldGroup[]);
+        return flattenFields(f.fields as FormFieldGroup[])
       }
 
-      return [f];
-    });
+      return [f]
+    })
   }
 
-  const flatFields: FormFieldProps[] = flattenFields(fields);
+  const flatFields: FormFieldProps[] = flattenFields(fields)
 
   const newShape = Object.fromEntries(
     flatFields.map((field) => {
-      const key = field.name;
-      const originalFieldSchema = objSchema.shape[key];
+      const key = field.name
+      const originalFieldSchema = objSchema.shape[key]
 
-      if (!originalFieldSchema) return [key, z.any()];
+      if (!originalFieldSchema) return [key, z.any()]
       return [
         key,
         field.hidden || field.type === "custom"
           ? originalFieldSchema.optional()
           : originalFieldSchema,
-      ];
-    })
-  );
+      ]
+    }),
+  )
 
-  return z.object(newShape);
+  return z.object(newShape)
 }
 
 interface FormFieldsProps<T extends FieldValues> {
-  fields: FormFieldGroup[];
-  formValues: T;
-  register: UseFormRegister<T>;
-  errors: FieldErrors<T>;
-  shouldShowError: (name: string) => boolean;
-  control: Control<T>;
-  labelSize?: string;
-  fieldSize?: string;
-  setValue?: UseFormSetValue<T>;
-  onChange?: (name: keyof T, value: FormValueType) => void;
-  autoFocusField?: string;
-  styles?: StatefulFormStyles;
-  rowWithFrame?: boolean;
-  disabled?: boolean;
-  mobile?: boolean;
-  className?: string;
-  id?: string;
+  fields: FormFieldGroup[]
+  formValues: T
+  register: UseFormRegister<T>
+  errors: FieldErrors<T>
+  shouldShowError: (name: string) => boolean
+  control: Control<T>
+  labelSize?: string
+  fieldSize?: string
+  setValue?: UseFormSetValue<T>
+  onChange?: (name: keyof T, value: FormValueType) => void
+  autoFocusField?: string
+  styles?: StatefulFormStyles
+  rowWithFrame?: boolean
+  disabled?: boolean
+  mobile?: boolean
+  className?: string
+  id?: string
 }
 
 function FormFields<T extends FieldValues>({
@@ -520,21 +520,21 @@ function FormFields<T extends FieldValues>({
   className,
   id,
 }: FormFieldsProps<T>) {
-  const { currentTheme } = useTheme();
-  const statefulFormTheme = currentTheme?.statefulForm;
-  const pinboxTheme = currentTheme?.pinbox;
-  const phoneboxTheme = currentTheme?.phonebox;
+  const { currentTheme } = useTheme()
+  const statefulFormTheme = currentTheme?.statefulForm
+  const pinboxTheme = currentTheme?.pinbox
+  const phoneboxTheme = currentTheme?.phonebox
 
-  const refs = useRef<Record<string, HTMLElement | null>>({});
+  const refs = useRef<Record<string, HTMLElement | null>>({})
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      const el = refs.current[autoFocusField];
-      el?.focus?.();
-    }, 50);
+      const el = refs.current[autoFocusField]
+      el?.focus?.()
+    }, 50)
 
-    return () => clearTimeout(timer);
-  }, []);
+    return () => clearTimeout(timer)
+  }, [])
 
   return (
     <ContainerFormField
@@ -544,29 +544,27 @@ function FormFields<T extends FieldValues>({
     >
       {fields.map((group: FormFieldGroup, indexGroup: number) => {
         const visibleFields = (Array.isArray(group) ? group : [group]).filter(
-          (field) => !field.hidden
-        );
+          (field) => !field.hidden,
+        )
 
         if (visibleFields.length === 0) {
-          return;
+          return
         }
 
         const rowJustifiedContent = visibleFields.find(
-          (field) => field.rowJustifyPosition
-        )?.rowJustifyPosition;
+          (field) => field.rowJustifyPosition,
+        )?.rowJustifyPosition
 
         const rowAlignedItem = visibleFields.find(
-          (field) => field.rowItemsAlignment
-        )?.rowItemsAlignment;
+          (field) => field.rowItemsAlignment,
+        )?.rowItemsAlignment
 
         const rowStyleItem = visibleFields.find(
-          (field) => field.rowStyle
-        )?.rowStyle;
+          (field) => field.rowStyle,
+        )?.rowStyle
 
-        const nonButtonFields = visibleFields.filter(
-          (f) => f.type !== "button"
-        );
-        const hasFieldTitle = nonButtonFields.some((f) => f.title);
+        const nonButtonFields = visibleFields.filter((f) => f.type !== "button")
+        const hasFieldTitle = nonButtonFields.some((f) => f.title)
 
         const mobileInputStyle =
           mobile &&
@@ -589,7 +587,7 @@ function FormFields<T extends FieldValues>({
               background-color: transparent !important;
               transition: background-color 9999s ease-in-out 0s;
             }
-          `;
+          `
 
         const mobileBodyStyle =
           mobile &&
@@ -597,23 +595,23 @@ function FormFields<T extends FieldValues>({
             gap: 0px;
             justify-content: space-between;
             align-items: center;
-          `;
+          `
 
         const mobileControlStyle =
           mobile &&
           css`
             width: fit-content;
-          `;
+          `
 
         const mobileLabelStyle =
           mobile &&
           css`
             width: 100%;
-          `;
+          `
 
         const isButtonRow =
           visibleFields.length > 0 &&
-          visibleFields.every((field) => field.type === "button");
+          visibleFields.every((field) => field.type === "button")
 
         const mobileRowFormFieldStyle =
           mobile &&
@@ -633,7 +631,7 @@ function FormFields<T extends FieldValues>({
               gap: 0px;
               overflow: hidden;
             `}
-          `;
+          `
 
         return (
           <RowFormField
@@ -667,15 +665,15 @@ function FormFields<T extends FieldValues>({
             {visibleFields.map((field: FormFieldProps, index: number) => {
               const labelPosition = mobile
                 ? (field?.labelPosition ?? "left")
-                : field?.labelPosition;
-              const isLast = index === visibleFields.length - 1;
+                : field?.labelPosition
+              const isLast = index === visibleFields.length - 1
               const showDivider =
-                mobile && !isLast && Array.isArray(group) && !isButtonRow;
-              const label = mobile ? null : field?.title;
+                mobile && !isLast && Array.isArray(group) && !isButtonRow
+              const label = mobile ? null : field?.title
               const placeholder = mobile
                 ? (field.placeholder ?? field.title)
-                : field.placeholder;
-              const required = mobile ? false : field.required;
+                : field.placeholder
+              const required = mobile ? false : field.required
 
               if (field.type === "frame") {
                 return (
@@ -722,13 +720,13 @@ function FormFields<T extends FieldValues>({
                       />
                     )}
                   </Frame>
-                );
+                )
               }
 
               const fieldNode = (() => {
                 switch (field.type) {
                   case "custom": {
-                    return <Fragment key={index}>{field.render}</Fragment>;
+                    return <Fragment key={index}>{field.render}</Fragment>
                   }
 
                   case "text":
@@ -753,17 +751,17 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e);
+                              field.onChange(e)
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value);
+                              onChange(field.name as keyof T, e.target.value)
                             }
                           },
                         })}
                         ref={(el) => {
-                          if (el) refs.current[field.name] = el;
-                          const { ref } = register(field.name as Path<T>);
-                          if (ref) ref(el);
+                          if (el) refs.current[field.name] = el
+                          const { ref } = register(field.name as Path<T>)
+                          if (ref) ref(el)
                         }}
                         showError={shouldShowError(field.name)}
                         errorMessage={
@@ -814,7 +812,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "pin": {
@@ -839,14 +837,14 @@ function FormFields<T extends FieldValues>({
                             helper={field.helper}
                             onBlur={controllerField.onBlur}
                             onChange={(e) => {
-                              controllerField.onChange(e);
+                              controllerField.onChange(e)
 
                               if (field.onChange) {
-                                field.onChange(e);
+                                field.onChange(e)
                               }
 
                               if (onChange) {
-                                onChange(field.name as keyof T, e.target.value);
+                                onChange(field.name as keyof T, e.target.value)
                               }
                             }}
                             showError={shouldShowError(field.name)}
@@ -920,11 +918,11 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "button": {
-                    const defaultVariant = field?.button?.variant ?? "default";
+                    const defaultVariant = field?.button?.variant ?? "default"
 
                     const mobileButtonStyle =
                       mobile &&
@@ -940,7 +938,7 @@ function FormFields<T extends FieldValues>({
                         css`
                           background-color: ${statefulFormTheme?.mobileRowFrameBackgroundColor};
                         `}
-                      `;
+                      `
 
                     return (
                       <Button
@@ -990,9 +988,9 @@ function FormFields<T extends FieldValues>({
                         }}
                         onClick={(e) => {
                           if (field?.button?.onClick) {
-                            field?.button?.onClick?.(e);
+                            field?.button?.onClick?.(e)
                           } else {
-                            field?.onClick?.(e);
+                            field?.onClick?.(e)
                           }
                         }}
                         disabled={field.disabled || disabled}
@@ -1005,7 +1003,7 @@ function FormFields<T extends FieldValues>({
 
                         {field.title}
                       </Button>
-                    );
+                    )
                   }
 
                   case "time": {
@@ -1023,9 +1021,9 @@ function FormFields<T extends FieldValues>({
                           typeof field.placeholder === "string"
                             ? (() => {
                                 const [hour = "", minute = "", second = ""] =
-                                  field.placeholder.split(/[:/]/);
+                                  field.placeholder.split(/[:/]/)
 
-                                return { hour, minute, second };
+                                return { hour, minute, second }
                               })()
                             : field.placeholder
                         }
@@ -1035,10 +1033,10 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e);
+                              field.onChange(e)
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value);
+                              onChange(field.name as keyof T, e.target.value)
                             }
                           },
                         })}
@@ -1145,12 +1143,12 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                         ref={(el) => {
-                          if (el) refs.current[field.name] = el;
-                          const { ref } = register(field.name as Path<T>);
-                          if (ref) ref(el);
+                          if (el) refs.current[field.name] = el
+                          const { ref } = register(field.name as Path<T>)
+                          if (ref) ref(el)
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "textarea": {
@@ -1171,17 +1169,17 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e);
+                              field.onChange(e)
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value);
+                              onChange(field.name as keyof T, e.target.value)
                             }
                           },
                         })}
                         ref={(el) => {
-                          if (el) refs.current[field.name] = el;
-                          const { ref } = register(field.name as Path<T>);
-                          if (ref) ref(el);
+                          if (el) refs.current[field.name] = el
+                          const { ref } = register(field.name as Path<T>)
+                          if (ref) ref(el)
                         }}
                         showError={shouldShowError(field.name)}
                         errorMessage={
@@ -1230,7 +1228,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "checkbox": {
@@ -1242,10 +1240,10 @@ function FormFields<T extends FieldValues>({
                         render={({ field: controllerField }) => {
                           const titleCheckbox = mobile
                             ? (field.title ?? field.placeholder)
-                            : field.title;
+                            : field.title
                           const placeholderCheckbox = mobile
                             ? undefined
-                            : field.placeholder;
+                            : field.placeholder
                           return (
                             <Checkbox
                               id={field.id}
@@ -1261,9 +1259,9 @@ function FormFields<T extends FieldValues>({
                               checked={controllerField.value ?? false}
                               helper={field.helper}
                               ref={(el) => {
-                                if (el) refs.current[field.name] = el;
-                                const { ref } = register(field.name as Path<T>);
-                                if (ref) ref(el);
+                                if (el) refs.current[field.name] = el
+                                const { ref } = register(field.name as Path<T>)
+                                if (ref) ref(el)
                               }}
                               errorMessage={
                                 errors[field.name as keyof T]?.message as
@@ -1273,15 +1271,15 @@ function FormFields<T extends FieldValues>({
                               required={required}
                               showError={shouldShowError(field.name)}
                               onChange={(e) => {
-                                controllerField?.onChange(e);
-                                controllerField?.onBlur();
+                                controllerField?.onChange(e)
+                                controllerField?.onBlur()
                                 if (onChange) {
                                   onChange(
                                     field.name as keyof T,
-                                    e.target.checked
-                                  );
+                                    e.target.checked,
+                                  )
                                 }
-                                field.onChange?.(e);
+                                field.onChange?.(e)
                               }}
                               disabled={field.disabled || disabled}
                               {...field.checkbox}
@@ -1355,10 +1353,10 @@ function FormFields<T extends FieldValues>({
                                 `,
                               }}
                             />
-                          );
+                          )
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "radio": {
@@ -1370,10 +1368,10 @@ function FormFields<T extends FieldValues>({
                         render={({ field: controllerField }) => {
                           const titleRadio = mobile
                             ? (field.title ?? field.placeholder)
-                            : field.title;
+                            : field.title
                           const placeholderRadio = mobile
                             ? undefined
-                            : field.placeholder;
+                            : field.placeholder
                           return (
                             <Radio
                               {...field.radio}
@@ -1396,15 +1394,15 @@ function FormFields<T extends FieldValues>({
                               required={required}
                               showError={shouldShowError(field.name)}
                               onChange={(e) => {
-                                controllerField?.onChange(e);
-                                controllerField?.onBlur();
+                                controllerField?.onChange(e)
+                                controllerField?.onBlur()
                                 if (onChange) {
                                   onChange(
                                     field.name as keyof T,
-                                    e.target.checked
-                                  );
+                                    e.target.checked,
+                                  )
                                 }
-                                field.onChange?.(e);
+                                field.onChange?.(e)
                               }}
                               disabled={field.disabled || disabled}
                               styles={{
@@ -1462,10 +1460,10 @@ function FormFields<T extends FieldValues>({
                                 `,
                               }}
                             />
-                          );
+                          )
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "phone": {
@@ -1486,8 +1484,8 @@ function FormFields<T extends FieldValues>({
                             className={field?.className}
                             required={required}
                             ref={(el) => {
-                              if (el) refs.current[field.name] = el;
-                              controllerField.ref(el);
+                              if (el) refs.current[field.name] = el
+                              controllerField.ref(el)
                             }}
                             onBlur={controllerField.onBlur}
                             value={controllerField.value}
@@ -1498,19 +1496,19 @@ function FormFields<T extends FieldValues>({
                               e:
                                 | {
                                     target: {
-                                      name: string;
-                                      value: PhoneboxCountryCode;
-                                    };
+                                      name: string
+                                      value: PhoneboxCountryCode
+                                    }
                                   }
-                                | ChangeEvent<HTMLInputElement>
+                                | ChangeEvent<HTMLInputElement>,
                             ) => {
                               if (e.target.name === "phone") {
-                                controllerField.onChange(e);
-                                onChange?.("phone", e.target.value);
+                                controllerField.onChange(e)
+                                onChange?.("phone", e.target.value)
                               } else if (e.target.name === "country_code") {
-                                onChange?.("country_code", e.target.value);
+                                onChange?.("country_code", e.target.value)
                               }
-                              field.onChange?.(e);
+                              field.onChange?.(e)
                             }}
                             showError={shouldShowError(field.name)}
                             errorMessage={
@@ -1579,7 +1577,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "color": {
@@ -1601,17 +1599,17 @@ function FormFields<T extends FieldValues>({
                             labelWidth={field.labelWidth}
                             labelPosition={labelPosition}
                             ref={(el) => {
-                              if (el) refs.current[field.name] = el;
-                              const { ref } = register(field.name as Path<T>);
-                              if (ref) ref(el);
+                              if (el) refs.current[field.name] = el
+                              const { ref } = register(field.name as Path<T>)
+                              if (ref) ref(el)
                             }}
                             value={controllerField.value}
                             onChange={(e) => {
-                              controllerField?.onChange(e);
-                              controllerField?.onBlur();
-                              field.onChange?.(e);
+                              controllerField?.onChange(e)
+                              controllerField?.onBlur()
+                              field.onChange?.(e)
                               if (onChange) {
-                                onChange(field.name as keyof T, e.target.value);
+                                onChange(field.name as keyof T, e.target.value)
                               }
                             }}
                             showError={shouldShowError(field.name)}
@@ -1699,7 +1697,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "file_drop_box": {
@@ -1720,10 +1718,10 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e);
+                              field.onChange(e)
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value);
+                              onChange(field.name as keyof T, e.target.value)
                             }
                           },
                         })}
@@ -1755,7 +1753,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "file": {
@@ -1785,24 +1783,24 @@ function FormFields<T extends FieldValues>({
                             setValue(field.name as Path<T>, files as any, {
                               shouldValidate: true,
                               shouldTouch: true,
-                            });
+                            })
 
-                            onChange?.(field.name, files);
+                            onChange?.(field.name, files)
 
                             field.onChange?.({
                               target: { name: field.name, value: files },
-                            });
+                            })
                           } else {
                             setValue(field.name as Path<T>, undefined, {
                               shouldValidate: true,
                               shouldTouch: true,
-                            });
+                            })
 
-                            onChange?.(field.name, undefined);
+                            onChange?.(field.name, undefined)
 
                             field.onChange?.({
                               target: { name: field.name, value: undefined },
-                            });
+                            })
                           }
                         }}
                         styles={{
@@ -1839,7 +1837,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "image": {
@@ -1855,26 +1853,26 @@ function FormFields<T extends FieldValues>({
                         helper={field.helper}
                         value={formValues[field.name as keyof T] ?? ""}
                         onFileSelected={(e: File | undefined) => {
-                          const file = e;
+                          const file = e
                           if (file instanceof File) {
                             setValue(field.name as Path<T>, file as any, {
                               shouldValidate: true,
                               shouldTouch: true,
-                            });
+                            })
                           } else {
                             setValue(field.name as Path<T>, undefined, {
                               shouldValidate: true,
                               shouldTouch: true,
-                            });
+                            })
                           }
                           field.onChange?.({
                             target: {
                               name: field.name,
                               value: file ?? undefined,
                             },
-                          });
+                          })
                           if (onChange) {
-                            onChange(field.name as keyof T, file ?? undefined);
+                            onChange(field.name as keyof T, file ?? undefined)
                           }
                         }}
                         label={field.title}
@@ -1883,10 +1881,10 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e);
+                              field.onChange(e)
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value);
+                              onChange(field.name as keyof T, e.target.value)
                             }
                           },
                         })}
@@ -1933,7 +1931,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "signbox": {
@@ -1954,10 +1952,10 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e);
+                              field.onChange(e)
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value);
+                              onChange(field.name as keyof T, e.target.value)
                             }
                           },
                         })}
@@ -1999,7 +1997,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "money": {
@@ -2018,8 +2016,8 @@ function FormFields<T extends FieldValues>({
                             labelPosition={labelPosition}
                             className={field?.className}
                             ref={(el) => {
-                              if (el) refs.current[field.name] = el;
-                              rhf.ref(el);
+                              if (el) refs.current[field.name] = el
+                              rhf.ref(el)
                             }}
                             name={field.name}
                             label={label}
@@ -2029,21 +2027,21 @@ function FormFields<T extends FieldValues>({
                             required={required}
                             disabled={field.disabled || disabled}
                             onChange={(e) => {
-                              const { name, value } = e.target;
+                              const { name, value } = e.target
 
                               if (field.onChange) {
-                                field.onChange(e);
+                                field.onChange(e)
                               }
 
                               if (onChange && name === "currency") {
-                                onChange("currency", value);
+                                onChange("currency", value)
                               } else {
-                                onChange(field.name as keyof T, value);
+                                onChange(field.name as keyof T, value)
                                 setValue(field.name as Path<T>, value as any, {
                                   shouldValidate: true,
                                   shouldTouch: true,
                                   shouldDirty: true,
-                                });
+                                })
                               }
                             }}
                             onBlur={rhf.onBlur}
@@ -2097,7 +2095,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "date": {
@@ -2107,11 +2105,11 @@ function FormFields<T extends FieldValues>({
                         name={field.name as Path<T>}
                         control={control}
                         render={({ field: controllerField }) => {
-                          const value = controllerField.value;
+                          const value = controllerField.value
 
                           const hasValue = Array.isArray(value)
                             ? value.some((v) => v !== "" && v != null)
-                            : value !== "" && value != null;
+                            : value !== "" && value != null
 
                           return (
                             <Datebox
@@ -2129,9 +2127,9 @@ function FormFields<T extends FieldValues>({
                               labelPosition={labelPosition}
                               mobile={mobile}
                               ref={(el) => {
-                                if (el) refs.current[field.name] = el;
-                                const { ref } = register(field.name as Path<T>);
-                                if (ref) ref(el);
+                                if (el) refs.current[field.name] = el
+                                const { ref } = register(field.name as Path<T>)
+                                if (ref) ref(el)
                               }}
                               errorMessage={
                                 errors[field.name as keyof T]?.[0]?.message as
@@ -2141,12 +2139,12 @@ function FormFields<T extends FieldValues>({
                               onChange={(e) => {
                                 const inputValueEvent = {
                                   target: { name: field.name, value: e },
-                                };
-                                controllerField.onChange(inputValueEvent);
-                                controllerField?.onBlur();
-                                field.onChange?.(inputValueEvent);
+                                }
+                                controllerField.onChange(inputValueEvent)
+                                controllerField?.onBlur()
+                                field.onChange?.(inputValueEvent)
                                 if (onChange) {
-                                  onChange(field.name as keyof T, e);
+                                  onChange(field.name as keyof T, e)
                                 }
                               }}
                               selectedDates={controllerField.value}
@@ -2203,10 +2201,10 @@ function FormFields<T extends FieldValues>({
                                 `,
                               }}
                             />
-                          );
+                          )
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "combo": {
@@ -2229,9 +2227,9 @@ function FormFields<T extends FieldValues>({
                             required={required}
                             showError={shouldShowError(field.name)}
                             ref={(el) => {
-                              if (el) refs.current[field.name] = el;
-                              const { ref } = register(field.name as Path<T>);
-                              if (ref) ref(el);
+                              if (el) refs.current[field.name] = el
+                              const { ref } = register(field.name as Path<T>)
+                              if (ref) ref(el)
                             }}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
@@ -2242,12 +2240,12 @@ function FormFields<T extends FieldValues>({
                             onChange={(e) => {
                               const inputValueEvent = {
                                 target: { name: field.name, value: e },
-                              };
-                              controllerField.onChange(inputValueEvent);
-                              controllerField?.onBlur();
-                              field.onChange?.(inputValueEvent);
+                              }
+                              controllerField.onChange(inputValueEvent)
+                              controllerField?.onBlur()
+                              field.onChange?.(inputValueEvent)
                               if (onChange) {
-                                onChange(field.name as keyof T, e);
+                                onChange(field.name as keyof T, e)
                               }
                             }}
                             selectedOptions={controllerField.value}
@@ -2313,7 +2311,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "chips": {
@@ -2338,30 +2336,27 @@ function FormFields<T extends FieldValues>({
                             disabled={field.disabled || disabled}
                             inputValue={controllerField.value}
                             setInputValue={(e) => {
-                              controllerField?.onChange(e);
-                              controllerField?.onBlur();
-                              field.onChange?.(e);
+                              controllerField?.onChange(e)
+                              controllerField?.onBlur()
+                              field.onChange?.(e)
 
                               if (onChange) {
                                 onChange(
                                   (field?.name as keyof T) ?? "chips",
-                                  e.target.value
-                                );
+                                  e.target.value,
+                                )
                               }
                             }}
                             onChange={(e) => {
-                              controllerField?.onChange(e);
-                              controllerField?.onBlur();
+                              controllerField?.onChange(e)
+                              controllerField?.onBlur()
                               const inputValueEvent = {
                                 target: { name: field.name, value: e },
-                              };
-                              field.onChange?.(inputValueEvent);
+                              }
+                              field.onChange?.(inputValueEvent)
 
                               if (onChange) {
-                                onChange(
-                                  (field?.name as keyof T) ?? "chips",
-                                  e
-                                );
+                                onChange((field?.name as keyof T) ?? "chips", e)
                               }
                             }}
                             {...field.chips}
@@ -2412,7 +2407,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "rating": {
@@ -2424,7 +2419,7 @@ function FormFields<T extends FieldValues>({
                         render={({ field: controllerField, fieldState }) => {
                           const size = mobile
                             ? (field?.rating?.size ?? "lg")
-                            : field?.rating?.size;
+                            : field?.rating?.size
 
                           return (
                             <Rating
@@ -2440,14 +2435,14 @@ function FormFields<T extends FieldValues>({
                               name={field.name}
                               rating={controllerField.value}
                               onChange={(e) => {
-                                controllerField.onChange(e.target.value);
-                                controllerField?.onBlur();
-                                field.onChange?.(e);
+                                controllerField.onChange(e.target.value)
+                                controllerField?.onBlur()
+                                field.onChange?.(e)
                                 if (onChange) {
                                   onChange(
                                     field.name as keyof T,
-                                    e.target.value
-                                  );
+                                    e.target.value,
+                                  )
                                 }
                               }}
                               showError={!!fieldState.error}
@@ -2494,10 +2489,10 @@ function FormFields<T extends FieldValues>({
                                 `,
                               }}
                             />
-                          );
+                          )
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "thumbfield": {
@@ -2520,22 +2515,22 @@ function FormFields<T extends FieldValues>({
                             {...register(field.name as Path<T>, {
                               onChange: (e) => {
                                 if (field.onChange) {
-                                  field.onChange(e);
+                                  field.onChange(e)
                                 }
                                 if (onChange) {
                                   onChange(
                                     field.name as keyof T,
-                                    e.target.checked
-                                  );
+                                    e.target.checked,
+                                  )
                                 }
                               },
                             })}
                             onChange={(e) => {
-                              controllerField?.onChange(e);
-                              controllerField?.onBlur();
-                              field.onChange?.(e);
+                              controllerField?.onChange(e)
+                              controllerField?.onBlur()
+                              field.onChange?.(e)
                               if (onChange) {
-                                onChange(field.name as keyof T, e.target.value);
+                                onChange(field.name as keyof T, e.target.value)
                               }
                             }}
                             showError={shouldShowError(field.name)}
@@ -2606,7 +2601,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "toggle": {
@@ -2628,14 +2623,14 @@ function FormFields<T extends FieldValues>({
                             required={required}
                             helper={field.helper}
                             onChange={(e) => {
-                              controllerField?.onChange(e);
-                              controllerField?.onBlur();
-                              field.onChange?.(e);
+                              controllerField?.onChange(e)
+                              controllerField?.onBlur()
+                              field.onChange?.(e)
                               if (onChange) {
                                 onChange(
                                   field.name as keyof T,
-                                  e.target.checked
-                                );
+                                  e.target.checked,
+                                )
                               }
                             }}
                             onBlur={controllerField.onBlur}
@@ -2696,7 +2691,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "capsule": {
@@ -2723,12 +2718,12 @@ function FormFields<T extends FieldValues>({
                             onTabChange={(e) => {
                               const inputValueEvent = {
                                 target: { name: field.name, value: e },
-                              };
-                              controllerField?.onChange(e);
-                              controllerField?.onBlur();
-                              field.onChange?.(inputValueEvent);
+                              }
+                              controllerField?.onChange(e)
+                              controllerField?.onBlur()
+                              field.onChange?.(inputValueEvent)
                               if (onChange) {
-                                onChange(field.name as keyof T, e);
+                                onChange(field.name as keyof T, e)
                               }
                             }}
                             showError={shouldShowError(field.name)}
@@ -2788,13 +2783,13 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   default:
-                    return null;
+                    return null
                 }
-              })();
+              })()
 
               return (
                 <Fragment key={index}>
@@ -2807,18 +2802,18 @@ function FormFields<T extends FieldValues>({
                     />
                   )}
                 </Fragment>
-              );
+              )
             })}
           </RowFormField>
-        );
+        )
       })}
     </ContainerFormField>
-  );
+  )
 }
 
 const Divider = styled.div<{
-  $theme?: StatefulFormThemeConfig;
-  $style?: CSSProp;
+  $theme?: StatefulFormThemeConfig
+  $style?: CSSProp
 }>`
   width: 100%;
   height: 1px;
@@ -2826,17 +2821,17 @@ const Divider = styled.div<{
     $theme?.borderColor ?? "rgba(0,0,0,0.08)"};
 
   ${({ $style }) => $style}
-`;
+`
 
 export interface StatefulFormLabelProps
   extends Omit<LabelHTMLAttributes<HTMLLabelElement>, "label" | "style"> {
-  label?: string;
-  helper?: string;
-  styles: { self?: CSSProp };
-  labelPosition?: FieldLaneProps["labelPosition"];
-  labelWidth?: FieldLaneProps["labelWidth"];
-  required?: boolean;
-  disabled?: boolean;
+  label?: string
+  helper?: string
+  styles: { self?: CSSProp }
+  labelPosition?: FieldLaneProps["labelPosition"]
+  labelWidth?: FieldLaneProps["labelWidth"]
+  required?: boolean
+  disabled?: boolean
 }
 
 function StatefulFormLabel({
@@ -2871,14 +2866,14 @@ function StatefulFormLabel({
 
       {helper && <Helper value={helper} />}
     </Label>
-  );
+  )
 }
 
 const Label = styled.label<{
-  $style?: CSSProp;
-  $labelWidth?: FieldLaneProps["labelWidth"];
-  $labelPosition?: FieldLaneProps["labelPosition"];
-  $disabled?: boolean;
+  $style?: CSSProp
+  $labelWidth?: FieldLaneProps["labelWidth"]
+  $labelPosition?: FieldLaneProps["labelPosition"]
+  $disabled?: boolean
 }>`
   font-size: 0.75rem;
   display: flex;
@@ -2895,24 +2890,24 @@ const Label = styled.label<{
       cursor: not-allowed;
     `}
   ${({ $style }) => $style}
-`;
+`
 
 const Asterisk = styled.span`
   color: red;
   margin-left: 2px;
-`;
+`
 
 const LabelText = styled.span`
   min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-`;
+`
 
 interface StatefulFormSanitizeIdProps {
-  name?: string;
-  id?: string;
-  prefix?: string;
+  name?: string
+  id?: string
+  prefix?: string
 }
 
 function sanitizeId({
@@ -2924,11 +2919,11 @@ function sanitizeId({
     str
       .toLowerCase()
       .replace(/\s+/g, "_") // 1. spaces → underscores
-      .replace(/[^0-9a-z_-]/g, ""); // 2. Remove all non-ASCII characters (allow only 0-9, a-z, A-Z, _ and -)
+      .replace(/[^0-9a-z_-]/g, "") // 2. Remove all non-ASCII characters (allow only 0-9, a-z, A-Z, _ and -)
 
-  if (id) return sanitize(id);
-  if (name) return `${prefix}-${sanitize(name)}`;
-  return prefix;
+  if (id) return sanitize(id)
+  if (name) return `${prefix}-${sanitize(name)}`
+  return prefix
 }
 
 const ContainerFormField = styled.div<{ $style: CSSProp }>`
@@ -2943,7 +2938,7 @@ const ContainerFormField = styled.div<{ $style: CSSProp }>`
   gap: 6px;
 
   ${({ $style }) => $style}
-`;
+`
 
 const RowFormField = styled.div<{ $style: CSSProp }>`
   display: flex;
@@ -2953,9 +2948,9 @@ const RowFormField = styled.div<{ $style: CSSProp }>`
   justify-content: start;
 
   ${({ $style }) => $style}
-`;
+`
 
-StatefulForm.Label = StatefulFormLabel;
-StatefulForm.sanitizeId = sanitizeId;
+StatefulForm.Label = StatefulFormLabel
+StatefulForm.sanitizeId = sanitizeId
 
-export { StatefulForm };
+export { StatefulForm }

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -238,6 +238,12 @@ function StatefulForm<Z extends ZodTypeAny>({
   const formConfig: UseFormProps<TypeOf<Z>> = {
     mode,
     values: formValues,
+    // Prevent RHF from resetting errors/touched on every formValues change
+    resetOptions: {
+      keepErrors: true,
+      keepTouched: true,
+      keepDirtyValues: true,
+    },
   }
 
   if (validationSchema) {
@@ -370,7 +376,7 @@ function StatefulForm<Z extends ZodTypeAny>({
     }
 
     if (typeof value === "string") {
-      return value.length > 0 && !!touched && hasErrorMessage(error)
+      return value.length > 1 && !!touched && hasErrorMessage(error)
     }
 
     if (typeof value === "number" || typeof value === "boolean") {

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -288,7 +288,7 @@ function StatefulForm<Z extends ZodTypeAny>({
   // Prevents empty/untouched fields from getting falsely marked as touched
   // on initial mount (which would make them show errors immediately).
   const hasMeaningfulValue = (value: unknown): boolean => {
-    if (typeof value === "string") return value.length > 1
+    if (typeof value === "string") return value.length > 0
     if (typeof value === "number" || typeof value === "boolean") return true
     if (isFile(value) || isFileArray(value)) return true
     return value != null
@@ -375,7 +375,7 @@ function StatefulForm<Z extends ZodTypeAny>({
     }
 
     if (typeof value === "string") {
-      return value.length > 1 && !!touched && hasErrorMessage(error)
+      return value.length > 0 && !!touched && hasErrorMessage(error)
     }
 
     if (typeof value === "number" || typeof value === "boolean") {

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -242,7 +242,6 @@ function StatefulForm<Z extends ZodTypeAny>({
     resetOptions: {
       keepErrors: true,
       keepTouched: true,
-      keepDirtyValues: true,
     },
   }
 

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -49,11 +49,11 @@ import { useTheme, StatefulFormThemeConfig } from "./../theme";
 export type StatefulOnChangeType =
   | ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   | {
-    target: {
-      name: string;
-      value: FormValueType;
+      target: {
+        name: string;
+        value: FormValueType;
+      };
     };
-  };
 
 export type FormValueType =
   | string
@@ -220,8 +220,16 @@ function StatefulForm<Z extends ZodTypeAny>({
   className,
   id,
 }: StatefulFormProps<Z>) {
+  // Tracks field names whose most recent change came from the internal
+  // onChange path (handleFieldChange), i.e. real user interaction through
+  // register/Controller — NOT from an external formValues update.
+  // RHF's own register/Controller already handles validate+touch for these,
+  // so we don't need (and don't want) to force setValue on them again.
+  const internallyChangedFieldsRef = useRef<Set<string>>(new Set());
+
   const handleFieldChange = (name: keyof TypeOf<Z>, value: FormValueType) => {
     if (disabled) return;
+    internallyChangedFieldsRef.current.add(name as string);
     onChange?.({ currentState: { [name]: value } });
   };
 
@@ -229,7 +237,7 @@ function StatefulForm<Z extends ZodTypeAny>({
 
   const formConfig: UseFormProps<TypeOf<Z>> = {
     mode,
-    defaultValues: formValues,
+    values: formValues,
   };
 
   if (validationSchema) {
@@ -243,22 +251,87 @@ function StatefulForm<Z extends ZodTypeAny>({
     formState: { errors, touchedFields, isValid },
   } = useForm(formConfig) as ReturnType<typeof useForm<TypeOf<Z>>>;
 
-  const customFieldNames = fields
-    .flat()
-    .filter((field) => field.type === "custom")
-    .map((field) => field.name);
+  const isFile = (val: unknown): val is File => val instanceof File;
 
-  const customValues = customFieldNames.map((name) => formValues[name]);
+  const isFileArray = (val: unknown): val is File[] =>
+    Array.isArray(val) && val.every((v) => v instanceof File);
 
-  useEffect(() => {
-    customFieldNames.map((name) => {
-      setValue(name as any, formValues[name as any], {
-        shouldValidate: true,
-        shouldTouch: true,
-        shouldDirty: true,
-      });
+  // Recursively collect ALL field names that hold a real form value —
+  // including "custom" fields now, since they need the same touched/validate
+  // sync logic as every other field type. Only skip "button" (no value)
+  // and "hidden" (not meant to be validated/shown).
+  function flattenAllFieldNames(fields: FormFieldGroup[]): string[] {
+    return fields.flatMap((f) => {
+      if (Array.isArray(f)) {
+        return flattenAllFieldNames(f);
+      }
+
+      if (f.type === "frame" && f.fields) {
+        return flattenAllFieldNames(f.fields as FormFieldGroup[]);
+      }
+
+      // skip fields that don't hold a real, validatable form value
+      if (f.type === "button" || f.type === "custom" || f.hidden) {
+        return [];
+      }
+
+      return [f.name];
     });
-  }, [JSON.stringify(customValues), setValue]);
+  }
+
+  // Decide whether a value is "real" enough to be worth touching/validating.
+  // Prevents empty/untouched fields from getting falsely marked as touched
+  // on initial mount (which would make them show errors immediately).
+  const hasMeaningfulValue = (value: unknown): boolean => {
+    if (typeof value === "string") return value.length > 1;
+    if (typeof value === "number" || typeof value === "boolean") return true;
+    if (isFile(value) || isFileArray(value)) return true;
+    return value != null;
+  };
+
+  const allFieldNames = flattenAllFieldNames(fields);
+
+  const prevFormValuesRef = useRef<TypeOf<Z>>(formValues);
+
+  // Whenever `formValues` changes — whether from an external source (values
+  // prop reactive sync) or a "custom" field's own render logic — RHF's
+  // internal reset (triggered by the `values` prop) does NOT automatically
+  // mark fields as touched or re-run validation for display purposes.
+  // So we manually diff against the previous values and force `setValue`
+  // with `shouldValidate` + `shouldTouch` only on fields that actually changed,
+  // avoiding unnecessary re-validation on fields that didn't change.
+  useEffect(() => {
+    const prevFormValues = prevFormValuesRef.current;
+
+    allFieldNames.forEach((name) => {
+      const key = name as keyof TypeOf<Z>;
+      const value = formValues[key];
+      const prevValue = prevFormValues[key];
+
+      const changedInternally = internallyChangedFieldsRef.current.has(name);
+
+      // consume the flag either way, so it doesn't leak into future renders
+      internallyChangedFieldsRef.current.delete(name);
+
+      if (changedInternally) {
+        // came from real user interaction via register/Controller —
+        // RHF already validated + touched it, nothing to do here
+        return;
+      }
+
+      // only reaches here for changes NOT triggered by handleFieldChange,
+      // i.e. genuinely external updates (props, server data, programmatic set, etc.)
+      if (value !== prevValue && hasMeaningfulValue(value)) {
+        setValue(name as any, value as any, {
+          shouldValidate: true,
+          shouldTouch: true,
+          shouldDirty: true,
+        });
+      }
+    });
+
+    prevFormValuesRef.current = formValues;
+  }, [formValues, setValue]);
 
   useEffect(() => {
     if (onValidityChange) {
@@ -281,11 +354,6 @@ function StatefulForm<Z extends ZodTypeAny>({
     const value = formValues[name];
     const touched = touchedFields[name];
     const error = errors[name];
-
-    const isFile = (val: unknown): val is File => val instanceof File;
-
-    const isFileArray = (val: unknown): val is File[] =>
-      Array.isArray(val) && val.every((v) => v instanceof File);
 
     const hasErrorMessage = (err: unknown): boolean => {
       if (!err || typeof err !== "object") return false;
@@ -700,8 +768,8 @@ function FormFields<T extends FieldValues>({
                         showError={shouldShowError(field.name)}
                         errorMessage={
                           errors[field.name as keyof T]?.message as
-                          | string
-                          | undefined
+                            | string
+                            | undefined
                         }
                         disabled={field.disabled || disabled}
                         {...field.textbox}
@@ -784,8 +852,8 @@ function FormFields<T extends FieldValues>({
                             showError={shouldShowError(field.name)}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
-                              | string
-                              | undefined
+                                | string
+                                | undefined
                             }
                             disabled={field.disabled || disabled}
                             {...field.pinbox}
@@ -826,16 +894,16 @@ function FormFields<T extends FieldValues>({
                                   box-shadow: none;
                                   border-bottom: 1px solid
                                     ${shouldShowError(field.name)
-                                    ? pinboxTheme.errorBorderColor ||
-                                    "#f87171"
-                                    : pinboxTheme.borderColor || "#d1d5db"};
+                                      ? pinboxTheme.errorBorderColor ||
+                                        "#f87171"
+                                      : pinboxTheme.borderColor || "#d1d5db"};
 
                                   &:focus {
                                     border: none;
                                     box-shadow: none;
                                     border-bottom: 1px solid
                                       ${pinboxTheme.focusedBorderColor ||
-                                  "#61A9F9"};
+                                      "#61A9F9"};
                                     z-index: 9999;
                                   }
                                 `};
@@ -954,11 +1022,11 @@ function FormFields<T extends FieldValues>({
                         placeholder={
                           typeof field.placeholder === "string"
                             ? (() => {
-                              const [hour = "", minute = "", second = ""] =
-                                field.placeholder.split(/[:/]/);
+                                const [hour = "", minute = "", second = ""] =
+                                  field.placeholder.split(/[:/]/);
 
-                              return { hour, minute, second };
-                            })()
+                                return { hour, minute, second };
+                              })()
                             : field.placeholder
                         }
                         helper={field.helper}
@@ -977,8 +1045,8 @@ function FormFields<T extends FieldValues>({
                         showError={shouldShowError(field.name)}
                         errorMessage={
                           errors[field.name as keyof T]?.message as
-                          | string
-                          | undefined
+                            | string
+                            | undefined
                         }
                         disabled={field.disabled || disabled}
                         {...field.timebox}
@@ -1005,16 +1073,16 @@ function FormFields<T extends FieldValues>({
                               box-shadow: none;
                               border-bottom: 1px solid
                                 ${shouldShowError(field.name)
-                                ? pinboxTheme.errorBorderColor || "#f87171"
-                                : pinboxTheme.borderColor || "#d1d5db"};
+                                  ? pinboxTheme.errorBorderColor || "#f87171"
+                                  : pinboxTheme.borderColor || "#d1d5db"};
 
                               &:focus {
                                 border: none;
                                 box-shadow: none;
                                 border-bottom: 1px solid
                                   ${shouldShowError(field.name)
-                                ? pinboxTheme.errorBorderColor || "#f87171"
-                                : pinboxTheme.borderColor || "#d1d5db"};
+                                    ? pinboxTheme.errorBorderColor || "#f87171"
+                                    : pinboxTheme.borderColor || "#d1d5db"};
                                 z-index: 9999;
                               }
                             `};
@@ -1118,8 +1186,8 @@ function FormFields<T extends FieldValues>({
                         showError={shouldShowError(field.name)}
                         errorMessage={
                           errors[field.name as keyof T]?.message as
-                          | string
-                          | undefined
+                            | string
+                            | undefined
                         }
                         disabled={field.disabled || disabled}
                         {...field.textarea}
@@ -1199,8 +1267,8 @@ function FormFields<T extends FieldValues>({
                               }}
                               errorMessage={
                                 errors[field.name as keyof T]?.message as
-                                | string
-                                | undefined
+                                  | string
+                                  | undefined
                               }
                               required={required}
                               showError={shouldShowError(field.name)}
@@ -1321,8 +1389,8 @@ function FormFields<T extends FieldValues>({
                               checked={controllerField.value ?? false}
                               errorMessage={
                                 errors[field.name as keyof T]?.message as
-                                | string
-                                | undefined
+                                  | string
+                                  | undefined
                               }
                               helper={field.helper}
                               required={required}
@@ -1429,11 +1497,11 @@ function FormFields<T extends FieldValues>({
                             onChange={(
                               e:
                                 | {
-                                  target: {
-                                    name: string;
-                                    value: PhoneboxCountryCode;
-                                  };
-                                }
+                                    target: {
+                                      name: string;
+                                      value: PhoneboxCountryCode;
+                                    };
+                                  }
                                 | ChangeEvent<HTMLInputElement>
                             ) => {
                               if (e.target.name === "phone") {
@@ -1447,8 +1515,8 @@ function FormFields<T extends FieldValues>({
                             showError={shouldShowError(field.name)}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
-                              | string
-                              | undefined
+                                | string
+                                | undefined
                             }
                             disabled={field.disabled || disabled}
                             {...field.phonebox}
@@ -1708,8 +1776,8 @@ function FormFields<T extends FieldValues>({
                         disabled={field.disabled || disabled}
                         errorMessage={
                           errors[field.name as keyof T]?.message as
-                          | string
-                          | undefined
+                            | string
+                            | undefined
                         }
                         {...field.fileInputBox}
                         onFilesSelected={(files: File[]) => {
@@ -1825,8 +1893,8 @@ function FormFields<T extends FieldValues>({
                         showError={shouldShowError(field.name)}
                         errorMessage={
                           errors[field.name as keyof T]?.message as
-                          | string
-                          | undefined
+                            | string
+                            | undefined
                         }
                         {...field.imagebox}
                         styles={{
@@ -1896,8 +1964,8 @@ function FormFields<T extends FieldValues>({
                         showError={shouldShowError(field.name)}
                         errorMessage={
                           errors[field.name as keyof T]?.message as
-                          | string
-                          | undefined
+                            | string
+                            | undefined
                         }
                         disabled={field.disabled || disabled}
                         {...field.signbox}
@@ -2067,8 +2135,8 @@ function FormFields<T extends FieldValues>({
                               }}
                               errorMessage={
                                 errors[field.name as keyof T]?.[0]?.message as
-                                | string
-                                | undefined
+                                  | string
+                                  | undefined
                               }
                               onChange={(e) => {
                                 const inputValueEvent = {
@@ -2167,8 +2235,8 @@ function FormFields<T extends FieldValues>({
                             }}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
-                              | string
-                              | undefined
+                                | string
+                                | undefined
                             }
                             helper={field.helper}
                             onChange={(e) => {
@@ -2473,8 +2541,8 @@ function FormFields<T extends FieldValues>({
                             showError={shouldShowError(field.name)}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
-                              | string
-                              | undefined
+                                | string
+                                | undefined
                             }
                             disabled={field.disabled || disabled}
                             {...field.thumbField}
@@ -2574,8 +2642,8 @@ function FormFields<T extends FieldValues>({
                             showError={shouldShowError(field.name)}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
-                              | string
-                              | undefined
+                                | string
+                                | undefined
                             }
                             disabled={field.disabled || disabled}
                             {...field.toggle}
@@ -2666,8 +2734,8 @@ function FormFields<T extends FieldValues>({
                             showError={shouldShowError(field.name)}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
-                              | string
-                              | undefined
+                                | string
+                                | undefined
                             }
                             {...field.capsule}
                             styles={{

--- a/package.json
+++ b/package.json
@@ -438,6 +438,7 @@
     "fast-glob": "^3.3.3",
     "fs-extra": "^11.3.4",
     "globals": "^15.15.0",
+    "oxfmt": "^0.62.0",
     "prettier": "^3.5.3",
     "storybook": "^8.6.14",
     "typescript": "^5.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       globals:
         specifier: ^15.15.0
         version: 15.15.0
+      oxfmt:
+        specifier: ^0.62.0
+        version: 0.62.0
       prettier:
         specifier: ^3.5.3
         version: 3.6.2
@@ -633,6 +636,120 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxfmt/binding-android-arm-eabi@0.62.0':
+    resolution: {integrity: sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.62.0':
+    resolution: {integrity: sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.62.0':
+    resolution: {integrity: sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.62.0':
+    resolution: {integrity: sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.62.0':
+    resolution: {integrity: sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.62.0':
+    resolution: {integrity: sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.62.0':
+    resolution: {integrity: sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.62.0':
+    resolution: {integrity: sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-musl@0.62.0':
+    resolution: {integrity: sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
+    resolution: {integrity: sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
+    resolution: {integrity: sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.62.0':
+    resolution: {integrity: sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.62.0':
+    resolution: {integrity: sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-gnu@0.62.0':
+    resolution: {integrity: sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-musl@0.62.0':
+    resolution: {integrity: sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-openharmony-arm64@0.62.0':
+    resolution: {integrity: sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.62.0':
+    resolution: {integrity: sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.62.0':
+    resolution: {integrity: sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.62.0':
+    resolution: {integrity: sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2444,6 +2561,19 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  oxfmt@0.62.0:
+    resolution: {integrity: sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-limit@1.3.0:
     resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
     engines: {node: '>=4'}
@@ -2910,6 +3040,10 @@ packages:
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
@@ -3619,6 +3753,63 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@oxfmt/binding-android-arm-eabi@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.62.0':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -5681,6 +5872,30 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  oxfmt@0.62.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.62.0
+      '@oxfmt/binding-android-arm64': 0.62.0
+      '@oxfmt/binding-darwin-arm64': 0.62.0
+      '@oxfmt/binding-darwin-x64': 0.62.0
+      '@oxfmt/binding-freebsd-x64': 0.62.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.62.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.62.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.62.0
+      '@oxfmt/binding-linux-arm64-musl': 0.62.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.62.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.62.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.62.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.62.0
+      '@oxfmt/binding-linux-x64-gnu': 0.62.0
+      '@oxfmt/binding-linux-x64-musl': 0.62.0
+      '@oxfmt/binding-openharmony-arm64': 0.62.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.62.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.62.0
+      '@oxfmt/binding-win32-x64-msvc': 0.62.0
+
   p-limit@1.3.0:
     dependencies:
       p-try: 1.0.0
@@ -6220,6 +6435,8 @@ snapshots:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@1.2.0:
     optional: true

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -447,7 +447,7 @@ describe("StatefulForm", () => {
         it("does not show the error", () => {
           cy.mount(<StatefulFormWithAsync state="empty" />)
 
-          cy.findByPlaceholderText("Enter first name").type("Te")
+          cy.findByPlaceholderText("Enter first name").type("T")
 
           cy.findByText("First name must be at least 3 characters long").should(
             "not.exist",
@@ -462,7 +462,7 @@ describe("StatefulForm", () => {
             "not.exist",
           )
 
-          cy.findByPlaceholderText("Enter first name").type("Te")
+          cy.findByPlaceholderText("Enter first name").type("T")
           cy.get("body").click("topRight")
 
           cy.findByText("First name must be at least 3 characters long").should(

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -442,9 +442,9 @@ describe("StatefulForm", () => {
       )
     }
 
-    context("when typing", () => {
-      context("when invalid, but still focus", () => {
-        it("still renders without error", () => {
+    context("when typing with invalid value", () => {
+      context("while focused", () => {
+        it("does not show the error", () => {
           cy.mount(<StatefulFormWithAsync state="empty" />)
 
           cy.findByPlaceholderText("Enter first name").type("Te")
@@ -455,8 +455,8 @@ describe("StatefulForm", () => {
         })
       })
 
-      context("when invalid, but unfocused", () => {
-        it("renders with error", () => {
+      context("after blur", () => {
+        it("shows the error", () => {
           cy.mount(<StatefulFormWithAsync state="empty" />)
           cy.findByText("First name must be at least 3 characters long").should(
             "not.exist",
@@ -468,6 +468,41 @@ describe("StatefulForm", () => {
           cy.findByText("First name must be at least 3 characters long").should(
             "be.visible",
           )
+        })
+
+        context("when typing in another field", () => {
+          it("keeps the previous error", () => {
+            cy.mount(<StatefulFormWithAsync state="empty" />)
+            cy.findByText(
+              "First name must be at least 3 characters long",
+            ).should("not.exist")
+
+            cy.findByPlaceholderText("Enter first name").type("Te")
+            cy.get("body").click("topRight")
+
+            cy.findByText(
+              "First name must be at least 3 characters long",
+            ).should("be.visible")
+
+            cy.findByPlaceholderText("Enter email address").type("iamalim@test")
+
+            // still shows if in focus
+
+            cy.findByText(
+              "First name must be at least 3 characters long",
+            ).should("be.visible")
+
+            cy.get("body").click("topRight")
+
+            // still shows after unfocused
+
+            cy.findByText(
+              "First name must be at least 3 characters long",
+            ).should("be.visible")
+            cy.findByText("Please enter a valid email address").should(
+              "be.visible",
+            )
+          })
         })
       })
     })

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -4,31 +4,31 @@ import {
   FormFieldType,
   StatefulForm,
   StatefulFormProps,
-} from "./../../components/stateful-form";
-import { COUNTRY_CODES } from "./../../constants/countries";
-import { Boxbar } from "./../../components/boxbar";
-import { Badge, BadgeProps } from "./../../components/badge";
-import { css } from "styled-components";
-import { SelectboxOption } from "./../../components/selectbox";
-import { CapsuleTab } from "./../../components/capsule";
-import { useMemo, useState } from "react";
+} from "./../../components/stateful-form"
+import { COUNTRY_CODES } from "./../../constants/countries"
+import { Boxbar } from "./../../components/boxbar"
+import { Badge, BadgeProps } from "./../../components/badge"
+import { css } from "styled-components"
+import { SelectboxOption } from "./../../components/selectbox"
+import { CapsuleTab } from "./../../components/capsule"
+import { useEffect, useMemo, useState } from "react"
 import {
   OnCompleteFunctionArgs,
   FileDropBox,
   OnFileDroppedFunctionArgs,
-} from "./../../components/file-drop-box";
-import { Table } from "./../../components/table";
-import { RiDeleteBin2Fill } from "@remixicon/react";
-import z from "zod";
-import { PinboxParts } from "./../../components/pinbox";
+} from "./../../components/file-drop-box"
+import { Table } from "./../../components/table"
+import { RiDeleteBin2Fill } from "@remixicon/react"
+import z from "zod"
+import { PinboxParts } from "./../../components/pinbox"
 
 const DEFAULT_COUNTRY_CODES = (() => {
   const code =
-    COUNTRY_CODES.find((data) => data.id === "US") ?? COUNTRY_CODES[206];
+    COUNTRY_CODES.find((data) => data.id === "US") ?? COUNTRY_CODES[206]
   if (!code)
-    throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
-  return code;
-})();
+    throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
+  return code
+})()
 
 const FRUIT_OPTIONS: SelectboxOption[] = [
   { text: "Apple", value: "1" },
@@ -38,7 +38,7 @@ const FRUIT_OPTIONS: SelectboxOption[] = [
   { text: "Pineapple", value: "5" },
   { text: "Strawberry", value: "6" },
   { text: "Watermelon", value: "7" },
-];
+]
 
 const MONTH_NAMES = [
   { text: "JAN", value: "1" },
@@ -53,12 +53,12 @@ const MONTH_NAMES = [
   { text: "OCT", value: "10" },
   { text: "NOV", value: "11" },
   { text: "DEC", value: "12" },
-];
+]
 
 const CAPSULE_TABS: CapsuleTab[] = [
   { id: "paid", title: "Paid" },
   { id: "unpaid", title: "Unpaid" },
-];
+]
 
 const PARTS_INPUT: PinboxParts[] = [
   { type: "static", text: "S" },
@@ -66,7 +66,7 @@ const PARTS_INPUT: PinboxParts[] = [
   { type: "digit" },
   { type: "alphabet" },
   { type: "static", text: "-" },
-];
+]
 
 const BADGE_OPTIONS_FULL = [
   { id: 1, caption: "Anime" },
@@ -79,12 +79,12 @@ const BADGE_OPTIONS_FULL = [
   { id: 8, caption: "Music" },
   { id: 9, caption: "Games" },
   { id: 10, caption: "Webtoons" },
-];
+]
 
 const BADGE_OPTIONS_SHORT: BadgeProps[] = [
   { id: "1", caption: "Anime" },
   { id: "2", caption: "Manga" },
-];
+]
 
 const TYPE_TO_ID_PREFIX: Record<FormFieldType, string> = {
   text: "textbox",
@@ -114,7 +114,7 @@ const TYPE_TO_ID_PREFIX: Record<FormFieldType, string> = {
   chips: "chips",
   custom: "custom",
   frame: "frame",
-};
+}
 
 const allValue = {
   text: "",
@@ -141,7 +141,7 @@ const allValue = {
   signature: "",
   capsule: "",
   country_code: DEFAULT_COUNTRY_CODES,
-};
+}
 
 const ALL_INPUT: FormFieldGroup[] = [
   [
@@ -315,14 +315,208 @@ const ALL_INPUT: FormFieldGroup[] = [
       tabs: CAPSULE_TABS,
     },
   },
-];
+]
 
 const flattenFields = (groups: FormFieldGroup[]): FormFieldProps[] =>
   groups.flatMap((group) =>
-    Array.isArray(group) ? flattenFields(group) : [group]
-  );
+    Array.isArray(group) ? flattenFields(group) : [group],
+  )
 
 describe("StatefulForm", () => {
+  context("general", () => {
+    function StatefulFormWithAsync({
+      state = "valid",
+    }: {
+      state?: "valid" | "invalid" | "empty"
+    }) {
+      const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
+        (data) => data.id === "US",
+      )
+
+      if (!DEFAULT_COUNTRY_CODES) {
+        throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
+      }
+
+      const [value, setValue] = useState({
+        name: "",
+        email: "",
+        phone: "",
+        country_code: DEFAULT_COUNTRY_CODES,
+      })
+
+      const [isFormValid, setIsFormValid] = useState(false)
+
+      useEffect(() => {
+        const timer = setTimeout(() => {
+          switch (state) {
+            case "valid":
+              setValue((prev) => ({
+                ...prev,
+                name: "John Doe",
+                email: "john@example.com",
+                phone: "081234567890",
+              }))
+              break
+
+            case "invalid":
+              setValue((prev) => ({
+                ...prev,
+                name: "Jo",
+                email: "invalid-email",
+                phone: "123",
+              }))
+              break
+
+            case "empty":
+            default:
+              break
+          }
+        }, 300)
+
+        return () => clearTimeout(timer)
+      }, [state])
+
+      const employeeSchema = z.object({
+        name: z
+          .string()
+          .min(3, "First name must be at least 3 characters long"),
+        email: z.string().email("Please enter a valid email address"),
+        phone: z
+          .string()
+          .regex(/^\d{10,15}$/, "Phone number must be between 10 and 15 digits")
+          .optional(),
+      })
+
+      const EMPLOYEE_FIELDS: FormFieldGroup[] = [
+        {
+          name: "name",
+          title: "First Name",
+          type: "text",
+          required: true,
+          placeholder: "Enter first name",
+        },
+        [
+          {
+            name: "email",
+            title: "Email",
+            type: "email",
+            required: true,
+            placeholder: "Enter email address",
+          },
+          {
+            name: "text",
+            title: "Verify",
+            type: "button",
+          },
+        ],
+        {
+          name: "phone",
+          title: "Phone Number",
+          type: "phone",
+          required: true,
+          placeholder: "Enter phone number",
+        },
+        {
+          name: "text",
+          title: "Save",
+          type: "button",
+          disabled: !isFormValid,
+          rowJustifyPosition: "end",
+        },
+      ]
+
+      return (
+        <StatefulForm
+          fields={EMPLOYEE_FIELDS}
+          formValues={value}
+          validationSchema={employeeSchema}
+          mode="onChange"
+          onValidityChange={setIsFormValid}
+          onChange={({ currentState }) => {
+            setValue((prev) => ({
+              ...prev,
+              ...currentState,
+            }))
+          }}
+        />
+      )
+    }
+
+    context("when typing", () => {
+      context("when invalid, but still focus", () => {
+        it("still renders without error", () => {
+          cy.mount(<StatefulFormWithAsync state="empty" />)
+
+          cy.findByPlaceholderText("Enter first name").type("Te")
+
+          cy.findByText("First name must be at least 3 characters long").should(
+            "not.exist",
+          )
+        })
+      })
+
+      context("when invalid, but unfocused", () => {
+        it("renders with error", () => {
+          cy.mount(<StatefulFormWithAsync state="empty" />)
+          cy.findByText("First name must be at least 3 characters long").should(
+            "not.exist",
+          )
+
+          cy.findByPlaceholderText("Enter first name").type("Te")
+          cy.get("body").click("topRight")
+
+          cy.findByText("First name must be at least 3 characters long").should(
+            "be.visible",
+          )
+        })
+      })
+    })
+
+    context("async", () => {
+      context("when data is valid", () => {
+        it("renders without error", () => {
+          cy.mount(<StatefulFormWithAsync state="valid" />)
+
+          cy.wait(600)
+
+          cy.findByDisplayValue("John Doe").should("exist")
+          cy.findByDisplayValue("john@example.com").should("exist")
+          cy.findByDisplayValue("081234567890").should("exist")
+
+          cy.findByText("First name must be at least 3 characters long").should(
+            "not.exist",
+          )
+          cy.findByText("Please enter a valid email address").should(
+            "not.exist",
+          )
+          cy.findByText("Phone number must be between 10 and 15 digits").should(
+            "not.exist",
+          )
+        })
+      })
+
+      context("when data is invalid", () => {
+        it("renders with error", () => {
+          cy.mount(<StatefulFormWithAsync state="invalid" />)
+
+          cy.wait(600)
+
+          cy.findByDisplayValue("Jo").should("exist")
+          cy.findByDisplayValue("invalid-email").should("exist")
+          cy.findByDisplayValue("123").should("exist")
+
+          cy.findByText("First name must be at least 3 characters long").should(
+            "exist",
+          )
+          cy.findByText("Please enter a valid email address").should("exist")
+          cy.findByText("Phone number must be between 10 and 15 digits").should(
+            "exist",
+          )
+        })
+      })
+    })
+  })
+
   context("mobile", () => {
     context("styles", () => {
       context("mobileFieldGroupStyle", () => {
@@ -339,17 +533,17 @@ describe("StatefulForm", () => {
                     padding: 30px;
                   `,
                 }}
-              />
-            );
+              />,
+            )
 
             cy.findAllByLabelText("stateful-form-field-group").should(
               "have.css",
               "padding",
-              "30px"
-            );
-          });
-        });
-      });
+              "30px",
+            )
+          })
+        })
+      })
 
       context("mobileFieldGroupRowDividerStyle", () => {
         context("when given color red", () => {
@@ -365,18 +559,18 @@ describe("StatefulForm", () => {
                     background-color: red;
                   `,
                 }}
-              />
-            );
+              />,
+            )
 
             cy.findAllByLabelText("stateful-form-field-group-divider").should(
               "have.css",
               "background-color",
-              "rgb(255, 0, 0)"
-            );
-          });
-        });
-      });
-    });
+              "rgb(255, 0, 0)",
+            )
+          })
+        })
+      })
+    })
     it("renders with background rgb(236, 236, 236)", () => {
       cy.mount(
         <StatefulForm
@@ -384,15 +578,15 @@ describe("StatefulForm", () => {
           formValues={allValue}
           mode="onChange"
           mobile
-        />
-      );
+        />,
+      )
 
       cy.findAllByLabelText("stateful-form-field-group").should(
         "have.css",
         "background-color",
-        "rgb(236, 236, 236)"
-      );
-    });
+        "rgb(236, 236, 236)",
+      )
+    })
 
     it("renders row with radius 24px and padding 10px 20px", () => {
       cy.mount(
@@ -401,18 +595,18 @@ describe("StatefulForm", () => {
           formValues={allValue}
           mode="onChange"
           mobile
-        />
-      );
+        />,
+      )
 
       cy.findAllByLabelText("stateful-form-field-group")
         .should("have.css", "border-radius", "24px")
-        .and("have.css", "padding", "10px 20px");
-    });
+        .and("have.css", "padding", "10px 20px")
+    })
 
     context("radio", () => {
       context("clicking in center row element", () => {
         it("should give callback in onChanges", () => {
-          const onChangeValue = cy.stub().as("onChangeValue");
+          const onChangeValue = cy.stub().as("onChangeValue")
 
           cy.mount(
             <StatefulForm
@@ -428,21 +622,21 @@ describe("StatefulForm", () => {
               mode="onChange"
               onChange={() => onChangeValue()}
               mobile
-            />
-          );
-          cy.get("@onChangeValue").should("not.have.been.calledOnce");
+            />,
+          )
+          cy.get("@onChangeValue").should("not.have.been.calledOnce")
 
-          cy.findAllByLabelText("stateful-form-field-group").click("center");
+          cy.findAllByLabelText("stateful-form-field-group").click("center")
 
-          cy.get("@onChangeValue").should("have.been.calledOnce");
-        });
-      });
-    });
+          cy.get("@onChangeValue").should("have.been.calledOnce")
+        })
+      })
+    })
 
     context("checkbox", () => {
       context("clicking in center row element", () => {
         it("should give callback in onChanges", () => {
-          const onChangeValue = cy.stub().as("onChangeValue");
+          const onChangeValue = cy.stub().as("onChangeValue")
 
           cy.mount(
             <StatefulForm
@@ -458,21 +652,21 @@ describe("StatefulForm", () => {
               mode="onChange"
               onChange={() => onChangeValue()}
               mobile
-            />
-          );
-          cy.get("@onChangeValue").should("not.have.been.calledOnce");
+            />,
+          )
+          cy.get("@onChangeValue").should("not.have.been.calledOnce")
 
-          cy.findAllByLabelText("stateful-form-field-group").click("center");
+          cy.findAllByLabelText("stateful-form-field-group").click("center")
 
-          cy.get("@onChangeValue").should("have.been.calledOnce");
-        });
-      });
-    });
+          cy.get("@onChangeValue").should("have.been.calledOnce")
+        })
+      })
+    })
 
     context("button", () => {
       context("when given 2 or more button", () => {
         it("should separate with percentage in flex row", () => {
-          cy.viewport(500, 500);
+          cy.viewport(500, 500)
           cy.mount(
             <StatefulForm
               fields={[
@@ -499,22 +693,22 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
           cy.findAllByLabelText("stateful-form-field-group")
             .should("have.css", "flex-direction", "row")
-            .and("have.css", "width", "460px");
+            .and("have.css", "width", "460px")
 
-          cy.findAllByRole("button").should("have.length", 2);
-          cy.findAllByRole("button").eq(0).should("have.css", "width", "230px");
-          cy.findAllByRole("button").eq(1).should("have.css", "width", "230px");
-        });
-      });
+          cy.findAllByRole("button").should("have.length", 2)
+          cy.findAllByRole("button").eq(0).should("have.css", "width", "230px")
+          cy.findAllByRole("button").eq(1).should("have.css", "width", "230px")
+        })
+      })
 
       context("when given 2 or more button and 1 input", () => {
         it("should renders as usual with flex column", () => {
-          cy.viewport(500, 500);
+          cy.viewport(500, 500)
           cy.mount(
             <StatefulForm
               fields={[
@@ -548,30 +742,30 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
           cy.findAllByLabelText("stateful-form-field-group")
             .should("have.css", "flex-direction", "column")
-            .and("have.css", "width", "460px");
+            .and("have.css", "width", "460px")
 
-          cy.findAllByRole("button").should("have.length", 2);
+          cy.findAllByRole("button").should("have.length", 2)
           cy.findAllByRole("button")
             .eq(0)
-            .should("not.have.css", "width", "230px");
+            .should("not.have.css", "width", "230px")
           cy.findAllByRole("button")
             .eq(1)
-            .should("not.have.css", "width", "230px");
-        });
-      });
-    });
+            .should("not.have.css", "width", "230px")
+        })
+      })
+    })
 
     context("Capsule", () => {
       context("when error", () => {
         it("should not render the error icon", () => {
           const capsuleSchema = z.object({
             capsule: z.string().max(4, "Paid is required"),
-          });
+          })
 
           cy.mount(
             <StatefulForm
@@ -590,22 +784,22 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
-          cy.findByText("Paid is required").should("not.exist");
-          cy.get("body").find("svg").should("not.exist");
+          cy.findByText("Paid is required").should("not.exist")
+          cy.get("body").find("svg").should("not.exist")
 
-          cy.findByText("Unpaid").click();
+          cy.findByText("Unpaid").click()
 
-          cy.findByText("Paid is required").should("exist");
+          cy.findByText("Paid is required").should("exist")
           cy.get("body")
             .find("svg")
             .parent()
-            .should("have.css", "display", "none");
-        });
-      });
-    });
+            .should("have.css", "display", "none")
+        })
+      })
+    })
 
     context("textbox", () => {
       context("when given title", () => {
@@ -623,11 +817,11 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
-          cy.findByPlaceholderText("Text Placeholder").should("exist");
-        });
+          cy.findByPlaceholderText("Text Placeholder").should("exist")
+        })
 
         context("when given placeholder", () => {
           it("should replace the placeholder input text", () => {
@@ -646,15 +840,15 @@ describe("StatefulForm", () => {
                 formValues={{}}
                 mode="onChange"
                 mobile
-              />
-            );
+              />,
+            )
 
-            cy.findByPlaceholderText("Text Placeholder").should("not.exist");
-            cy.findByPlaceholderText("Enter text").should("not.exist");
-          });
-        });
-      });
-    });
+            cy.findByPlaceholderText("Text Placeholder").should("not.exist")
+            cy.findByPlaceholderText("Enter text").should("not.exist")
+          })
+        })
+      })
+    })
 
     context("colorbox", () => {
       it("renders with flex row-reverse", () => {
@@ -672,14 +866,14 @@ describe("StatefulForm", () => {
             formValues={{}}
             mode="onChange"
             mobile
-          />
-        );
+          />,
+        )
 
         cy.findByLabelText("colorbox")
           .should("exist")
-          .and("have.css", "flex-direction", "row-reverse");
-      });
-    });
+          .and("have.css", "flex-direction", "row-reverse")
+      })
+    })
 
     context("moneybox", () => {
       context("when clicking the currency button", () => {
@@ -700,17 +894,17 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
-          cy.findByLabelText("moneybox-currency-toggle").click();
+          cy.findByLabelText("moneybox-currency-toggle").click()
 
           cy.findByLabelText("combobox-drawer-mobile")
             .should("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed");
-        });
-      });
-    });
+            .and("have.css", "position", "fixed")
+        })
+      })
+    })
 
     context("chips", () => {
       function ProductStatefulChips() {
@@ -719,7 +913,7 @@ describe("StatefulForm", () => {
             selectedOptions: [],
             searchText: "",
           },
-        });
+        })
 
         return (
           <StatefulForm
@@ -738,7 +932,7 @@ describe("StatefulForm", () => {
               },
             ]}
             onChange={({ currentState }) => {
-              const [[key, value]] = Object.entries(currentState);
+              const [[key, value]] = Object.entries(currentState)
 
               setValue((prev) => ({
                 ...prev,
@@ -752,46 +946,46 @@ describe("StatefulForm", () => {
                       },
                     }
                   : currentState),
-              }));
+              }))
             }}
             formValues={value}
             mode="onChange"
           />
-        );
+        )
       }
 
       it("renders with row reverse", () => {
-        cy.mount(<ProductStatefulChips />);
+        cy.mount(<ProductStatefulChips />)
 
-        cy.findByLabelText("chips-container-input").click();
+        cy.findByLabelText("chips-container-input").click()
 
         cy.findByLabelText("combobox-drawer-mobile")
           .should("exist")
           .and("have.css", "bottom", "10px")
-          .and("have.css", "position", "fixed");
+          .and("have.css", "position", "fixed")
 
-        cy.findByText("Anime").click();
-        cy.findByText("Manga").click();
+        cy.findByText("Anime").click()
+        cy.findByText("Manga").click()
 
         cy.findByLabelText("chips-container-input").should(
           "have.css",
           "flex-direction",
-          "row-reverse"
-        );
-      });
+          "row-reverse",
+        )
+      })
       context("when clicking the button", () => {
         it("renders in the bottom of screen", () => {
-          cy.mount(<ProductStatefulChips />);
+          cy.mount(<ProductStatefulChips />)
 
-          cy.findByLabelText("chips-container-input").click();
+          cy.findByLabelText("chips-container-input").click()
 
           cy.findByLabelText("combobox-drawer-mobile")
             .should("exist")
             .and("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed");
-        });
-      });
-    });
+            .and("have.css", "position", "fixed")
+        })
+      })
+    })
 
     context("datebox", () => {
       context("when clicking the selectbox", () => {
@@ -810,18 +1004,18 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
-          cy.findAllByPlaceholderText("Select a date").click();
+          cy.findAllByPlaceholderText("Select a date").click()
 
           cy.findByLabelText("calendar")
             .should("exist")
             .and("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed");
-        });
-      });
-    });
+            .and("have.css", "position", "fixed")
+        })
+      })
+    })
 
     context("phonebox", () => {
       context("renders in the text align to right side", () => {
@@ -840,14 +1034,14 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
           cy.findByLabelText("phonebox-input-number")
             .should("exist")
-            .and("have.css", "text-align", "end");
-        });
-      });
+            .and("have.css", "text-align", "end")
+        })
+      })
 
       context("when clicking the countrybox", () => {
         it("renders drawer in the bottom of screen", () => {
@@ -865,18 +1059,18 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
-          cy.findByLabelText("phonebox-country-toggle").click();
+          cy.findByLabelText("phonebox-country-toggle").click()
 
           cy.findByLabelText("combobox-drawer-mobile")
             .should("exist")
             .and("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed");
-        });
-      });
-    });
+            .and("have.css", "position", "fixed")
+        })
+      })
+    })
 
     context("timebox", () => {
       context("when clicking the input", () => {
@@ -894,19 +1088,19 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
-          cy.findByLabelText("timebox-hour").click();
+          cy.findByLabelText("timebox-hour").click()
 
           cy.findByLabelText("wheel-container")
             .should("exist")
             .and("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed");
-        });
-      });
-    });
-  });
+            .and("have.css", "position", "fixed")
+        })
+      })
+    })
+  })
 
   context("chips", () => {
     function StatefulChips() {
@@ -915,7 +1109,7 @@ describe("StatefulForm", () => {
           selectedOptions: [],
           searchText: "",
         },
-      });
+      })
       return (
         <StatefulForm
           fields={[
@@ -932,7 +1126,7 @@ describe("StatefulForm", () => {
             },
           ]}
           onChange={({ currentState }) => {
-            const [[key, value]] = Object.entries(currentState);
+            const [[key, value]] = Object.entries(currentState)
 
             setValue((prev) => ({
               ...prev,
@@ -945,37 +1139,37 @@ describe("StatefulForm", () => {
                     },
                   }
                 : currentState),
-            }));
+            }))
           }}
           formValues={value}
           mode="onChange"
         />
-      );
+      )
     }
 
     context("when select one option", () => {
       it("renders option selected", () => {
-        cy.mount(<StatefulChips />);
-        cy.findByRole("button").click();
+        cy.mount(<StatefulChips />)
+        cy.findByRole("button").click()
 
-        cy.findAllByLabelText("chips-selected").should("not.exist");
+        cy.findAllByLabelText("chips-selected").should("not.exist")
 
-        cy.findByText("Anime").click();
-        cy.findByText("Manga").click();
+        cy.findByText("Anime").click()
+        cy.findByText("Manga").click()
 
-        cy.wait(400);
+        cy.wait(400)
 
         cy.findAllByLabelText("chips-selected")
           .eq(0)
           .should("exist")
-          .should("have.css", "background-color", "rgb(255, 255, 255)");
+          .should("have.css", "background-color", "rgb(255, 255, 255)")
         cy.findAllByLabelText("chips-selected")
           .eq(1)
           .should("exist")
-          .should("have.css", "background-color", "rgb(255, 255, 255)");
-      });
-    });
-  });
+          .should("have.css", "background-color", "rgb(255, 255, 255)")
+      })
+    })
+  })
 
   context("height", () => {
     it("mostly renders with 34px", () => {
@@ -984,12 +1178,12 @@ describe("StatefulForm", () => {
           fields={ALL_INPUT}
           formValues={allValue}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
       flattenFields(ALL_INPUT).map((field) => {
         if (field.type === "frame" || field.type === "chips") {
-          return;
+          return
         } else if (
           field.type === "radio" ||
           field.type === "image" ||
@@ -1001,56 +1195,56 @@ describe("StatefulForm", () => {
           cy.findAllByLabelText("radio-input-container").should(
             "have.css",
             "height",
-            "16px"
-          );
+            "16px",
+          )
           cy.findAllByLabelText("file-input-box-wrapper").should(
             "have.css",
             "height",
-            "47px"
-          );
+            "47px",
+          )
           cy.findAllByLabelText("imagebox-input").should(
             "have.css",
             "height",
-            "120px"
-          );
+            "120px",
+          )
           cy.findAllByLabelText("signbox-canvas").should(
             "have.css",
             "height",
-            "200px"
-          );
+            "200px",
+          )
           cy.findAllByLabelText("file-drop-box-area").should(
             "have.css",
             "height",
-            "221px"
-          );
+            "221px",
+          )
           cy.findAllByLabelText("signbox-canvas").should(
             "have.css",
             "height",
-            "200px"
-          );
+            "200px",
+          )
           cy.findAllByLabelText("rating-wrapper").should(
             "have.css",
             "height",
-            "24px"
-          );
+            "24px",
+          )
         } else {
           cy.findAllByLabelText("field-lane-control").should(
             "have.css",
             "height",
-            "34px"
-          );
+            "34px",
+          )
         }
-      });
-    });
-  });
+      })
+    })
+  })
 
   context("combobox", () => {
     const comboField = flattenFields(ALL_INPUT).filter(
-      (field) => field.type === "combo"
-    );
+      (field) => field.type === "combo",
+    )
 
     function ComboboxInput(props: Partial<StatefulFormProps<any>>) {
-      const [value, setValue] = useState({ combo: ["4"] });
+      const [value, setValue] = useState({ combo: ["4"] })
 
       return (
         <StatefulForm
@@ -1061,20 +1255,20 @@ describe("StatefulForm", () => {
           }
           {...props}
         />
-      );
+      )
     }
 
     beforeEach(() => {
-      cy.mount(<ComboboxInput />);
-    });
+      cy.mount(<ComboboxInput />)
+    })
 
     it("should shows value from formValues", () => {
-      cy.get("#combobox-combo").should("have.value", "Grape");
-    });
+      cy.get("#combobox-combo").should("have.value", "Grape")
+    })
 
     context("when given four comboboxes in a row", () => {
       it("renders each with a width smaller than 140px (min-width)", () => {
-        cy.viewport(500, 750);
+        cy.viewport(500, 750)
         const fields = Array.from({ length: 4 }, (_, i) => ({
           id: `combo-${i + 1}`,
           name: `combo${i + 1}`,
@@ -1085,26 +1279,26 @@ describe("StatefulForm", () => {
           combobox: {
             options: FRUIT_OPTIONS,
           },
-        }));
-        cy.mount(<StatefulForm fields={[fields]} formValues={{}} />);
+        }))
+        cy.mount(<StatefulForm fields={[fields]} formValues={{}} />)
 
         cy.then(() => {
-          const widths: number[] = [];
+          const widths: number[] = []
 
           cy.wrap(fields).each((field: (typeof fields)[number]) => {
             cy.get(`#${field.id}`).then(($el) => {
-              widths.push($el[0].getBoundingClientRect().width);
-            });
-          });
+              widths.push($el[0].getBoundingClientRect().width)
+            })
+          })
 
           cy.then(() => {
             widths.forEach((width) => {
-              expect(width).to.be.closeTo(110.5, 1);
-            });
-          });
-        });
-      });
-    });
+              expect(width).to.be.closeTo(110.5, 1)
+            })
+          })
+        })
+      })
+    })
 
     context("when given value from selectedOptions", () => {
       const comboFieldWithValue = comboField.map((field) => ({
@@ -1113,25 +1307,25 @@ describe("StatefulForm", () => {
           ...field?.combobox,
           selectedOptions: ["1"],
         },
-      }));
+      }))
 
       beforeEach(() => {
-        cy.mount(<ComboboxInput fields={comboFieldWithValue} />);
-      });
+        cy.mount(<ComboboxInput fields={comboFieldWithValue} />)
+      })
       it("should shows value from formValues", () => {
-        cy.get("#combobox-combo").should("have.value", "Apple");
-      });
-    });
-  });
+        cy.get("#combobox-combo").should("have.value", "Apple")
+      })
+    })
+  })
 
   context("with type frame", () => {
     function StatefulWithFrame() {
-      const [isFormValid, setIsFormValid] = useState(false);
+      const [isFormValid, setIsFormValid] = useState(false)
       const [value, setValue] = useState({
         start_date: [""],
         end_date: [""],
         purpose: "",
-      });
+      })
 
       const EMPLOYEE_FIELDS: FormFieldGroup[] = [
         {
@@ -1176,19 +1370,19 @@ describe("StatefulForm", () => {
           disabled: !isFormValid,
           rowJustifyPosition: "end",
         },
-      ];
+      ]
 
       const dateArraySchema = z
         .array(
-          z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date")
+          z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date"),
         )
-        .min(1, "At least one date is required");
+        .min(1, "At least one date is required")
 
       const employeeSchema = z.object({
         start_date: dateArraySchema,
         end_date: dateArraySchema,
         purpose: z.string().min(10, "Business purpose is required"),
-      });
+      })
 
       return (
         <div
@@ -1206,7 +1400,7 @@ describe("StatefulForm", () => {
         >
           <StatefulForm
             onChange={({ currentState }) => {
-              setValue((prev) => ({ ...prev, ...currentState }));
+              setValue((prev) => ({ ...prev, ...currentState }))
             }}
             fields={EMPLOYEE_FIELDS}
             onValidityChange={setIsFormValid}
@@ -1215,107 +1409,107 @@ describe("StatefulForm", () => {
             mode="onChange"
           />
         </div>
-      );
+      )
     }
 
     const initializeFrame = () => {
-      cy.mount(<StatefulWithFrame />);
+      cy.mount(<StatefulWithFrame />)
       cy.findAllByLabelText("frame").then(() => {
-        cy.findAllByLabelText("stateful-form-row").should("have.length", 4);
-        cy.get("#datebox-start_date").should("exist");
-        cy.get("#datebox-end_date").should("exist");
-        cy.get("#textbox-purpose").should("exist");
-        cy.findByRole("button").should("exist").and("be.disabled");
-      });
-    };
+        cy.findAllByLabelText("stateful-form-row").should("have.length", 4)
+        cy.get("#datebox-start_date").should("exist")
+        cy.get("#datebox-end_date").should("exist")
+        cy.get("#textbox-purpose").should("exist")
+        cy.findByRole("button").should("exist").and("be.disabled")
+      })
+    }
 
     beforeEach(() => {
-      initializeFrame();
-    });
+      initializeFrame()
+    })
 
     it("shows the form fields inside of frame", () => {
       // shows from beforeEach
-    });
+    })
 
     context("when typing", () => {
       it("should added value", () => {
         cy.get("#datebox-start_date")
           .click()
           .then(($el) => {
-            cy.findByLabelText("calendar-select-date").click();
-            cy.findByLabelText("combobox-month").click();
-            cy.findByText("March").click();
-            cy.findByLabelText("combobox-year").click();
-            cy.findByText("2026").click();
-            cy.findByText("20").click();
-            cy.wrap($el).should("have.value", "03/20/2026");
-          });
+            cy.findByLabelText("calendar-select-date").click()
+            cy.findByLabelText("combobox-month").click()
+            cy.findByText("March").click()
+            cy.findByLabelText("combobox-year").click()
+            cy.findByText("2026").click()
+            cy.findByText("20").click()
+            cy.wrap($el).should("have.value", "03/20/2026")
+          })
         cy.get("#datebox-end_date")
           .click()
           .then(($el) => {
-            cy.findByLabelText("calendar-select-date").click();
-            cy.findByLabelText("combobox-month").click();
-            cy.findByText("March").click();
-            cy.findByLabelText("combobox-year").click();
-            cy.findByText("2026").click();
-            cy.findByText("20").click();
-            cy.wrap($el).should("have.value", "03/20/2026");
-          });
+            cy.findByLabelText("calendar-select-date").click()
+            cy.findByLabelText("combobox-month").click()
+            cy.findByText("March").click()
+            cy.findByLabelText("combobox-year").click()
+            cy.findByText("2026").click()
+            cy.findByText("20").click()
+            cy.wrap($el).should("have.value", "03/20/2026")
+          })
         cy.get("#textbox-purpose")
           .type("Getting better life")
-          .should("have.value", "Getting better life");
+          .should("have.value", "Getting better life")
 
-        cy.findByRole("button").should("exist").and("not.be.disabled");
-      });
-    });
+        cy.findByRole("button").should("exist").and("not.be.disabled")
+      })
+    })
 
     context("when typing but not fully", () => {
       it("renders error validation", () => {
-        cy.findByText("Business purpose is required").should("not.exist");
+        cy.findByText("Business purpose is required").should("not.exist")
 
         cy.get("#datebox-start_date")
           .click()
           .then(($el) => {
-            cy.findByLabelText("calendar-select-date").click();
-            cy.findByLabelText("combobox-month").click();
-            cy.findByText("March").click();
-            cy.findByLabelText("combobox-year").click();
-            cy.findByText("2026").click();
-            cy.findByText("20").click();
-            cy.wrap($el).should("have.value", "03/20/2026");
-          });
+            cy.findByLabelText("calendar-select-date").click()
+            cy.findByLabelText("combobox-month").click()
+            cy.findByText("March").click()
+            cy.findByLabelText("combobox-year").click()
+            cy.findByText("2026").click()
+            cy.findByText("20").click()
+            cy.wrap($el).should("have.value", "03/20/2026")
+          })
         cy.get("#datebox-end_date")
           .click()
           .then(($el) => {
-            cy.findByLabelText("calendar-select-date").click();
-            cy.findByLabelText("combobox-month").click();
-            cy.findByText("March").click();
-            cy.findByLabelText("combobox-year").click();
-            cy.findByText("2026").click();
-            cy.findByText("20").click();
-            cy.wrap($el).should("have.value", "03/20/2026");
-          });
+            cy.findByLabelText("calendar-select-date").click()
+            cy.findByLabelText("combobox-month").click()
+            cy.findByText("March").click()
+            cy.findByLabelText("combobox-year").click()
+            cy.findByText("2026").click()
+            cy.findByText("20").click()
+            cy.wrap($el).should("have.value", "03/20/2026")
+          })
         cy.get("#textbox-purpose")
           .type("Getting")
-          .should("have.value", "Getting");
-        cy.get("body").click("bottomRight");
+          .should("have.value", "Getting")
+        cy.get("body").click("bottomRight")
 
-        cy.findByText("Business purpose is required").should("exist");
-        cy.findByRole("button").should("exist").and("be.disabled");
-      });
-    });
-  });
+        cy.findByText("Business purpose is required").should("exist")
+        cy.findByRole("button").should("exist").and("be.disabled")
+      })
+    })
+  })
 
   context("conditional form", () => {
     function ConditionalStatefulForm() {
-      const [isFormValid, setIsFormValid] = useState(false);
+      const [isFormValid, setIsFormValid] = useState(false)
       const [formFields, setFormFields] = useState({
         quantType: "",
         compEffort: "",
         scheIterations: "",
         target: "",
         hostArch: "",
-      });
+      })
 
       const schema = z.object({
         quantType: z.string().optional(),
@@ -1326,46 +1520,46 @@ describe("StatefulForm", () => {
           .optional(),
         target: z.string().min(1, "Target is required"),
         hostArch: z.string().optional(),
-      });
+      })
 
       const HostArchitecture = {
         x86: 0,
         x64: 1,
         ARM: 2,
         ARM64: 3,
-      } as const;
+      } as const
 
       const CompilationTarget = {
         Interpreter: 0,
         Simulator: 1,
         IP: 2,
-      } as const;
+      } as const
 
       const CompilationEffort = {
         SimpleScheduling: 0,
         Performance: 1,
         Aggressive: 2,
-      } as const;
+      } as const
 
       const Quantization = {
         Int8: 0,
         Bf16: 1,
         Fp16: 2,
         Fp32: 3,
-      } as const;
+      } as const
 
       const HOST_ARCHITECTURE_OPTIONS: SelectboxOption[] = [
         { value: String(HostArchitecture.x86), text: "x86" },
         { value: String(HostArchitecture.x64), text: "x64" },
         { value: String(HostArchitecture.ARM), text: "ARM" },
         { value: String(HostArchitecture.ARM64), text: "ARM64" },
-      ];
+      ]
 
       const COMPILATION_TARGET_OPTIONS: SelectboxOption[] = [
         { value: String(CompilationTarget.Interpreter), text: "Interpreter" },
         { value: String(CompilationTarget.Simulator), text: "Simulator" },
         { value: String(CompilationTarget.IP), text: "IP" },
-      ];
+      ]
 
       const COMPILATION_EFFORT_OPTIONS: SelectboxOption[] = [
         {
@@ -1380,21 +1574,21 @@ describe("StatefulForm", () => {
           value: String(CompilationEffort.Aggressive),
           text: "Aggressive",
         },
-      ];
+      ]
 
       const QUANTIZATION_TYPE_OPTIONS: SelectboxOption[] = [
         { value: String(Quantization.Int8), text: "INT8" },
         { value: String(Quantization.Bf16), text: "BF16" },
         { value: String(Quantization.Fp16), text: "FP16" },
         { value: String(Quantization.Fp32), text: "FP32" },
-      ];
+      ]
 
       const COMPILATION_FIELDS: FormFieldGroup[] = useMemo(() => {
         const isInt8Quantization =
-          formFields.quantType === String(Quantization.Int8);
+          formFields.quantType === String(Quantization.Int8)
 
         const isPerfCompilation =
-          formFields.compEffort === String(CompilationEffort.Performance);
+          formFields.compEffort === String(CompilationEffort.Performance)
 
         return [
           {
@@ -1454,13 +1648,13 @@ describe("StatefulForm", () => {
             type: "button",
             disabled: !isFormValid,
           },
-        ];
-      }, [formFields.compEffort, formFields.quantType, isFormValid]);
+        ]
+      }, [formFields.compEffort, formFields.quantType, isFormValid])
 
       return (
         <StatefulForm
           onChange={({ currentState }) => {
-            setFormFields((prev) => ({ ...prev, ...currentState }));
+            setFormFields((prev) => ({ ...prev, ...currentState }))
           }}
           onValidityChange={setIsFormValid}
           validationSchema={schema}
@@ -1468,27 +1662,27 @@ describe("StatefulForm", () => {
           formValues={formFields}
           mode="onChange"
         />
-      );
+      )
     }
 
     context("when choosen option", () => {
       it("shows the value on the another field", () => {
-        cy.mount(<ConditionalStatefulForm />);
-        cy.findAllByLabelText("stateful-form-row").should("have.length", 4);
-        cy.findByText("Compilation Effort").should("not.exist");
-        cy.findByText("Precision").should("exist").click();
-        cy.findByText("INT8").should("exist").click();
+        cy.mount(<ConditionalStatefulForm />)
+        cy.findAllByLabelText("stateful-form-row").should("have.length", 4)
+        cy.findByText("Compilation Effort").should("not.exist")
+        cy.findByText("Precision").should("exist").click()
+        cy.findByText("INT8").should("exist").click()
 
-        cy.findAllByLabelText("stateful-form-row").should("have.length", 5);
-        cy.findByText("Compilation Effort").should("exist");
-      });
-    });
-  });
+        cy.findAllByLabelText("stateful-form-row").should("have.length", 5)
+        cy.findByText("Compilation Effort").should("exist")
+      })
+    })
+  })
 
   context("disabled", () => {
     context("when given by parent", () => {
       it("should render with cursor not-allowed and user-select none", () => {
-        const onChange = cy.spy().as("onChange");
+        const onChange = cy.spy().as("onChange")
         cy.mount(
           <StatefulForm
             fields={ALL_INPUT}
@@ -1496,23 +1690,23 @@ describe("StatefulForm", () => {
             disabled={true}
             mode="onChange"
             onChange={onChange}
-          />
-        );
+          />,
+        )
 
         cy.findAllByLabelText("field-lane-wrapper")
           .should("have.css", "cursor", "not-allowed")
-          .and("have.css", "user-select", "none");
+          .and("have.css", "user-select", "none")
         cy.findAllByLabelText("chips-container-input")
           .should("have.css", "cursor", "not-allowed")
-          .and("have.css", "user-select", "none");
+          .and("have.css", "user-select", "none")
         cy.findAllByLabelText("file-drop-box-container")
           .should("have.css", "cursor", "not-allowed")
-          .and("have.css", "user-select", "none");
-      });
+          .and("have.css", "user-select", "none")
+      })
 
       context("when trying to interact", () => {
         it("should not change value", () => {
-          const onChange = cy.spy().as("onChange");
+          const onChange = cy.spy().as("onChange")
           cy.mount(
             <StatefulForm
               fields={ALL_INPUT}
@@ -1520,19 +1714,19 @@ describe("StatefulForm", () => {
               disabled={true}
               mode="onChange"
               onChange={onChange}
-            />
-          );
+            />,
+          )
 
           cy.get("input, textarea, [role='radio'], [role='checkbox']").each(
             ($el) => {
-              cy.wrap($el).should("be.disabled").click({ force: true });
-            }
-          );
+              cy.wrap($el).should("be.disabled").click({ force: true })
+            },
+          )
 
-          cy.get("@onChange").should("not.have.been.called");
-        });
-      });
-    });
+          cy.get("@onChange").should("not.have.been.called")
+        })
+      })
+    })
 
     context("when given by per field", () => {
       const INPUT_WITH_DISABLED: FormFieldGroup[] = ALL_INPUT.map((group) =>
@@ -1544,8 +1738,8 @@ describe("StatefulForm", () => {
           : {
               ...group,
               disabled: true,
-            }
-      );
+            },
+      )
       context("when given true", () => {
         it("should render with cursor not-allowed and user-select none", () => {
           cy.mount(
@@ -1558,20 +1752,20 @@ describe("StatefulForm", () => {
                   width: 480px;
                 `,
               }}
-            />
-          );
+            />,
+          )
 
           cy.findAllByLabelText("field-lane-wrapper")
             .should("have.css", "cursor", "not-allowed")
-            .and("have.css", "user-select", "none");
+            .and("have.css", "user-select", "none")
           cy.findAllByLabelText("chips-container-input")
             .should("have.css", "cursor", "not-allowed")
-            .and("have.css", "user-select", "none");
+            .and("have.css", "user-select", "none")
           cy.findAllByLabelText("file-drop-box-container")
             .should("have.css", "cursor", "not-allowed")
-            .and("have.css", "user-select", "none");
-        });
-      });
+            .and("have.css", "user-select", "none")
+        })
+      })
 
       it("should renders with disabled each input", () => {
         cy.mount(
@@ -1579,17 +1773,17 @@ describe("StatefulForm", () => {
             fields={INPUT_WITH_DISABLED}
             formValues={allValue}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         cy.get("input, textarea, [role='radio'], [role='checkbox']").each(
           ($el) => {
-            cy.wrap($el).should("be.disabled");
-          }
-        );
-      });
-    });
-  });
+            cy.wrap($el).should("be.disabled")
+          },
+        )
+      })
+    })
+  })
 
   context("label", () => {
     context("labelPosition", () => {
@@ -1604,8 +1798,8 @@ describe("StatefulForm", () => {
               : {
                   ...group,
                   labelPosition: "left",
-                }
-        );
+                },
+        )
 
         it("should render with flex-row and 25% width label", () => {
           cy.mount(
@@ -1618,26 +1812,26 @@ describe("StatefulForm", () => {
                   width: 480px;
                 `,
               }}
-            />
-          );
+            />,
+          )
 
           cy.findAllByLabelText("stateful-form-label-wrapper").each(
             ($el, i) => {
               cy.wrap($el)
                 .invoke("css", "width")
                 .then((width) => {
-                  const w = width as unknown as string;
+                  const w = width as unknown as string
                   if (i < 2) {
-                    expect(parseFloat(w)).to.be.closeTo(45, 3);
+                    expect(parseFloat(w)).to.be.closeTo(45, 3)
                   } else {
-                    expect(parseFloat(w)).to.be.closeTo(90, 6);
+                    expect(parseFloat(w)).to.be.closeTo(90, 6)
                   }
-                });
-            }
-          );
-        });
-      });
-    });
+                })
+            },
+          )
+        })
+      })
+    })
 
     context("labelWidth", () => {
       context("when given 70%", () => {
@@ -1653,8 +1847,8 @@ describe("StatefulForm", () => {
                   ...group,
                   labelPosition: "left",
                   labelWidth: "70%",
-                }
-          );
+                },
+          )
 
         it("should render with 70% width", () => {
           cy.mount(
@@ -1667,26 +1861,26 @@ describe("StatefulForm", () => {
                   width: 480px;
                 `,
               }}
-            />
-          );
+            />,
+          )
 
           cy.findAllByLabelText("stateful-form-label-wrapper").each(
             ($el, i) => {
               cy.wrap($el)
                 .invoke("css", "width")
                 .then((width) => {
-                  const w = width as unknown as string;
+                  const w = width as unknown as string
                   if (i < 2) {
-                    expect(parseFloat(w)).to.be.closeTo(100, 6);
+                    expect(parseFloat(w)).to.be.closeTo(100, 6)
                   } else {
-                    expect(parseFloat(w)).to.be.closeTo(200, 12);
+                    expect(parseFloat(w)).to.be.closeTo(200, 12)
                   }
-                });
-            }
-          );
-        });
-      });
-    });
+                })
+            },
+          )
+        })
+      })
+    })
 
     context("labelGap", () => {
       context("when given 30px", () => {
@@ -1702,8 +1896,8 @@ describe("StatefulForm", () => {
                   ...group,
                   labelPosition: "left",
                   labelGap: 30,
-                }
-          );
+                },
+          )
 
         it("should render with 30px width", () => {
           cy.mount(
@@ -1711,23 +1905,23 @@ describe("StatefulForm", () => {
               fields={INPUT_WITH_LABEL_POSITION_AND_GAP}
               formValues={allValue}
               mode="onChange"
-            />
-          );
+            />,
+          )
 
           cy.findAllByLabelText("field-lane-wrapper")
             .should("have.length", 22)
             .each(($el) => {
-              cy.wrap($el).should("have.css", "gap", "30px");
-            });
+              cy.wrap($el).should("have.css", "gap", "30px")
+            })
           cy.findAllByLabelText("file-drop-box-container")
             .should("have.length", 1)
             .each(($el) => {
-              cy.wrap($el).should("have.css", "gap", "30px");
-            });
-        });
-      });
-    });
-  });
+              cy.wrap($el).should("have.css", "gap", "30px")
+            })
+        })
+      })
+    })
+  })
 
   context("asterisk", () => {
     context("when given required", () => {
@@ -1737,25 +1931,25 @@ describe("StatefulForm", () => {
             fields={ALL_INPUT}
             formValues={allValue}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         const inputWithRequired = flattenFields(ALL_INPUT).filter(
-          (props) => props.required
-        );
+          (props) => props.required,
+        )
 
         cy.findAllByLabelText("stateful-form-label-asterisk").should(
           "have.length",
-          inputWithRequired.length
-        );
-      });
-    });
-  });
+          inputWithRequired.length,
+        )
+      })
+    })
+  })
 
   context("pinbox", () => {
     const pinboxSchema = z.object({
       pin: z.string().min(4, "Pinbox does not follow the acceptable format"),
-    });
+    })
 
     const FIELDS: FormFieldGroup[] = [
       {
@@ -1768,10 +1962,10 @@ describe("StatefulForm", () => {
           parts: PARTS_INPUT,
         },
       },
-    ];
+    ]
 
     function PinboxProduct() {
-      const [state, setState] = useState({ pin: "" });
+      const [state, setState] = useState({ pin: "" })
       return (
         <StatefulForm
           validationSchema={pinboxSchema}
@@ -1779,36 +1973,36 @@ describe("StatefulForm", () => {
           fields={FIELDS}
           formValues={state}
         />
-      );
+      )
     }
 
     context("validation error", () => {
       context("when pressing 2 character (not eligible)", () => {
         it("should not show an error", () => {
-          cy.mount(<PinboxProduct />);
-          cy.findAllByRole("textbox").eq(1).type("23");
+          cy.mount(<PinboxProduct />)
+          cy.findAllByRole("textbox").eq(1).type("23")
           cy.findByText("Pinbox does not follow the acceptable format").should(
-            "not.exist"
-          );
-        });
+            "not.exist",
+          )
+        })
 
         context("when blurring from the input", () => {
           it("should displaying an error", () => {
-            cy.mount(<PinboxProduct />);
-            cy.findAllByRole("textbox").eq(1).type("23");
+            cy.mount(<PinboxProduct />)
+            cy.findAllByRole("textbox").eq(1).type("23")
             cy.findByText(
-              "Pinbox does not follow the acceptable format"
-            ).should("not.exist");
-            cy.get("body").click("top");
-            cy.wait(200);
+              "Pinbox does not follow the acceptable format",
+            ).should("not.exist")
+            cy.get("body").click("top")
+            cy.wait(200)
             cy.findByText(
-              "Pinbox does not follow the acceptable format"
-            ).should("exist");
-          });
-        });
-      });
-    });
-  });
+              "Pinbox does not follow the acceptable format",
+            ).should("exist")
+          })
+        })
+      })
+    })
+  })
 
   context("button", () => {
     const VARIANTS = [
@@ -1847,13 +2041,13 @@ describe("StatefulForm", () => {
         hover: "rgb(42, 115, 195)",
         active: "rgb(30, 91, 168)",
       },
-    ] as const;
+    ] as const
 
     context("when hover", () => {
       it("renders the the hover color", () => {
         cy.window().then((win) => {
-          cy.spy(win.console, "log").as("consoleLog");
-        });
+          cy.spy(win.console, "log").as("consoleLog")
+        })
 
         cy.mount(
           <StatefulForm
@@ -1868,25 +2062,25 @@ describe("StatefulForm", () => {
             }))}
             formValues={{}}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         VARIANTS.forEach(({ hover }, index) => {
           cy.findAllByRole("button")
             .eq(index)
             .realHover()
             .wait(200)
-            .should("have.css", "background-color", hover);
-        });
-      });
-    });
+            .should("have.css", "background-color", hover)
+        })
+      })
+    })
 
     context("when given an onClick", () => {
       context("when clicking", () => {
         it("renders the the active with usual color", () => {
           cy.window().then((win) => {
-            cy.spy(win.console, "log").as("consoleLog");
-          });
+            cy.spy(win.console, "log").as("consoleLog")
+          })
 
           cy.mount(
             <StatefulForm
@@ -1902,24 +2096,24 @@ describe("StatefulForm", () => {
               }))}
               formValues={{}}
               mode="onChange"
-            />
-          );
+            />,
+          )
 
           VARIANTS.forEach(({ active }, index) => {
-            cy.findAllByRole("button").eq(index).realMouseDown();
+            cy.findAllByRole("button").eq(index).realMouseDown()
 
             cy.findAllByRole("button")
               .eq(index)
-              .should("have.css", "background-color", active);
+              .should("have.css", "background-color", active)
 
-            cy.findAllByRole("button").eq(index).realMouseUp();
-          });
-        });
+            cy.findAllByRole("button").eq(index).realMouseUp()
+          })
+        })
 
         it("renders the callback from top-level", () => {
           cy.window().then((win) => {
-            cy.spy(win.console, "log").as("consoleLog");
-          });
+            cy.spy(win.console, "log").as("consoleLog")
+          })
 
           cy.mount(
             <StatefulForm
@@ -1934,24 +2128,24 @@ describe("StatefulForm", () => {
               ]}
               formValues={{}}
               mode="onChange"
-            />
-          );
+            />,
+          )
 
-          cy.findByRole("button").eq(0).click();
+          cy.findByRole("button").eq(0).click()
 
           cy.get("@consoleLog").should(
             "have.been.calledWith",
-            "this is callback from the top level"
-          );
-        });
-      });
+            "this is callback from the top level",
+          )
+        })
+      })
 
       context("when given a buttonProps.onClick", () => {
         context("when clicking", () => {
           it("renders the callback from buttonProps instead", () => {
             cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
+              cy.spy(win.console, "log").as("consoleLog")
+            })
 
             cy.mount(
               <StatefulForm
@@ -1970,20 +2164,20 @@ describe("StatefulForm", () => {
                 ]}
                 formValues={{}}
                 mode="onChange"
-              />
-            );
+              />,
+            )
 
-            cy.findByRole("button").eq(0).click();
+            cy.findByRole("button").eq(0).click()
 
             cy.get("@consoleLog").should(
               "have.been.calledWith",
-              "this is callback from the specific level"
-            );
-          });
-        });
-      });
-    });
-  });
+              "this is callback from the specific level",
+            )
+          })
+        })
+      })
+    })
+  })
 
   context("when array of array", () => {
     const value = {
@@ -1994,7 +2188,7 @@ describe("StatefulForm", () => {
       note: "",
       access: false,
       country_code: DEFAULT_COUNTRY_CODES,
-    };
+    }
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
@@ -2041,7 +2235,7 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ];
+    ]
 
     it("render in the one row", () => {
       cy.mount(
@@ -2049,20 +2243,20 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS}
           formValues={value}
           mode="onChange"
-        />
-      );
+        />,
+      )
       cy.findAllByLabelText("stateful-form-row")
         .eq(0)
         .within(() => {
-          cy.contains("First Name").should("exist");
-          cy.contains("Last Name").should("exist");
+          cy.contains("First Name").should("exist")
+          cy.contains("Last Name").should("exist")
 
-          cy.contains("Email").should("not.exist");
-          cy.contains("Phone Number").should("not.exist");
-          cy.contains("Note").should("not.exist");
-          cy.contains("Has access to login").should("not.exist");
-        });
-    });
+          cy.contains("Email").should("not.exist")
+          cy.contains("Phone Number").should("not.exist")
+          cy.contains("Note").should("not.exist")
+          cy.contains("Has access to login").should("not.exist")
+        })
+    })
 
     context("when given without title", () => {
       const FIELDS_WITHOUT_TITLE: FormFieldGroup[] = [
@@ -2115,63 +2309,63 @@ describe("StatefulForm", () => {
             type: "button",
           },
         ],
-      ];
+      ]
 
       it("should not break the height", () => {
-        cy.viewport(1000, 900);
+        cy.viewport(1000, 900)
         cy.mount(
           <StatefulForm
             fields={FIELDS_WITHOUT_TITLE}
             formValues={value}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         cy.findAllByLabelText("stateful-form-row")
           .eq(0)
           .within(() => {
-            cy.contains("First Name").should("exist");
-            cy.contains("Last Name").should("not.exist");
-            cy.contains("Phone").should("not.exist");
-            cy.contains("Combo").should("not.exist");
+            cy.contains("First Name").should("exist")
+            cy.contains("Last Name").should("not.exist")
+            cy.contains("Phone").should("not.exist")
+            cy.contains("Combo").should("not.exist")
           })
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
 
         cy.get("#textbox-first_name")
           .parent()
           .parent()
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
         cy.get("#textbox-last_name")
           .parent()
           .parent()
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
         cy.get("#phonebox-phone")
           .parent()
           .parent()
           .parent()
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
         cy.get("#capsule-capsule")
           .parent()
           .parent()
           .parent()
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
         cy.get("#combobox-combo")
           .parent()
           .parent()
           .parent()
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
         cy.get("#datebox-date")
           .parent()
           .parent()
           .parent()
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
         cy.findAllByRole("button")
           .eq(1)
           .parent()
-          .should("have.css", "margin-top", "26px");
-      });
-    });
-  });
+          .should("have.css", "margin-top", "26px")
+      })
+    })
+  })
 
   context("id", () => {
     it("renders each field with a proper and unique ID", () => {
@@ -2180,26 +2374,26 @@ describe("StatefulForm", () => {
           fields={ALL_INPUT}
           formValues={allValue}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
       flattenFields(ALL_INPUT).map((field) => {
         if (field.type === "frame" || field.type === "chips") {
-          return;
+          return
         } else if (field.type === "radio") {
-          cy.get(`#radio-value-radio`).should("exist");
+          cy.get(`#radio-value-radio`).should("exist")
         } else {
           const prefix =
             TYPE_TO_ID_PREFIX[field.type] ??
-            field.type.replace(/\s+/g, "_").toLowerCase();
+            field.type.replace(/\s+/g, "_").toLowerCase()
           const expectedId = field.name
             ? `${prefix}-${field.name.replace(/\s+/g, "_").toLowerCase()}`
-            : prefix;
+            : prefix
 
-          cy.get(`#${expectedId}`).should("exist");
+          cy.get(`#${expectedId}`).should("exist")
         }
-      });
-    });
+      })
+    })
 
     context("when given with non-ASCII IDs", () => {
       const FIELDS_NOT_NORMAL_ASCII: FormFieldGroup[] = [
@@ -2328,7 +2522,7 @@ describe("StatefulForm", () => {
           required: false,
           id: "field-signature-✍️ sign here!",
         },
-      ];
+      ]
 
       it("renders sanitized ASCII-only IDs for input elements", () => {
         cy.mount(
@@ -2336,12 +2530,12 @@ describe("StatefulForm", () => {
             fields={FIELDS_NOT_NORMAL_ASCII}
             formValues={allValue}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         const sanitized = flattenFields(FIELDS_NOT_NORMAL_ASCII).map((field) =>
-          StatefulForm.sanitizeId({ id: field.id })
-        );
+          StatefulForm.sanitizeId({ id: field.id }),
+        )
 
         const expected = [
           "field-text-_hello_world",
@@ -2360,14 +2554,14 @@ describe("StatefulForm", () => {
           "field-money-_1000",
           "field-phone-_askdaosdk",
           "field-signature-_sign_here",
-        ];
+        ]
 
         sanitized.map((result, i) => {
-          expect(result).to.equal(expected[i]);
-        });
-      });
-    });
-  });
+          expect(result).to.equal(expected[i])
+        })
+      })
+    })
+  })
 
   context("with type custom", () => {
     function StatefulFormCustom() {
@@ -2375,9 +2569,9 @@ describe("StatefulForm", () => {
         first_name: "",
         access: false,
         files: [],
-      });
+      })
 
-      const [isFormValid, setIsFormValid] = useState(false);
+      const [isFormValid, setIsFormValid] = useState(false)
 
       const onFileDropped = async ({
         error,
@@ -2385,28 +2579,28 @@ describe("StatefulForm", () => {
         setProgressLabel,
         succeed,
       }: OnFileDroppedFunctionArgs) => {
-        const file = files[0];
-        setValue((prev) => ({ ...prev, files: [...prev.files, file] }));
-        setProgressLabel(`Uploading ${file.name}`);
+        const file = files[0]
+        setValue((prev) => ({ ...prev, files: [...prev.files, file] }))
+        setProgressLabel(`Uploading ${file.name}`)
 
         return new Promise<void>((resolve) => {
-          let progress = 0;
+          let progress = 0
           const interval = setInterval(() => {
-            progress += 20;
+            progress += 20
 
             if (progress >= 100) {
-              clearInterval(interval);
+              clearInterval(interval)
               if (file === null) {
-                error(file, `file ${file.name} is not uploaded`);
+                error(file, `file ${file.name} is not uploaded`)
               } else {
-                succeed(file);
+                succeed(file)
               }
-              setProgressLabel(`Uploaded ${files[0].name}`);
-              resolve();
+              setProgressLabel(`Uploaded ${files[0].name}`)
+              resolve()
             }
-          }, 300);
-        });
-      };
+          }, 300)
+        })
+      }
 
       const onComplete = async ({
         failedFiles,
@@ -2415,14 +2609,14 @@ describe("StatefulForm", () => {
         hideProgressLabel,
         showUploaderForm,
       }: OnCompleteFunctionArgs) => {
-        console.log(succeedFiles, "This is succeedFiles");
-        console.log(failedFiles, "This is failedFiles");
+        console.log(succeedFiles, "This is succeedFiles")
+        console.log(failedFiles, "This is failedFiles")
         await setProgressLabel(
-          `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`
-        );
-        await hideProgressLabel();
-        await showUploaderForm();
-      };
+          `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`,
+        )
+        await hideProgressLabel()
+        await showUploaderForm()
+      }
 
       const CUSTOM_FIELDS: FormFieldGroup[] = [
         {
@@ -2499,9 +2693,9 @@ describe("StatefulForm", () => {
                             setValue((prev) => ({
                               ...prev,
                               files: prev.files.filter(
-                                (val) => val.name !== id
+                                (val) => val.name !== id,
                               ),
-                            }));
+                            }))
                           }
                         },
                       },
@@ -2535,7 +2729,7 @@ describe("StatefulForm", () => {
           disabled: !isFormValid,
           rowJustifyPosition: "end",
         },
-      ];
+      ]
 
       const customSchema = z.object({
         first_name: z
@@ -2548,29 +2742,29 @@ describe("StatefulForm", () => {
           .array(
             z.instanceof(File).refine(
               (file) => {
-                if (!file) return false;
+                if (!file) return false
 
-                const allowedExtensions = ["png", "jpg", "jpeg", "gif"];
-                const ext = file.name.split(".").pop()?.toLowerCase();
+                const allowedExtensions = ["png", "jpg", "jpeg", "gif"]
+                const ext = file.name.split(".").pop()?.toLowerCase()
 
                 const isImage =
                   (file.type && file.type.startsWith("image/")) ||
-                  (ext ? allowedExtensions.includes(ext) : false);
+                  (ext ? allowedExtensions.includes(ext) : false)
 
-                if (!isImage) return false;
+                if (!isImage) return false
 
-                if (file.size > 5 * 1024 * 1024) return false;
+                if (file.size > 5 * 1024 * 1024) return false
 
-                return true;
+                return true
               },
               {
                 message:
                   "File must be an image (png, jpg, jpeg, gif) and ≤ 5 MB",
-              }
-            )
+              },
+            ),
           )
           .min(1, "At least one file must be selected"),
-      });
+      })
 
       return (
         <StatefulForm
@@ -2583,25 +2777,25 @@ describe("StatefulForm", () => {
           }
           mode="onChange"
         />
-      );
+      )
     }
 
     it("should render custom renderer", () => {
-      cy.mount(<StatefulFormCustom />);
+      cy.mount(<StatefulFormCustom />)
 
-      cy.findByLabelText("boxbar-toggle").click();
+      cy.findByLabelText("boxbar-toggle").click()
 
       BADGE_OPTIONS_FULL.map((data) => {
-        cy.findByText(data.caption).should("exist");
-      });
-    });
+        cy.findByText(data.caption).should("exist")
+      })
+    })
 
     context("when given validationSchema", () => {
       it("should synchronize values after all fields valid", () => {
-        cy.mount(<StatefulFormCustom />);
-        cy.findAllByRole("button").eq(1).and("be.disabled");
+        cy.mount(<StatefulFormCustom />)
+        cy.findAllByRole("button").eq(1).and("be.disabled")
 
-        cy.get("#textbox-first_name").type("Alim Naufal");
+        cy.get("#textbox-first_name").type("Alim Naufal")
         cy.findByLabelText("file-drop-box-area").selectFile(
           [
             "test/fixtures/test-images/sample-1.jpg",
@@ -2610,21 +2804,21 @@ describe("StatefulForm", () => {
           {
             action: "drag-drop",
             force: true,
-          }
-        );
-        cy.wait(1000);
+          },
+        )
+        cy.wait(1000)
 
         cy.findByLabelText("file-drop-box-area").then(($input) => {
-          cy.spy($input[0], "click").as("fileClick");
-        });
-        cy.findByText("sample-1.jpg").should("be.visible").click();
-        cy.findByText("sample-2.jpg").should("be.visible").click();
-        cy.findByText("Access").should("be.visible").click();
+          cy.spy($input[0], "click").as("fileClick")
+        })
+        cy.findByText("sample-1.jpg").should("be.visible").click()
+        cy.findByText("sample-2.jpg").should("be.visible").click()
+        cy.findByText("Access").should("be.visible").click()
 
-        cy.findAllByRole("button").eq(1).and("not.be.disabled");
-      });
-    });
-  });
+        cy.findAllByRole("button").eq(1).and("not.be.disabled")
+      })
+    })
+  })
 
   context("helper", () => {
     const FIELD_HELPERS: Record<string, string> = {
@@ -2651,7 +2845,7 @@ describe("StatefulForm", () => {
       toggle: "Toggle the switch.",
       chips: "Select one or more chips.",
       capsule: "Choose a monetary option.",
-    };
+    }
 
     const INPUT_WITH_HELPER = ALL_INPUT.map((group) =>
       Array.isArray(group)
@@ -2662,10 +2856,10 @@ describe("StatefulForm", () => {
         : {
             ...group,
             helper: FIELD_HELPERS[group.type],
-          }
-    );
+          },
+    )
 
-    const FLAT_INPUT = INPUT_WITH_HELPER.flatMap((props) => props);
+    const FLAT_INPUT = INPUT_WITH_HELPER.flatMap((props) => props)
 
     it("renders with tooltip", () => {
       cy.mount(
@@ -2673,18 +2867,18 @@ describe("StatefulForm", () => {
           fields={INPUT_WITH_HELPER}
           formValues={allValue}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
       cy.findAllByLabelText("tooltip-trigger")
         .should("have.length", FLAT_INPUT.length)
         .each(($el, index) => {
-          cy.wrap($el).trigger("mouseover");
+          cy.wrap($el).trigger("mouseover")
 
-          cy.findByText(String(FLAT_INPUT[index].helper));
-        });
-    });
-  });
+          cy.findByText(String(FLAT_INPUT[index].helper))
+        })
+    })
+  })
 
   context("with style", () => {
     context("when given background wheat", () => {
@@ -2839,7 +3033,7 @@ describe("StatefulForm", () => {
             },
           },
         },
-      };
+      }
 
       const INPUT_WITH_STYLE = ALL_INPUT.map((group) =>
         Array.isArray(group)
@@ -2850,8 +3044,8 @@ describe("StatefulForm", () => {
           : {
               ...group,
               ...FIELD_STYLES[group.type],
-            }
-      );
+            },
+      )
 
       it("renders with background wheat", () => {
         cy.mount(
@@ -2859,15 +3053,15 @@ describe("StatefulForm", () => {
             fields={INPUT_WITH_STYLE}
             formValues={allValue}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         const isFieldWithPlaceholder = (
-          field: FormFieldGroup
+          field: FormFieldGroup,
         ): field is FormFieldProps & { placeholder: string } =>
           !Array.isArray(field) &&
           "placeholder" in field &&
-          typeof field.placeholder === "string";
+          typeof field.placeholder === "string"
 
         const PLACEHOLDER_FIELDS = INPUT_WITH_STYLE.filter(
           (field): field is FormFieldProps & { placeholder: string } =>
@@ -2885,48 +3079,48 @@ describe("StatefulForm", () => {
               "date",
               "signature",
               "image",
-            ].includes(field.type)
-        );
+            ].includes(field.type),
+        )
 
         PLACEHOLDER_FIELDS.forEach((field) => {
           if (field.type === "image") {
             cy.findByPlaceholderText("imagebox-input")
               .should("exist")
-              .and("have.css", "background-color", "rgb(245, 222, 179)");
+              .and("have.css", "background-color", "rgb(245, 222, 179)")
           } else if (field.type === "signbox") {
             cy.findByPlaceholderText("signbox-canvas")
               .should("exist")
-              .and("have.css", "background-color", "rgb(245, 222, 179)");
+              .and("have.css", "background-color", "rgb(245, 222, 179)")
           } else if (field.type === "phone") {
             cy.findByPlaceholderText(field.placeholder)
               .should("exist")
               .parent()
-              .and("have.css", "background-color", "rgb(245, 222, 179)");
+              .and("have.css", "background-color", "rgb(245, 222, 179)")
           } else if (field.type === "color") {
             cy.findByPlaceholderText(field.placeholder)
               .should("exist")
               .parent()
               .parent()
-              .and("have.css", "background-color", "rgb(245, 222, 179)");
+              .and("have.css", "background-color", "rgb(245, 222, 179)")
           } else if (field.type === "money") {
             cy.findByPlaceholderText(field.placeholder)
               .should("exist")
               .parent()
-              .and("have.css", "background-color", "rgb(245, 222, 179)");
+              .and("have.css", "background-color", "rgb(245, 222, 179)")
           } else {
             cy.findByPlaceholderText(field.placeholder)
               .should("exist")
-              .and("have.css", "background-color", "rgb(245, 222, 179)");
+              .and("have.css", "background-color", "rgb(245, 222, 179)")
           }
-        });
-      });
-    });
-  });
+        })
+      })
+    })
+  })
 
   context("radio", () => {
     const value = {
       access: false,
-    };
+    }
 
     const RADIO_FIELDS: FormFieldGroup[] = [
       {
@@ -2936,7 +3130,7 @@ describe("StatefulForm", () => {
         type: "radio",
         required: false,
       },
-    ];
+    ]
     context("with title", () => {
       it("should render on the label field", () => {
         cy.mount(
@@ -2944,12 +3138,12 @@ describe("StatefulForm", () => {
             fields={RADIO_FIELDS}
             formValues={value}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
-        cy.findAllByText(RADIO_FIELDS[0]["title"]).eq(0).should("be.visible");
-      });
-    });
+        cy.findAllByText(RADIO_FIELDS[0]["title"]).eq(0).should("be.visible")
+      })
+    })
 
     context("with placeholder", () => {
       it("should render on the right side", () => {
@@ -2958,21 +3152,21 @@ describe("StatefulForm", () => {
             fields={RADIO_FIELDS}
             formValues={value}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         cy.findByLabelText("radio-label-wrapper").should(
           "have.text",
-          RADIO_FIELDS[0]["placeholder"]
-        );
-      });
-    });
-  });
+          RADIO_FIELDS[0]["placeholder"],
+        )
+      })
+    })
+  })
 
   context("capsule", () => {
     const value = {
       capsule: "unpaid",
-    };
+    }
 
     context("when initial value", () => {
       const CHECKBOX_TITLE_FIELDS: FormFieldGroup[] = [
@@ -2985,7 +3179,7 @@ describe("StatefulForm", () => {
             tabs: CAPSULE_TABS,
           },
         },
-      ];
+      ]
 
       it("should render active related with id value", () => {
         cy.mount(
@@ -2993,23 +3187,23 @@ describe("StatefulForm", () => {
             fields={CHECKBOX_TITLE_FIELDS}
             formValues={value}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
-        cy.findByText("Paid").should("have.css", "color", "rgb(17, 24, 39)");
+        cy.findByText("Paid").should("have.css", "color", "rgb(17, 24, 39)")
         cy.findByText("Unpaid").should(
           "have.css",
           "color",
-          "rgb(255, 255, 255)"
-        );
-      });
-    });
-  });
+          "rgb(255, 255, 255)",
+        )
+      })
+    })
+  })
 
   context("checkbox", () => {
     const value = {
       access: false,
-    };
+    }
 
     const CHECKBOX_TITLE_FIELDS: FormFieldGroup[] = [
       {
@@ -3019,7 +3213,7 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ];
+    ]
 
     const statefulForCheckbox = () =>
       cy.mount(
@@ -3027,49 +3221,49 @@ describe("StatefulForm", () => {
           fields={CHECKBOX_TITLE_FIELDS}
           formValues={value}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
     context("with title", () => {
       it("should render on the label field", () => {
-        statefulForCheckbox();
+        statefulForCheckbox()
 
         cy.findAllByText(CHECKBOX_TITLE_FIELDS[0]["title"])
           .eq(0)
-          .should("be.visible");
-      });
+          .should("be.visible")
+      })
 
       context("when clicking", () => {
         it("renders checked the checkbox", () => {
-          statefulForCheckbox();
+          statefulForCheckbox()
 
-          cy.findByRole("checkbox").should("not.be.checked");
-          cy.findByText("Access").click();
-          cy.findByRole("checkbox").should("be.checked");
-        });
-      });
-    });
+          cy.findByRole("checkbox").should("not.be.checked")
+          cy.findByText("Access").click()
+          cy.findByRole("checkbox").should("be.checked")
+        })
+      })
+    })
 
     context("with placeholder", () => {
       it("should render on the right side", () => {
-        statefulForCheckbox();
+        statefulForCheckbox()
 
         cy.findAllByText(CHECKBOX_TITLE_FIELDS[0]["placeholder"])
           .eq(0)
-          .should("be.visible");
-      });
+          .should("be.visible")
+      })
 
       context("when clicking", () => {
         it("renders checked the checkbox", () => {
-          statefulForCheckbox();
+          statefulForCheckbox()
 
-          cy.findByRole("checkbox").should("not.be.checked");
-          cy.findByText("Access placeholder").click();
-          cy.findByRole("checkbox").should("be.checked");
-        });
-      });
-    });
-  });
+          cy.findByRole("checkbox").should("not.be.checked")
+          cy.findByText("Access placeholder").click()
+          cy.findByRole("checkbox").should("be.checked")
+        })
+      })
+    })
+  })
 
   context("with justifyContent", () => {
     const value = {
@@ -3080,7 +3274,7 @@ describe("StatefulForm", () => {
       note: "",
       access: false,
       country_code: DEFAULT_COUNTRY_CODES,
-    };
+    }
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
@@ -3136,7 +3330,7 @@ describe("StatefulForm", () => {
         width: "15%",
         rowJustifyPosition: "end",
       },
-    ];
+    ]
 
     it("render style align on the one row", () => {
       cy.mount(
@@ -3144,14 +3338,14 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS}
           formValues={value}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
       cy.findAllByLabelText("stateful-form-row")
         .eq(5)
-        .should("have.css", "justify-content", "end");
-    });
-  });
+        .should("have.css", "justify-content", "end")
+    })
+  })
 
   context("with autoFocusField", () => {
     const value = {
@@ -3162,7 +3356,7 @@ describe("StatefulForm", () => {
       note: "",
       access: false,
       country_code: DEFAULT_COUNTRY_CODES,
-    };
+    }
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
@@ -3209,7 +3403,7 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ];
+    ]
 
     it("render in the one row", () => {
       cy.mount(
@@ -3218,21 +3412,21 @@ describe("StatefulForm", () => {
           formValues={value}
           mode="onChange"
           autoFocusField="first_name"
-        />
-      );
+        />,
+      )
       cy.findAllByLabelText("stateful-form-row")
         .eq(0)
         .within(() => {
-          cy.findAllByRole("textbox").eq(0).should("exist").and("be.focused");
-        });
-    });
-  });
+          cy.findAllByRole("textbox").eq(0).should("exist").and("be.focused")
+        })
+    })
+  })
 
   context("when not given a title", () => {
     const value = {
       first_name: "",
       access: false,
-    };
+    }
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       {
@@ -3247,11 +3441,11 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ];
+    ]
 
-    const TITLE_EMPLOYEE_FIELD = ["First Name", "Has access to login"];
+    const TITLE_EMPLOYEE_FIELD = ["First Name", "Has access to login"]
 
-    const PLACEHOLDER_EMPLOYEE_FIELD = ["Enter first name"];
+    const PLACEHOLDER_EMPLOYEE_FIELD = ["Enter first name"]
 
     it("should render only the input", () => {
       cy.mount(
@@ -3259,22 +3453,22 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS}
           formValues={value}
           mode="onChange"
-        />
-      );
+        />,
+      )
       PLACEHOLDER_EMPLOYEE_FIELD.map((data) => {
-        cy.findByPlaceholderText(data).should("exist");
-      });
+        cy.findByPlaceholderText(data).should("exist")
+      })
       TITLE_EMPLOYEE_FIELD.map((data) => {
-        cy.findByText(data).should("not.exist");
-      });
-    });
-  });
+        cy.findByText(data).should("not.exist")
+      })
+    })
+  })
 
   context("with hidden", () => {
     const value = {
       first_name: "",
       access: false,
-    };
+    }
 
     const EMPLOYEE_FIELDS_WITH_HIDDEN: FormFieldGroup[] = [
       {
@@ -3298,7 +3492,7 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ];
+    ]
 
     it("should hidden the input element", () => {
       cy.mount(
@@ -3306,15 +3500,13 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS_WITH_HIDDEN}
           formValues={value}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
-      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[0]["title"]).should("exist");
-      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[1]["title"]).should(
-        "not.exist"
-      );
-      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[2]["title"]).should("exist");
-    });
+      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[0]["title"]).should("exist")
+      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[1]["title"]).should("not.exist")
+      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[2]["title"]).should("exist")
+    })
 
     it("should hidden the row input element", () => {
       cy.mount(
@@ -3322,12 +3514,12 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS_WITH_HIDDEN}
           formValues={value}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
-      cy.findAllByLabelText("stateful-form-row").should("have.length", 2);
-    });
-  });
+      cy.findAllByLabelText("stateful-form-row").should("have.length", 2)
+    })
+  })
 
   context("with width", () => {
     context("when given all input elements", () => {
@@ -3335,44 +3527,44 @@ describe("StatefulForm", () => {
         const INPUT_WITH_WIDTH = ALL_INPUT.map((group) =>
           Array.isArray(group)
             ? group.map((item) => ({ ...item, width: "50%" }))
-            : { ...group, width: "50%" }
-        );
+            : { ...group, width: "50%" },
+        )
 
         cy.mount(
           <StatefulForm
             fields={INPUT_WITH_WIDTH}
             formValues={allValue}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         flattenFields(INPUT_WITH_WIDTH).forEach((prop) => {
-          if (prop.name === "country_code") return;
+          if (prop.name === "country_code") return
           if (prop.name === "toggle") {
             cy.findByLabelText("toggle-row-wrapper").then(($el) => {
-              const width = $el.width();
-              expect(width).to.be.closeTo(222.5, 10);
-            });
+              const width = $el.width()
+              expect(width).to.be.closeTo(222.5, 10)
+            })
           } else {
             cy.findByText(prop.title)
               .parent()
               .then(($el) => {
-                const elWidth = $el.width();
-                expect(elWidth).to.be.closeTo(222.5, 10);
-              });
+                const elWidth = $el.width()
+                expect(elWidth).to.be.closeTo(222.5, 10)
+              })
           }
-        });
-      });
+        })
+      })
 
       context("when using small screen", () => {
         it("still render input elements with sizing", () => {
           const INPUT_WITH_WIDTH = ALL_INPUT.map((group) =>
             Array.isArray(group)
               ? group.map((item) => ({ ...item, width: "50%" }))
-              : { ...group, width: "50%" }
-          );
+              : { ...group, width: "50%" },
+          )
 
-          cy.viewport(440, 750);
+          cy.viewport(440, 750)
           // assume this in phone
 
           cy.mount(
@@ -3380,27 +3572,27 @@ describe("StatefulForm", () => {
               fields={INPUT_WITH_WIDTH}
               formValues={allValue}
               mode="onChange"
-            />
-          );
+            />,
+          )
 
           flattenFields(INPUT_WITH_WIDTH).forEach((prop) => {
-            if (prop.name === "country_code") return;
+            if (prop.name === "country_code") return
             if (prop.name === "toggle") {
               cy.findByLabelText("toggle-row-wrapper").then(($el) => {
-                const width = $el.width();
-                expect(width).to.be.closeTo(197.5, 10);
-              });
+                const width = $el.width()
+                expect(width).to.be.closeTo(197.5, 10)
+              })
             } else {
               cy.findByText(prop.title)
                 .parent()
                 .then(($el) => {
-                  const elWidth = $el.width();
-                  expect(elWidth).to.be.closeTo(197.5, 10);
-                });
+                  const elWidth = $el.width()
+                  expect(elWidth).to.be.closeTo(197.5, 10)
+                })
             }
-          });
-        });
-      });
-    });
-  });
-});
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Description:
This pull request migrates `StatefulForm` from React Hook Form's (`RHF`) `defaultValues` to the reactive `values` API, enabling fully controlled form state and reactive synchronization with external updates.

  | defaultValues | values
-- | -- | --
When it's applied | Once, on mount only | Reactively, every time the object reference changes
Reacts to later prop changes? | ❌ No — ignored after initial mount | ✅ Yes — triggers RHF's internal reset()
Best suited for | Static initial state (e.g. data fetched once before the form renders) | Live external state that needs to stay in sync (e.g. a controlled formValues prop)
Updates raw field values on change? | doesn't update after mount | ✅ Yes
Auto-marks changed fields as touched? | ❌ No | ❌ No
Auto re-runs validation for display (errors)? | ❌ No | ❌ No
Risk if used naively | Form silently stops reflecting new external data | Field values update, but touchedFields/errors silently fall out of sync

### How is the `asynchronous` issue solved?
1. Diffs the latest formValues against prevFormValuesRef.
2. Detects whether the change originated from:
   - Internal user interaction (handleFieldChange via RHF), or
   - External updates (API responses, parent state changes, resets, etc.).
3. Calls:
```tsx
setValue(name, value, {
  shouldValidate: true,
  shouldTouch: true,
  shouldDirty: true,
})
``` 
on genuinely external changes only (via `internallyChangedFieldsRef` to skip changes that already came from `handleFieldChange`)

Source:
[[Research] SYST-820: Use `RHF` with `values`, instead of `defaultValues`](https://linear.app/systatum/issue/SYST-820/use-rhf-with-values-instead-of-defaultvalues)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself