### PR TITLE
[Bug] SYST-821: Fix `LoadingSkeleton` issue if wrapped by another element.

### DIFF
--- a/components/loading-skeleton.tsx
+++ b/components/loading-skeleton.tsx
@@ -1,10 +1,9 @@
 import {
-  Children,
-  cloneElement,
+  createContext,
   HTMLAttributes,
-  isValidElement,
-  ReactElement,
   ReactNode,
+  useContext,
+  useMemo,
 } from "react";
 import styled, { css, CSSProp, keyframes } from "styled-components";
 import { useTheme } from "./../theme/provider";
@@ -37,10 +36,8 @@ export interface LoadingSkeletonOption {
   highlightColor?: string;
 }
 
-interface LoadingSkeletonBaseProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  "style"
-> {
+interface LoadingSkeletonBaseProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "style"> {
   children?: ReactNode;
   styles?: LoadingSkeletonStyles;
 }
@@ -50,10 +47,17 @@ export interface LoadingSkeletonStyles {
 }
 
 export interface LoadingSkeletonProps
-  extends LoadingSkeletonBaseProps, LoadingSkeletonOption {
+  extends LoadingSkeletonBaseProps,
+    LoadingSkeletonOption {
   height?: number | string;
   width?: number | string;
 }
+
+// Context carries the resolved defaults down to LoadingSkeleton.Item
+// without needing to walk/clone the children tree.
+const LoadingSkeletonContext = createContext<LoadingSkeletonOption>({});
+
+const useLoadingSkeletonContext = () => useContext(LoadingSkeletonContext);
 
 function LoadingSkeleton({
   styles,
@@ -73,37 +77,28 @@ function LoadingSkeleton({
   const finalHighlightColor =
     highlightColor ?? loadingSkeletonTheme.highlightColor;
 
-  const childArray = Children.toArray(children).filter(isValidElement);
+  const contextValue = useMemo(
+    () => ({
+      flashDirection,
+      flashRate,
+      baseColor: finalBaseColor,
+      highlightColor: finalHighlightColor,
+    }),
+    [flashDirection, flashRate, finalBaseColor, finalHighlightColor]
+  );
 
   return (
-    <LoadingSkeletonWrapper
-      aria-label="loading-skeleton-wrapper"
-      {...props}
-      id={id}
-      className={applyClassName("loading-skeleton", className)}
-      $style={styles?.self}
-    >
-      {childArray.map((child, index) => {
-        const componentChild = child as ReactElement<
-          LoadingSkeletonItemProps & LoadingSkeletonOption
-        >;
-
-        const isItem = componentChild.type === LoadingSkeleton.Item;
-
-        return cloneElement(componentChild, {
-          key: index,
-          ...(isItem && {
-            ...componentChild.props,
-            flashDirection:
-              componentChild.props.flashDirection ?? flashDirection,
-            flashRate: componentChild.props.flashRate ?? flashRate,
-            baseColor: componentChild.props.baseColor ?? finalBaseColor,
-            highlightColor:
-              componentChild.props.highlightColor ?? finalHighlightColor,
-          }),
-        });
-      })}
-    </LoadingSkeletonWrapper>
+    <LoadingSkeletonContext value={contextValue}>
+      <LoadingSkeletonWrapper
+        aria-label="loading-skeleton-wrapper"
+        {...props}
+        id={id}
+        className={applyClassName("loading-skeleton", className)}
+        $style={styles?.self}
+      >
+        {children}
+      </LoadingSkeletonWrapper>
+    </LoadingSkeletonContext>
   );
 }
 
@@ -121,7 +116,8 @@ const LoadingSkeletonWrapper = styled.div<{ $style?: CSSProp }>`
 `;
 
 export interface LoadingSkeletonItemProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "style">, LoadingSkeletonOption {
+  extends Omit<HTMLAttributes<HTMLDivElement>, "style">,
+    LoadingSkeletonOption {
   styles?: LoadingSkeletonStyles;
   height?: number | string;
   width?: number | string;
@@ -131,12 +127,22 @@ function LoadingSkeletonItem({
   styles,
   height,
   width,
-  flashDirection,
-  flashRate,
-  baseColor,
-  highlightColor,
+  flashDirection: _flashDirection,
+  flashRate: _flashRate,
+  baseColor: _baseColor,
+  highlightColor: _highlightColor,
   ...props
 }: LoadingSkeletonItemProps) {
+  const loadingSkeletonContext = useLoadingSkeletonContext();
+
+  // Own props win over the values inherited from the parent LoadingSkeleton.
+  const flashDirection =
+    _flashDirection ?? loadingSkeletonContext.flashDirection;
+  const flashRate = _flashRate ?? loadingSkeletonContext.flashRate;
+  const baseColor = _baseColor ?? loadingSkeletonContext.baseColor;
+  const highlightColor =
+    _highlightColor ?? loadingSkeletonContext.highlightColor;
+
   return (
     <LoadingSkeletonItemStyled
       aria-label="loading-skeleton-item"

--- a/test/component/loading-skeleton.cy.tsx
+++ b/test/component/loading-skeleton.cy.tsx
@@ -3,6 +3,93 @@ import { Grid } from "./../../components/grid";
 import { LoadingSkeleton } from "./../../components/loading-skeleton";
 
 describe("Loading Skeleton", () => {
+  function WrappedLoadingSkeleton() {
+    return (
+      <LoadingSkeleton
+        flashDirection="left-to-right"
+        flashRate="normal"
+        styles={{
+          self: css`
+            border-radius: 12px;
+            padding: 16px;
+            width: 100%;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+          `,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+          }}
+        >
+          <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+            <LoadingSkeleton.Item
+              height={40}
+              width={40}
+              styles={{
+                self: css`
+                  border-radius: 50%;
+                `,
+              }}
+            />
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              <LoadingSkeleton.Item height={16} width={120} />
+              <LoadingSkeleton.Item height={13} width={80} />
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+              alignItems: "flex-end",
+            }}
+          >
+            <LoadingSkeleton.Item height={20} width={32} />
+            <LoadingSkeleton.Item height={16} width={100} />
+          </div>
+        </div>
+
+        <LoadingSkeleton.Item height={16} width="90%" />
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+            <LoadingSkeleton.Item height={24} width={40} />
+            <LoadingSkeleton.Item height={24} width={40} />
+          </div>
+          <LoadingSkeleton.Item height={24} width={70} />
+        </div>
+      </LoadingSkeleton>
+    );
+  }
+
+  context("when wrapped by another element", () => {
+    it("uses the same color for all skeleton items", () => {
+      cy.mount(<WrappedLoadingSkeleton />);
+
+      cy.findAllByLabelText("loading-skeleton-item")
+        .should("have.length.greaterThan", 0)
+        .then(($items) => {
+          const firstColor = getComputedStyle($items[0]).backgroundColor;
+
+          Cypress.$($items).each((_, item) => {
+            expect(getComputedStyle(item).backgroundColor).to.equal(firstColor);
+          });
+        });
+    });
+  });
+
   context("when given", () => {
     it("renders content with loading", () => {
       function CardComponent() {


### PR DESCRIPTION
Description:
Previously, the `LoadingSkeleton` was error if wrapped by some `div` or another `element`, causes the `style` from `parent` level providing by `cloneElement`, for some case is not handled properly, 

Then, after learn case from `Table`, `cloneElement` causing re-renders. This ticket fixes `LoadingSkeleton` with `useContext` to can always get state from parent if `provided`.

Error:
<img width="638" height="562" alt="Screenshot 2026-08-06 at 11 12 21" src="https://github.com/user-attachments/assets/3f4a3d21-8aa1-448e-aa91-5c9e4b439103" />

Source:
[[Bug] SYST-821: Fix `LoadingSkeleton` issue when wrapping by another element.](https://linear.app/systatum/issue/SYST-821/fix-loadingskeleton-issue-when-wrapping-by-another-element)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself