### PR TITLE
[Improvement] SYST-822: Allow `StatefulForm.helper` to be react node

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,10 @@
 {
-  "semi": true,
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": [],
+  "semi": false,
   "singleQuote": false,
-  "trailingComma": "es5",
-  "tabWidth": 2
+  "trailingComma": "all",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "endOfLine": "lf"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,10 +1,6 @@
 {
-  "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": [],
-  "semi": false,
+  "semi": true,
   "singleQuote": false,
-  "trailingComma": "all",
-  "printWidth": 80,
-  "tabWidth": 2,
-  "endOfLine": "lf"
+  "trailingComma": "es5",
+  "tabWidth": 2
 }

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -2,91 +2,91 @@ import {
   RiArrowLeftSLine,
   RiArrowRightSLine,
   RiCheckLine,
-} from "@remixicon/react";
-import { Fragment, useMemo, ReactNode } from "react";
-import React, { useState, useEffect } from "react";
-import { Button } from "./button";
-import { Combobox } from "./combobox";
-import { DrawerProps, SelectboxOption } from "./selectbox";
-import styled, { css, CSSProp } from "styled-components";
+} from "@remixicon/react"
+import { Fragment, useMemo, ReactNode } from "react"
+import React, { useState, useEffect } from "react"
+import { Button } from "./button"
+import { Combobox } from "./combobox"
+import { DrawerProps, SelectboxOption } from "./selectbox"
+import styled, { css, CSSProp } from "styled-components"
 import {
   getValidMultipleDate,
   isValidDateString,
   isWeekend,
   removeWeekend,
-} from "../lib/date";
-import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { useTheme } from "./../theme/provider";
-import { CalendarThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
+} from "../lib/date"
+import { StatefulForm } from "./stateful-form"
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
+import { useTheme } from "./../theme/provider"
+import { CalendarThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
 
 export interface BaseCalendarProps extends Partial<DrawerProps> {
-  options?: CalendarOption[];
-  selectedDates?: string[];
-  onChange?: (dates: string[]) => void;
-  dayNames?: CalendarOption[];
-  monthNames?: CalendarOption[];
-  disableWeekend?: boolean;
-  format?: CalendarFormat;
-  yearPastReach?: number;
-  futurePastReach?: number;
-  onClick?: () => void;
-  onCalendarPeriodChanged?: (date: Date) => void;
-  styles?: BaseCalendarStyles;
-  footer?: ReactNode;
-  todayButtonCaption?: string;
-  selectabilityMode?: CalendarSelectabilityMode;
-  id?: string;
-  name?: string;
+  options?: CalendarOption[]
+  selectedDates?: string[]
+  onChange?: (dates: string[]) => void
+  dayNames?: CalendarOption[]
+  monthNames?: CalendarOption[]
+  disableWeekend?: boolean
+  format?: CalendarFormat
+  yearPastReach?: number
+  futurePastReach?: number
+  onClick?: () => void
+  onCalendarPeriodChanged?: (date: Date) => void
+  styles?: BaseCalendarStyles
+  footer?: ReactNode
+  todayButtonCaption?: string
+  selectabilityMode?: CalendarSelectabilityMode
+  id?: string
+  name?: string
 }
 
-export type CalendarOption = SelectboxOption;
+export type CalendarOption = SelectboxOption
 
 export interface BaseCalendarStyles {
-  self?: CSSProp;
-  containerStyle?: CSSProp;
-  labelStyle?: CSSProp;
+  self?: CSSProp
+  containerStyle?: CSSProp
+  labelStyle?: CSSProp
 }
 
 interface CalendarState {
-  open: boolean;
-  month: string[];
-  year: string[];
+  open: boolean
+  month: string[]
+  year: string[]
 }
 
 type CustomChangeEvent = {
   target: {
-    name: string;
-    value: string[];
-  };
-};
+    name: string
+    value: string[]
+  }
+}
 
 export const CalendarFormat = {
   MM_DD_YYYY: "mm/dd/yyyy",
   YYYY_MM_DD: "yyyy/mm/dd",
   DD_MM_YYYY: "dd/mm/yyyy",
-} as const;
+} as const
 
 export type CalendarFormat =
-  (typeof CalendarFormat)[keyof typeof CalendarFormat];
+  (typeof CalendarFormat)[keyof typeof CalendarFormat]
 
 const DateBoxOpen = {
   Open: "open",
   Month: "month",
   Year: "year",
-} as const;
+} as const
 
-type DateBoxOpen = (typeof DateBoxOpen)[keyof typeof DateBoxOpen];
+type DateBoxOpen = (typeof DateBoxOpen)[keyof typeof DateBoxOpen]
 
 export const CalendarSelectabilityMode = {
   Single: "single",
   Multiple: "multiple",
   Ranged: "ranged",
-} as const;
+} as const
 
 export type CalendarSelectabilityMode =
-  (typeof CalendarSelectabilityMode)[keyof typeof CalendarSelectabilityMode];
+  (typeof CalendarSelectabilityMode)[keyof typeof CalendarSelectabilityMode]
 
 const DEFAULT_DAY_NAMES = [
   { text: "Su", value: "1" },
@@ -96,7 +96,7 @@ const DEFAULT_DAY_NAMES = [
   { text: "Th", value: "5" },
   { text: "Fr", value: "6" },
   { text: "Sa", value: "7" },
-];
+]
 
 const DEFAULT_MONTH_NAMES = [
   { text: "January", value: "1" },
@@ -111,7 +111,7 @@ const DEFAULT_MONTH_NAMES = [
   { text: "October", value: "10" },
   { text: "November", value: "11" },
   { text: "December", value: "12" },
-];
+]
 
 function BaseCalendar({
   highlightedIndex,
@@ -134,386 +134,386 @@ function BaseCalendar({
   onCalendarPeriodChanged,
   selectabilityMode = "single",
 }: BaseCalendarProps) {
-  const { currentTheme } = useTheme();
-  const calendarTheme = currentTheme?.calendar;
+  const { currentTheme } = useTheme()
+  const calendarTheme = currentTheme?.calendar
 
-  const today = new Date();
+  const today = new Date()
   const currentMonth = monthNames.find(
-    (data) => Number(data.value) === today.getMonth() + 1
-  );
-  const currentYear = today.getFullYear();
+    (data) => Number(data.value) === today.getMonth() + 1,
+  )
+  const currentYear = today.getFullYear()
 
   const initialValueState = () => {
-    const raw = selectedDates?.[0];
+    const raw = selectedDates?.[0]
     if (selectabilityMode === "ranged") {
       if (disableWeekend) {
         if (raw?.split("-")) {
-          return isWeekend(today) ? "" : formatDate(today, format);
+          return isWeekend(today) ? "" : formatDate(today, format)
         }
 
-        const value = raw?.split(", ") ?? [];
-        const firstValue = value[0];
-        const latestValue = value[value.length - 1];
+        const value = raw?.split(", ") ?? []
+        const firstValue = value[0]
+        const latestValue = value[value.length - 1]
 
-        return `${firstValue}-${latestValue}`;
+        return `${firstValue}-${latestValue}`
       }
 
-      return isValidDateString(raw) ? raw : "";
+      return isValidDateString(raw) ? raw : ""
     }
 
     if (selectabilityMode === "multiple") {
-      let validDates = getValidMultipleDate(raw);
+      let validDates = getValidMultipleDate(raw)
 
       if (disableWeekend) {
-        validDates = removeWeekend(validDates);
+        validDates = removeWeekend(validDates)
       }
 
-      return validDates.length > 0 ? validDates.join(", ") : "";
+      return validDates.length > 0 ? validDates.join(", ") : ""
     }
 
-    return isValidDateString(raw) ? raw : formatDate(today, format);
-  };
+    return isValidDateString(raw) ? raw : formatDate(today, format)
+  }
 
-  const normalized = initialValueState();
+  const normalized = initialValueState()
 
   const stateDate = useMemo(() => {
-    if (!normalized) return new Date();
+    if (!normalized) return new Date()
 
     const firstStr = normalized.includes(",")
       ? normalized.split(",")[0].trim()
       : normalized.includes("-")
         ? normalized.split("-")[0].trim()
-        : normalized.trim();
+        : normalized.trim()
 
-    const d = new Date(firstStr);
-    return isNaN(d.getTime()) ? new Date() : d;
-  }, [normalized]);
+    const d = new Date(firstStr)
+    return isNaN(d.getTime()) ? new Date() : d
+  }, [normalized])
 
-  const [currentDate, setCurrentDate] = useState(stateDate);
+  const [currentDate, setCurrentDate] = useState(stateDate)
 
   const [calendarState, setCalendarState] = useState<CalendarState>({
     open: false,
     month: [String(stateDate.getMonth() + 1)],
     year: [String(stateDate.getFullYear())],
-  });
+  })
 
   const [selectedDatesLocal, setSelectedDatesLocal] =
-    useState(initialValueState());
+    useState(initialValueState())
 
   const [startPicked, setStartPicked] = useState<{
-    picked: boolean;
-    indexPicked: Date | null;
-  }>({ picked: false, indexPicked: null });
+    picked: boolean
+    indexPicked: Date | null
+  }>({ picked: false, indexPicked: null })
 
-  const [highlightedIndexInternal, setHighlightedIndexInternal] = useState(0);
-  const highlightedIndexChange = highlightedIndex ?? highlightedIndexInternal;
+  const [highlightedIndexInternal, setHighlightedIndexInternal] = useState(0)
+  const highlightedIndexChange = highlightedIndex ?? highlightedIndexInternal
 
   const setHighlightedIndexChange = (index: number) => {
     if (setHighlightedIndex) {
-      setHighlightedIndex(index);
+      setHighlightedIndex(index)
     } else {
-      setHighlightedIndexInternal(index);
+      setHighlightedIndexInternal(index)
     }
-  };
+  }
 
   if (listRef && !listRef.current) {
-    listRef.current = [];
+    listRef.current = []
   }
 
   const onChangeValueDate = (e: CustomChangeEvent) => {
-    const { name, value } = e.target;
-    handleChangeValueDate(name, value);
-  };
+    const { name, value } = e.target
+    handleChangeValueDate(name, value)
+  }
 
   const handleChangeValueDate = (name: string, value: string[]) => {
-    setCalendarState((prev) => ({ ...prev, [name]: value }));
+    setCalendarState((prev) => ({ ...prev, [name]: value }))
 
     if (name === "month") {
-      const monthIndex = Number(value[0]) - 1;
-      const dateMonth = new Date(currentDate.getFullYear(), monthIndex, 1);
-      setCurrentDate(dateMonth);
+      const monthIndex = Number(value[0]) - 1
+      const dateMonth = new Date(currentDate.getFullYear(), monthIndex, 1)
+      setCurrentDate(dateMonth)
       if (onCalendarPeriodChanged) {
-        onCalendarPeriodChanged(dateMonth);
+        onCalendarPeriodChanged(dateMonth)
       }
     } else if (name === "year") {
-      const yearNumber = Number(value[0]);
+      const yearNumber = Number(value[0])
       if (!isNaN(yearNumber)) {
-        const month = currentDate.getMonth();
+        const month = currentDate.getMonth()
         const day = Math.min(
           currentDate.getDate(),
-          new Date(yearNumber, month + 1, 0).getDate()
-        );
-        const dateYear = new Date(yearNumber, month, day);
-        setCurrentDate(dateYear);
+          new Date(yearNumber, month + 1, 0).getDate(),
+        )
+        const dateYear = new Date(yearNumber, month, day)
+        setCurrentDate(dateYear)
         if (onCalendarPeriodChanged) {
-          onCalendarPeriodChanged(dateYear);
+          onCalendarPeriodChanged(dateYear)
         }
       }
     }
-  };
+  }
 
   const dates = useMemo(() => {
-    const year = currentDate.getFullYear();
-    const month = currentDate.getMonth();
-    const lastDate = new Date(year, month + 1, 0).getDate();
-    const arr: Date[] = [];
-    for (let i = 1; i <= lastDate; i++) arr.push(new Date(year, month, i));
-    return arr;
-  }, [currentDate]);
+    const year = currentDate.getFullYear()
+    const month = currentDate.getMonth()
+    const lastDate = new Date(year, month + 1, 0).getDate()
+    const arr: Date[] = []
+    for (let i = 1; i <= lastDate; i++) arr.push(new Date(year, month, i))
+    return arr
+  }, [currentDate])
 
   const { yearOptions } = useMemo(() => {
-    const t = new Date();
+    const t = new Date()
     const min = new Date(
       t.getFullYear() - (yearPastReach ?? 80),
       t.getMonth(),
-      t.getDate()
-    );
+      t.getDate(),
+    )
     const max = new Date(
       t.getFullYear() + (futurePastReach ?? 50),
       t.getMonth(),
-      t.getDate()
-    );
+      t.getDate(),
+    )
     const years = Array.from(
       { length: max.getFullYear() - min.getFullYear() + 1 },
       (_, i) => ({
         text: String(min.getFullYear() + i),
         value: String(min.getFullYear() + i),
-      })
-    );
-    return { yearOptions: years };
-  }, [yearPastReach, futurePastReach]);
+      }),
+    )
+    return { yearOptions: years }
+  }, [yearPastReach, futurePastReach])
 
   const prevMonth = useMemo(
     () => new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1),
-    [currentDate]
-  );
+    [currentDate],
+  )
 
   const nextMonth = useMemo(
     () => new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 1),
-    [currentDate]
-  );
+    [currentDate],
+  )
 
   const handleClickPrevMonth = (e: React.MouseEvent) => {
-    e.preventDefault();
+    e.preventDefault()
 
     if (onCalendarPeriodChanged) {
-      onCalendarPeriodChanged(prevMonth);
+      onCalendarPeriodChanged(prevMonth)
     }
-    setCurrentDate(prevMonth);
-    setHighlightedIndexChange(0);
+    setCurrentDate(prevMonth)
+    setHighlightedIndexChange(0)
     setCalendarState((prev) => ({
       ...prev,
       month: [String(prevMonth.getMonth() + 1)],
       year: [prevMonth.getFullYear().toString()],
-    }));
-  };
+    }))
+  }
 
   const handleClickNextMonth = (e: React.MouseEvent) => {
-    e.preventDefault();
+    e.preventDefault()
 
-    setCurrentDate(nextMonth);
+    setCurrentDate(nextMonth)
     if (onCalendarPeriodChanged) {
-      onCalendarPeriodChanged(nextMonth);
+      onCalendarPeriodChanged(nextMonth)
     }
-    setHighlightedIndexChange(0);
+    setHighlightedIndexChange(0)
     setCalendarState((prev) => ({
       ...prev,
       month: [String(nextMonth.getMonth() + 1)],
       year: [String(nextMonth.getFullYear())],
-    }));
-  };
+    }))
+  }
 
   const handleMoveToToday = () => {
     if (onCalendarPeriodChanged) {
-      onCalendarPeriodChanged(today);
+      onCalendarPeriodChanged(today)
     }
-    setCurrentDate(today);
+    setCurrentDate(today)
     if (onChange) {
-      onChange([formatDate(today, format)]);
+      onChange([formatDate(today, format)])
     }
 
-    setHighlightedIndexChange(0);
+    setHighlightedIndexChange(0)
     setCalendarState((prev) => ({
       ...prev,
       month: [String(currentMonth)],
       year: [String(currentYear)],
-    }));
-  };
+    }))
+  }
 
   const handleSelect = async (date: Date, e?: React.MouseEvent) => {
-    const formattedData = formatDate(date, format);
-    let newValues: string[];
+    const formattedData = formatDate(date, format)
+    let newValues: string[]
 
     if (selectabilityMode === "multiple") {
       await setSelectedDatesLocal((prev) => {
-        const values = prev ? prev.split(", ") : [];
+        const values = prev ? prev.split(", ") : []
 
         if (e?.shiftKey && values.length > 0) {
-          const lastDate = new Date(values[values.length - 1]);
-          const start = lastDate.getTime() < date.getTime() ? lastDate : date;
-          const end = lastDate.getTime() > date.getTime() ? lastDate : date;
+          const lastDate = new Date(values[values.length - 1])
+          const start = lastDate.getTime() < date.getTime() ? lastDate : date
+          const end = lastDate.getTime() > date.getTime() ? lastDate : date
 
-          const range: string[] = [];
-          let cursor = new Date(start);
+          const range: string[] = []
+          let cursor = new Date(start)
 
           while (cursor.getTime() <= end.getTime()) {
             if (!disableWeekend || !isWeekend(cursor)) {
-              range.push(formatDate(new Date(cursor), format));
+              range.push(formatDate(new Date(cursor), format))
             }
-            cursor.setDate(cursor.getDate() + 1);
+            cursor.setDate(cursor.getDate() + 1)
           }
 
-          const unique = new Set([...values, ...range]);
+          const unique = new Set([...values, ...range])
           newValues = Array.from(unique).sort(
-            (a, b) => new Date(a).getTime() - new Date(b).getTime()
-          );
+            (a, b) => new Date(a).getTime() - new Date(b).getTime(),
+          )
         } else {
           if (values.includes(formattedData)) {
-            newValues = values.filter((value) => value !== formattedData);
+            newValues = values.filter((value) => value !== formattedData)
           } else {
-            newValues = [...values, formattedData];
+            newValues = [...values, formattedData]
           }
 
           newValues = newValues.sort(
-            (a, b) => new Date(a).getTime() - new Date(b).getTime()
-          );
+            (a, b) => new Date(a).getTime() - new Date(b).getTime(),
+          )
         }
 
-        const finalValues = newValues.join(", ");
+        const finalValues = newValues.join(", ")
         if (onChange) {
-          onChange([finalValues]);
+          onChange([finalValues])
         }
 
-        return finalValues;
-      });
+        return finalValues
+      })
     } else if (selectabilityMode === "ranged") {
       await setSelectedDatesLocal((prev) => {
-        const values = prev ? prev.split("-") : [];
+        const values = prev ? prev.split("-") : []
         if (!startPicked.picked) {
-          newValues = [formattedData];
-          setStartPicked((prev) => ({ ...prev, picked: true }));
+          newValues = [formattedData]
+          setStartPicked((prev) => ({ ...prev, picked: true }))
         } else {
           if (values.includes(formattedData)) {
             if (disableWeekend) {
-              newValues = [...new Set([...values, formattedData])];
+              newValues = [...new Set([...values, formattedData])]
             } else {
-              newValues = [formattedData, formattedData];
+              newValues = [formattedData, formattedData]
             }
           } else {
             if (disableWeekend) {
-              const startDate = new Date(values[0]);
-              const endDate = date;
+              const startDate = new Date(values[0])
+              const endDate = date
               const start =
-                startDate.getTime() < endDate.getTime() ? startDate : endDate;
+                startDate.getTime() < endDate.getTime() ? startDate : endDate
               const end =
-                startDate.getTime() > endDate.getTime() ? startDate : endDate;
+                startDate.getTime() > endDate.getTime() ? startDate : endDate
 
-              const rangeValues: string[] = [];
-              let cursor = new Date(start);
+              const rangeValues: string[] = []
+              let cursor = new Date(start)
 
               while (cursor.getTime() <= end.getTime()) {
                 if (!disableWeekend || !isWeekend(cursor)) {
-                  rangeValues.push(formatDate(new Date(cursor), format));
+                  rangeValues.push(formatDate(new Date(cursor), format))
                 }
-                cursor.setDate(cursor.getDate() + 1);
+                cursor.setDate(cursor.getDate() + 1)
               }
 
-              newValues = rangeValues;
+              newValues = rangeValues
             } else {
-              newValues = [...new Set([...values, formattedData])];
+              newValues = [...new Set([...values, formattedData])]
             }
           }
-          setStartPicked({ picked: false, indexPicked: null });
+          setStartPicked({ picked: false, indexPicked: null })
         }
 
         newValues = newValues.sort((a, b) => {
-          const dateA = new Date(a);
-          const dateB = new Date(b);
-          return dateA.getTime() - dateB.getTime();
-        });
+          const dateA = new Date(a)
+          const dateB = new Date(b)
+          return dateA.getTime() - dateB.getTime()
+        })
 
         const finalValues = disableWeekend
           ? newValues.join(", ")
-          : newValues.join("-");
+          : newValues.join("-")
 
-        const firstValueLocal = newValues[0];
+        const firstValueLocal = newValues[0]
         const latestValueLocal = newValues[newValues.length - 1]
           ? `-${newValues[newValues.length - 1]}`
-          : "";
+          : ""
 
-        const newValuesLocal = `${firstValueLocal}${latestValueLocal}`;
+        const newValuesLocal = `${firstValueLocal}${latestValueLocal}`
 
         if (onChange) {
-          onChange([finalValues]);
+          onChange([finalValues])
         }
 
-        return newValuesLocal;
-      });
+        return newValuesLocal
+      })
     }
 
     if (selectabilityMode === "single") {
       if (onChange) {
-        await onChange([formatDate(date, format)]);
+        await onChange([formatDate(date, format)])
       }
-      await setSelectedDatesLocal(formatDate(date, format));
+      await setSelectedDatesLocal(formatDate(date, format))
     }
 
     if (setIsOpen && selectabilityMode !== "single") {
-      await setIsOpen(true);
+      await setIsOpen(true)
     } else if (setIsOpen) {
-      await setIsOpen(false);
+      await setIsOpen(false)
     }
-  };
+  }
 
   const emptyCellsCount = new Date(
     currentDate.getFullYear(),
     currentDate.getMonth(),
-    1
-  ).getDay();
+    1,
+  ).getDay()
 
   const handleClickMode = (data: DateBoxOpen) => {
     if (data === "open") {
       setCalendarState((prev) => ({
         ...prev,
         open: !calendarState.open,
-      }));
+      }))
     }
-  };
+  }
 
   // for automaticly change when prop added disable weekend and today it's weekend
   useEffect(() => {
     if (selectedDates?.length > 0) {
-      const newDate = new Date(selectedDates[0]);
+      const newDate = new Date(selectedDates[0])
       if (!isNaN(newDate.getTime())) {
-        let validDate = newDate;
+        let validDate = newDate
 
         if (disableWeekend) {
-          const day = validDate.getDay();
+          const day = validDate.getDay()
           if (day === 6) {
-            validDate.setDate(validDate.getDate() - 1);
+            validDate.setDate(validDate.getDate() - 1)
           } else if (day === 0) {
-            validDate.setDate(validDate.getDate() + 1);
+            validDate.setDate(validDate.getDate() + 1)
           }
         }
 
         if (onCalendarPeriodChanged) {
-          onCalendarPeriodChanged(validDate);
+          onCalendarPeriodChanged(validDate)
         }
-        setCurrentDate(validDate);
+        setCurrentDate(validDate)
 
-        setSelectedDatesLocal(formatDate(validDate, format));
+        setSelectedDatesLocal(formatDate(validDate, format))
 
         if (selectedDates[0].length > 9) {
           if (onChange) {
-            onChange([formatDate(validDate, format)]);
+            onChange([formatDate(validDate, format)])
           }
         }
       }
     }
-  }, [selectedDates?.[0], format]);
+  }, [selectedDates?.[0], format])
 
   const SELECTED_DATES = useMemo(() => {
-    if (!selectedDatesLocal) return [];
+    if (!selectedDatesLocal) return []
 
     switch (selectabilityMode) {
       case "ranged":
@@ -521,30 +521,30 @@ function BaseCalendar({
           .split("-")
           .filter(Boolean)
           .map((dateStr) => {
-            const date = new Date(dateStr.trim());
-            return isNaN(date.getTime()) ? null : date;
+            const date = new Date(dateStr.trim())
+            return isNaN(date.getTime()) ? null : date
           })
-          .filter(Boolean);
+          .filter(Boolean)
 
       case "multiple":
         return selectedDatesLocal
           .split(", ")
           .filter(Boolean)
           .map((dateStr) => {
-            const date = new Date(dateStr.trim());
-            return isNaN(date.getTime()) ? null : date;
+            const date = new Date(dateStr.trim())
+            return isNaN(date.getTime()) ? null : date
           })
-          .filter(Boolean);
+          .filter(Boolean)
 
       case "single":
       default:
         if (selectedDatesLocal) {
-          const date = new Date(selectedDatesLocal);
-          return isNaN(date.getTime()) ? [] : [date];
+          const date = new Date(selectedDatesLocal)
+          return isNaN(date.getTime()) ? [] : [date]
         }
-        return [];
+        return []
     }
-  }, [selectedDatesLocal, selectabilityMode]);
+  }, [selectedDatesLocal, selectabilityMode])
 
   return (
     <CalendarContainer
@@ -599,9 +599,9 @@ function BaseCalendar({
               }}
               aria-label="calendar-select-date"
               onMouseDown={(e) => {
-                e.preventDefault();
+                e.preventDefault()
                 if (!calendarState.open) {
-                  handleClickMode("open");
+                  handleClickMode("open")
                 }
               }}
             >
@@ -635,7 +635,7 @@ function BaseCalendar({
                 onChange={(value: string[]) => {
                   onChangeValueDate({
                     target: { name: "month", value },
-                  });
+                  })
                 }}
               />
               <Combobox
@@ -651,7 +651,7 @@ function BaseCalendar({
                 onChange={(value: string[]) => {
                   onChangeValueDate({
                     target: { name: "year", value },
-                  });
+                  })
                 }}
               />
             </div>
@@ -786,113 +786,112 @@ function BaseCalendar({
               <li key={`empty-${i}`} />
             ))}
           {dates.map((date, i) => {
-            const idx = i + emptyCellsCount + 1;
-            const isHighlighted = idx === highlightedIndexChange;
+            const idx = i + emptyCellsCount + 1
+            const isHighlighted = idx === highlightedIndexChange
 
-            let isCurrentDate: boolean;
-            let isDisabled: boolean;
-            let isRangeStart: boolean;
-            let isRangeEnd: boolean;
-            let isInRange: boolean;
-            let isHighlightedPicked: boolean;
-            let isSameDate: boolean;
+            let isCurrentDate: boolean
+            let isDisabled: boolean
+            let isRangeStart: boolean
+            let isRangeEnd: boolean
+            let isInRange: boolean
+            let isHighlightedPicked: boolean
+            let isSameDate: boolean
 
             if (selectabilityMode === "ranged") {
               if (startPicked.picked) {
-                const selectedDate = SELECTED_DATES[0];
-                isDisabled = date.getTime() < selectedDate.getTime();
+                const selectedDate = SELECTED_DATES[0]
+                isDisabled = date.getTime() < selectedDate.getTime()
 
-                isRangeStart = date.getTime() === selectedDate.getTime();
+                isRangeStart = date.getTime() === selectedDate.getTime()
                 isHighlightedPicked =
                   date.getTime() >= selectedDate.getTime() &&
-                  date.getTime() <= startPicked?.indexPicked?.getTime();
+                  date.getTime() <= startPicked?.indexPicked?.getTime()
                 isSameDate =
-                  selectedDate.getTime() ===
-                  startPicked?.indexPicked?.getTime();
+                  selectedDate.getTime() === startPicked?.indexPicked?.getTime()
               }
 
               if (SELECTED_DATES.length === 2 && !startPicked.picked) {
-                const [startDate, endDate] = SELECTED_DATES;
+                const [startDate, endDate] = SELECTED_DATES
                 isCurrentDate =
                   date.getTime() >= startDate.getTime() &&
-                  date.getTime() <= endDate.getTime();
-                isRangeStart = date.getTime() === startDate.getTime();
-                isRangeEnd = date.getTime() === endDate.getTime();
+                  date.getTime() <= endDate.getTime()
+                isRangeStart = date.getTime() === startDate.getTime()
+                isRangeEnd = date.getTime() === endDate.getTime()
                 isInRange =
                   date.getTime() > startDate.getTime() &&
-                  date.getTime() < endDate.getTime();
+                  date.getTime() < endDate.getTime()
 
-                isSameDate = startDate.getTime() === endDate.getTime();
+                isSameDate = startDate.getTime() === endDate.getTime()
 
-                isCurrentDate = isRangeStart || isRangeEnd || isInRange;
+                isCurrentDate = isRangeStart || isRangeEnd || isInRange
               } else {
                 isCurrentDate = SELECTED_DATES.some(
                   (selected) =>
                     date.getDate() === selected.getDate() &&
                     date.getMonth() === selected.getMonth() &&
-                    date.getFullYear() === selected.getFullYear()
-                );
+                    date.getFullYear() === selected.getFullYear(),
+                )
               }
             } else if (selectabilityMode === "multiple") {
               isCurrentDate = SELECTED_DATES.some(
                 (selected) =>
                   date.getDate() === selected.getDate() &&
                   date.getMonth() === selected.getMonth() &&
-                  date.getFullYear() === selected.getFullYear()
-              );
+                  date.getFullYear() === selected.getFullYear(),
+              )
             } else {
               const selectedDate = selectedDatesLocal
                 ? new Date(selectedDatesLocal)
-                : new Date();
+                : new Date()
 
               if (disableWeekend && !selectedDatesLocal) {
-                const day = selectedDate.getDay();
+                const day = selectedDate.getDay()
                 if (day === 6) {
-                  selectedDate.setDate(selectedDate.getDate() - 1);
+                  selectedDate.setDate(selectedDate.getDate() - 1)
                 } else if (day === 0) {
-                  selectedDate.setDate(selectedDate.getDate() + 1);
+                  selectedDate.setDate(selectedDate.getDate() + 1)
                 }
               }
 
               isCurrentDate =
                 date.getDate() === selectedDate.getDate() &&
                 date.getMonth() === selectedDate.getMonth() &&
-                date.getFullYear() === selectedDate.getFullYear();
+                date.getFullYear() === selectedDate.getFullYear()
             }
 
             const isToday =
               date.getDate() === today.getDate() &&
               date.getMonth() === today.getMonth() &&
-              date.getFullYear() === today.getFullYear();
+              date.getFullYear() === today.getFullYear()
 
-            const isDateWeekend = isWeekend(date);
+            const isDateWeekend = isWeekend(date)
 
             return (
               <DateCellWrapper
                 key={date.toISOString()}
                 ref={(el) => {
                   if (listRef?.current) {
-                    listRef.current[idx] = el;
+                    listRef.current[idx] = el
                   }
                 }}
                 role="option"
                 aria-selected={isHighlighted}
                 id={`option-${idx}`}
                 onMouseDown={async (e) => {
-                  e.preventDefault();
+                  e.preventDefault()
 
                   if ((isDateWeekend && disableWeekend) || isDisabled) {
-                    return;
+                    return
                   }
 
-                  await handleSelect(date, e);
+                  await handleSelect(date, e)
                   if (onClick) {
-                    await onClick();
+                    await onClick()
                   }
                 }}
                 onMouseEnter={() => {
-                  setHighlightedIndexChange(idx);
-                  setStartPicked((prev) => ({ ...prev, indexPicked: date }));
+                  setHighlightedIndexChange(idx)
+                  setStartPicked((prev) => ({ ...prev, indexPicked: date }))
                 }}
                 tabIndex={isHighlighted ? 0 : -1}
                 $isHighlighted={isHighlighted}
@@ -971,21 +970,21 @@ function BaseCalendar({
                   )}
                 </DateCell>
               </DateCellWrapper>
-            );
+            )
           })}
         </GridDate>
       </>
       <>{footer}</>
     </CalendarContainer>
-  );
+  )
 }
 
-export type CalendarStyles = BaseCalendarStyles & FieldLaneStyles;
+export type CalendarStyles = BaseCalendarStyles & FieldLaneStyles
 
 export interface CalendarProps
   extends Omit<BaseCalendarProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: CalendarStyles;
+  styles?: CalendarStyles
 }
 
 function Calendar({
@@ -1005,15 +1004,18 @@ function Calendar({
     prefix: "calendar",
     name,
     id,
-  });
+  })
 
   const {
     bodyStyle,
     controlStyle,
     containerStyle,
     labelStyle,
+    helperDrawerStyle,
+    helperIconStyle,
+    helperArrowStyle,
     ...baseCalendartyles
-  } = styles ?? {};
+  } = styles ?? {}
 
   return (
     <FieldLane
@@ -1031,15 +1033,18 @@ function Calendar({
         controlStyle,
         containerStyle,
         labelStyle,
+        helperDrawerStyle,
+        helperIconStyle,
+        helperArrowStyle,
       }}
     >
       <BaseCalendar {...rest} id={inputId} styles={baseCalendartyles} />
     </FieldLane>
-  );
+  )
 }
 
 const CalendarContainer = styled.div<{
-  $style?: CSSProp;
+  $style?: CSSProp
 }>`
   *,
   ::before,
@@ -1048,7 +1053,7 @@ const CalendarContainer = styled.div<{
   }
 
   ${({ $style }) => $style}
-`;
+`
 
 const CalendarHeader = styled.div`
   display: flex;
@@ -1061,7 +1066,7 @@ const CalendarHeader = styled.div`
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   gap: 0.5rem;
-`;
+`
 
 const GridDay = styled.div<{ $theme?: CalendarThemeConfig }>`
   display: grid;
@@ -1074,7 +1079,7 @@ const GridDay = styled.div<{ $theme?: CalendarThemeConfig }>`
   pointer-events: none;
 
   color: ${({ $theme }) => $theme?.dayTextColor || "#6b7280"};
-`;
+`
 
 const GridDate = styled.div`
   display: grid;
@@ -1084,12 +1089,12 @@ const GridDate = styled.div`
   width: 100%;
   overflow: hidden;
   text-align: center;
-`;
+`
 
 const DateCellWrapper = styled.li<{
-  $isHighlighted: boolean;
-  $isDisabled: boolean;
-  $isWeekend?: boolean;
+  $isHighlighted: boolean
+  $isDisabled: boolean
+  $isWeekend?: boolean
 }>`
   display: flex;
   align-self: center;
@@ -1104,19 +1109,19 @@ const DateCellWrapper = styled.li<{
     css`
       cursor: pointer;
     `}
-`;
+`
 
 export const DateCell = styled.span<{
-  $style?: CSSProp;
-  $isDisabled?: boolean;
-  $isWeekend?: boolean;
-  $disableWeekend?: boolean;
-  $isHighlighted?: boolean;
-  $isCurrentDate?: boolean;
-  $isToday?: boolean;
-  $isInRange?: boolean;
-  $isPickingProcess?: boolean;
-  $theme: CalendarThemeConfig;
+  $style?: CSSProp
+  $isDisabled?: boolean
+  $isWeekend?: boolean
+  $disableWeekend?: boolean
+  $isHighlighted?: boolean
+  $isCurrentDate?: boolean
+  $isToday?: boolean
+  $isInRange?: boolean
+  $isPickingProcess?: boolean
+  $theme: CalendarThemeConfig
 }>`
   width: 27px;
   height: 27px;
@@ -1200,22 +1205,22 @@ export const DateCell = styled.span<{
       return css`
         color: ${$theme?.hightlightDateColor || "#61a9f9"};
         background-color: transparent;
-      `;
+      `
     }
     if ($isToday && $isHighlighted && $isCurrentDate) {
       return css`
         color: ${$theme?.highlightedDateTextColor || "white"};
-      `;
+      `
     }
     if ($isToday && $isHighlighted && !$isWeekend) {
       return css`
         color: ${$theme?.hightlightDateColor || "#61a9f9"};
-      `;
+      `
     }
     if ($isToday && !$isCurrentDate && $isPickingProcess && $isDisabled) {
       return css`
         color: ${$theme?.disabledDateColor || "#d1d5db"};
-      `;
+      `
     }
     if (
       $isHighlighted &&
@@ -1226,15 +1231,15 @@ export const DateCell = styled.span<{
       return css`
         color: ${$theme?.disabledDateColor || "#d1d5db"};
         background-color: transparent;
-      `;
+      `
     }
 
     if ($isToday && !$isCurrentDate && !$disableWeekend) {
       return css`
         color: ${$theme?.hightlightDateColor || "#61a9f9"};
-      `;
+      `
     }
-    return null;
+    return null
   }};
 
   ${({ $isInRange, $disableWeekend, $isWeekend, $theme }) =>
@@ -1251,17 +1256,17 @@ export const DateCell = styled.span<{
         : null};
 
   ${({ $style }) => $style}
-`;
+`
 
 const DataCellRange = styled.span<{
-  $isInRange?: boolean;
-  $isRangeStart?: boolean;
-  $isRangeEnd?: boolean;
-  $isSameDate?: boolean;
-  $isPickingProcess?: boolean;
-  $disableWeekend?: boolean;
-  $isCurrentDate?: boolean;
-  $theme?: CalendarThemeConfig;
+  $isInRange?: boolean
+  $isRangeStart?: boolean
+  $isRangeEnd?: boolean
+  $isSameDate?: boolean
+  $isPickingProcess?: boolean
+  $disableWeekend?: boolean
+  $isCurrentDate?: boolean
+  $theme?: CalendarThemeConfig
 }>`
   position: absolute;
   width: 45px;
@@ -1297,16 +1302,16 @@ const DataCellRange = styled.span<{
       width: ${!$isPickingProcess && $isSameDate ? "0px" : "25px"};
       transform: translateX(-10%) translateY(-50%);
     `};
-`;
+`
 
 const DateCellTodayDot = styled.div<{
-  $isToday?: boolean;
-  $isDisabled?: boolean;
-  $isPickingProcess?: boolean;
-  $disableWeekend?: boolean;
-  $isWeekend?: boolean;
-  $isCurrentDate?: boolean;
-  $theme: CalendarThemeConfig;
+  $isToday?: boolean
+  $isDisabled?: boolean
+  $isPickingProcess?: boolean
+  $disableWeekend?: boolean
+  $isWeekend?: boolean
+  $isCurrentDate?: boolean
+  $theme: CalendarThemeConfig
 }>`
   position: absolute;
   bottom: 1px;
@@ -1339,22 +1344,22 @@ const DateCellTodayDot = styled.div<{
           background-color: ${$theme?.disabledDateColor || "#d1d5db"};
           border-color: ${$theme?.disabledDateColor || "#d1d5db"};
         `}
-`;
+`
 
 function formatDate(date: Date, format: CalendarFormat) {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
 
   switch (format) {
     case "yyyy/mm/dd":
-      return `${year}/${month}/${day}`;
+      return `${year}/${month}/${day}`
     case "dd/mm/yyyy":
-      return `${day}/${month}/${year}`;
+      return `${day}/${month}/${year}`
     case "mm/dd/yyyy":
     default:
-      return `${month}/${day}/${year}`;
+      return `${month}/${day}/${year}`
   }
 }
 
-export { Calendar };
+export { Calendar }

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -2,91 +2,91 @@ import {
   RiArrowLeftSLine,
   RiArrowRightSLine,
   RiCheckLine,
-} from "@remixicon/react"
-import { Fragment, useMemo, ReactNode } from "react"
-import React, { useState, useEffect } from "react"
-import { Button } from "./button"
-import { Combobox } from "./combobox"
-import { DrawerProps, SelectboxOption } from "./selectbox"
-import styled, { css, CSSProp } from "styled-components"
+} from "@remixicon/react";
+import { Fragment, useMemo, ReactNode } from "react";
+import React, { useState, useEffect } from "react";
+import { Button } from "./button";
+import { Combobox } from "./combobox";
+import { DrawerProps, SelectboxOption } from "./selectbox";
+import styled, { css, CSSProp } from "styled-components";
 import {
   getValidMultipleDate,
   isValidDateString,
   isWeekend,
   removeWeekend,
-} from "../lib/date"
-import { StatefulForm } from "./stateful-form"
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
-import { useTheme } from "./../theme/provider"
-import { CalendarThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
+} from "../lib/date";
+import { StatefulForm } from "./stateful-form";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
+import { useTheme } from "./../theme/provider";
+import { CalendarThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 
 export interface BaseCalendarProps extends Partial<DrawerProps> {
-  options?: CalendarOption[]
-  selectedDates?: string[]
-  onChange?: (dates: string[]) => void
-  dayNames?: CalendarOption[]
-  monthNames?: CalendarOption[]
-  disableWeekend?: boolean
-  format?: CalendarFormat
-  yearPastReach?: number
-  futurePastReach?: number
-  onClick?: () => void
-  onCalendarPeriodChanged?: (date: Date) => void
-  styles?: BaseCalendarStyles
-  footer?: ReactNode
-  todayButtonCaption?: string
-  selectabilityMode?: CalendarSelectabilityMode
-  id?: string
-  name?: string
+  options?: CalendarOption[];
+  selectedDates?: string[];
+  onChange?: (dates: string[]) => void;
+  dayNames?: CalendarOption[];
+  monthNames?: CalendarOption[];
+  disableWeekend?: boolean;
+  format?: CalendarFormat;
+  yearPastReach?: number;
+  futurePastReach?: number;
+  onClick?: () => void;
+  onCalendarPeriodChanged?: (date: Date) => void;
+  styles?: BaseCalendarStyles;
+  footer?: ReactNode;
+  todayButtonCaption?: string;
+  selectabilityMode?: CalendarSelectabilityMode;
+  id?: string;
+  name?: string;
 }
 
-export type CalendarOption = SelectboxOption
+export type CalendarOption = SelectboxOption;
 
 export interface BaseCalendarStyles {
-  self?: CSSProp
-  containerStyle?: CSSProp
-  labelStyle?: CSSProp
+  self?: CSSProp;
+  containerStyle?: CSSProp;
+  labelStyle?: CSSProp;
 }
 
 interface CalendarState {
-  open: boolean
-  month: string[]
-  year: string[]
+  open: boolean;
+  month: string[];
+  year: string[];
 }
 
 type CustomChangeEvent = {
   target: {
-    name: string
-    value: string[]
-  }
-}
+    name: string;
+    value: string[];
+  };
+};
 
 export const CalendarFormat = {
   MM_DD_YYYY: "mm/dd/yyyy",
   YYYY_MM_DD: "yyyy/mm/dd",
   DD_MM_YYYY: "dd/mm/yyyy",
-} as const
+} as const;
 
 export type CalendarFormat =
-  (typeof CalendarFormat)[keyof typeof CalendarFormat]
+  (typeof CalendarFormat)[keyof typeof CalendarFormat];
 
 const DateBoxOpen = {
   Open: "open",
   Month: "month",
   Year: "year",
-} as const
+} as const;
 
-type DateBoxOpen = (typeof DateBoxOpen)[keyof typeof DateBoxOpen]
+type DateBoxOpen = (typeof DateBoxOpen)[keyof typeof DateBoxOpen];
 
 export const CalendarSelectabilityMode = {
   Single: "single",
   Multiple: "multiple",
   Ranged: "ranged",
-} as const
+} as const;
 
 export type CalendarSelectabilityMode =
-  (typeof CalendarSelectabilityMode)[keyof typeof CalendarSelectabilityMode]
+  (typeof CalendarSelectabilityMode)[keyof typeof CalendarSelectabilityMode];
 
 const DEFAULT_DAY_NAMES = [
   { text: "Su", value: "1" },
@@ -96,7 +96,7 @@ const DEFAULT_DAY_NAMES = [
   { text: "Th", value: "5" },
   { text: "Fr", value: "6" },
   { text: "Sa", value: "7" },
-]
+];
 
 const DEFAULT_MONTH_NAMES = [
   { text: "January", value: "1" },
@@ -111,7 +111,7 @@ const DEFAULT_MONTH_NAMES = [
   { text: "October", value: "10" },
   { text: "November", value: "11" },
   { text: "December", value: "12" },
-]
+];
 
 function BaseCalendar({
   highlightedIndex,
@@ -134,386 +134,386 @@ function BaseCalendar({
   onCalendarPeriodChanged,
   selectabilityMode = "single",
 }: BaseCalendarProps) {
-  const { currentTheme } = useTheme()
-  const calendarTheme = currentTheme?.calendar
+  const { currentTheme } = useTheme();
+  const calendarTheme = currentTheme?.calendar;
 
-  const today = new Date()
+  const today = new Date();
   const currentMonth = monthNames.find(
-    (data) => Number(data.value) === today.getMonth() + 1,
-  )
-  const currentYear = today.getFullYear()
+    (data) => Number(data.value) === today.getMonth() + 1
+  );
+  const currentYear = today.getFullYear();
 
   const initialValueState = () => {
-    const raw = selectedDates?.[0]
+    const raw = selectedDates?.[0];
     if (selectabilityMode === "ranged") {
       if (disableWeekend) {
         if (raw?.split("-")) {
-          return isWeekend(today) ? "" : formatDate(today, format)
+          return isWeekend(today) ? "" : formatDate(today, format);
         }
 
-        const value = raw?.split(", ") ?? []
-        const firstValue = value[0]
-        const latestValue = value[value.length - 1]
+        const value = raw?.split(", ") ?? [];
+        const firstValue = value[0];
+        const latestValue = value[value.length - 1];
 
-        return `${firstValue}-${latestValue}`
+        return `${firstValue}-${latestValue}`;
       }
 
-      return isValidDateString(raw) ? raw : ""
+      return isValidDateString(raw) ? raw : "";
     }
 
     if (selectabilityMode === "multiple") {
-      let validDates = getValidMultipleDate(raw)
+      let validDates = getValidMultipleDate(raw);
 
       if (disableWeekend) {
-        validDates = removeWeekend(validDates)
+        validDates = removeWeekend(validDates);
       }
 
-      return validDates.length > 0 ? validDates.join(", ") : ""
+      return validDates.length > 0 ? validDates.join(", ") : "";
     }
 
-    return isValidDateString(raw) ? raw : formatDate(today, format)
-  }
+    return isValidDateString(raw) ? raw : formatDate(today, format);
+  };
 
-  const normalized = initialValueState()
+  const normalized = initialValueState();
 
   const stateDate = useMemo(() => {
-    if (!normalized) return new Date()
+    if (!normalized) return new Date();
 
     const firstStr = normalized.includes(",")
       ? normalized.split(",")[0].trim()
       : normalized.includes("-")
         ? normalized.split("-")[0].trim()
-        : normalized.trim()
+        : normalized.trim();
 
-    const d = new Date(firstStr)
-    return isNaN(d.getTime()) ? new Date() : d
-  }, [normalized])
+    const d = new Date(firstStr);
+    return isNaN(d.getTime()) ? new Date() : d;
+  }, [normalized]);
 
-  const [currentDate, setCurrentDate] = useState(stateDate)
+  const [currentDate, setCurrentDate] = useState(stateDate);
 
   const [calendarState, setCalendarState] = useState<CalendarState>({
     open: false,
     month: [String(stateDate.getMonth() + 1)],
     year: [String(stateDate.getFullYear())],
-  })
+  });
 
   const [selectedDatesLocal, setSelectedDatesLocal] =
-    useState(initialValueState())
+    useState(initialValueState());
 
   const [startPicked, setStartPicked] = useState<{
-    picked: boolean
-    indexPicked: Date | null
-  }>({ picked: false, indexPicked: null })
+    picked: boolean;
+    indexPicked: Date | null;
+  }>({ picked: false, indexPicked: null });
 
-  const [highlightedIndexInternal, setHighlightedIndexInternal] = useState(0)
-  const highlightedIndexChange = highlightedIndex ?? highlightedIndexInternal
+  const [highlightedIndexInternal, setHighlightedIndexInternal] = useState(0);
+  const highlightedIndexChange = highlightedIndex ?? highlightedIndexInternal;
 
   const setHighlightedIndexChange = (index: number) => {
     if (setHighlightedIndex) {
-      setHighlightedIndex(index)
+      setHighlightedIndex(index);
     } else {
-      setHighlightedIndexInternal(index)
+      setHighlightedIndexInternal(index);
     }
-  }
+  };
 
   if (listRef && !listRef.current) {
-    listRef.current = []
+    listRef.current = [];
   }
 
   const onChangeValueDate = (e: CustomChangeEvent) => {
-    const { name, value } = e.target
-    handleChangeValueDate(name, value)
-  }
+    const { name, value } = e.target;
+    handleChangeValueDate(name, value);
+  };
 
   const handleChangeValueDate = (name: string, value: string[]) => {
-    setCalendarState((prev) => ({ ...prev, [name]: value }))
+    setCalendarState((prev) => ({ ...prev, [name]: value }));
 
     if (name === "month") {
-      const monthIndex = Number(value[0]) - 1
-      const dateMonth = new Date(currentDate.getFullYear(), monthIndex, 1)
-      setCurrentDate(dateMonth)
+      const monthIndex = Number(value[0]) - 1;
+      const dateMonth = new Date(currentDate.getFullYear(), monthIndex, 1);
+      setCurrentDate(dateMonth);
       if (onCalendarPeriodChanged) {
-        onCalendarPeriodChanged(dateMonth)
+        onCalendarPeriodChanged(dateMonth);
       }
     } else if (name === "year") {
-      const yearNumber = Number(value[0])
+      const yearNumber = Number(value[0]);
       if (!isNaN(yearNumber)) {
-        const month = currentDate.getMonth()
+        const month = currentDate.getMonth();
         const day = Math.min(
           currentDate.getDate(),
-          new Date(yearNumber, month + 1, 0).getDate(),
-        )
-        const dateYear = new Date(yearNumber, month, day)
-        setCurrentDate(dateYear)
+          new Date(yearNumber, month + 1, 0).getDate()
+        );
+        const dateYear = new Date(yearNumber, month, day);
+        setCurrentDate(dateYear);
         if (onCalendarPeriodChanged) {
-          onCalendarPeriodChanged(dateYear)
+          onCalendarPeriodChanged(dateYear);
         }
       }
     }
-  }
+  };
 
   const dates = useMemo(() => {
-    const year = currentDate.getFullYear()
-    const month = currentDate.getMonth()
-    const lastDate = new Date(year, month + 1, 0).getDate()
-    const arr: Date[] = []
-    for (let i = 1; i <= lastDate; i++) arr.push(new Date(year, month, i))
-    return arr
-  }, [currentDate])
+    const year = currentDate.getFullYear();
+    const month = currentDate.getMonth();
+    const lastDate = new Date(year, month + 1, 0).getDate();
+    const arr: Date[] = [];
+    for (let i = 1; i <= lastDate; i++) arr.push(new Date(year, month, i));
+    return arr;
+  }, [currentDate]);
 
   const { yearOptions } = useMemo(() => {
-    const t = new Date()
+    const t = new Date();
     const min = new Date(
       t.getFullYear() - (yearPastReach ?? 80),
       t.getMonth(),
-      t.getDate(),
-    )
+      t.getDate()
+    );
     const max = new Date(
       t.getFullYear() + (futurePastReach ?? 50),
       t.getMonth(),
-      t.getDate(),
-    )
+      t.getDate()
+    );
     const years = Array.from(
       { length: max.getFullYear() - min.getFullYear() + 1 },
       (_, i) => ({
         text: String(min.getFullYear() + i),
         value: String(min.getFullYear() + i),
-      }),
-    )
-    return { yearOptions: years }
-  }, [yearPastReach, futurePastReach])
+      })
+    );
+    return { yearOptions: years };
+  }, [yearPastReach, futurePastReach]);
 
   const prevMonth = useMemo(
     () => new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1),
-    [currentDate],
-  )
+    [currentDate]
+  );
 
   const nextMonth = useMemo(
     () => new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 1),
-    [currentDate],
-  )
+    [currentDate]
+  );
 
   const handleClickPrevMonth = (e: React.MouseEvent) => {
-    e.preventDefault()
+    e.preventDefault();
 
     if (onCalendarPeriodChanged) {
-      onCalendarPeriodChanged(prevMonth)
+      onCalendarPeriodChanged(prevMonth);
     }
-    setCurrentDate(prevMonth)
-    setHighlightedIndexChange(0)
+    setCurrentDate(prevMonth);
+    setHighlightedIndexChange(0);
     setCalendarState((prev) => ({
       ...prev,
       month: [String(prevMonth.getMonth() + 1)],
       year: [prevMonth.getFullYear().toString()],
-    }))
-  }
+    }));
+  };
 
   const handleClickNextMonth = (e: React.MouseEvent) => {
-    e.preventDefault()
+    e.preventDefault();
 
-    setCurrentDate(nextMonth)
+    setCurrentDate(nextMonth);
     if (onCalendarPeriodChanged) {
-      onCalendarPeriodChanged(nextMonth)
+      onCalendarPeriodChanged(nextMonth);
     }
-    setHighlightedIndexChange(0)
+    setHighlightedIndexChange(0);
     setCalendarState((prev) => ({
       ...prev,
       month: [String(nextMonth.getMonth() + 1)],
       year: [String(nextMonth.getFullYear())],
-    }))
-  }
+    }));
+  };
 
   const handleMoveToToday = () => {
     if (onCalendarPeriodChanged) {
-      onCalendarPeriodChanged(today)
+      onCalendarPeriodChanged(today);
     }
-    setCurrentDate(today)
+    setCurrentDate(today);
     if (onChange) {
-      onChange([formatDate(today, format)])
+      onChange([formatDate(today, format)]);
     }
 
-    setHighlightedIndexChange(0)
+    setHighlightedIndexChange(0);
     setCalendarState((prev) => ({
       ...prev,
       month: [String(currentMonth)],
       year: [String(currentYear)],
-    }))
-  }
+    }));
+  };
 
   const handleSelect = async (date: Date, e?: React.MouseEvent) => {
-    const formattedData = formatDate(date, format)
-    let newValues: string[]
+    const formattedData = formatDate(date, format);
+    let newValues: string[];
 
     if (selectabilityMode === "multiple") {
       await setSelectedDatesLocal((prev) => {
-        const values = prev ? prev.split(", ") : []
+        const values = prev ? prev.split(", ") : [];
 
         if (e?.shiftKey && values.length > 0) {
-          const lastDate = new Date(values[values.length - 1])
-          const start = lastDate.getTime() < date.getTime() ? lastDate : date
-          const end = lastDate.getTime() > date.getTime() ? lastDate : date
+          const lastDate = new Date(values[values.length - 1]);
+          const start = lastDate.getTime() < date.getTime() ? lastDate : date;
+          const end = lastDate.getTime() > date.getTime() ? lastDate : date;
 
-          const range: string[] = []
-          let cursor = new Date(start)
+          const range: string[] = [];
+          let cursor = new Date(start);
 
           while (cursor.getTime() <= end.getTime()) {
             if (!disableWeekend || !isWeekend(cursor)) {
-              range.push(formatDate(new Date(cursor), format))
+              range.push(formatDate(new Date(cursor), format));
             }
-            cursor.setDate(cursor.getDate() + 1)
+            cursor.setDate(cursor.getDate() + 1);
           }
 
-          const unique = new Set([...values, ...range])
+          const unique = new Set([...values, ...range]);
           newValues = Array.from(unique).sort(
-            (a, b) => new Date(a).getTime() - new Date(b).getTime(),
-          )
+            (a, b) => new Date(a).getTime() - new Date(b).getTime()
+          );
         } else {
           if (values.includes(formattedData)) {
-            newValues = values.filter((value) => value !== formattedData)
+            newValues = values.filter((value) => value !== formattedData);
           } else {
-            newValues = [...values, formattedData]
+            newValues = [...values, formattedData];
           }
 
           newValues = newValues.sort(
-            (a, b) => new Date(a).getTime() - new Date(b).getTime(),
-          )
+            (a, b) => new Date(a).getTime() - new Date(b).getTime()
+          );
         }
 
-        const finalValues = newValues.join(", ")
+        const finalValues = newValues.join(", ");
         if (onChange) {
-          onChange([finalValues])
+          onChange([finalValues]);
         }
 
-        return finalValues
-      })
+        return finalValues;
+      });
     } else if (selectabilityMode === "ranged") {
       await setSelectedDatesLocal((prev) => {
-        const values = prev ? prev.split("-") : []
+        const values = prev ? prev.split("-") : [];
         if (!startPicked.picked) {
-          newValues = [formattedData]
-          setStartPicked((prev) => ({ ...prev, picked: true }))
+          newValues = [formattedData];
+          setStartPicked((prev) => ({ ...prev, picked: true }));
         } else {
           if (values.includes(formattedData)) {
             if (disableWeekend) {
-              newValues = [...new Set([...values, formattedData])]
+              newValues = [...new Set([...values, formattedData])];
             } else {
-              newValues = [formattedData, formattedData]
+              newValues = [formattedData, formattedData];
             }
           } else {
             if (disableWeekend) {
-              const startDate = new Date(values[0])
-              const endDate = date
+              const startDate = new Date(values[0]);
+              const endDate = date;
               const start =
-                startDate.getTime() < endDate.getTime() ? startDate : endDate
+                startDate.getTime() < endDate.getTime() ? startDate : endDate;
               const end =
-                startDate.getTime() > endDate.getTime() ? startDate : endDate
+                startDate.getTime() > endDate.getTime() ? startDate : endDate;
 
-              const rangeValues: string[] = []
-              let cursor = new Date(start)
+              const rangeValues: string[] = [];
+              let cursor = new Date(start);
 
               while (cursor.getTime() <= end.getTime()) {
                 if (!disableWeekend || !isWeekend(cursor)) {
-                  rangeValues.push(formatDate(new Date(cursor), format))
+                  rangeValues.push(formatDate(new Date(cursor), format));
                 }
-                cursor.setDate(cursor.getDate() + 1)
+                cursor.setDate(cursor.getDate() + 1);
               }
 
-              newValues = rangeValues
+              newValues = rangeValues;
             } else {
-              newValues = [...new Set([...values, formattedData])]
+              newValues = [...new Set([...values, formattedData])];
             }
           }
-          setStartPicked({ picked: false, indexPicked: null })
+          setStartPicked({ picked: false, indexPicked: null });
         }
 
         newValues = newValues.sort((a, b) => {
-          const dateA = new Date(a)
-          const dateB = new Date(b)
-          return dateA.getTime() - dateB.getTime()
-        })
+          const dateA = new Date(a);
+          const dateB = new Date(b);
+          return dateA.getTime() - dateB.getTime();
+        });
 
         const finalValues = disableWeekend
           ? newValues.join(", ")
-          : newValues.join("-")
+          : newValues.join("-");
 
-        const firstValueLocal = newValues[0]
+        const firstValueLocal = newValues[0];
         const latestValueLocal = newValues[newValues.length - 1]
           ? `-${newValues[newValues.length - 1]}`
-          : ""
+          : "";
 
-        const newValuesLocal = `${firstValueLocal}${latestValueLocal}`
+        const newValuesLocal = `${firstValueLocal}${latestValueLocal}`;
 
         if (onChange) {
-          onChange([finalValues])
+          onChange([finalValues]);
         }
 
-        return newValuesLocal
-      })
+        return newValuesLocal;
+      });
     }
 
     if (selectabilityMode === "single") {
       if (onChange) {
-        await onChange([formatDate(date, format)])
+        await onChange([formatDate(date, format)]);
       }
-      await setSelectedDatesLocal(formatDate(date, format))
+      await setSelectedDatesLocal(formatDate(date, format));
     }
 
     if (setIsOpen && selectabilityMode !== "single") {
-      await setIsOpen(true)
+      await setIsOpen(true);
     } else if (setIsOpen) {
-      await setIsOpen(false)
+      await setIsOpen(false);
     }
-  }
+  };
 
   const emptyCellsCount = new Date(
     currentDate.getFullYear(),
     currentDate.getMonth(),
-    1,
-  ).getDay()
+    1
+  ).getDay();
 
   const handleClickMode = (data: DateBoxOpen) => {
     if (data === "open") {
       setCalendarState((prev) => ({
         ...prev,
         open: !calendarState.open,
-      }))
+      }));
     }
-  }
+  };
 
   // for automaticly change when prop added disable weekend and today it's weekend
   useEffect(() => {
     if (selectedDates?.length > 0) {
-      const newDate = new Date(selectedDates[0])
+      const newDate = new Date(selectedDates[0]);
       if (!isNaN(newDate.getTime())) {
-        let validDate = newDate
+        let validDate = newDate;
 
         if (disableWeekend) {
-          const day = validDate.getDay()
+          const day = validDate.getDay();
           if (day === 6) {
-            validDate.setDate(validDate.getDate() - 1)
+            validDate.setDate(validDate.getDate() - 1);
           } else if (day === 0) {
-            validDate.setDate(validDate.getDate() + 1)
+            validDate.setDate(validDate.getDate() + 1);
           }
         }
 
         if (onCalendarPeriodChanged) {
-          onCalendarPeriodChanged(validDate)
+          onCalendarPeriodChanged(validDate);
         }
-        setCurrentDate(validDate)
+        setCurrentDate(validDate);
 
-        setSelectedDatesLocal(formatDate(validDate, format))
+        setSelectedDatesLocal(formatDate(validDate, format));
 
         if (selectedDates[0].length > 9) {
           if (onChange) {
-            onChange([formatDate(validDate, format)])
+            onChange([formatDate(validDate, format)]);
           }
         }
       }
     }
-  }, [selectedDates?.[0], format])
+  }, [selectedDates?.[0], format]);
 
   const SELECTED_DATES = useMemo(() => {
-    if (!selectedDatesLocal) return []
+    if (!selectedDatesLocal) return [];
 
     switch (selectabilityMode) {
       case "ranged":
@@ -521,30 +521,30 @@ function BaseCalendar({
           .split("-")
           .filter(Boolean)
           .map((dateStr) => {
-            const date = new Date(dateStr.trim())
-            return isNaN(date.getTime()) ? null : date
+            const date = new Date(dateStr.trim());
+            return isNaN(date.getTime()) ? null : date;
           })
-          .filter(Boolean)
+          .filter(Boolean);
 
       case "multiple":
         return selectedDatesLocal
           .split(", ")
           .filter(Boolean)
           .map((dateStr) => {
-            const date = new Date(dateStr.trim())
-            return isNaN(date.getTime()) ? null : date
+            const date = new Date(dateStr.trim());
+            return isNaN(date.getTime()) ? null : date;
           })
-          .filter(Boolean)
+          .filter(Boolean);
 
       case "single":
       default:
         if (selectedDatesLocal) {
-          const date = new Date(selectedDatesLocal)
-          return isNaN(date.getTime()) ? [] : [date]
+          const date = new Date(selectedDatesLocal);
+          return isNaN(date.getTime()) ? [] : [date];
         }
-        return []
+        return [];
     }
-  }, [selectedDatesLocal, selectabilityMode])
+  }, [selectedDatesLocal, selectabilityMode]);
 
   return (
     <CalendarContainer
@@ -599,9 +599,9 @@ function BaseCalendar({
               }}
               aria-label="calendar-select-date"
               onMouseDown={(e) => {
-                e.preventDefault()
+                e.preventDefault();
                 if (!calendarState.open) {
-                  handleClickMode("open")
+                  handleClickMode("open");
                 }
               }}
             >
@@ -635,7 +635,7 @@ function BaseCalendar({
                 onChange={(value: string[]) => {
                   onChangeValueDate({
                     target: { name: "month", value },
-                  })
+                  });
                 }}
               />
               <Combobox
@@ -651,7 +651,7 @@ function BaseCalendar({
                 onChange={(value: string[]) => {
                   onChangeValueDate({
                     target: { name: "year", value },
-                  })
+                  });
                 }}
               />
             </div>
@@ -786,112 +786,113 @@ function BaseCalendar({
               <li key={`empty-${i}`} />
             ))}
           {dates.map((date, i) => {
-            const idx = i + emptyCellsCount + 1
-            const isHighlighted = idx === highlightedIndexChange
+            const idx = i + emptyCellsCount + 1;
+            const isHighlighted = idx === highlightedIndexChange;
 
-            let isCurrentDate: boolean
-            let isDisabled: boolean
-            let isRangeStart: boolean
-            let isRangeEnd: boolean
-            let isInRange: boolean
-            let isHighlightedPicked: boolean
-            let isSameDate: boolean
+            let isCurrentDate: boolean;
+            let isDisabled: boolean;
+            let isRangeStart: boolean;
+            let isRangeEnd: boolean;
+            let isInRange: boolean;
+            let isHighlightedPicked: boolean;
+            let isSameDate: boolean;
 
             if (selectabilityMode === "ranged") {
               if (startPicked.picked) {
-                const selectedDate = SELECTED_DATES[0]
-                isDisabled = date.getTime() < selectedDate.getTime()
+                const selectedDate = SELECTED_DATES[0];
+                isDisabled = date.getTime() < selectedDate.getTime();
 
-                isRangeStart = date.getTime() === selectedDate.getTime()
+                isRangeStart = date.getTime() === selectedDate.getTime();
                 isHighlightedPicked =
                   date.getTime() >= selectedDate.getTime() &&
-                  date.getTime() <= startPicked?.indexPicked?.getTime()
+                  date.getTime() <= startPicked?.indexPicked?.getTime();
                 isSameDate =
-                  selectedDate.getTime() === startPicked?.indexPicked?.getTime()
+                  selectedDate.getTime() ===
+                  startPicked?.indexPicked?.getTime();
               }
 
               if (SELECTED_DATES.length === 2 && !startPicked.picked) {
-                const [startDate, endDate] = SELECTED_DATES
+                const [startDate, endDate] = SELECTED_DATES;
                 isCurrentDate =
                   date.getTime() >= startDate.getTime() &&
-                  date.getTime() <= endDate.getTime()
-                isRangeStart = date.getTime() === startDate.getTime()
-                isRangeEnd = date.getTime() === endDate.getTime()
+                  date.getTime() <= endDate.getTime();
+                isRangeStart = date.getTime() === startDate.getTime();
+                isRangeEnd = date.getTime() === endDate.getTime();
                 isInRange =
                   date.getTime() > startDate.getTime() &&
-                  date.getTime() < endDate.getTime()
+                  date.getTime() < endDate.getTime();
 
-                isSameDate = startDate.getTime() === endDate.getTime()
+                isSameDate = startDate.getTime() === endDate.getTime();
 
-                isCurrentDate = isRangeStart || isRangeEnd || isInRange
+                isCurrentDate = isRangeStart || isRangeEnd || isInRange;
               } else {
                 isCurrentDate = SELECTED_DATES.some(
                   (selected) =>
                     date.getDate() === selected.getDate() &&
                     date.getMonth() === selected.getMonth() &&
-                    date.getFullYear() === selected.getFullYear(),
-                )
+                    date.getFullYear() === selected.getFullYear()
+                );
               }
             } else if (selectabilityMode === "multiple") {
               isCurrentDate = SELECTED_DATES.some(
                 (selected) =>
                   date.getDate() === selected.getDate() &&
                   date.getMonth() === selected.getMonth() &&
-                  date.getFullYear() === selected.getFullYear(),
-              )
+                  date.getFullYear() === selected.getFullYear()
+              );
             } else {
               const selectedDate = selectedDatesLocal
                 ? new Date(selectedDatesLocal)
-                : new Date()
+                : new Date();
 
               if (disableWeekend && !selectedDatesLocal) {
-                const day = selectedDate.getDay()
+                const day = selectedDate.getDay();
                 if (day === 6) {
-                  selectedDate.setDate(selectedDate.getDate() - 1)
+                  selectedDate.setDate(selectedDate.getDate() - 1);
                 } else if (day === 0) {
-                  selectedDate.setDate(selectedDate.getDate() + 1)
+                  selectedDate.setDate(selectedDate.getDate() + 1);
                 }
               }
 
               isCurrentDate =
                 date.getDate() === selectedDate.getDate() &&
                 date.getMonth() === selectedDate.getMonth() &&
-                date.getFullYear() === selectedDate.getFullYear()
+                date.getFullYear() === selectedDate.getFullYear();
             }
 
             const isToday =
               date.getDate() === today.getDate() &&
               date.getMonth() === today.getMonth() &&
-              date.getFullYear() === today.getFullYear()
+              date.getFullYear() === today.getFullYear();
 
-            const isDateWeekend = isWeekend(date)
+            const isDateWeekend = isWeekend(date);
 
             return (
               <DateCellWrapper
                 key={date.toISOString()}
                 ref={(el) => {
                   if (listRef?.current) {
-                    listRef.current[idx] = el
+                    listRef.current[idx] = el;
                   }
                 }}
                 role="option"
                 aria-selected={isHighlighted}
                 id={`option-${idx}`}
                 onMouseDown={async (e) => {
-                  e.preventDefault()
+                  e.preventDefault();
 
                   if ((isDateWeekend && disableWeekend) || isDisabled) {
-                    return
+                    return;
                   }
 
-                  await handleSelect(date, e)
+                  await handleSelect(date, e);
                   if (onClick) {
-                    await onClick()
+                    await onClick();
                   }
                 }}
                 onMouseEnter={() => {
-                  setHighlightedIndexChange(idx)
-                  setStartPicked((prev) => ({ ...prev, indexPicked: date }))
+                  setHighlightedIndexChange(idx);
+                  setStartPicked((prev) => ({ ...prev, indexPicked: date }));
                 }}
                 tabIndex={isHighlighted ? 0 : -1}
                 $isHighlighted={isHighlighted}
@@ -970,21 +971,21 @@ function BaseCalendar({
                   )}
                 </DateCell>
               </DateCellWrapper>
-            )
+            );
           })}
         </GridDate>
       </>
       <>{footer}</>
     </CalendarContainer>
-  )
+  );
 }
 
-export type CalendarStyles = BaseCalendarStyles & FieldLaneStyles
+export type CalendarStyles = BaseCalendarStyles & FieldLaneStyles;
 
 export interface CalendarProps
   extends Omit<BaseCalendarProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: CalendarStyles
+  styles?: CalendarStyles;
 }
 
 function Calendar({
@@ -1004,7 +1005,7 @@ function Calendar({
     prefix: "calendar",
     name,
     id,
-  })
+  });
 
   const {
     bodyStyle,
@@ -1015,7 +1016,7 @@ function Calendar({
     helperIconStyle,
     helperArrowStyle,
     ...baseCalendartyles
-  } = styles ?? {}
+  } = styles ?? {};
 
   return (
     <FieldLane
@@ -1040,11 +1041,11 @@ function Calendar({
     >
       <BaseCalendar {...rest} id={inputId} styles={baseCalendartyles} />
     </FieldLane>
-  )
+  );
 }
 
 const CalendarContainer = styled.div<{
-  $style?: CSSProp
+  $style?: CSSProp;
 }>`
   *,
   ::before,
@@ -1053,7 +1054,7 @@ const CalendarContainer = styled.div<{
   }
 
   ${({ $style }) => $style}
-`
+`;
 
 const CalendarHeader = styled.div`
   display: flex;
@@ -1066,7 +1067,7 @@ const CalendarHeader = styled.div`
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   gap: 0.5rem;
-`
+`;
 
 const GridDay = styled.div<{ $theme?: CalendarThemeConfig }>`
   display: grid;
@@ -1079,7 +1080,7 @@ const GridDay = styled.div<{ $theme?: CalendarThemeConfig }>`
   pointer-events: none;
 
   color: ${({ $theme }) => $theme?.dayTextColor || "#6b7280"};
-`
+`;
 
 const GridDate = styled.div`
   display: grid;
@@ -1089,12 +1090,12 @@ const GridDate = styled.div`
   width: 100%;
   overflow: hidden;
   text-align: center;
-`
+`;
 
 const DateCellWrapper = styled.li<{
-  $isHighlighted: boolean
-  $isDisabled: boolean
-  $isWeekend?: boolean
+  $isHighlighted: boolean;
+  $isDisabled: boolean;
+  $isWeekend?: boolean;
 }>`
   display: flex;
   align-self: center;
@@ -1109,19 +1110,19 @@ const DateCellWrapper = styled.li<{
     css`
       cursor: pointer;
     `}
-`
+`;
 
 export const DateCell = styled.span<{
-  $style?: CSSProp
-  $isDisabled?: boolean
-  $isWeekend?: boolean
-  $disableWeekend?: boolean
-  $isHighlighted?: boolean
-  $isCurrentDate?: boolean
-  $isToday?: boolean
-  $isInRange?: boolean
-  $isPickingProcess?: boolean
-  $theme: CalendarThemeConfig
+  $style?: CSSProp;
+  $isDisabled?: boolean;
+  $isWeekend?: boolean;
+  $disableWeekend?: boolean;
+  $isHighlighted?: boolean;
+  $isCurrentDate?: boolean;
+  $isToday?: boolean;
+  $isInRange?: boolean;
+  $isPickingProcess?: boolean;
+  $theme: CalendarThemeConfig;
 }>`
   width: 27px;
   height: 27px;
@@ -1205,22 +1206,22 @@ export const DateCell = styled.span<{
       return css`
         color: ${$theme?.hightlightDateColor || "#61a9f9"};
         background-color: transparent;
-      `
+      `;
     }
     if ($isToday && $isHighlighted && $isCurrentDate) {
       return css`
         color: ${$theme?.highlightedDateTextColor || "white"};
-      `
+      `;
     }
     if ($isToday && $isHighlighted && !$isWeekend) {
       return css`
         color: ${$theme?.hightlightDateColor || "#61a9f9"};
-      `
+      `;
     }
     if ($isToday && !$isCurrentDate && $isPickingProcess && $isDisabled) {
       return css`
         color: ${$theme?.disabledDateColor || "#d1d5db"};
-      `
+      `;
     }
     if (
       $isHighlighted &&
@@ -1231,15 +1232,15 @@ export const DateCell = styled.span<{
       return css`
         color: ${$theme?.disabledDateColor || "#d1d5db"};
         background-color: transparent;
-      `
+      `;
     }
 
     if ($isToday && !$isCurrentDate && !$disableWeekend) {
       return css`
         color: ${$theme?.hightlightDateColor || "#61a9f9"};
-      `
+      `;
     }
-    return null
+    return null;
   }};
 
   ${({ $isInRange, $disableWeekend, $isWeekend, $theme }) =>
@@ -1256,17 +1257,17 @@ export const DateCell = styled.span<{
         : null};
 
   ${({ $style }) => $style}
-`
+`;
 
 const DataCellRange = styled.span<{
-  $isInRange?: boolean
-  $isRangeStart?: boolean
-  $isRangeEnd?: boolean
-  $isSameDate?: boolean
-  $isPickingProcess?: boolean
-  $disableWeekend?: boolean
-  $isCurrentDate?: boolean
-  $theme?: CalendarThemeConfig
+  $isInRange?: boolean;
+  $isRangeStart?: boolean;
+  $isRangeEnd?: boolean;
+  $isSameDate?: boolean;
+  $isPickingProcess?: boolean;
+  $disableWeekend?: boolean;
+  $isCurrentDate?: boolean;
+  $theme?: CalendarThemeConfig;
 }>`
   position: absolute;
   width: 45px;
@@ -1302,16 +1303,16 @@ const DataCellRange = styled.span<{
       width: ${!$isPickingProcess && $isSameDate ? "0px" : "25px"};
       transform: translateX(-10%) translateY(-50%);
     `};
-`
+`;
 
 const DateCellTodayDot = styled.div<{
-  $isToday?: boolean
-  $isDisabled?: boolean
-  $isPickingProcess?: boolean
-  $disableWeekend?: boolean
-  $isWeekend?: boolean
-  $isCurrentDate?: boolean
-  $theme: CalendarThemeConfig
+  $isToday?: boolean;
+  $isDisabled?: boolean;
+  $isPickingProcess?: boolean;
+  $disableWeekend?: boolean;
+  $isWeekend?: boolean;
+  $isCurrentDate?: boolean;
+  $theme: CalendarThemeConfig;
 }>`
   position: absolute;
   bottom: 1px;
@@ -1344,22 +1345,22 @@ const DateCellTodayDot = styled.div<{
           background-color: ${$theme?.disabledDateColor || "#d1d5db"};
           border-color: ${$theme?.disabledDateColor || "#d1d5db"};
         `}
-`
+`;
 
 function formatDate(date: Date, format: CalendarFormat) {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, "0")
-  const day = String(date.getDate()).padStart(2, "0")
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
 
   switch (format) {
     case "yyyy/mm/dd":
-      return `${year}/${month}/${day}`
+      return `${year}/${month}/${day}`;
     case "dd/mm/yyyy":
-      return `${day}/${month}/${year}`
+      return `${day}/${month}/${year}`;
     case "mm/dd/yyyy":
     default:
-      return `${month}/${day}/${year}`
+      return `${month}/${day}/${year}`;
   }
 }
 
-export { Calendar }
+export { Calendar };

--- a/components/capsule.tsx
+++ b/components/capsule.tsx
@@ -1,40 +1,40 @@
-import { ReactNode, useEffect, useRef, useState } from "react";
-import { motion } from "framer-motion";
-import styled, { css, CSSProp } from "styled-components";
-import { StatefulForm } from "./stateful-form";
-import { Figure, FigureProps } from "./figure";
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { CapsuleThemeConfig } from "./../theme";
-import { useTheme } from "./../theme/provider";
-import { applyClassName } from "./../constants/classname";
+import { ReactNode, useEffect, useRef, useState } from "react"
+import { motion } from "framer-motion"
+import styled, { css, CSSProp } from "styled-components"
+import { StatefulForm } from "./stateful-form"
+import { Figure, FigureProps } from "./figure"
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
+import { CapsuleThemeConfig } from "./../theme"
+import { useTheme } from "./../theme/provider"
+import { applyClassName } from "./../constants/classname"
 
 export interface CapsuleTab {
-  id: string;
-  title?: string;
-  content?: ReactNode;
-  icon?: FigureProps;
-  className?: string;
+  id: string
+  title?: string
+  content?: ReactNode
+  icon?: FigureProps
+  className?: string
 }
 
 interface BaseCapsuleProps {
-  tabs: CapsuleTab[];
-  activeTab?: string | null;
-  onTabChange?: (id: string) => void;
-  full?: boolean;
-  activeBackgroundColor?: string;
-  activeColor?: string;
-  styles?: BaseCapsuleStyles;
-  id?: string;
-  name?: string;
-  fontSize?: number;
-  disabled?: boolean;
-  showError?: boolean;
-  mobile?: boolean;
+  tabs: CapsuleTab[]
+  activeTab?: string | null
+  onTabChange?: (id: string) => void
+  full?: boolean
+  activeBackgroundColor?: string
+  activeColor?: string
+  styles?: BaseCapsuleStyles
+  id?: string
+  name?: string
+  fontSize?: number
+  disabled?: boolean
+  showError?: boolean
+  mobile?: boolean
 }
 
 interface BaseCapsuleStyles {
-  capsuleWrapperStyle?: CSSProp;
-  tabStyle?: CSSProp;
+  capsuleWrapperStyle?: CSSProp
+  tabStyle?: CSSProp
 }
 
 function BaseCapsule({
@@ -51,56 +51,56 @@ function BaseCapsule({
   showError,
   mobile,
 }: BaseCapsuleProps) {
-  const { currentTheme } = useTheme();
-  const capsuleTheme = currentTheme.capsule;
+  const { currentTheme } = useTheme()
+  const capsuleTheme = currentTheme.capsule
 
-  const [hovered, setHovered] = useState<string | null>(null);
+  const [hovered, setHovered] = useState<string | null>(null)
 
-  const activeId = hovered || activeTab;
-  const activeIndex = tabs.findIndex((item) => item.id === activeTab);
-  const hoverIndex = tabs.findIndex((item) => item.id === activeId);
+  const activeId = hovered || activeTab
+  const activeIndex = tabs.findIndex((item) => item.id === activeTab)
+  const hoverIndex = tabs.findIndex((item) => item.id === activeId)
 
-  const tabRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const tabRefs = useRef<Array<HTMLDivElement | null>>([])
   const [tabSizes, setTabSizes] = useState<{ width: number; left: number }[]>(
-    []
-  );
+    [],
+  )
 
-  const [maxTabWidth, setMaxTabWidth] = useState<number>(0);
+  const [maxTabWidth, setMaxTabWidth] = useState<number>(0)
 
   useEffect(() => {
-    if (!mobile || !tabRefs.current.length) return;
+    if (!mobile || !tabRefs.current.length) return
 
     const calculateMaxWidth = () => {
-      if (!mobile || !tabRefs.current.length) return;
+      if (!mobile || !tabRefs.current.length) return
 
       const widths: number[] = tabRefs.current.map(
-        (el) => el?.getBoundingClientRect().width ?? 0
-      );
+        (el) => el?.getBoundingClientRect().width ?? 0,
+      )
 
-      const largest: number = widths.length ? Math.max(...widths) : 0;
+      const largest: number = widths.length ? Math.max(...widths) : 0
 
-      setMaxTabWidth((prev) => (prev !== largest ? largest : prev));
-    };
+      setMaxTabWidth((prev) => (prev !== largest ? largest : prev))
+    }
 
-    calculateMaxWidth();
-  }, [tabs, mobile]);
+    calculateMaxWidth()
+  }, [tabs, mobile])
 
-  const [isInitialized, setIsInitialized] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
-    tabRefs.current = tabRefs.current.slice(0, tabs.length);
+    tabRefs.current = tabRefs.current.slice(0, tabs.length)
 
     while (tabRefs.current.length < tabs.length) {
-      tabRefs.current.push(null);
+      tabRefs.current.push(null)
     }
-  }, [tabs]);
+  }, [tabs])
 
   useEffect(() => {
     if (!activeTab && tabs.length > 0) {
-      onTabChange(tabs[0].id);
+      onTabChange(tabs[0].id)
     }
-  }, [activeTab, tabs, onTabChange]);
+  }, [activeTab, tabs, onTabChange])
 
   useEffect(() => {
     const calculateTabSizes = () => {
@@ -109,46 +109,46 @@ function BaseCapsule({
         !tabRefs.current[0] ||
         !containerRef.current
       )
-        return;
+        return
 
-      const parentRect = containerRef.current.getBoundingClientRect();
+      const parentRect = containerRef.current.getBoundingClientRect()
 
       const sizes = tabRefs.current.map((tabRef) => {
-        if (!tabRef) return { width: 0, left: 0 };
+        if (!tabRef) return { width: 0, left: 0 }
 
-        const rect = tabRef.getBoundingClientRect();
-        const tabWidth = rect.width;
-        const bgWidth = tabWidth - 4;
-        const leftOffset = (tabWidth - bgWidth) / 4;
+        const rect = tabRef.getBoundingClientRect()
+        const tabWidth = rect.width
+        const bgWidth = tabWidth - 4
+        const leftOffset = (tabWidth - bgWidth) / 4
 
         return {
           width: bgWidth,
           left: rect.left - parentRect.left + leftOffset,
-        };
-      });
+        }
+      })
 
-      setTabSizes(sizes);
-      setIsInitialized(true);
-    };
+      setTabSizes(sizes)
+      setIsInitialized(true)
+    }
 
-    calculateTabSizes();
-    const timeoutId = setTimeout(calculateTabSizes, 50);
+    calculateTabSizes()
+    const timeoutId = setTimeout(calculateTabSizes, 50)
 
-    window.addEventListener("resize", calculateTabSizes);
+    window.addEventListener("resize", calculateTabSizes)
     return () => {
-      window.removeEventListener("resize", calculateTabSizes);
-      clearTimeout(timeoutId);
-    };
-  }, [tabs.length]);
+      window.removeEventListener("resize", calculateTabSizes)
+      clearTimeout(timeoutId)
+    }
+  }, [tabs.length])
 
   const setTabRef = (index: number) => (element: HTMLDivElement | null) => {
-    tabRefs.current[index] = element;
-  };
+    tabRefs.current[index] = element
+  }
 
   const getInitialPosition = () => {
     if (!isInitialized && tabs.length > 0) {
       if (activeIndex === 0) {
-        return { left: 0, width: 60 };
+        return { left: 0, width: 60 }
       }
     }
 
@@ -156,16 +156,16 @@ function BaseCapsule({
       return {
         left: tabSizes[activeIndex].left,
         width: tabSizes[activeIndex].width,
-      };
+      }
     }
 
-    return { left: 0, width: 60 };
-  };
+    return { left: 0, width: 60 }
+  }
 
   const getHoverPosition = () => {
     if (!isInitialized && tabs.length > 0) {
       if (hoverIndex === 0) {
-        return { left: 0, width: 60 };
+        return { left: 0, width: 60 }
       }
     }
 
@@ -173,14 +173,14 @@ function BaseCapsule({
       return {
         left: tabSizes[hoverIndex].left,
         width: tabSizes[hoverIndex].width,
-      };
+      }
     }
 
-    return { left: 0, width: 60 };
-  };
+    return { left: 0, width: 60 }
+  }
 
-  const hoverPosition = getHoverPosition();
-  const initialPosition = getInitialPosition();
+  const hoverPosition = getHoverPosition()
+  const initialPosition = getInitialPosition()
 
   return (
     <CapsuleWrapper
@@ -237,7 +237,7 @@ function BaseCapsule({
       )}
 
       {tabs.map((tab, index) => {
-        const isActive = activeTab === tab.id;
+        const isActive = activeTab === tab.id
 
         return (
           <Tab
@@ -268,18 +268,18 @@ function BaseCapsule({
             )}
             {tab.title && tab.title}
           </Tab>
-        );
+        )
       })}
     </CapsuleWrapper>
-  );
+  )
 }
 
-export type CapsuleStyles = BaseCapsuleStyles & FieldLaneStyles;
+export type CapsuleStyles = BaseCapsuleStyles & FieldLaneStyles
 
 export interface CapsuleProps
   extends Omit<BaseCapsuleProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: CapsuleStyles;
+  styles?: CapsuleStyles
 }
 
 function Capsule({
@@ -298,11 +298,21 @@ function Capsule({
   errorIconPosition,
   ...rest
 }: CapsuleProps) {
+  const {
+    bodyStyle,
+    controlStyle,
+    containerStyle,
+    labelStyle,
+    helperDrawerStyle,
+    helperIconStyle,
+    helperArrowStyle,
+    ...capsuleStyles
+  } = styles ?? {}
   const inputId = StatefulForm.sanitizeId({
     prefix: "capsule",
     name,
     id,
-  });
+  })
 
   return (
     <FieldLane
@@ -319,10 +329,13 @@ function Capsule({
       required={rest.required}
       errorIconPosition={errorIconPosition}
       styles={{
-        bodyStyle: styles?.bodyStyle,
-        controlStyle: styles?.controlStyle,
-        containerStyle: styles?.containerStyle,
-        labelStyle: styles?.labelStyle,
+        bodyStyle,
+        controlStyle,
+        containerStyle,
+        labelStyle,
+        helperDrawerStyle,
+        helperIconStyle,
+        helperArrowStyle,
       }}
     >
       <BaseCapsule
@@ -330,21 +343,18 @@ function Capsule({
         id={inputId}
         disabled={disabled}
         showError={showError}
-        styles={{
-          capsuleWrapperStyle: styles?.capsuleWrapperStyle,
-          tabStyle: styles?.tabStyle,
-        }}
+        styles={capsuleStyles}
       />
     </FieldLane>
-  );
+  )
 }
 
 const CapsuleWrapper = styled.div<{
-  $full?: boolean;
-  $containerStyle?: CSSProp;
-  $disabled?: boolean;
-  $theme?: CapsuleThemeConfig;
-  $showError?: boolean;
+  $full?: boolean
+  $containerStyle?: CSSProp
+  $disabled?: boolean
+  $theme?: CapsuleThemeConfig
+  $showError?: boolean
 }>`
   *,
   ::before,
@@ -389,12 +399,12 @@ const CapsuleWrapper = styled.div<{
     `};
 
   ${({ $containerStyle }) => $containerStyle}
-`;
+`
 
 const ActiveBackground = styled(motion.div)<{
-  $style?: CSSProp;
-  $activeBackgroundColor?: string;
-  $theme?: CapsuleThemeConfig;
+  $style?: CSSProp
+  $activeBackgroundColor?: string
+  $theme?: CapsuleThemeConfig
 }>`
   position: absolute;
   top: 50%;
@@ -407,12 +417,12 @@ const ActiveBackground = styled(motion.div)<{
     $activeBackgroundColor ?? $theme?.active?.backgroundColor};
 
   ${({ $style }) => $style}
-`;
+`
 
 const HoverBorder = styled(motion.div)<{
-  $style?: CSSProp;
-  $activeBackgroundColor?: string;
-  $theme?: CapsuleThemeConfig;
+  $style?: CSSProp
+  $activeBackgroundColor?: string
+  $theme?: CapsuleThemeConfig
 }>`
   position: absolute;
   top: 50%;
@@ -426,18 +436,18 @@ const HoverBorder = styled(motion.div)<{
       $activeBackgroundColor ?? $theme?.hover?.borderColor};
 
   ${({ $style }) => $style}
-`;
+`
 
 const Tab = styled.div<{
-  $isActive?: boolean;
-  $activeTabStyle?: CSSProp;
-  $fontSize?: number;
-  $disabled?: boolean;
-  $activeColor?: string;
-  $theme?: CapsuleThemeConfig;
-  $mobile?: boolean;
-  $width?: number;
-  $tabsLength?: number;
+  $isActive?: boolean
+  $activeTabStyle?: CSSProp
+  $fontSize?: number
+  $disabled?: boolean
+  $activeColor?: string
+  $theme?: CapsuleThemeConfig
+  $mobile?: boolean
+  $width?: number
+  $tabsLength?: number
 }>`
   display: flex;
   flex-direction: row;
@@ -480,6 +490,6 @@ const Tab = styled.div<{
     `};
 
   ${({ $activeTabStyle }) => $activeTabStyle}
-`;
+`
 
-export { Capsule };
+export { Capsule }

--- a/components/capsule.tsx
+++ b/components/capsule.tsx
@@ -1,40 +1,40 @@
-import { ReactNode, useEffect, useRef, useState } from "react"
-import { motion } from "framer-motion"
-import styled, { css, CSSProp } from "styled-components"
-import { StatefulForm } from "./stateful-form"
-import { Figure, FigureProps } from "./figure"
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
-import { CapsuleThemeConfig } from "./../theme"
-import { useTheme } from "./../theme/provider"
-import { applyClassName } from "./../constants/classname"
+import { ReactNode, useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
+import styled, { css, CSSProp } from "styled-components";
+import { StatefulForm } from "./stateful-form";
+import { Figure, FigureProps } from "./figure";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
+import { CapsuleThemeConfig } from "./../theme";
+import { useTheme } from "./../theme/provider";
+import { applyClassName } from "./../constants/classname";
 
 export interface CapsuleTab {
-  id: string
-  title?: string
-  content?: ReactNode
-  icon?: FigureProps
-  className?: string
+  id: string;
+  title?: string;
+  content?: ReactNode;
+  icon?: FigureProps;
+  className?: string;
 }
 
 interface BaseCapsuleProps {
-  tabs: CapsuleTab[]
-  activeTab?: string | null
-  onTabChange?: (id: string) => void
-  full?: boolean
-  activeBackgroundColor?: string
-  activeColor?: string
-  styles?: BaseCapsuleStyles
-  id?: string
-  name?: string
-  fontSize?: number
-  disabled?: boolean
-  showError?: boolean
-  mobile?: boolean
+  tabs: CapsuleTab[];
+  activeTab?: string | null;
+  onTabChange?: (id: string) => void;
+  full?: boolean;
+  activeBackgroundColor?: string;
+  activeColor?: string;
+  styles?: BaseCapsuleStyles;
+  id?: string;
+  name?: string;
+  fontSize?: number;
+  disabled?: boolean;
+  showError?: boolean;
+  mobile?: boolean;
 }
 
 interface BaseCapsuleStyles {
-  capsuleWrapperStyle?: CSSProp
-  tabStyle?: CSSProp
+  capsuleWrapperStyle?: CSSProp;
+  tabStyle?: CSSProp;
 }
 
 function BaseCapsule({
@@ -51,56 +51,56 @@ function BaseCapsule({
   showError,
   mobile,
 }: BaseCapsuleProps) {
-  const { currentTheme } = useTheme()
-  const capsuleTheme = currentTheme.capsule
+  const { currentTheme } = useTheme();
+  const capsuleTheme = currentTheme.capsule;
 
-  const [hovered, setHovered] = useState<string | null>(null)
+  const [hovered, setHovered] = useState<string | null>(null);
 
-  const activeId = hovered || activeTab
-  const activeIndex = tabs.findIndex((item) => item.id === activeTab)
-  const hoverIndex = tabs.findIndex((item) => item.id === activeId)
+  const activeId = hovered || activeTab;
+  const activeIndex = tabs.findIndex((item) => item.id === activeTab);
+  const hoverIndex = tabs.findIndex((item) => item.id === activeId);
 
-  const tabRefs = useRef<Array<HTMLDivElement | null>>([])
+  const tabRefs = useRef<Array<HTMLDivElement | null>>([]);
   const [tabSizes, setTabSizes] = useState<{ width: number; left: number }[]>(
-    [],
-  )
+    []
+  );
 
-  const [maxTabWidth, setMaxTabWidth] = useState<number>(0)
+  const [maxTabWidth, setMaxTabWidth] = useState<number>(0);
 
   useEffect(() => {
-    if (!mobile || !tabRefs.current.length) return
+    if (!mobile || !tabRefs.current.length) return;
 
     const calculateMaxWidth = () => {
-      if (!mobile || !tabRefs.current.length) return
+      if (!mobile || !tabRefs.current.length) return;
 
       const widths: number[] = tabRefs.current.map(
-        (el) => el?.getBoundingClientRect().width ?? 0,
-      )
+        (el) => el?.getBoundingClientRect().width ?? 0
+      );
 
-      const largest: number = widths.length ? Math.max(...widths) : 0
+      const largest: number = widths.length ? Math.max(...widths) : 0;
 
-      setMaxTabWidth((prev) => (prev !== largest ? largest : prev))
-    }
+      setMaxTabWidth((prev) => (prev !== largest ? largest : prev));
+    };
 
-    calculateMaxWidth()
-  }, [tabs, mobile])
+    calculateMaxWidth();
+  }, [tabs, mobile]);
 
-  const [isInitialized, setIsInitialized] = useState(false)
-  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [isInitialized, setIsInitialized] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    tabRefs.current = tabRefs.current.slice(0, tabs.length)
+    tabRefs.current = tabRefs.current.slice(0, tabs.length);
 
     while (tabRefs.current.length < tabs.length) {
-      tabRefs.current.push(null)
+      tabRefs.current.push(null);
     }
-  }, [tabs])
+  }, [tabs]);
 
   useEffect(() => {
     if (!activeTab && tabs.length > 0) {
-      onTabChange(tabs[0].id)
+      onTabChange(tabs[0].id);
     }
-  }, [activeTab, tabs, onTabChange])
+  }, [activeTab, tabs, onTabChange]);
 
   useEffect(() => {
     const calculateTabSizes = () => {
@@ -109,46 +109,46 @@ function BaseCapsule({
         !tabRefs.current[0] ||
         !containerRef.current
       )
-        return
+        return;
 
-      const parentRect = containerRef.current.getBoundingClientRect()
+      const parentRect = containerRef.current.getBoundingClientRect();
 
       const sizes = tabRefs.current.map((tabRef) => {
-        if (!tabRef) return { width: 0, left: 0 }
+        if (!tabRef) return { width: 0, left: 0 };
 
-        const rect = tabRef.getBoundingClientRect()
-        const tabWidth = rect.width
-        const bgWidth = tabWidth - 4
-        const leftOffset = (tabWidth - bgWidth) / 4
+        const rect = tabRef.getBoundingClientRect();
+        const tabWidth = rect.width;
+        const bgWidth = tabWidth - 4;
+        const leftOffset = (tabWidth - bgWidth) / 4;
 
         return {
           width: bgWidth,
           left: rect.left - parentRect.left + leftOffset,
-        }
-      })
+        };
+      });
 
-      setTabSizes(sizes)
-      setIsInitialized(true)
-    }
+      setTabSizes(sizes);
+      setIsInitialized(true);
+    };
 
-    calculateTabSizes()
-    const timeoutId = setTimeout(calculateTabSizes, 50)
+    calculateTabSizes();
+    const timeoutId = setTimeout(calculateTabSizes, 50);
 
-    window.addEventListener("resize", calculateTabSizes)
+    window.addEventListener("resize", calculateTabSizes);
     return () => {
-      window.removeEventListener("resize", calculateTabSizes)
-      clearTimeout(timeoutId)
-    }
-  }, [tabs.length])
+      window.removeEventListener("resize", calculateTabSizes);
+      clearTimeout(timeoutId);
+    };
+  }, [tabs.length]);
 
   const setTabRef = (index: number) => (element: HTMLDivElement | null) => {
-    tabRefs.current[index] = element
-  }
+    tabRefs.current[index] = element;
+  };
 
   const getInitialPosition = () => {
     if (!isInitialized && tabs.length > 0) {
       if (activeIndex === 0) {
-        return { left: 0, width: 60 }
+        return { left: 0, width: 60 };
       }
     }
 
@@ -156,16 +156,16 @@ function BaseCapsule({
       return {
         left: tabSizes[activeIndex].left,
         width: tabSizes[activeIndex].width,
-      }
+      };
     }
 
-    return { left: 0, width: 60 }
-  }
+    return { left: 0, width: 60 };
+  };
 
   const getHoverPosition = () => {
     if (!isInitialized && tabs.length > 0) {
       if (hoverIndex === 0) {
-        return { left: 0, width: 60 }
+        return { left: 0, width: 60 };
       }
     }
 
@@ -173,14 +173,14 @@ function BaseCapsule({
       return {
         left: tabSizes[hoverIndex].left,
         width: tabSizes[hoverIndex].width,
-      }
+      };
     }
 
-    return { left: 0, width: 60 }
-  }
+    return { left: 0, width: 60 };
+  };
 
-  const hoverPosition = getHoverPosition()
-  const initialPosition = getInitialPosition()
+  const hoverPosition = getHoverPosition();
+  const initialPosition = getInitialPosition();
 
   return (
     <CapsuleWrapper
@@ -237,7 +237,7 @@ function BaseCapsule({
       )}
 
       {tabs.map((tab, index) => {
-        const isActive = activeTab === tab.id
+        const isActive = activeTab === tab.id;
 
         return (
           <Tab
@@ -268,18 +268,18 @@ function BaseCapsule({
             )}
             {tab.title && tab.title}
           </Tab>
-        )
+        );
       })}
     </CapsuleWrapper>
-  )
+  );
 }
 
-export type CapsuleStyles = BaseCapsuleStyles & FieldLaneStyles
+export type CapsuleStyles = BaseCapsuleStyles & FieldLaneStyles;
 
 export interface CapsuleProps
   extends Omit<BaseCapsuleProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: CapsuleStyles
+  styles?: CapsuleStyles;
 }
 
 function Capsule({
@@ -307,12 +307,12 @@ function Capsule({
     helperIconStyle,
     helperArrowStyle,
     ...capsuleStyles
-  } = styles ?? {}
+  } = styles ?? {};
   const inputId = StatefulForm.sanitizeId({
     prefix: "capsule",
     name,
     id,
-  })
+  });
 
   return (
     <FieldLane
@@ -346,15 +346,15 @@ function Capsule({
         styles={capsuleStyles}
       />
     </FieldLane>
-  )
+  );
 }
 
 const CapsuleWrapper = styled.div<{
-  $full?: boolean
-  $containerStyle?: CSSProp
-  $disabled?: boolean
-  $theme?: CapsuleThemeConfig
-  $showError?: boolean
+  $full?: boolean;
+  $containerStyle?: CSSProp;
+  $disabled?: boolean;
+  $theme?: CapsuleThemeConfig;
+  $showError?: boolean;
 }>`
   *,
   ::before,
@@ -399,12 +399,12 @@ const CapsuleWrapper = styled.div<{
     `};
 
   ${({ $containerStyle }) => $containerStyle}
-`
+`;
 
 const ActiveBackground = styled(motion.div)<{
-  $style?: CSSProp
-  $activeBackgroundColor?: string
-  $theme?: CapsuleThemeConfig
+  $style?: CSSProp;
+  $activeBackgroundColor?: string;
+  $theme?: CapsuleThemeConfig;
 }>`
   position: absolute;
   top: 50%;
@@ -417,12 +417,12 @@ const ActiveBackground = styled(motion.div)<{
     $activeBackgroundColor ?? $theme?.active?.backgroundColor};
 
   ${({ $style }) => $style}
-`
+`;
 
 const HoverBorder = styled(motion.div)<{
-  $style?: CSSProp
-  $activeBackgroundColor?: string
-  $theme?: CapsuleThemeConfig
+  $style?: CSSProp;
+  $activeBackgroundColor?: string;
+  $theme?: CapsuleThemeConfig;
 }>`
   position: absolute;
   top: 50%;
@@ -436,18 +436,18 @@ const HoverBorder = styled(motion.div)<{
       $activeBackgroundColor ?? $theme?.hover?.borderColor};
 
   ${({ $style }) => $style}
-`
+`;
 
 const Tab = styled.div<{
-  $isActive?: boolean
-  $activeTabStyle?: CSSProp
-  $fontSize?: number
-  $disabled?: boolean
-  $activeColor?: string
-  $theme?: CapsuleThemeConfig
-  $mobile?: boolean
-  $width?: number
-  $tabsLength?: number
+  $isActive?: boolean;
+  $activeTabStyle?: CSSProp;
+  $fontSize?: number;
+  $disabled?: boolean;
+  $activeColor?: string;
+  $theme?: CapsuleThemeConfig;
+  $mobile?: boolean;
+  $width?: number;
+  $tabsLength?: number;
 }>`
   display: flex;
   flex-direction: row;
@@ -490,6 +490,6 @@ const Tab = styled.div<{
     `};
 
   ${({ $activeTabStyle }) => $activeTabStyle}
-`
+`;
 
-export { Capsule }
+export { Capsule };

--- a/components/checkbox.tsx
+++ b/components/checkbox.tsx
@@ -1,47 +1,46 @@
-import styled, { css, CSSProp } from "styled-components";
+import styled, { css, CSSProp } from "styled-components"
 import {
   DetailedHTMLProps,
   InputHTMLAttributes,
   useEffect,
   useRef,
-} from "react";
-import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { useTheme } from "./../theme/provider";
-import { CheckboxThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
+} from "react"
+import { StatefulForm } from "./stateful-form"
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
+import { useTheme } from "./../theme/provider"
+import { CheckboxThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
 
-type WithoutStyle<T> = Omit<T, "style">;
+type WithoutStyle<T> = Omit<T, "style">
 
 export interface CheckboxOption {
-  value: string;
-  label: string;
-  description: string;
+  value: string
+  label: string
+  description: string
 }
 
 interface BaseCheckboxProps
   extends WithoutStyle<
     DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>
   > {
-  label?: string;
-  name?: string;
-  showError?: boolean;
-  errorMessage?: string;
-  indeterminate?: boolean;
-  description?: string;
-  highlightOnChecked?: boolean;
-  styles?: BaseCheckboxStyles;
-  helper?: string;
+  label?: string
+  name?: string
+  showError?: boolean
+  errorMessage?: string
+  indeterminate?: boolean
+  description?: string
+  highlightOnChecked?: boolean
+  styles?: BaseCheckboxStyles
 }
 
 interface BaseCheckboxStyles {
-  self?: CSSProp;
-  inputWrapperStyle?: CSSProp;
-  titleStyle?: CSSProp;
-  labelStyle?: CSSProp;
-  iconStyle?: CSSProp;
-  boxStyle?: CSSProp;
-  descriptionStyle?: CSSProp;
+  self?: CSSProp
+  inputWrapperStyle?: CSSProp
+  titleStyle?: CSSProp
+  labelStyle?: CSSProp
+  iconStyle?: CSSProp
+  boxStyle?: CSSProp
+  descriptionStyle?: CSSProp
 }
 
 function BaseCheckbox({
@@ -55,18 +54,18 @@ function BaseCheckbox({
   id,
   ...props
 }: BaseCheckboxProps) {
-  const { currentTheme } = useTheme();
-  const checkboxTheme = currentTheme.checkbox;
+  const { currentTheme } = useTheme()
+  const checkboxTheme = currentTheme.checkbox
 
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null)
 
-  const isChecked = Boolean(props.checked);
+  const isChecked = Boolean(props.checked)
 
   useEffect(() => {
     if (inputRef.current) {
-      inputRef.current.indeterminate = indeterminate;
+      inputRef.current.indeterminate = indeterminate
     }
-  }, [indeterminate]);
+  }, [indeterminate])
 
   return (
     <InputWrapper
@@ -151,15 +150,15 @@ function BaseCheckbox({
         </DescriptionText>
       )}
     </InputWrapper>
-  );
+  )
 }
 
-export type CheckboxStyles = BaseCheckboxStyles & FieldLaneStyles;
+export type CheckboxStyles = BaseCheckboxStyles & FieldLaneStyles
 
 export interface CheckboxProps
   extends Omit<BaseCheckboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: CheckboxStyles;
+  styles?: CheckboxStyles
 }
 
 function Checkbox({
@@ -183,15 +182,18 @@ function Checkbox({
     prefix: "checkbox",
     name,
     id,
-  });
+  })
 
   const {
     bodyStyle,
     controlStyle,
     containerStyle,
     titleStyle,
-    ...CheckboxStyles
-  } = styles ?? {};
+    helperArrowStyle,
+    helperDrawerStyle,
+    helperIconStyle,
+    ...checkboxStyles
+  } = styles ?? {}
 
   return (
     <FieldLane
@@ -218,6 +220,9 @@ function Checkbox({
           ${containerStyle}
         `,
         labelStyle: titleStyle,
+        helperArrowStyle,
+        helperDrawerStyle,
+        helperIconStyle,
       }}
     >
       <BaseCheckbox
@@ -225,22 +230,22 @@ function Checkbox({
         id={inputId}
         disabled={disabled}
         showError={showError}
-        styles={CheckboxStyles}
+        styles={checkboxStyles}
         label={label}
         name={name}
         description={description}
       />
     </FieldLane>
-  );
+  )
 }
 
 const InputWrapper = styled.label<{
-  $hasDescription: boolean;
-  $highlight: boolean;
-  $checked: boolean;
-  $theme: CheckboxThemeConfig;
-  $style?: CSSProp;
-  $disabled?: boolean;
+  $hasDescription: boolean
+  $highlight: boolean
+  $checked: boolean
+  $theme: CheckboxThemeConfig
+  $style?: CSSProp
+  $disabled?: boolean
 }>`
   width: 100%;
   display: flex;
@@ -264,11 +269,11 @@ const InputWrapper = styled.label<{
       &:hover {
         background-color: ${() => {
           if ($highlight && $checked) {
-            return $theme?.highlightCheckedBackgroundColor ?? "#E7F2FC";
+            return $theme?.highlightCheckedBackgroundColor ?? "#E7F2FC"
           } else if ($highlight) {
-            return $theme?.highlightHoverBackgroundColor;
+            return $theme?.highlightHoverBackgroundColor
           } else {
-            return "transparent";
+            return "transparent"
           }
         }};
       }
@@ -283,7 +288,7 @@ const InputWrapper = styled.label<{
     `}
 
   ${({ $style }) => $style}
-`;
+`
 
 const CheckboxBox = styled.div<{ $highlight: boolean; $style?: CSSProp }>`
   position: relative;
@@ -292,18 +297,18 @@ const CheckboxBox = styled.div<{ $highlight: boolean; $style?: CSSProp }>`
   justify-content: center;
 
   ${({ $style }) => $style}
-`;
+`
 
 const HiddenCheckbox = styled.input<{
-  $isError?: boolean;
-  $checked?: boolean;
-  $indeterminate?: boolean;
-  $backgroundColor?: string;
-  $checkedBackgroundColor?: string;
-  $borderColor?: string;
-  $checkedBorderColor?: string;
-  $style?: CSSProp;
-  $disabled?: boolean;
+  $isError?: boolean
+  $checked?: boolean
+  $indeterminate?: boolean
+  $backgroundColor?: string
+  $checkedBackgroundColor?: string
+  $borderColor?: string
+  $checkedBorderColor?: string
+  $style?: CSSProp
+  $disabled?: boolean
 }>`
   margin: 0;
   padding: 0;
@@ -346,12 +351,12 @@ const HiddenCheckbox = styled.input<{
       }
     `}
   ${({ $style }) => $style};
-`;
+`
 
 const Icon = styled.svg<{
-  $visible?: boolean;
-  $iconColor?: string;
-  $style?: CSSProp;
+  $visible?: boolean
+  $iconColor?: string
+  $style?: CSSProp
 }>`
   position: absolute;
   top: 50%;
@@ -366,7 +371,7 @@ const Icon = styled.svg<{
   transition: transform 150ms;
   pointer-events: none;
   ${({ $style }) => $style};
-`;
+`
 
 const InputContainer = styled.div`
   display: flex;
@@ -374,12 +379,12 @@ const InputContainer = styled.div`
   align-items: center;
   gap: 0.5rem;
   height: 100%;
-`;
+`
 
 const DescriptionText = styled.span<{
-  $highlight?: boolean;
-  $descriptionColor?: string;
-  $style?: CSSProp;
+  $highlight?: boolean
+  $descriptionColor?: string
+  $style?: CSSProp
 }>`
   ${({ $highlight }) =>
     $highlight &&
@@ -389,6 +394,6 @@ const DescriptionText = styled.span<{
   margin-left: 24px;
   color: ${({ $descriptionColor }) => $descriptionColor ?? "#4b5563"};
   ${({ $style }) => $style};
-`;
+`
 
-export { Checkbox };
+export { Checkbox }

--- a/components/checkbox.tsx
+++ b/components/checkbox.tsx
@@ -1,46 +1,46 @@
-import styled, { css, CSSProp } from "styled-components"
+import styled, { css, CSSProp } from "styled-components";
 import {
   DetailedHTMLProps,
   InputHTMLAttributes,
   useEffect,
   useRef,
-} from "react"
-import { StatefulForm } from "./stateful-form"
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
-import { useTheme } from "./../theme/provider"
-import { CheckboxThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
+} from "react";
+import { StatefulForm } from "./stateful-form";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
+import { useTheme } from "./../theme/provider";
+import { CheckboxThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 
-type WithoutStyle<T> = Omit<T, "style">
+type WithoutStyle<T> = Omit<T, "style">;
 
 export interface CheckboxOption {
-  value: string
-  label: string
-  description: string
+  value: string;
+  label: string;
+  description: string;
 }
 
 interface BaseCheckboxProps
   extends WithoutStyle<
     DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>
   > {
-  label?: string
-  name?: string
-  showError?: boolean
-  errorMessage?: string
-  indeterminate?: boolean
-  description?: string
-  highlightOnChecked?: boolean
-  styles?: BaseCheckboxStyles
+  label?: string;
+  name?: string;
+  showError?: boolean;
+  errorMessage?: string;
+  indeterminate?: boolean;
+  description?: string;
+  highlightOnChecked?: boolean;
+  styles?: BaseCheckboxStyles;
 }
 
 interface BaseCheckboxStyles {
-  self?: CSSProp
-  inputWrapperStyle?: CSSProp
-  titleStyle?: CSSProp
-  labelStyle?: CSSProp
-  iconStyle?: CSSProp
-  boxStyle?: CSSProp
-  descriptionStyle?: CSSProp
+  self?: CSSProp;
+  inputWrapperStyle?: CSSProp;
+  titleStyle?: CSSProp;
+  labelStyle?: CSSProp;
+  iconStyle?: CSSProp;
+  boxStyle?: CSSProp;
+  descriptionStyle?: CSSProp;
 }
 
 function BaseCheckbox({
@@ -54,18 +54,18 @@ function BaseCheckbox({
   id,
   ...props
 }: BaseCheckboxProps) {
-  const { currentTheme } = useTheme()
-  const checkboxTheme = currentTheme.checkbox
+  const { currentTheme } = useTheme();
+  const checkboxTheme = currentTheme.checkbox;
 
-  const inputRef = useRef<HTMLInputElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const isChecked = Boolean(props.checked)
+  const isChecked = Boolean(props.checked);
 
   useEffect(() => {
     if (inputRef.current) {
-      inputRef.current.indeterminate = indeterminate
+      inputRef.current.indeterminate = indeterminate;
     }
-  }, [indeterminate])
+  }, [indeterminate]);
 
   return (
     <InputWrapper
@@ -150,15 +150,15 @@ function BaseCheckbox({
         </DescriptionText>
       )}
     </InputWrapper>
-  )
+  );
 }
 
-export type CheckboxStyles = BaseCheckboxStyles & FieldLaneStyles
+export type CheckboxStyles = BaseCheckboxStyles & FieldLaneStyles;
 
 export interface CheckboxProps
   extends Omit<BaseCheckboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: CheckboxStyles
+  styles?: CheckboxStyles;
 }
 
 function Checkbox({
@@ -182,7 +182,7 @@ function Checkbox({
     prefix: "checkbox",
     name,
     id,
-  })
+  });
 
   const {
     bodyStyle,
@@ -193,7 +193,7 @@ function Checkbox({
     helperDrawerStyle,
     helperIconStyle,
     ...checkboxStyles
-  } = styles ?? {}
+  } = styles ?? {};
 
   return (
     <FieldLane
@@ -236,16 +236,16 @@ function Checkbox({
         description={description}
       />
     </FieldLane>
-  )
+  );
 }
 
 const InputWrapper = styled.label<{
-  $hasDescription: boolean
-  $highlight: boolean
-  $checked: boolean
-  $theme: CheckboxThemeConfig
-  $style?: CSSProp
-  $disabled?: boolean
+  $hasDescription: boolean;
+  $highlight: boolean;
+  $checked: boolean;
+  $theme: CheckboxThemeConfig;
+  $style?: CSSProp;
+  $disabled?: boolean;
 }>`
   width: 100%;
   display: flex;
@@ -269,11 +269,11 @@ const InputWrapper = styled.label<{
       &:hover {
         background-color: ${() => {
           if ($highlight && $checked) {
-            return $theme?.highlightCheckedBackgroundColor ?? "#E7F2FC"
+            return $theme?.highlightCheckedBackgroundColor ?? "#E7F2FC";
           } else if ($highlight) {
-            return $theme?.highlightHoverBackgroundColor
+            return $theme?.highlightHoverBackgroundColor;
           } else {
-            return "transparent"
+            return "transparent";
           }
         }};
       }
@@ -288,7 +288,7 @@ const InputWrapper = styled.label<{
     `}
 
   ${({ $style }) => $style}
-`
+`;
 
 const CheckboxBox = styled.div<{ $highlight: boolean; $style?: CSSProp }>`
   position: relative;
@@ -297,18 +297,18 @@ const CheckboxBox = styled.div<{ $highlight: boolean; $style?: CSSProp }>`
   justify-content: center;
 
   ${({ $style }) => $style}
-`
+`;
 
 const HiddenCheckbox = styled.input<{
-  $isError?: boolean
-  $checked?: boolean
-  $indeterminate?: boolean
-  $backgroundColor?: string
-  $checkedBackgroundColor?: string
-  $borderColor?: string
-  $checkedBorderColor?: string
-  $style?: CSSProp
-  $disabled?: boolean
+  $isError?: boolean;
+  $checked?: boolean;
+  $indeterminate?: boolean;
+  $backgroundColor?: string;
+  $checkedBackgroundColor?: string;
+  $borderColor?: string;
+  $checkedBorderColor?: string;
+  $style?: CSSProp;
+  $disabled?: boolean;
 }>`
   margin: 0;
   padding: 0;
@@ -351,12 +351,12 @@ const HiddenCheckbox = styled.input<{
       }
     `}
   ${({ $style }) => $style};
-`
+`;
 
 const Icon = styled.svg<{
-  $visible?: boolean
-  $iconColor?: string
-  $style?: CSSProp
+  $visible?: boolean;
+  $iconColor?: string;
+  $style?: CSSProp;
 }>`
   position: absolute;
   top: 50%;
@@ -371,7 +371,7 @@ const Icon = styled.svg<{
   transition: transform 150ms;
   pointer-events: none;
   ${({ $style }) => $style};
-`
+`;
 
 const InputContainer = styled.div`
   display: flex;
@@ -379,12 +379,12 @@ const InputContainer = styled.div`
   align-items: center;
   gap: 0.5rem;
   height: 100%;
-`
+`;
 
 const DescriptionText = styled.span<{
-  $highlight?: boolean
-  $descriptionColor?: string
-  $style?: CSSProp
+  $highlight?: boolean;
+  $descriptionColor?: string;
+  $style?: CSSProp;
 }>`
   ${({ $highlight }) =>
     $highlight &&
@@ -394,6 +394,6 @@ const DescriptionText = styled.span<{
   margin-left: 24px;
   color: ${({ $descriptionColor }) => $descriptionColor ?? "#4b5563"};
   ${({ $style }) => $style};
-`
+`;
 
-export { Checkbox }
+export { Checkbox };

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -1,5 +1,5 @@
-import { RiAddLine } from "@remixicon/react"
-import { Badge, BadgeAction, BadgeProps } from "./badge"
+import { RiAddLine } from "@remixicon/react";
+import { Badge, BadgeAction, BadgeProps } from "./badge";
 import {
   ChangeEvent,
   Fragment,
@@ -9,7 +9,7 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react"
+} from "react";
 import {
   autoUpdate,
   flip,
@@ -19,61 +19,61 @@ import {
   useFloating,
   useInteractions,
   useRole,
-} from "@floating-ui/react"
-import styled, { css, CSSProp } from "styled-components"
-import { StatefulForm } from "./stateful-form"
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
-import { useTheme } from "./../theme/provider"
-import { ChipsThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
-import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox"
-import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox"
+} from "@floating-ui/react";
+import styled, { css, CSSProp } from "styled-components";
+import { StatefulForm } from "./stateful-form";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
+import { useTheme } from "./../theme/provider";
+import { ChipsThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
+import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox";
+import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox";
 
-export type ChipAction = BadgeAction
+export type ChipAction = BadgeAction;
 
-export type ChipProps = BadgeProps
+export type ChipProps = BadgeProps;
 
 interface BaseChipsProps {
-  options?: ChipProps[]
-  inputValue?: string
+  options?: ChipProps[];
+  inputValue?: string;
   setInputValue?: (
-    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => void
-  filterPlaceholder?: string
-  missingOptionLabel?: string
-  creatable?: boolean
-  selectedOptions?: string[]
-  onChange?: (selectedOptions: string[]) => void
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => void;
+  filterPlaceholder?: string;
+  missingOptionLabel?: string;
+  creatable?: boolean;
+  selectedOptions?: string[];
+  onChange?: (selectedOptions: string[]) => void;
   missingOptionForm?:
     | ReactNode
-    | ((props?: MissingOptionFormProps) => ReactNode)
-  emptySlate?: string
-  renderer?: (props: ChipRendererProps) => ReactNode
-  styles?: BaseChipsStyles
-  name?: string
-  id?: string
-  disabled?: boolean
-  mobile?: boolean
-  drawerHeight?: string
+    | ((props?: MissingOptionFormProps) => ReactNode);
+  emptySlate?: string;
+  renderer?: (props: ChipRendererProps) => ReactNode;
+  styles?: BaseChipsStyles;
+  name?: string;
+  id?: string;
+  disabled?: boolean;
+  mobile?: boolean;
+  drawerHeight?: string;
 }
 
 export interface BaseChipsStyles {
-  chipsContainerStyle?: CSSProp
-  chipSelectedStyle?: CSSProp
-  chipOptionWrapperStyle?: CSSProp
-  chipOptionStyle?: CSSProp
-  chipsDrawerStyle?: CSSProp
+  chipsContainerStyle?: CSSProp;
+  chipSelectedStyle?: CSSProp;
+  chipOptionWrapperStyle?: CSSProp;
+  chipOptionStyle?: CSSProp;
+  chipsDrawerStyle?: CSSProp;
 }
 
 export interface ChipRendererProps {
-  id?: string
-  caption?: string
-  metadata?: Record<string, unknown>
+  id?: string;
+  caption?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface MissingOptionFormProps {
-  firstInputRef?: Ref<HTMLInputElement>
-  closeForm?: () => void
+  firstInputRef?: Ref<HTMLInputElement>;
+  closeForm?: () => void;
 }
 
 function BaseChips({
@@ -95,23 +95,23 @@ function BaseChips({
   mobile,
   drawerHeight,
 }: BaseChipsProps) {
-  const { currentTheme } = useTheme()
-  const chipsTheme = currentTheme.chips
-  const textboxTheme = currentTheme.textbox
+  const { currentTheme } = useTheme();
+  const chipsTheme = currentTheme.chips;
+  const textboxTheme = currentTheme.textbox;
 
-  const inputRef = useRef<HTMLInputElement>(null)
-  const inputMissingRef = useRef<HTMLInputElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null);
+  const inputMissingRef = useRef<HTMLInputElement>(null);
 
-  const [mode, setMode] = useState<"idle" | "create">("idle")
+  const [mode, setMode] = useState<"idle" | "create">("idle");
 
-  const [isOpen, setIsOpen] = useState(false)
-  const [hasInteracted, setHasInteracted] = useState(false)
-  const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const [isOpen, setIsOpen] = useState(false);
+  const [hasInteracted, setHasInteracted] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [interactionMode, setInteractionMode] = useState<"mouse" | "keyboard">(
-    "keyboard",
-  )
+    "keyboard"
+  );
 
-  const listRef = useRef<(HTMLLIElement | null)[]>([])
+  const listRef = useRef<(HTMLLIElement | null)[]>([]);
 
   const { refs, floatingStyles, context } = useFloating({
     open: isOpen,
@@ -122,50 +122,50 @@ function BaseChips({
     ],
     whileElementsMounted: autoUpdate,
     placement: "bottom-start",
-  })
+  });
 
-  const click = useClick(context)
-  const dismiss = useDismiss(context)
-  const role = useRole(context)
+  const click = useClick(context);
+  const dismiss = useDismiss(context);
+  const role = useRole(context);
 
   const { getReferenceProps, getFloatingProps } = useInteractions([
     click,
     dismiss,
     role,
-  ])
+  ]);
 
   // Keep selected options at the top, following the order in selectedOptions.
   // Unselected options preserve their original order.
   const sortedOptions = [...options].sort((a, b) => {
-    const aIndex = selectedOptions?.findIndex((id) => id === a.id) ?? -1
-    const bIndex = selectedOptions?.findIndex((id) => id === b.id) ?? -1
+    const aIndex = selectedOptions?.findIndex((id) => id === a.id) ?? -1;
+    const bIndex = selectedOptions?.findIndex((id) => id === b.id) ?? -1;
 
     if (aIndex !== -1 && bIndex !== -1) {
-      return aIndex - bIndex
+      return aIndex - bIndex;
     }
 
-    if (aIndex !== -1) return -1
-    if (bIndex !== -1) return 1
+    if (aIndex !== -1) return -1;
+    if (bIndex !== -1) return 1;
 
-    return 0
-  })
+    return 0;
+  });
 
   const FINAL_OPTIONS: ComboboxOption[] = useMemo(() => {
     return sortedOptions.map((badge, index) => {
       const isSelected = selectedOptions?.some(
-        (selectedOption) => selectedOption === badge.id,
-      )
+        (selectedOption) => selectedOption === badge.id
+      );
 
       const badgeActions = badge?.actions?.map((action) => ({
         ...action,
         onClick: ({ badge, event }) => {
-          event?.preventDefault()
+          event?.preventDefault();
           action?.onClick?.({
             badge,
             event,
-          })
+          });
         },
-      }))
+      }));
 
       return {
         text: badge.caption,
@@ -176,7 +176,7 @@ function BaseChips({
               sortedOptions[index - 1] &&
               selectedOptions?.some(
                 (selectedOption) =>
-                  selectedOption === sortedOptions[index - 1].id,
+                  selectedOption === sortedOptions[index - 1].id
               ) &&
               !isSelected && (
                 <Divider
@@ -209,80 +209,80 @@ function BaseChips({
             />
           </Fragment>
         ),
-      }
-    })
-  }, [sortedOptions, selectedOptions, styles?.chipOptionStyle, chipsTheme])
+      };
+    });
+  }, [sortedOptions, selectedOptions, styles?.chipOptionStyle, chipsTheme]);
 
   const FILTERED_OPTIONS: ComboboxOption[] = useMemo(() => {
-    if (!hasInteracted || !inputValue) return FINAL_OPTIONS
+    if (!hasInteracted || !inputValue) return FINAL_OPTIONS;
 
-    const search = inputValue.toLowerCase()
+    const search = inputValue.toLowerCase();
 
     return FINAL_OPTIONS.filter((option) => {
-      return option.text?.toLowerCase().includes(search)
-    })
-  }, [hasInteracted, inputValue, FINAL_OPTIONS])
+      return option.text?.toLowerCase().includes(search);
+    });
+  }, [hasInteracted, inputValue, FINAL_OPTIONS]);
 
-  const hasNoFilter = FILTERED_OPTIONS.length === 0 && inputValue.length > 1
+  const hasNoFilter = FILTERED_OPTIONS.length === 0 && inputValue.length > 1;
 
   const RENDER_SELECTED_OPTIONS: BadgeProps[] = useMemo(() => {
     return sortedOptions.filter((badge) =>
-      selectedOptions?.some((selectedOption) => selectedOption === badge.id),
-    )
-  }, [sortedOptions, selectedOptions])
+      selectedOptions?.some((selectedOption) => selectedOption === badge.id)
+    );
+  }, [sortedOptions, selectedOptions]);
 
   useEffect(() => {
     if (isOpen && mode === "idle") {
-      inputRef.current?.focus()
+      inputRef.current?.focus();
     }
-  }, [isOpen])
+  }, [isOpen]);
 
   const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (disabled) return
+    if (disabled) return;
 
-    setInteractionMode("keyboard")
+    setInteractionMode("keyboard");
 
     if (e.key === "ArrowDown") {
-      e.preventDefault()
-      if (!isOpen) await setIsOpen(true)
+      e.preventDefault();
+      if (!isOpen) await setIsOpen(true);
       await setHighlightedIndex((prev) =>
-        Math.min(prev + 1, FILTERED_OPTIONS.length - 1),
-      )
+        Math.min(prev + 1, FILTERED_OPTIONS.length - 1)
+      );
     } else if (e.key === "ArrowUp") {
-      e.preventDefault()
-      if (!isOpen) await setIsOpen(true)
-      await setHighlightedIndex((prev) => Math.max(prev - 1, 0))
+      e.preventDefault();
+      if (!isOpen) await setIsOpen(true);
+      await setHighlightedIndex((prev) => Math.max(prev - 1, 0));
     } else if (e.key === "Enter") {
-      e.preventDefault()
+      e.preventDefault();
       if (hasNoFilter) {
-        await setMode("create")
-        await inputMissingRef?.current?.focus()
+        await setMode("create");
+        await inputMissingRef?.current?.focus();
       } else {
-        const selectedOption = FILTERED_OPTIONS[highlightedIndex]
-        if (!selectedOption) return
+        const selectedOption = FILTERED_OPTIONS[highlightedIndex];
+        if (!selectedOption) return;
 
-        const optionId = String(selectedOption.value)
-        const isSelected = selectedOptions?.some((id) => id === optionId)
+        const optionId = String(selectedOption.value);
+        const isSelected = selectedOptions?.some((id) => id === optionId);
 
         const finalSelectedOptions = isSelected
           ? selectedOptions?.filter((id) => id !== optionId)
-          : [...(selectedOptions ?? []), optionId]
+          : [...(selectedOptions ?? []), optionId];
 
         if (onChange) {
-          onChange(finalSelectedOptions)
+          onChange(finalSelectedOptions);
         }
       }
     } else if (e.key === "Escape") {
-      e.preventDefault()
-      await setIsOpen(false)
+      e.preventDefault();
+      await setIsOpen(false);
     }
-  }
+  };
 
   const finalDrawerHeight = mobile
     ? (drawerHeight ?? "320px")
-    : (drawerHeight ?? "220px")
+    : (drawerHeight ?? "220px");
 
-  const hasFewOptions = FILTERED_OPTIONS?.length < 5
+  const hasFewOptions = FILTERED_OPTIONS?.length < 5;
 
   return (
     <>
@@ -303,7 +303,7 @@ function BaseChips({
             <Badge
               key={badge.id}
               onClick={(e) => {
-                e.stopPropagation()
+                e.stopPropagation();
               }}
               aria-label="chips-selected"
               variant={badge.variant}
@@ -319,7 +319,7 @@ function BaseChips({
               caption={badge.caption}
               withCircle
             />
-          ),
+          )
         )}
 
         <AddButton
@@ -330,7 +330,7 @@ function BaseChips({
           $isOpen={isOpen}
           {...getReferenceProps({
             onClick: (e) => {
-              e.preventDefault()
+              e.preventDefault();
             },
           })}
         />
@@ -419,8 +419,8 @@ function BaseChips({
           }}
           fadeEffect={hasFewOptions ? [] : ["bottom"]}
           onChange={async (selectedOptions?: SelectboxSelectedOptions) => {
-            if (!Array.isArray(selectedOptions)) return
-            onChange?.(selectedOptions as string[])
+            if (!Array.isArray(selectedOptions)) return;
+            onChange?.(selectedOptions as string[]);
           }}
           setSelectedOptionsLocal={(selectedOptionsLocal?: SelectboxOption) => {
             setInputValue?.({
@@ -428,7 +428,7 @@ function BaseChips({
                 name,
                 value: selectedOptionsLocal?.text || "",
               },
-            } as ChangeEvent<HTMLInputElement>)
+            } as ChangeEvent<HTMLInputElement>);
           }}
           setHasInteracted={setHasInteracted}
           options={mode === "idle" ? FILTERED_OPTIONS : []}
@@ -442,8 +442,8 @@ function BaseChips({
           {mode === "idle" && hasNoFilter && creatable && (
             <EmptyOptionContainer
               onClick={async () => {
-                await setMode("create")
-                await inputMissingRef?.current?.focus()
+                await setMode("create");
+                await inputMissingRef?.current?.focus();
               }}
               $hovered={highlightedIndex === 0}
               $theme={chipsTheme}
@@ -470,8 +470,8 @@ function BaseChips({
                 ? missingOptionForm({
                     firstInputRef: inputMissingRef,
                     closeForm: async () => {
-                      await setMode("idle")
-                      await inputRef.current?.focus()
+                      await setMode("idle");
+                      await inputRef.current?.focus();
                     },
                   })
                 : missingOptionForm}
@@ -480,12 +480,12 @@ function BaseChips({
         </Combobox.Drawer>
       )}
     </>
-  )
+  );
 }
 
 const InputGroup = styled.div<{
-  $containerStyle?: CSSProp
-  $disabled?: boolean
+  $containerStyle?: CSSProp;
+  $disabled?: boolean;
 }>`
   display: flex;
   flex-direction: row;
@@ -500,12 +500,12 @@ const InputGroup = styled.div<{
     `};
 
   ${({ $containerStyle }) => $containerStyle}
-`
+`;
 
 const AddButton = styled(RiAddLine)<{
-  $isOpen?: boolean
-  $disabled?: boolean
-  $theme?: ChipsThemeConfig
+  $isOpen?: boolean;
+  $disabled?: boolean;
+  $theme?: ChipsThemeConfig;
 }>`
   cursor: pointer;
   border: 1px solid transparent;
@@ -535,14 +535,14 @@ const AddButton = styled(RiAddLine)<{
       box-shadow: ${$theme?.boxShadow || "0 4px 6px rgba(0,0,0,0.1)"};
       border-color: ${$theme?.borderColor || "#d1d5db"};
     `}
-`
+`;
 
-export type ChipsStyles = BaseChipsStyles & FieldLaneStyles
+export type ChipsStyles = BaseChipsStyles & FieldLaneStyles;
 
 export interface ChipsProps
   extends Omit<BaseChipsProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: ChipsStyles
+  styles?: ChipsStyles;
 }
 
 function Chips({
@@ -565,7 +565,7 @@ function Chips({
     prefix: "chips",
     name,
     id,
-  })
+  });
 
   const {
     bodyStyle,
@@ -576,7 +576,7 @@ function Chips({
     helperIconStyle,
     helperArrowStyle,
     ...baseChipStyles
-  } = styles ?? {}
+  } = styles ?? {};
 
   return (
     <FieldLane
@@ -612,11 +612,11 @@ function Chips({
         disabled={disabled}
       />
     </FieldLane>
-  )
+  );
 }
 
 const Divider = styled.div<{
-  $theme?: ChipsThemeConfig
+  $theme?: ChipsThemeConfig;
 }>`
   position: absolute;
   top: 0;
@@ -626,11 +626,11 @@ const Divider = styled.div<{
   transform: translateX(-50%);
 
   border-bottom: 1px solid ${({ $theme }) => $theme?.dividerColor};
-`
+`;
 
 const EmptyOptionContainer = styled.div<{
-  $hovered?: boolean
-  $theme: ChipsThemeConfig
+  $hovered?: boolean;
+  $theme: ChipsThemeConfig;
 }>`
   display: flex;
   flex-direction: row;
@@ -657,6 +657,6 @@ const EmptyOptionContainer = styled.div<{
       background-color: ${$theme.hoverBackgroundColor};
     `}
   `}
-`
+`;
 
-export { Chips }
+export { Chips };

--- a/components/chips.tsx
+++ b/components/chips.tsx
@@ -1,5 +1,5 @@
-import { RiAddLine } from "@remixicon/react";
-import { Badge, BadgeAction, BadgeProps } from "./badge";
+import { RiAddLine } from "@remixicon/react"
+import { Badge, BadgeAction, BadgeProps } from "./badge"
 import {
   ChangeEvent,
   Fragment,
@@ -9,7 +9,7 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react";
+} from "react"
 import {
   autoUpdate,
   flip,
@@ -19,61 +19,61 @@ import {
   useFloating,
   useInteractions,
   useRole,
-} from "@floating-ui/react";
-import styled, { css, CSSProp } from "styled-components";
-import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { useTheme } from "./../theme/provider";
-import { ChipsThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
-import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox";
-import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox";
+} from "@floating-ui/react"
+import styled, { css, CSSProp } from "styled-components"
+import { StatefulForm } from "./stateful-form"
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
+import { useTheme } from "./../theme/provider"
+import { ChipsThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
+import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox"
+import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox"
 
-export type ChipAction = BadgeAction;
+export type ChipAction = BadgeAction
 
-export type ChipProps = BadgeProps;
+export type ChipProps = BadgeProps
 
 interface BaseChipsProps {
-  options?: ChipProps[];
-  inputValue?: string;
+  options?: ChipProps[]
+  inputValue?: string
   setInputValue?: (
-    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => void;
-  filterPlaceholder?: string;
-  missingOptionLabel?: string;
-  creatable?: boolean;
-  selectedOptions?: string[];
-  onChange?: (selectedOptions: string[]) => void;
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void
+  filterPlaceholder?: string
+  missingOptionLabel?: string
+  creatable?: boolean
+  selectedOptions?: string[]
+  onChange?: (selectedOptions: string[]) => void
   missingOptionForm?:
     | ReactNode
-    | ((props?: MissingOptionFormProps) => ReactNode);
-  emptySlate?: string;
-  renderer?: (props: ChipRendererProps) => ReactNode;
-  styles?: BaseChipsStyles;
-  name?: string;
-  id?: string;
-  disabled?: boolean;
-  mobile?: boolean;
-  drawerHeight?: string;
+    | ((props?: MissingOptionFormProps) => ReactNode)
+  emptySlate?: string
+  renderer?: (props: ChipRendererProps) => ReactNode
+  styles?: BaseChipsStyles
+  name?: string
+  id?: string
+  disabled?: boolean
+  mobile?: boolean
+  drawerHeight?: string
 }
 
 export interface BaseChipsStyles {
-  chipsContainerStyle?: CSSProp;
-  chipSelectedStyle?: CSSProp;
-  chipOptionWrapperStyle?: CSSProp;
-  chipOptionStyle?: CSSProp;
-  chipsDrawerStyle?: CSSProp;
+  chipsContainerStyle?: CSSProp
+  chipSelectedStyle?: CSSProp
+  chipOptionWrapperStyle?: CSSProp
+  chipOptionStyle?: CSSProp
+  chipsDrawerStyle?: CSSProp
 }
 
 export interface ChipRendererProps {
-  id?: string;
-  caption?: string;
-  metadata?: Record<string, unknown>;
+  id?: string
+  caption?: string
+  metadata?: Record<string, unknown>
 }
 
 export interface MissingOptionFormProps {
-  firstInputRef?: Ref<HTMLInputElement>;
-  closeForm?: () => void;
+  firstInputRef?: Ref<HTMLInputElement>
+  closeForm?: () => void
 }
 
 function BaseChips({
@@ -95,23 +95,23 @@ function BaseChips({
   mobile,
   drawerHeight,
 }: BaseChipsProps) {
-  const { currentTheme } = useTheme();
-  const chipsTheme = currentTheme.chips;
-  const textboxTheme = currentTheme.textbox;
+  const { currentTheme } = useTheme()
+  const chipsTheme = currentTheme.chips
+  const textboxTheme = currentTheme.textbox
 
-  const inputRef = useRef<HTMLInputElement>(null);
-  const inputMissingRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null)
+  const inputMissingRef = useRef<HTMLInputElement>(null)
 
-  const [mode, setMode] = useState<"idle" | "create">("idle");
+  const [mode, setMode] = useState<"idle" | "create">("idle")
 
-  const [isOpen, setIsOpen] = useState(false);
-  const [hasInteracted, setHasInteracted] = useState(false);
-  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [isOpen, setIsOpen] = useState(false)
+  const [hasInteracted, setHasInteracted] = useState(false)
+  const [highlightedIndex, setHighlightedIndex] = useState(0)
   const [interactionMode, setInteractionMode] = useState<"mouse" | "keyboard">(
-    "keyboard"
-  );
+    "keyboard",
+  )
 
-  const listRef = useRef<(HTMLLIElement | null)[]>([]);
+  const listRef = useRef<(HTMLLIElement | null)[]>([])
 
   const { refs, floatingStyles, context } = useFloating({
     open: isOpen,
@@ -122,50 +122,50 @@ function BaseChips({
     ],
     whileElementsMounted: autoUpdate,
     placement: "bottom-start",
-  });
+  })
 
-  const click = useClick(context);
-  const dismiss = useDismiss(context);
-  const role = useRole(context);
+  const click = useClick(context)
+  const dismiss = useDismiss(context)
+  const role = useRole(context)
 
   const { getReferenceProps, getFloatingProps } = useInteractions([
     click,
     dismiss,
     role,
-  ]);
+  ])
 
   // Keep selected options at the top, following the order in selectedOptions.
   // Unselected options preserve their original order.
   const sortedOptions = [...options].sort((a, b) => {
-    const aIndex = selectedOptions?.findIndex((id) => id === a.id) ?? -1;
-    const bIndex = selectedOptions?.findIndex((id) => id === b.id) ?? -1;
+    const aIndex = selectedOptions?.findIndex((id) => id === a.id) ?? -1
+    const bIndex = selectedOptions?.findIndex((id) => id === b.id) ?? -1
 
     if (aIndex !== -1 && bIndex !== -1) {
-      return aIndex - bIndex;
+      return aIndex - bIndex
     }
 
-    if (aIndex !== -1) return -1;
-    if (bIndex !== -1) return 1;
+    if (aIndex !== -1) return -1
+    if (bIndex !== -1) return 1
 
-    return 0;
-  });
+    return 0
+  })
 
   const FINAL_OPTIONS: ComboboxOption[] = useMemo(() => {
     return sortedOptions.map((badge, index) => {
       const isSelected = selectedOptions?.some(
-        (selectedOption) => selectedOption === badge.id
-      );
+        (selectedOption) => selectedOption === badge.id,
+      )
 
       const badgeActions = badge?.actions?.map((action) => ({
         ...action,
         onClick: ({ badge, event }) => {
-          event?.preventDefault();
+          event?.preventDefault()
           action?.onClick?.({
             badge,
             event,
-          });
+          })
         },
-      }));
+      }))
 
       return {
         text: badge.caption,
@@ -176,7 +176,7 @@ function BaseChips({
               sortedOptions[index - 1] &&
               selectedOptions?.some(
                 (selectedOption) =>
-                  selectedOption === sortedOptions[index - 1].id
+                  selectedOption === sortedOptions[index - 1].id,
               ) &&
               !isSelected && (
                 <Divider
@@ -209,80 +209,80 @@ function BaseChips({
             />
           </Fragment>
         ),
-      };
-    });
-  }, [sortedOptions, selectedOptions, styles?.chipOptionStyle, chipsTheme]);
+      }
+    })
+  }, [sortedOptions, selectedOptions, styles?.chipOptionStyle, chipsTheme])
 
   const FILTERED_OPTIONS: ComboboxOption[] = useMemo(() => {
-    if (!hasInteracted || !inputValue) return FINAL_OPTIONS;
+    if (!hasInteracted || !inputValue) return FINAL_OPTIONS
 
-    const search = inputValue.toLowerCase();
+    const search = inputValue.toLowerCase()
 
     return FINAL_OPTIONS.filter((option) => {
-      return option.text?.toLowerCase().includes(search);
-    });
-  }, [hasInteracted, inputValue, FINAL_OPTIONS]);
+      return option.text?.toLowerCase().includes(search)
+    })
+  }, [hasInteracted, inputValue, FINAL_OPTIONS])
 
-  const hasNoFilter = FILTERED_OPTIONS.length === 0 && inputValue.length > 1;
+  const hasNoFilter = FILTERED_OPTIONS.length === 0 && inputValue.length > 1
 
   const RENDER_SELECTED_OPTIONS: BadgeProps[] = useMemo(() => {
     return sortedOptions.filter((badge) =>
-      selectedOptions?.some((selectedOption) => selectedOption === badge.id)
-    );
-  }, [sortedOptions, selectedOptions]);
+      selectedOptions?.some((selectedOption) => selectedOption === badge.id),
+    )
+  }, [sortedOptions, selectedOptions])
 
   useEffect(() => {
     if (isOpen && mode === "idle") {
-      inputRef.current?.focus();
+      inputRef.current?.focus()
     }
-  }, [isOpen]);
+  }, [isOpen])
 
   const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (disabled) return;
+    if (disabled) return
 
-    setInteractionMode("keyboard");
+    setInteractionMode("keyboard")
 
     if (e.key === "ArrowDown") {
-      e.preventDefault();
-      if (!isOpen) await setIsOpen(true);
+      e.preventDefault()
+      if (!isOpen) await setIsOpen(true)
       await setHighlightedIndex((prev) =>
-        Math.min(prev + 1, FILTERED_OPTIONS.length - 1)
-      );
+        Math.min(prev + 1, FILTERED_OPTIONS.length - 1),
+      )
     } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      if (!isOpen) await setIsOpen(true);
-      await setHighlightedIndex((prev) => Math.max(prev - 1, 0));
+      e.preventDefault()
+      if (!isOpen) await setIsOpen(true)
+      await setHighlightedIndex((prev) => Math.max(prev - 1, 0))
     } else if (e.key === "Enter") {
-      e.preventDefault();
+      e.preventDefault()
       if (hasNoFilter) {
-        await setMode("create");
-        await inputMissingRef?.current?.focus();
+        await setMode("create")
+        await inputMissingRef?.current?.focus()
       } else {
-        const selectedOption = FILTERED_OPTIONS[highlightedIndex];
-        if (!selectedOption) return;
+        const selectedOption = FILTERED_OPTIONS[highlightedIndex]
+        if (!selectedOption) return
 
-        const optionId = String(selectedOption.value);
-        const isSelected = selectedOptions?.some((id) => id === optionId);
+        const optionId = String(selectedOption.value)
+        const isSelected = selectedOptions?.some((id) => id === optionId)
 
         const finalSelectedOptions = isSelected
           ? selectedOptions?.filter((id) => id !== optionId)
-          : [...(selectedOptions ?? []), optionId];
+          : [...(selectedOptions ?? []), optionId]
 
         if (onChange) {
-          onChange(finalSelectedOptions);
+          onChange(finalSelectedOptions)
         }
       }
     } else if (e.key === "Escape") {
-      e.preventDefault();
-      await setIsOpen(false);
+      e.preventDefault()
+      await setIsOpen(false)
     }
-  };
+  }
 
   const finalDrawerHeight = mobile
     ? (drawerHeight ?? "320px")
-    : (drawerHeight ?? "220px");
+    : (drawerHeight ?? "220px")
 
-  const hasFewOptions = FILTERED_OPTIONS?.length < 5;
+  const hasFewOptions = FILTERED_OPTIONS?.length < 5
 
   return (
     <>
@@ -303,7 +303,7 @@ function BaseChips({
             <Badge
               key={badge.id}
               onClick={(e) => {
-                e.stopPropagation();
+                e.stopPropagation()
               }}
               aria-label="chips-selected"
               variant={badge.variant}
@@ -319,7 +319,7 @@ function BaseChips({
               caption={badge.caption}
               withCircle
             />
-          )
+          ),
         )}
 
         <AddButton
@@ -330,7 +330,7 @@ function BaseChips({
           $isOpen={isOpen}
           {...getReferenceProps({
             onClick: (e) => {
-              e.preventDefault();
+              e.preventDefault()
             },
           })}
         />
@@ -419,8 +419,8 @@ function BaseChips({
           }}
           fadeEffect={hasFewOptions ? [] : ["bottom"]}
           onChange={async (selectedOptions?: SelectboxSelectedOptions) => {
-            if (!Array.isArray(selectedOptions)) return;
-            onChange?.(selectedOptions as string[]);
+            if (!Array.isArray(selectedOptions)) return
+            onChange?.(selectedOptions as string[])
           }}
           setSelectedOptionsLocal={(selectedOptionsLocal?: SelectboxOption) => {
             setInputValue?.({
@@ -428,7 +428,7 @@ function BaseChips({
                 name,
                 value: selectedOptionsLocal?.text || "",
               },
-            } as ChangeEvent<HTMLInputElement>);
+            } as ChangeEvent<HTMLInputElement>)
           }}
           setHasInteracted={setHasInteracted}
           options={mode === "idle" ? FILTERED_OPTIONS : []}
@@ -442,8 +442,8 @@ function BaseChips({
           {mode === "idle" && hasNoFilter && creatable && (
             <EmptyOptionContainer
               onClick={async () => {
-                await setMode("create");
-                await inputMissingRef?.current?.focus();
+                await setMode("create")
+                await inputMissingRef?.current?.focus()
               }}
               $hovered={highlightedIndex === 0}
               $theme={chipsTheme}
@@ -470,8 +470,8 @@ function BaseChips({
                 ? missingOptionForm({
                     firstInputRef: inputMissingRef,
                     closeForm: async () => {
-                      await setMode("idle");
-                      await inputRef.current?.focus();
+                      await setMode("idle")
+                      await inputRef.current?.focus()
                     },
                   })
                 : missingOptionForm}
@@ -480,12 +480,12 @@ function BaseChips({
         </Combobox.Drawer>
       )}
     </>
-  );
+  )
 }
 
 const InputGroup = styled.div<{
-  $containerStyle?: CSSProp;
-  $disabled?: boolean;
+  $containerStyle?: CSSProp
+  $disabled?: boolean
 }>`
   display: flex;
   flex-direction: row;
@@ -500,12 +500,12 @@ const InputGroup = styled.div<{
     `};
 
   ${({ $containerStyle }) => $containerStyle}
-`;
+`
 
 const AddButton = styled(RiAddLine)<{
-  $isOpen?: boolean;
-  $disabled?: boolean;
-  $theme?: ChipsThemeConfig;
+  $isOpen?: boolean
+  $disabled?: boolean
+  $theme?: ChipsThemeConfig
 }>`
   cursor: pointer;
   border: 1px solid transparent;
@@ -535,14 +535,14 @@ const AddButton = styled(RiAddLine)<{
       box-shadow: ${$theme?.boxShadow || "0 4px 6px rgba(0,0,0,0.1)"};
       border-color: ${$theme?.borderColor || "#d1d5db"};
     `}
-`;
+`
 
-export type ChipsStyles = BaseChipsStyles & FieldLaneStyles;
+export type ChipsStyles = BaseChipsStyles & FieldLaneStyles
 
 export interface ChipsProps
   extends Omit<BaseChipsProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: ChipsStyles;
+  styles?: ChipsStyles
 }
 
 function Chips({
@@ -565,15 +565,18 @@ function Chips({
     prefix: "chips",
     name,
     id,
-  });
+  })
 
   const {
     bodyStyle,
     controlStyle,
     containerStyle,
     labelStyle,
+    helperDrawerStyle,
+    helperIconStyle,
+    helperArrowStyle,
     ...baseChipStyles
-  } = styles ?? {};
+  } = styles ?? {}
 
   return (
     <FieldLane
@@ -596,6 +599,9 @@ function Chips({
         controlStyle,
         containerStyle,
         labelStyle,
+        helperDrawerStyle,
+        helperIconStyle,
+        helperArrowStyle,
       }}
     >
       <BaseChips
@@ -606,11 +612,11 @@ function Chips({
         disabled={disabled}
       />
     </FieldLane>
-  );
+  )
 }
 
 const Divider = styled.div<{
-  $theme?: ChipsThemeConfig;
+  $theme?: ChipsThemeConfig
 }>`
   position: absolute;
   top: 0;
@@ -620,11 +626,11 @@ const Divider = styled.div<{
   transform: translateX(-50%);
 
   border-bottom: 1px solid ${({ $theme }) => $theme?.dividerColor};
-`;
+`
 
 const EmptyOptionContainer = styled.div<{
-  $hovered?: boolean;
-  $theme: ChipsThemeConfig;
+  $hovered?: boolean
+  $theme: ChipsThemeConfig
 }>`
   display: flex;
   flex-direction: row;
@@ -651,6 +657,6 @@ const EmptyOptionContainer = styled.div<{
       background-color: ${$theme.hoverBackgroundColor};
     `}
   `}
-`;
+`
 
-export { Chips };
+export { Chips }

--- a/components/colorbox.tsx
+++ b/components/colorbox.tsx
@@ -5,35 +5,35 @@ import {
   useCallback,
   useRef,
   useState,
-} from "react"
-import styled, { css, CSSProp } from "styled-components"
+} from "react";
+import styled, { css, CSSProp } from "styled-components";
 import {
   FieldLane,
   FieldLaneAction,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane"
-import { StatefulForm } from "./stateful-form"
-import { ColorboxThemeConfig } from "theme"
-import { useTheme } from "./../theme/provider"
-import { applyClassName } from "./../constants/classname"
+} from "./field-lane";
+import { StatefulForm } from "./stateful-form";
+import { ColorboxThemeConfig } from "theme";
+import { useTheme } from "./../theme/provider";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseColorboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "style"> {
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
-  value?: string
-  showError?: boolean
-  onClick?: () => void
-  styles?: BaseColorboxStyles
-  id?: string
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  value?: string;
+  showError?: boolean;
+  onClick?: () => void;
+  styles?: BaseColorboxStyles;
+  id?: string;
 }
 
 export interface BaseColorboxStyles {
-  textInputGroupStyle?: CSSProp
-  textInputStyle?: CSSProp
-  boxStyle?: CSSProp
-  self?: CSSProp
+  textInputGroupStyle?: CSSProp;
+  textInputStyle?: CSSProp;
+  boxStyle?: CSSProp;
+  self?: CSSProp;
 }
 
 const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
@@ -49,21 +49,21 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
       disabled,
       ...props
     },
-    ref,
+    ref
   ) => {
-    const { currentTheme } = useTheme()
-    const colorboxTheme = currentTheme?.colorbox
+    const { currentTheme } = useTheme();
+    const colorboxTheme = currentTheme?.colorbox;
 
-    const [hovered, setHovered] = useState(false)
+    const [hovered, setHovered] = useState(false);
 
-    const debounceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const debounceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const handleColorChange = useCallback(
       (e: ChangeEvent<HTMLInputElement>) => {
-        const newValue = e.target.value
+        const newValue = e.target.value;
 
         if (debounceTimeout.current) {
-          clearTimeout(debounceTimeout.current)
+          clearTimeout(debounceTimeout.current);
         }
 
         debounceTimeout.current = setTimeout(() => {
@@ -73,12 +73,12 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
                 name: props.name,
                 value: newValue,
               },
-            } as ChangeEvent<HTMLInputElement>)
+            } as ChangeEvent<HTMLInputElement>);
           }
-        }, 2)
+        }, 2);
       },
-      [onChange, props.name],
-    )
+      [onChange, props.name]
+    );
 
     return (
       <ColorInputContainer
@@ -89,7 +89,7 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
         $hovered={hovered}
         $showError={!!showError}
         onBlur={() => {
-          setHovered(false)
+          setHovered(false);
         }}
       >
         <ColorBox
@@ -97,9 +97,9 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
           $theme={colorboxTheme}
           $disabled={disabled}
           onClick={() => {
-            setHovered(true)
-            document.getElementById(id)?.click()
-            if (onClick) onClick()
+            setHovered(true);
+            document.getElementById(id)?.click();
+            if (onClick) onClick();
           }}
           tabIndex={0}
           $bgColor={value}
@@ -138,16 +138,16 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
             $style={styles?.textInputStyle}
             value={value?.replace(/^#/, "")}
             onChange={(e) => {
-              const cleanValue = e.target.value.replace(/#/g, "")
+              const cleanValue = e.target.value.replace(/#/g, "");
 
               const inputChangeEvent = {
                 target: {
                   name: props.name,
                   value: `#${cleanValue}`,
                 },
-              } as ChangeEvent<HTMLInputElement>
+              } as ChangeEvent<HTMLInputElement>;
               if (onChange) {
-                onChange(inputChangeEvent)
+                onChange(inputChangeEvent);
               }
             }}
             placeholder={placeholder}
@@ -159,20 +159,20 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
           />
         </TextInputGroup>
       </ColorInputContainer>
-    )
-  },
-)
+    );
+  }
+);
 
-export type ColorboxDropdownOption = FieldLaneDropdownOption
+export type ColorboxDropdownOption = FieldLaneDropdownOption;
 
-export type ColorboxStyles = BaseColorboxStyles & FieldLaneStyles
+export type ColorboxStyles = BaseColorboxStyles & FieldLaneStyles;
 export interface ColorboxProps
   extends Omit<BaseColorboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type"> {
-  styles?: ColorboxStyles
+  styles?: ColorboxStyles;
 }
 
-export type ColorboxAction = FieldLaneAction
+export type ColorboxAction = FieldLaneAction;
 
 const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
   ({ ...props }, ref) => {
@@ -191,13 +191,13 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
       labelPosition,
       className,
       ...rest
-    } = props
+    } = props;
 
     const inputId = StatefulForm.sanitizeId({
       prefix: "colorbox",
       name: props.name,
       id: props.id,
-    })
+    });
 
     const {
       self,
@@ -205,7 +205,7 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
       textInputStyle,
       boxStyle,
       ...fieldLaneInput
-    } = styles ?? {}
+    } = styles ?? {};
 
     return (
       <FieldLane
@@ -246,16 +246,16 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
           ref={ref}
         />
       </FieldLane>
-    )
-  },
-)
+    );
+  }
+);
 
 const ColorInputContainer = styled.div<{
-  $hovered: boolean
-  $showError: boolean
-  $style?: CSSProp
-  $disabled?: boolean
-  $theme: ColorboxThemeConfig
+  $hovered: boolean;
+  $showError: boolean;
+  $style?: CSSProp;
+  $disabled?: boolean;
+  $theme: ColorboxThemeConfig;
 }>`
   position: relative;
   display: flex;
@@ -285,14 +285,14 @@ const ColorInputContainer = styled.div<{
     `};
 
   ${({ $style }) => $style}
-`
+`;
 
 const ColorBox = styled.div<{
-  $bgColor?: string
-  $showError?: boolean
-  $disabled?: boolean
-  $theme: ColorboxThemeConfig
-  $style?: CSSProp
+  $bgColor?: string;
+  $showError?: boolean;
+  $disabled?: boolean;
+  $theme: ColorboxThemeConfig;
+  $style?: CSSProp;
 }>`
   min-width: 24px;
   min-height: 24px;
@@ -317,7 +317,7 @@ const ColorBox = styled.div<{
     `};
 
   ${({ $style }) => $style}
-`
+`;
 
 const HiddenColorInput = styled.input`
   position: absolute;
@@ -326,14 +326,14 @@ const HiddenColorInput = styled.input`
   width: 1px;
   height: 1px;
   opacity: 0;
-`
+`;
 
 const TextInputGroup = styled.span<{
-  $hovered: boolean
-  $showError: boolean
-  $disabled?: boolean
-  $theme: ColorboxThemeConfig
-  $style?: CSSProp
+  $hovered: boolean;
+  $showError: boolean;
+  $disabled?: boolean;
+  $theme: ColorboxThemeConfig;
+  $style?: CSSProp;
 }>`
   display: flex;
   align-items: center;
@@ -357,21 +357,21 @@ const TextInputGroup = styled.span<{
   width: 100%;
 
   ${({ $style }) => $style}
-`
+`;
 
 const Prefix = styled.span<{
-  $showError: boolean
-  $theme: ColorboxThemeConfig
+  $showError: boolean;
+  $theme: ColorboxThemeConfig;
 }>`
   color: ${({ $theme, $showError }) =>
     $showError ? $theme.errorTextColor : $theme.prefixColor};
-`
+`;
 
 const TextInput = styled.input<{
-  $showError: boolean
-  $disabled?: boolean
-  $theme: ColorboxThemeConfig
-  $style?: CSSProp
+  $showError: boolean;
+  $disabled?: boolean;
+  $theme: ColorboxThemeConfig;
+  $style?: CSSProp;
 }>`
   flex: 1;
   width: 100%;
@@ -396,6 +396,6 @@ const TextInput = styled.input<{
         : $theme.textColor};
 
   ${({ $style }) => $style}
-`
+`;
 
-export { Colorbox }
+export { Colorbox };

--- a/components/colorbox.tsx
+++ b/components/colorbox.tsx
@@ -5,35 +5,35 @@ import {
   useCallback,
   useRef,
   useState,
-} from "react";
-import styled, { css, CSSProp } from "styled-components";
+} from "react"
+import styled, { css, CSSProp } from "styled-components"
 import {
   FieldLane,
   FieldLaneAction,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane";
-import { StatefulForm } from "./stateful-form";
-import { ColorboxThemeConfig } from "theme";
-import { useTheme } from "./../theme/provider";
-import { applyClassName } from "./../constants/classname";
+} from "./field-lane"
+import { StatefulForm } from "./stateful-form"
+import { ColorboxThemeConfig } from "theme"
+import { useTheme } from "./../theme/provider"
+import { applyClassName } from "./../constants/classname"
 
 interface BaseColorboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "style"> {
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-  value?: string;
-  showError?: boolean;
-  onClick?: () => void;
-  styles?: BaseColorboxStyles;
-  id?: string;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
+  value?: string
+  showError?: boolean
+  onClick?: () => void
+  styles?: BaseColorboxStyles
+  id?: string
 }
 
 export interface BaseColorboxStyles {
-  textInputGroupStyle?: CSSProp;
-  textInputStyle?: CSSProp;
-  boxStyle?: CSSProp;
-  self?: CSSProp;
+  textInputGroupStyle?: CSSProp
+  textInputStyle?: CSSProp
+  boxStyle?: CSSProp
+  self?: CSSProp
 }
 
 const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
@@ -49,21 +49,21 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
       disabled,
       ...props
     },
-    ref
+    ref,
   ) => {
-    const { currentTheme } = useTheme();
-    const colorboxTheme = currentTheme?.colorbox;
+    const { currentTheme } = useTheme()
+    const colorboxTheme = currentTheme?.colorbox
 
-    const [hovered, setHovered] = useState(false);
+    const [hovered, setHovered] = useState(false)
 
-    const debounceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const debounceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 
     const handleColorChange = useCallback(
       (e: ChangeEvent<HTMLInputElement>) => {
-        const newValue = e.target.value;
+        const newValue = e.target.value
 
         if (debounceTimeout.current) {
-          clearTimeout(debounceTimeout.current);
+          clearTimeout(debounceTimeout.current)
         }
 
         debounceTimeout.current = setTimeout(() => {
@@ -73,12 +73,12 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
                 name: props.name,
                 value: newValue,
               },
-            } as ChangeEvent<HTMLInputElement>);
+            } as ChangeEvent<HTMLInputElement>)
           }
-        }, 2);
+        }, 2)
       },
-      [onChange, props.name]
-    );
+      [onChange, props.name],
+    )
 
     return (
       <ColorInputContainer
@@ -89,7 +89,7 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
         $hovered={hovered}
         $showError={!!showError}
         onBlur={() => {
-          setHovered(false);
+          setHovered(false)
         }}
       >
         <ColorBox
@@ -97,9 +97,9 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
           $theme={colorboxTheme}
           $disabled={disabled}
           onClick={() => {
-            setHovered(true);
-            document.getElementById(id)?.click();
-            if (onClick) onClick();
+            setHovered(true)
+            document.getElementById(id)?.click()
+            if (onClick) onClick()
           }}
           tabIndex={0}
           $bgColor={value}
@@ -138,16 +138,16 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
             $style={styles?.textInputStyle}
             value={value?.replace(/^#/, "")}
             onChange={(e) => {
-              const cleanValue = e.target.value.replace(/#/g, "");
+              const cleanValue = e.target.value.replace(/#/g, "")
 
               const inputChangeEvent = {
                 target: {
                   name: props.name,
                   value: `#${cleanValue}`,
                 },
-              } as ChangeEvent<HTMLInputElement>;
+              } as ChangeEvent<HTMLInputElement>
               if (onChange) {
-                onChange(inputChangeEvent);
+                onChange(inputChangeEvent)
               }
             }}
             placeholder={placeholder}
@@ -159,20 +159,20 @@ const BaseColorbox = forwardRef<HTMLInputElement, BaseColorboxProps>(
           />
         </TextInputGroup>
       </ColorInputContainer>
-    );
-  }
-);
+    )
+  },
+)
 
-export type ColorboxDropdownOption = FieldLaneDropdownOption;
+export type ColorboxDropdownOption = FieldLaneDropdownOption
 
-export type ColorboxStyles = BaseColorboxStyles & FieldLaneStyles;
+export type ColorboxStyles = BaseColorboxStyles & FieldLaneStyles
 export interface ColorboxProps
   extends Omit<BaseColorboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type"> {
-  styles?: ColorboxStyles;
+  styles?: ColorboxStyles
 }
 
-export type ColorboxAction = FieldLaneAction;
+export type ColorboxAction = FieldLaneAction
 
 const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
   ({ ...props }, ref) => {
@@ -191,13 +191,13 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
       labelPosition,
       className,
       ...rest
-    } = props;
+    } = props
 
     const inputId = StatefulForm.sanitizeId({
       prefix: "colorbox",
       name: props.name,
       id: props.id,
-    });
+    })
 
     const {
       self,
@@ -205,7 +205,7 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
       textInputStyle,
       boxStyle,
       ...fieldLaneInput
-    } = styles ?? {};
+    } = styles ?? {}
 
     return (
       <FieldLane
@@ -246,16 +246,16 @@ const Colorbox = forwardRef<HTMLInputElement, ColorboxProps>(
           ref={ref}
         />
       </FieldLane>
-    );
-  }
-);
+    )
+  },
+)
 
 const ColorInputContainer = styled.div<{
-  $hovered: boolean;
-  $showError: boolean;
-  $style?: CSSProp;
-  $disabled?: boolean;
-  $theme: ColorboxThemeConfig;
+  $hovered: boolean
+  $showError: boolean
+  $style?: CSSProp
+  $disabled?: boolean
+  $theme: ColorboxThemeConfig
 }>`
   position: relative;
   display: flex;
@@ -285,14 +285,14 @@ const ColorInputContainer = styled.div<{
     `};
 
   ${({ $style }) => $style}
-`;
+`
 
 const ColorBox = styled.div<{
-  $bgColor?: string;
-  $showError?: boolean;
-  $disabled?: boolean;
-  $theme: ColorboxThemeConfig;
-  $style?: CSSProp;
+  $bgColor?: string
+  $showError?: boolean
+  $disabled?: boolean
+  $theme: ColorboxThemeConfig
+  $style?: CSSProp
 }>`
   min-width: 24px;
   min-height: 24px;
@@ -317,7 +317,7 @@ const ColorBox = styled.div<{
     `};
 
   ${({ $style }) => $style}
-`;
+`
 
 const HiddenColorInput = styled.input`
   position: absolute;
@@ -326,14 +326,14 @@ const HiddenColorInput = styled.input`
   width: 1px;
   height: 1px;
   opacity: 0;
-`;
+`
 
 const TextInputGroup = styled.span<{
-  $hovered: boolean;
-  $showError: boolean;
-  $disabled?: boolean;
-  $theme: ColorboxThemeConfig;
-  $style?: CSSProp;
+  $hovered: boolean
+  $showError: boolean
+  $disabled?: boolean
+  $theme: ColorboxThemeConfig
+  $style?: CSSProp
 }>`
   display: flex;
   align-items: center;
@@ -357,21 +357,21 @@ const TextInputGroup = styled.span<{
   width: 100%;
 
   ${({ $style }) => $style}
-`;
+`
 
 const Prefix = styled.span<{
-  $showError: boolean;
-  $theme: ColorboxThemeConfig;
+  $showError: boolean
+  $theme: ColorboxThemeConfig
 }>`
   color: ${({ $theme, $showError }) =>
     $showError ? $theme.errorTextColor : $theme.prefixColor};
-`;
+`
 
 const TextInput = styled.input<{
-  $showError: boolean;
-  $disabled?: boolean;
-  $theme: ColorboxThemeConfig;
-  $style?: CSSProp;
+  $showError: boolean
+  $disabled?: boolean
+  $theme: ColorboxThemeConfig
+  $style?: CSSProp
 }>`
   flex: 1;
   width: 100%;
@@ -396,6 +396,6 @@ const TextInput = styled.input<{
         : $theme.textColor};
 
   ${({ $style }) => $style}
-`;
+`
 
-export { Colorbox };
+export { Colorbox }

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -10,7 +10,7 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react";
+} from "react"
 import {
   castValue,
   DrawerProps,
@@ -19,116 +19,115 @@ import {
   SelectboxLabels,
   SelectboxSelectedOptions,
   SelectboxStyles,
-} from "./selectbox";
-import styled, { css, CSSProp } from "styled-components";
-import { FieldLaneDropdownOption, FieldLaneProps } from "./field-lane";
-import { StatefulForm } from "./stateful-form";
-import { useTheme } from "./../theme/provider";
-import { ComboboxThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
+} from "./selectbox"
+import styled, { css, CSSProp } from "styled-components"
+import { FieldLaneDropdownOption, FieldLaneProps } from "./field-lane"
+import { StatefulForm } from "./stateful-form"
+import { useTheme } from "./../theme/provider"
+import { ComboboxThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
 import {
   TreeList,
   TreeListAction,
   TreeListContent,
   TreeListItem,
   TreeListItemAction,
-} from "./treelist";
-import { Searchbox, SearchboxProps } from "./searchbox";
-import { Checkbox, CheckboxProps } from "./checkbox";
-import { createPortal } from "react-dom";
+} from "./treelist"
+import { Searchbox, SearchboxProps } from "./searchbox"
+import { Checkbox, CheckboxProps } from "./checkbox"
+import { createPortal } from "react-dom"
 
 interface BaseComboboxProps {
-  selectedOptions?: SelectboxSelectedOptions;
-  onChange?: (selectedOptions: SelectboxSelectedOptions) => void;
-  clearable?: boolean;
-  placeholder?: string;
-  emptySlate?: string;
-  highlightOnMatch?: boolean;
-  actions?: ComboboxAction[];
-  name?: string;
-  multiple?: boolean;
-  maxSelectableItems?: number | undefined;
-  styles?: ComboboxStyles;
-  helper?: string;
-  disabled?: boolean;
-  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
-  onClick?: () => void;
-  strict?: boolean;
-  options: ComboboxOption[];
-  isLoading?: boolean;
-  labels?: ComboboxLabelsProps;
-  mobile?: boolean;
-  drawerHeight?: string;
+  selectedOptions?: SelectboxSelectedOptions
+  onChange?: (selectedOptions: SelectboxSelectedOptions) => void
+  clearable?: boolean
+  placeholder?: string
+  emptySlate?: string
+  highlightOnMatch?: boolean
+  actions?: ComboboxAction[]
+  name?: string
+  multiple?: boolean
+  maxSelectableItems?: number | undefined
+  styles?: ComboboxStyles
+  disabled?: boolean
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
+  onClick?: () => void
+  strict?: boolean
+  options: ComboboxOption[]
+  isLoading?: boolean
+  labels?: ComboboxLabelsProps
+  mobile?: boolean
+  drawerHeight?: string
 }
 
 export const ComboboxGroupInitialState = {
   Opened: "opened",
   Closed: "closed",
-} as const;
+} as const
 
 export type ComboboxGroupInitialState =
-  (typeof ComboboxGroupInitialState)[keyof typeof ComboboxGroupInitialState];
+  (typeof ComboboxGroupInitialState)[keyof typeof ComboboxGroupInitialState]
 
 export type ComboboxOption = SelectboxOption &
   ComboboxActionOption & {
-    groupOptions?: ComboboxOption[];
-    groupSetting?: ComboboxGroupSetting;
-  };
+    groupOptions?: ComboboxOption[]
+    groupSetting?: ComboboxGroupSetting
+  }
 
 interface ComboboxGroupSetting {
-  collapsible?: boolean;
-  initialState?: ComboboxGroupInitialState;
+  collapsible?: boolean
+  initialState?: ComboboxGroupInitialState
 }
 
 interface ComboboxActionOption {
-  actions?: (id?: string) => ComboboxItemAction[];
+  actions?: (id?: string) => ComboboxItemAction[]
 }
 
-export type ComboboxItemAction = TreeListItemAction;
+export type ComboboxItemAction = TreeListItemAction
 
-export type ComboboxDropdownOption = FieldLaneDropdownOption;
+export type ComboboxDropdownOption = FieldLaneDropdownOption
 
 export interface ComboboxLabelsProps extends SelectboxLabels {}
 
 export interface ComboboxStyles extends Omit<SelectboxStyles, "self"> {
-  selectboxStyle?: CSSProp;
-  drawerStyle?: CSSProp;
-  rowStyle?: CSSProp;
-  rowContainerStyle?: CSSProp;
+  selectboxStyle?: CSSProp
+  drawerStyle?: CSSProp
+  rowStyle?: CSSProp
+  rowContainerStyle?: CSSProp
 }
 
-export type ComboboxAction = TreeListAction;
+export type ComboboxAction = TreeListAction
 
 export type ComboboxDrawerProps = Omit<DrawerProps, "refs"> &
   BaseComboboxProps & {
-    inputRef?: Ref<HTMLInputElement>;
-    handleKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
-    selectedOptionsLocal: SelectboxOption;
-    setSelectedOptionsLocal: (value: SelectboxOption) => void;
-    setHasInteracted?: (value: boolean) => void;
-    setConfirmedValue?: (option: SelectboxOption | null) => void;
-    openedCategoryGroup?: Set<string>;
+    inputRef?: Ref<HTMLInputElement>
+    handleKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
+    selectedOptionsLocal: SelectboxOption
+    setSelectedOptionsLocal: (value: SelectboxOption) => void
+    setHasInteracted?: (value: boolean) => void
+    setConfirmedValue?: (option: SelectboxOption | null) => void
+    openedCategoryGroup?: Set<string>
     setOpenedCategoryGroup?: (
-      updater: (prev: Set<string>) => Set<string>
-    ) => void;
+      updater: (prev: Set<string>) => Set<string>,
+    ) => void
     refs?: {
-      setFloating?: Ref<HTMLUListElement>;
-      reference?: Ref<HTMLElement> & { current?: HTMLElement | null };
-    };
-    children?: ReactNode;
-    navigableOptions?: SelectboxOption[];
-    fadeEffect?: ComboboxDrawerFadeEffect[];
-    searchbox?: SearchboxProps | boolean;
-    checkbox?: CheckboxProps | boolean;
-  };
+      setFloating?: Ref<HTMLUListElement>
+      reference?: Ref<HTMLElement> & { current?: HTMLElement | null }
+    }
+    children?: ReactNode
+    navigableOptions?: SelectboxOption[]
+    fadeEffect?: ComboboxDrawerFadeEffect[]
+    searchbox?: SearchboxProps | boolean
+    checkbox?: CheckboxProps | boolean
+  }
 
 export const ComboboxDrawerFadeEffect = {
   Top: "top",
   Bottom: "bottom",
-} as const;
+} as const
 
 export type ComboboxDrawerFadeEffect =
-  (typeof ComboboxDrawerFadeEffect)[keyof typeof ComboboxDrawerFadeEffect];
+  (typeof ComboboxDrawerFadeEffect)[keyof typeof ComboboxDrawerFadeEffect]
 
 export interface ComboboxProps
   extends BaseComboboxProps,
@@ -173,72 +172,84 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       mobile,
       drawerHeight,
     },
-    ref
+    ref,
   ) => {
     const inputId = StatefulForm.sanitizeId({
       prefix: "combobox",
       name,
       id,
-    });
+    })
 
     const finalGroup = useMemo(() => {
       const collectOpened = (items: ComboboxOption[]): string[] => {
         return items.flatMap((item) => {
-          if (item.hidden) return [];
+          if (item.hidden) return []
           const self =
             (item.groupSetting?.initialState ?? "closed") === "opened"
               ? [String(item.value)]
-              : [];
+              : []
           const children = item.groupOptions?.length
             ? collectOpened(item.groupOptions)
-            : [];
-          return [...self, ...children];
-        });
-      };
-      return collectOpened(options ?? []);
-    }, [options]);
+            : []
+          return [...self, ...children]
+        })
+      }
+      return collectOpened(options ?? [])
+    }, [options])
 
     const [openedCategoryGroup, setOpenedCategoryGroup] = useState<Set<string>>(
-      () => new Set(finalGroup)
-    );
+      () => new Set(finalGroup),
+    )
 
     const flatOptions = useMemo<SelectboxOption[]>(() => {
       return (
         options?.flatMap((item) => {
-          if (item.hidden) return [];
+          if (item.hidden) return []
           if (item.groupOptions?.length) {
             const allChildren = item.groupOptions
               .filter((o) => !o.hidden)
               .flatMap((child) =>
                 child.groupOptions?.length
                   ? [child, ...child.groupOptions.filter((o) => !o.hidden)]
-                  : [child]
-              );
-            return [item, ...allChildren];
+                  : [child],
+              )
+            return [item, ...allChildren]
           }
-          return [item];
+          return [item]
         }) ?? []
-      );
-    }, [options]);
+      )
+    }, [options])
 
     const navigableOptions = useMemo<SelectboxOption[]>(() => {
       const flatten = (items: ComboboxOption[]): SelectboxOption[] => {
         return items.flatMap((item) => {
-          if (item.hidden) return [];
+          if (item.hidden) return []
 
           if (item.groupOptions?.length) {
             // Group parent → skip self, only include children if open
-            if (!openedCategoryGroup.has(String(item.value))) return [];
-            return flatten(item.groupOptions);
+            if (!openedCategoryGroup.has(String(item.value))) return []
+            return flatten(item.groupOptions)
           }
 
           // Leaf node
-          return [item];
-        });
-      };
+          return [item]
+        })
+      }
 
-      return flatten(options ?? []);
-    }, [options, openedCategoryGroup]);
+      return flatten(options ?? [])
+    }, [options, openedCategoryGroup])
+
+    const {
+      containerStyle,
+      bodyStyle,
+      controlStyle,
+      labelStyle,
+      helperArrowStyle,
+      helperDrawerStyle,
+      helperIconStyle,
+      selectboxStyle,
+      ...comboboxDrawerStyles
+    } = styles ?? {}
 
     return (
       <Selectbox
@@ -259,17 +270,20 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         required={required}
         labels={labels}
         styles={{
-          bodyStyle: styles?.bodyStyle,
-          controlStyle: styles?.controlStyle,
-          containerStyle: styles?.containerStyle,
-          labelStyle: styles?.labelStyle,
+          bodyStyle,
+          controlStyle,
+          containerStyle,
+          labelStyle,
+          helperArrowStyle,
+          helperDrawerStyle,
+          helperIconStyle,
           self: css`
             ${dropdowns &&
             css`
               border-top-left-radius: 0px;
               border-bottom-left-radius: 0px;
             `}
-            ${styles?.selectboxStyle}
+            ${selectboxStyle}
           `,
         }}
         id={inputId}
@@ -294,37 +308,37 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
            */
           const filterOptions = (
             opts: ComboboxOption[],
-            search: string
+            search: string,
           ): ComboboxOption[] => {
             return opts
               .map((opt) => {
-                if (opt.hidden) return null;
+                if (opt.hidden) return null
 
                 if (opt.groupOptions?.length) {
-                  const selfMatches = opt.text.toLowerCase().includes(search);
+                  const selfMatches = opt.text.toLowerCase().includes(search)
 
                   // Parent matches — keep it with ALL children untouched
                   if (selfMatches) {
-                    return opt;
+                    return opt
                   }
 
                   // Parent doesn't match — recurse into children
                   const filteredChildren = filterOptions(
                     opt.groupOptions,
-                    search
-                  );
+                    search,
+                  )
                   if (filteredChildren.length > 0) {
-                    return { ...opt, groupOptions: filteredChildren };
+                    return { ...opt, groupOptions: filteredChildren }
                   }
 
-                  return null;
+                  return null
                 }
 
                 // Leaf node
-                return opt.text.toLowerCase().includes(search) ? opt : null;
+                return opt.text.toLowerCase().includes(search) ? opt : null
               })
-              .filter(Boolean) as ComboboxOption[];
-          };
+              .filter(Boolean) as ComboboxOption[]
+          }
 
           /**
            * filteredNavigableOptions — search-filtered navigable options passed to the drawer.
@@ -339,23 +353,23 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
                   opt?.text
                     ?.toLowerCase()
                     .includes(
-                      props?.selectedOptionsLocal?.text?.toLowerCase() ?? ""
-                    )
+                      props?.selectedOptionsLocal?.text?.toLowerCase() ?? "",
+                    ),
                 )
-              : navigableOptions;
+              : navigableOptions
 
           // Then replace the filteredForDrawer block:
           const filteredForDrawer: ComboboxOption[] = props?.hasInteracted
             ? filterOptions(
                 options ?? [],
-                props?.selectedOptionsLocal?.text?.toLowerCase() ?? ""
+                props?.selectedOptionsLocal?.text?.toLowerCase() ?? "",
               )
-            : options;
+            : options
 
           return (
             <ComboboxDrawer
               {...props}
-              styles={styles}
+              styles={comboboxDrawerStyles}
               mobile={mobile}
               navigableOptions={filteredNavigableOptions}
               inputRef={props.ref}
@@ -376,16 +390,16 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
               openedCategoryGroup={openedCategoryGroup}
               setOpenedCategoryGroup={setOpenedCategoryGroup}
             />
-          );
+          )
         }}
       </Selectbox>
-    );
-  }
+    )
+  },
 ) as ForwardRefExoticComponent<
   ComboboxProps & RefAttributes<HTMLInputElement>
 > & {
-  Drawer: typeof ComboboxDrawer;
-};
+  Drawer: typeof ComboboxDrawer
+}
 
 function ComboboxDrawer({
   floatingStyles,
@@ -424,64 +438,64 @@ function ComboboxDrawer({
   checkbox,
   fadeEffect,
 }: ComboboxDrawerProps) {
-  const { mode, currentTheme } = useTheme();
-  const comboboxTheme = currentTheme?.combobox;
-  const treeListTheme = currentTheme?.treelist;
+  const { mode, currentTheme } = useTheme()
+  const comboboxTheme = currentTheme?.combobox
+  const treeListTheme = currentTheme?.treelist
 
-  const [hasScrolled, setHasScrolled] = useState(false);
-  const [showFadeTop, setShowFadeTop] = useState(true);
-  const [showFadeBottom, setShowFadeBottom] = useState(true);
+  const [hasScrolled, setHasScrolled] = useState(false)
+  const [showFadeTop, setShowFadeTop] = useState(true)
+  const [showFadeBottom, setShowFadeBottom] = useState(true)
 
-  const floatingRef = useRef<HTMLUListElement>(null);
+  const floatingRef = useRef<HTMLUListElement>(null)
 
-  const hasNestedOptions = options?.some((opt) => opt.groupOptions?.length);
+  const hasNestedOptions = options?.some((opt) => opt.groupOptions?.length)
 
   const finalOptions = useMemo<SelectboxOption[]>(() => {
     return (
       options?.flatMap((item) => {
-        if (item?.hidden) return [];
+        if (item?.hidden) return []
         if (item.groupOptions?.length) {
-          return [item, ...item.groupOptions.filter((o) => !o.hidden)];
+          return [item, ...item.groupOptions.filter((o) => !o.hidden)]
         }
-        return [item];
+        return [item]
       }) ?? []
-    );
-  }, [options, openedCategoryGroup]);
+    )
+  }, [options, openedCategoryGroup])
 
   const finalSelectedOptions = useMemo(() => {
     if (Array.isArray(selectedOptions)) {
-      return selectedOptions.map(String);
+      return selectedOptions.map(String)
     }
     if (selectedOptions != null) {
-      return [String(selectedOptions)];
+      return [String(selectedOptions)]
     }
-    return [];
-  }, [selectedOptions]);
+    return []
+  }, [selectedOptions])
 
   const selectedIndex = useMemo(
     () =>
       finalOptions?.findIndex((option) =>
-        finalSelectedOptions?.includes(String(option.value))
+        finalSelectedOptions?.includes(String(option.value)),
       ) + (actions?.length ?? 0),
-    [finalOptions, finalSelectedOptions, actions]
-  );
+    [finalOptions, finalSelectedOptions, actions],
+  )
 
   const handleOnChange = (values: string[]) => {
-    if (!onChange) return;
+    if (!onChange) return
 
     if (Array.isArray(selectedOptions)) {
-      onChange(castValue(values, selectedOptions));
-      return;
+      onChange(castValue(values, selectedOptions))
+      return
     }
 
-    onChange(castValue(values[0], selectedOptions));
-  };
+    onChange(castValue(values[0], selectedOptions))
+  }
 
   useEffect(() => {
     if (isOpen && selectedIndex) {
-      setHighlightedIndex(selectedIndex);
+      setHighlightedIndex(selectedIndex)
     }
-  }, [isOpen]);
+  }, [isOpen])
 
   useEffect(() => {
     if (
@@ -489,12 +503,12 @@ function ComboboxDrawer({
       finalSelectedOptions?.length > 0 &&
       finalOptions?.length > 0
     ) {
-      const selectedEl = listRef.current[selectedIndex];
+      const selectedEl = listRef.current[selectedIndex]
       if (selectedEl) {
         requestAnimationFrame(() => {
-          selectedEl.scrollIntoView({ block: "center" });
-        });
-        setHasScrolled(true);
+          selectedEl.scrollIntoView({ block: "center" })
+        })
+        setHasScrolled(true)
       }
     }
   }, [
@@ -502,7 +516,7 @@ function ComboboxDrawer({
     hasScrolled,
     finalSelectedOptions?.length,
     finalOptions?.length,
-  ]);
+  ])
 
   useEffect(() => {
     if (
@@ -511,33 +525,33 @@ function ComboboxDrawer({
       searchbox &&
       interactionMode === "keyboard"
     ) {
-      const element = listRef.current[highlightedIndex];
-      const container = floatingRef.current;
+      const element = listRef.current[highlightedIndex]
+      const container = floatingRef.current
 
       if (element && container) {
-        const searchboxHeight = 38;
-        const elementTop = element.offsetTop;
-        const containerScrollTop = container.scrollTop;
-        const containerHeight = container.clientHeight;
+        const searchboxHeight = 38
+        const elementTop = element.offsetTop
+        const containerScrollTop = container.scrollTop
+        const containerHeight = container.clientHeight
 
         if (elementTop < containerScrollTop + searchboxHeight) {
-          container.scrollTop = elementTop - searchboxHeight;
+          container.scrollTop = elementTop - searchboxHeight
         } else if (
           elementTop + element.clientHeight >
           containerScrollTop + containerHeight
         ) {
           container.scrollTop =
-            elementTop + element.clientHeight - containerHeight;
+            elementTop + element.clientHeight - containerHeight
         }
       }
     }
-  }, [highlightedIndex, searchbox, interactionMode]);
+  }, [highlightedIndex, searchbox, interactionMode])
 
   const filteredActions: TreeListAction[] = Array.isArray(actions)
     ? actions
         ?.filter((action) => !action?.hidden)
         .map((action, index) => {
-          const shouldHighlight = highlightedIndex === index;
+          const shouldHighlight = highlightedIndex === index
 
           return {
             id: action?.id,
@@ -545,12 +559,12 @@ function ComboboxDrawer({
             hidden: action?.hidden,
             icon: action?.icon,
             onClick: () => {
-              action?.onClick();
-              setIsOpen(false);
+              action?.onClick()
+              setIsOpen(false)
             },
             onMouseEnter: () => {
-              if (interactionMode !== "mouse") return;
-              setHighlightedIndex(index);
+              if (interactionMode !== "mouse") return
+              setHighlightedIndex(index)
             },
             className: shouldHighlight ? "is-highlighted" : "",
             styles: {
@@ -567,45 +581,45 @@ function ComboboxDrawer({
                 ${action?.styles?.self}
               `,
             },
-          };
+          }
         })
-    : [];
+    : []
 
-  const optionByTreeId = useRef<Record<string, ComboboxOption>>({});
+  const optionByTreeId = useRef<Record<string, ComboboxOption>>({})
 
   const flatIndexMap = useMemo(() => {
-    const map: Record<string, number> = {};
-    const offset = filteredActions.length;
+    const map: Record<string, number> = {}
+    const offset = filteredActions.length
 
     navigableOptions?.forEach((opt, i) => {
-      map[String(opt.value)] = i + offset;
-    });
+      map[String(opt.value)] = i + offset
+    })
 
-    return map;
-  }, [navigableOptions, filteredActions.length]);
+    return map
+  }, [navigableOptions, filteredActions.length])
 
-  const checkboxProps = typeof checkbox === "object" && checkbox;
+  const checkboxProps = typeof checkbox === "object" && checkbox
 
   const generateContent = (): TreeListContent[] => {
-    optionByTreeId.current = {};
+    optionByTreeId.current = {}
 
     const registerAll = (opts: ComboboxOption[]) => {
       for (const opt of opts) {
-        optionByTreeId.current[String(opt.value)] = opt;
-        if (opt.groupOptions?.length) registerAll(opt.groupOptions);
+        optionByTreeId.current[String(opt.value)] = opt
+        if (opt.groupOptions?.length) registerAll(opt.groupOptions)
       }
-    };
+    }
 
-    registerAll(finalOptions);
+    registerAll(finalOptions)
 
     const renderCaption = (opt: ComboboxOption): ReactNode => {
-      const isSelected = finalSelectedOptions.includes(String(opt.value));
+      const isSelected = finalSelectedOptions.includes(String(opt.value))
 
-      const label = opt.render ?? opt.text;
-      const hasChildren = Boolean(opt?.groupOptions?.length);
+      const label = opt.render ?? opt.text
+      const hasChildren = Boolean(opt?.groupOptions?.length)
 
       if (multiple && hasChildren) {
-        return label;
+        return label
       }
 
       return (
@@ -667,16 +681,16 @@ function ComboboxDrawer({
           )}
           {label}
         </>
-      );
-    };
+      )
+    }
 
     const mapToItem = (opt: ComboboxOption): TreeListItem => {
-      const id = String(opt.value);
+      const id = String(opt.value)
 
-      const itemIndex = flatIndexMap[id];
-      const isSelected = finalSelectedOptions.includes(id);
+      const itemIndex = flatIndexMap[id]
+      const isSelected = finalSelectedOptions.includes(id)
       const shouldHighlight =
-        highlightOnMatch && isSelected ? true : highlightedIndex === itemIndex;
+        highlightOnMatch && isSelected ? true : highlightedIndex === itemIndex
 
       return {
         id,
@@ -696,7 +710,7 @@ function ComboboxDrawer({
         })),
         onClick: ({ withoutSelection }) => {
           if (opt?.groupOptions?.length > 0) {
-            withoutSelection();
+            withoutSelection()
           }
         },
         ...(opt?.groupOptions?.length > 0
@@ -706,16 +720,16 @@ function ComboboxDrawer({
                 .map((child) => mapToItem(child)),
             }
           : {}),
-      };
-    };
+      }
+    }
 
     const mapToContent = (option: ComboboxOption): TreeListContent => {
-      const id = String(option.value);
+      const id = String(option.value)
 
-      const itemIndex = flatIndexMap[id];
-      const isSelected = finalSelectedOptions.includes(id);
+      const itemIndex = flatIndexMap[id]
+      const isSelected = finalSelectedOptions.includes(id)
       const shouldHighlight =
-        highlightOnMatch && isSelected ? true : highlightedIndex === itemIndex;
+        highlightOnMatch && isSelected ? true : highlightedIndex === itemIndex
 
       return {
         id,
@@ -741,11 +755,11 @@ function ComboboxDrawer({
                 .map((child) => mapToItem(child)),
             }
           : {}),
-      };
-    };
+      }
+    }
 
-    return (options ?? []).filter((opt) => !opt.hidden).map(mapToContent);
-  };
+    return (options ?? []).filter((opt) => !opt.hidden).map(mapToContent)
+  }
 
   const content = useMemo(
     () => generateContent(),
@@ -757,29 +771,29 @@ function ComboboxDrawer({
       flatIndexMap,
       multiple,
       mobile,
-    ]
-  );
+    ],
+  )
 
   const onMouseDown = (props: {
-    event: React.MouseEvent;
-    item?: TreeListContent;
+    event: React.MouseEvent
+    item?: TreeListContent
   }) => {
-    const { event, item } = props;
-    event?.preventDefault();
-    event?.stopPropagation();
+    const { event, item } = props
+    event?.preventDefault()
+    event?.stopPropagation()
 
-    const hasChildren = item?.items?.length > 0;
+    const hasChildren = item?.items?.length > 0
 
-    if (hasChildren) return;
+    if (hasChildren) return
 
-    const originalOption = optionByTreeId.current[item?.id];
+    const originalOption = optionByTreeId.current[item?.id]
 
     const option: ComboboxOption = {
       text: originalOption?.text ?? "",
       value: item?.id,
-    };
+    }
 
-    const optionValue = item?.id;
+    const optionValue = item?.id
 
     if (multiple) {
       if (!finalSelectedOptions.includes(item?.id)) {
@@ -787,48 +801,48 @@ function ComboboxDrawer({
           !maxSelectableItems ||
           finalSelectedOptions?.length < maxSelectableItems
         ) {
-          handleOnChange([...finalSelectedOptions, item?.id]);
+          handleOnChange([...finalSelectedOptions, item?.id])
         }
       } else {
-        handleOnChange(finalSelectedOptions.filter((val) => val !== item?.id));
+        handleOnChange(finalSelectedOptions.filter((val) => val !== item?.id))
       }
 
-      (inputRef as RefObject<HTMLInputElement>)?.current?.focus();
+      ;(inputRef as RefObject<HTMLInputElement>)?.current?.focus()
     } else {
-      const hasChildren = (item?.items?.length ?? 0) > 0;
-      if (hasChildren) return;
+      const hasChildren = (item?.items?.length ?? 0) > 0
+      if (hasChildren) return
 
-      setIsOpen(false);
-      setConfirmedValue?.(option);
-      setSelectedOptionsLocal(option);
-      handleOnChange([optionValue]);
-      setHasInteracted(false);
+      setIsOpen(false)
+      setConfirmedValue?.(option)
+      setSelectedOptionsLocal(option)
+      handleOnChange([optionValue])
+      setHasInteracted(false)
     }
 
     requestAnimationFrame(() => {
-      if (!multiple) setHighlightedIndex(null);
-    });
-    onClick?.();
-  };
+      if (!multiple) setHighlightedIndex(null)
+    })
+    onClick?.()
+  }
 
   const onMouseMove = () => {
     if (interactionMode !== "mouse") {
-      setInteractionMode("mouse");
+      setInteractionMode("mouse")
     }
-  };
+  }
 
   const onMouseEnter = (props: {
-    event: React.MouseEvent;
-    item?: TreeListContent;
+    event: React.MouseEvent
+    item?: TreeListContent
   }) => {
-    const { item } = props;
-    const index = flatIndexMap[item.id];
+    const { item } = props
+    const index = flatIndexMap[item.id]
 
-    if (interactionMode !== "mouse") return;
+    if (interactionMode !== "mouse") return
     if (typeof index === "number") {
-      setHighlightedIndex(index);
+      setHighlightedIndex(index)
     }
-  };
+  }
 
   /**
    * Dynamically show/hide the top and bottom fade overlays based on the
@@ -838,55 +852,55 @@ function ComboboxDrawer({
    * `threshold` pixels of that edge, and reappears once it scrolls past.
    */
   useEffect(() => {
-    const container = floatingRef.current;
-    if (!container || !mobile) return;
+    const container = floatingRef.current
+    if (!container || !mobile) return
 
     const updateFade = () => {
-      const selectedEl = listRef.current[selectedIndex];
+      const selectedEl = listRef.current[selectedIndex]
 
       if (!selectedEl) {
-        setShowFadeTop(true);
-        setShowFadeBottom(true);
-        return;
+        setShowFadeTop(true)
+        setShowFadeBottom(true)
+        return
       }
 
-      const containerRect = container.getBoundingClientRect();
-      const itemRect = selectedEl.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect()
+      const itemRect = selectedEl.getBoundingClientRect()
 
-      const itemMidY = itemRect.top + itemRect.height / 2;
+      const itemMidY = itemRect.top + itemRect.height / 2
 
-      const distanceFromTop = itemMidY - containerRect.top;
-      const distanceFromBottom = containerRect.bottom - itemMidY;
+      const distanceFromTop = itemMidY - containerRect.top
+      const distanceFromBottom = containerRect.bottom - itemMidY
 
-      const threshold = 40;
+      const threshold = 40
 
-      const itemNearTop = distanceFromTop >= 0 && distanceFromTop <= threshold;
+      const itemNearTop = distanceFromTop >= 0 && distanceFromTop <= threshold
       const itemNearBottom =
-        distanceFromBottom >= 0 && distanceFromBottom <= threshold;
+        distanceFromBottom >= 0 && distanceFromBottom <= threshold
 
-      setShowFadeTop(!itemNearTop);
-      setShowFadeBottom(!itemNearBottom);
-      setShowFadeBottom(!itemNearBottom);
-    };
+      setShowFadeTop(!itemNearTop)
+      setShowFadeBottom(!itemNearBottom)
+      setShowFadeBottom(!itemNearBottom)
+    }
 
-    updateFade();
-    container.addEventListener("scroll", updateFade);
+    updateFade()
+    container.addEventListener("scroll", updateFade)
 
-    return () => container.removeEventListener("scroll", updateFade);
-  }, [selectedIndex, finalOptions.length]);
+    return () => container.removeEventListener("scroll", updateFade)
+  }, [selectedIndex, finalOptions.length])
 
-  const searchboxProps = typeof searchbox === "object" && searchbox;
+  const searchboxProps = typeof searchbox === "object" && searchbox
 
-  const hasFewOptions = finalOptions?.length <= 5;
+  const hasFewOptions = finalOptions?.length <= 5
 
   const mainCombobox = (
     <DrawerWrapper
       {...getFloatingProps()}
       ref={(node) => {
         if (typeof refs?.setFloating === "function") {
-          refs?.setFloating(node);
+          refs?.setFloating(node)
         }
-        floatingRef.current = node;
+        floatingRef.current = node
       }}
       $hasFewOptions={hasFewOptions}
       $hasNestedOptions={hasNestedOptions}
@@ -905,13 +919,13 @@ function ComboboxDrawer({
         <Searchbox
           onKeyDown={handleKeyDown}
           onChange={(e) => {
-            const { value } = e.target;
-            setHasInteracted(true);
-            setHighlightedIndex(0);
+            const { value } = e.target
+            setHasInteracted(true)
+            setHighlightedIndex(0)
             setSelectedOptionsLocal({
               ...selectedOptionsLocal,
               text: value,
-            });
+            })
           }}
           autoComplete="off"
           ref={inputRef}
@@ -972,15 +986,15 @@ function ComboboxDrawer({
         <>
           <TreeList
             ref={({ el, item }) => {
-              const index = flatIndexMap[item.id];
+              const index = flatIndexMap[item.id]
               if (typeof index === "number") {
-                listRef.current[index] = el;
+                listRef.current[index] = el
               }
             }}
             refItem={({ el, item }) => {
-              const index = flatIndexMap[item.id];
+              const index = flatIndexMap[item.id]
               if (typeof index === "number") {
-                listRef.current[index] = el;
+                listRef.current[index] = el
               }
             }}
             multiple={multiple}
@@ -995,14 +1009,14 @@ function ComboboxDrawer({
             onMouseEnterItem={onMouseEnter}
             onOpenChange={({ id }) => {
               setOpenedCategoryGroup((prev) => {
-                const next = new Set(prev);
+                const next = new Set(prev)
                 if (next.has(id)) {
-                  next.delete(id);
+                  next.delete(id)
                 } else {
-                  next.add(id);
+                  next.add(id)
                 }
-                return next;
-              });
+                return next
+              })
             }}
             arrowSize={mobile ? 18 : 14}
             maxActionsBeforeCollapsing={1}
@@ -1157,11 +1171,11 @@ function ComboboxDrawer({
         </>
       )}
     </DrawerWrapper>
-  );
+  )
 
   if (mobile) {
     const finalFadeEffect =
-      fadeEffect ?? (searchbox ? ["bottom"] : ["top", "bottom"]);
+      fadeEffect ?? (searchbox ? ["bottom"] : ["top", "bottom"])
 
     return createPortal(
       <DrawerContainer
@@ -1185,16 +1199,16 @@ function ComboboxDrawer({
         )}
         {mainCombobox}
       </DrawerContainer>,
-      document.body
-    );
+      document.body,
+    )
   }
 
-  return mainCombobox;
+  return mainCombobox
 }
 
 const DrawerContainer = styled.div<{
-  $theme?: ComboboxThemeConfig;
-  $mobile?: boolean;
+  $theme?: ComboboxThemeConfig
+  $mobile?: boolean
 }>`
   *,
   ::before,
@@ -1211,17 +1225,17 @@ const DrawerContainer = styled.div<{
   border-radius: 14px;
   background-color: ${({ $mobile, $theme }) =>
     $mobile ? $theme.mobileBackgroundColor : $theme.backgroundColor};
-`;
+`
 
 const DrawerWrapper = styled.ul<{
-  $width?: number;
-  $theme: ComboboxThemeConfig;
-  $style?: CSSProp;
-  $mobile?: boolean;
-  $searchbox?: boolean;
-  $hasNestedOptions?: boolean;
-  $hasFewOptions?: boolean;
-  $drawerHeight?: string;
+  $width?: number
+  $theme: ComboboxThemeConfig
+  $style?: CSSProp
+  $mobile?: boolean
+  $searchbox?: boolean
+  $hasNestedOptions?: boolean
+  $hasFewOptions?: boolean
+  $drawerHeight?: string
 }>`
   *,
   ::before,
@@ -1268,7 +1282,7 @@ const DrawerWrapper = styled.ul<{
     $drawerHeight,
     $hasFewOptions,
   }) => {
-    const $height = $drawerHeight ?? "220px";
+    const $height = $drawerHeight ?? "220px"
 
     return css`
       height: ${$hasFewOptions ? "fit-content" : $height};
@@ -1293,11 +1307,11 @@ const DrawerWrapper = styled.ul<{
             ? $theme.mobileBackgroundColor
             : $theme.backgroundColor};
       `}
-    `;
+    `
   }}
 
   ${({ $style }) => $style}
-`;
+`
 
 const rowStyle = ({
   interactionMode,
@@ -1307,12 +1321,12 @@ const rowStyle = ({
   hasNestedOptions,
   level,
 }: {
-  interactionMode?: "mouse" | "keyboard";
-  multiple?: boolean;
-  theme?: ComboboxThemeConfig;
-  mobile?: boolean;
-  hasNestedOptions?: boolean;
-  level?: number;
+  interactionMode?: "mouse" | "keyboard"
+  multiple?: boolean
+  theme?: ComboboxThemeConfig
+  mobile?: boolean
+  hasNestedOptions?: boolean
+  level?: number
 }) => css`
   transition: background-color 0ms;
   background-color: ${mobile
@@ -1370,12 +1384,12 @@ const rowStyle = ({
       }
     `}
   }
-`;
+`
 
 const FadeTop = styled.div<{
-  $style?: CSSProp;
-  $theme: ComboboxThemeConfig;
-  $visible?: boolean;
+  $style?: CSSProp
+  $theme: ComboboxThemeConfig
+  $visible?: boolean
 }>`
   pointer-events: none;
   position: absolute;
@@ -1393,12 +1407,12 @@ const FadeTop = styled.div<{
   z-index: 99999999;
 
   ${({ $style }) => $style}
-`;
+`
 
 const FadeBottom = styled.div<{
-  $style?: CSSProp;
-  $theme: ComboboxThemeConfig;
-  $visible?: boolean;
+  $style?: CSSProp
+  $theme: ComboboxThemeConfig
+  $visible?: boolean
 }>`
   pointer-events: none;
   position: absolute;
@@ -1416,8 +1430,8 @@ const FadeBottom = styled.div<{
   z-index: 99999999;
 
   ${({ $style }) => $style}
-`;
+`
 
-Combobox.Drawer = ComboboxDrawer;
+Combobox.Drawer = ComboboxDrawer
 
-export { Combobox };
+export { Combobox }

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -10,7 +10,7 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react"
+} from "react";
 import {
   castValue,
   DrawerProps,
@@ -19,115 +19,115 @@ import {
   SelectboxLabels,
   SelectboxSelectedOptions,
   SelectboxStyles,
-} from "./selectbox"
-import styled, { css, CSSProp } from "styled-components"
-import { FieldLaneDropdownOption, FieldLaneProps } from "./field-lane"
-import { StatefulForm } from "./stateful-form"
-import { useTheme } from "./../theme/provider"
-import { ComboboxThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
+} from "./selectbox";
+import styled, { css, CSSProp } from "styled-components";
+import { FieldLaneDropdownOption, FieldLaneProps } from "./field-lane";
+import { StatefulForm } from "./stateful-form";
+import { useTheme } from "./../theme/provider";
+import { ComboboxThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 import {
   TreeList,
   TreeListAction,
   TreeListContent,
   TreeListItem,
   TreeListItemAction,
-} from "./treelist"
-import { Searchbox, SearchboxProps } from "./searchbox"
-import { Checkbox, CheckboxProps } from "./checkbox"
-import { createPortal } from "react-dom"
+} from "./treelist";
+import { Searchbox, SearchboxProps } from "./searchbox";
+import { Checkbox, CheckboxProps } from "./checkbox";
+import { createPortal } from "react-dom";
 
 interface BaseComboboxProps {
-  selectedOptions?: SelectboxSelectedOptions
-  onChange?: (selectedOptions: SelectboxSelectedOptions) => void
-  clearable?: boolean
-  placeholder?: string
-  emptySlate?: string
-  highlightOnMatch?: boolean
-  actions?: ComboboxAction[]
-  name?: string
-  multiple?: boolean
-  maxSelectableItems?: number | undefined
-  styles?: ComboboxStyles
-  disabled?: boolean
-  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
-  onClick?: () => void
-  strict?: boolean
-  options: ComboboxOption[]
-  isLoading?: boolean
-  labels?: ComboboxLabelsProps
-  mobile?: boolean
-  drawerHeight?: string
+  selectedOptions?: SelectboxSelectedOptions;
+  onChange?: (selectedOptions: SelectboxSelectedOptions) => void;
+  clearable?: boolean;
+  placeholder?: string;
+  emptySlate?: string;
+  highlightOnMatch?: boolean;
+  actions?: ComboboxAction[];
+  name?: string;
+  multiple?: boolean;
+  maxSelectableItems?: number | undefined;
+  styles?: ComboboxStyles;
+  disabled?: boolean;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+  onClick?: () => void;
+  strict?: boolean;
+  options: ComboboxOption[];
+  isLoading?: boolean;
+  labels?: ComboboxLabelsProps;
+  mobile?: boolean;
+  drawerHeight?: string;
 }
 
 export const ComboboxGroupInitialState = {
   Opened: "opened",
   Closed: "closed",
-} as const
+} as const;
 
 export type ComboboxGroupInitialState =
-  (typeof ComboboxGroupInitialState)[keyof typeof ComboboxGroupInitialState]
+  (typeof ComboboxGroupInitialState)[keyof typeof ComboboxGroupInitialState];
 
 export type ComboboxOption = SelectboxOption &
   ComboboxActionOption & {
-    groupOptions?: ComboboxOption[]
-    groupSetting?: ComboboxGroupSetting
-  }
+    groupOptions?: ComboboxOption[];
+    groupSetting?: ComboboxGroupSetting;
+  };
 
 interface ComboboxGroupSetting {
-  collapsible?: boolean
-  initialState?: ComboboxGroupInitialState
+  collapsible?: boolean;
+  initialState?: ComboboxGroupInitialState;
 }
 
 interface ComboboxActionOption {
-  actions?: (id?: string) => ComboboxItemAction[]
+  actions?: (id?: string) => ComboboxItemAction[];
 }
 
-export type ComboboxItemAction = TreeListItemAction
+export type ComboboxItemAction = TreeListItemAction;
 
-export type ComboboxDropdownOption = FieldLaneDropdownOption
+export type ComboboxDropdownOption = FieldLaneDropdownOption;
 
 export interface ComboboxLabelsProps extends SelectboxLabels {}
 
 export interface ComboboxStyles extends Omit<SelectboxStyles, "self"> {
-  selectboxStyle?: CSSProp
-  drawerStyle?: CSSProp
-  rowStyle?: CSSProp
-  rowContainerStyle?: CSSProp
+  selectboxStyle?: CSSProp;
+  drawerStyle?: CSSProp;
+  rowStyle?: CSSProp;
+  rowContainerStyle?: CSSProp;
 }
 
-export type ComboboxAction = TreeListAction
+export type ComboboxAction = TreeListAction;
 
 export type ComboboxDrawerProps = Omit<DrawerProps, "refs"> &
   BaseComboboxProps & {
-    inputRef?: Ref<HTMLInputElement>
-    handleKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
-    selectedOptionsLocal: SelectboxOption
-    setSelectedOptionsLocal: (value: SelectboxOption) => void
-    setHasInteracted?: (value: boolean) => void
-    setConfirmedValue?: (option: SelectboxOption | null) => void
-    openedCategoryGroup?: Set<string>
+    inputRef?: Ref<HTMLInputElement>;
+    handleKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+    selectedOptionsLocal: SelectboxOption;
+    setSelectedOptionsLocal: (value: SelectboxOption) => void;
+    setHasInteracted?: (value: boolean) => void;
+    setConfirmedValue?: (option: SelectboxOption | null) => void;
+    openedCategoryGroup?: Set<string>;
     setOpenedCategoryGroup?: (
-      updater: (prev: Set<string>) => Set<string>,
-    ) => void
+      updater: (prev: Set<string>) => Set<string>
+    ) => void;
     refs?: {
-      setFloating?: Ref<HTMLUListElement>
-      reference?: Ref<HTMLElement> & { current?: HTMLElement | null }
-    }
-    children?: ReactNode
-    navigableOptions?: SelectboxOption[]
-    fadeEffect?: ComboboxDrawerFadeEffect[]
-    searchbox?: SearchboxProps | boolean
-    checkbox?: CheckboxProps | boolean
-  }
+      setFloating?: Ref<HTMLUListElement>;
+      reference?: Ref<HTMLElement> & { current?: HTMLElement | null };
+    };
+    children?: ReactNode;
+    navigableOptions?: SelectboxOption[];
+    fadeEffect?: ComboboxDrawerFadeEffect[];
+    searchbox?: SearchboxProps | boolean;
+    checkbox?: CheckboxProps | boolean;
+  };
 
 export const ComboboxDrawerFadeEffect = {
   Top: "top",
   Bottom: "bottom",
-} as const
+} as const;
 
 export type ComboboxDrawerFadeEffect =
-  (typeof ComboboxDrawerFadeEffect)[keyof typeof ComboboxDrawerFadeEffect]
+  (typeof ComboboxDrawerFadeEffect)[keyof typeof ComboboxDrawerFadeEffect];
 
 export interface ComboboxProps
   extends BaseComboboxProps,
@@ -172,72 +172,72 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       mobile,
       drawerHeight,
     },
-    ref,
+    ref
   ) => {
     const inputId = StatefulForm.sanitizeId({
       prefix: "combobox",
       name,
       id,
-    })
+    });
 
     const finalGroup = useMemo(() => {
       const collectOpened = (items: ComboboxOption[]): string[] => {
         return items.flatMap((item) => {
-          if (item.hidden) return []
+          if (item.hidden) return [];
           const self =
             (item.groupSetting?.initialState ?? "closed") === "opened"
               ? [String(item.value)]
-              : []
+              : [];
           const children = item.groupOptions?.length
             ? collectOpened(item.groupOptions)
-            : []
-          return [...self, ...children]
-        })
-      }
-      return collectOpened(options ?? [])
-    }, [options])
+            : [];
+          return [...self, ...children];
+        });
+      };
+      return collectOpened(options ?? []);
+    }, [options]);
 
     const [openedCategoryGroup, setOpenedCategoryGroup] = useState<Set<string>>(
-      () => new Set(finalGroup),
-    )
+      () => new Set(finalGroup)
+    );
 
     const flatOptions = useMemo<SelectboxOption[]>(() => {
       return (
         options?.flatMap((item) => {
-          if (item.hidden) return []
+          if (item.hidden) return [];
           if (item.groupOptions?.length) {
             const allChildren = item.groupOptions
               .filter((o) => !o.hidden)
               .flatMap((child) =>
                 child.groupOptions?.length
                   ? [child, ...child.groupOptions.filter((o) => !o.hidden)]
-                  : [child],
-              )
-            return [item, ...allChildren]
+                  : [child]
+              );
+            return [item, ...allChildren];
           }
-          return [item]
+          return [item];
         }) ?? []
-      )
-    }, [options])
+      );
+    }, [options]);
 
     const navigableOptions = useMemo<SelectboxOption[]>(() => {
       const flatten = (items: ComboboxOption[]): SelectboxOption[] => {
         return items.flatMap((item) => {
-          if (item.hidden) return []
+          if (item.hidden) return [];
 
           if (item.groupOptions?.length) {
             // Group parent → skip self, only include children if open
-            if (!openedCategoryGroup.has(String(item.value))) return []
-            return flatten(item.groupOptions)
+            if (!openedCategoryGroup.has(String(item.value))) return [];
+            return flatten(item.groupOptions);
           }
 
           // Leaf node
-          return [item]
-        })
-      }
+          return [item];
+        });
+      };
 
-      return flatten(options ?? [])
-    }, [options, openedCategoryGroup])
+      return flatten(options ?? []);
+    }, [options, openedCategoryGroup]);
 
     const {
       containerStyle,
@@ -249,7 +249,7 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       helperIconStyle,
       selectboxStyle,
       ...comboboxDrawerStyles
-    } = styles ?? {}
+    } = styles ?? {};
 
     return (
       <Selectbox
@@ -308,37 +308,37 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
            */
           const filterOptions = (
             opts: ComboboxOption[],
-            search: string,
+            search: string
           ): ComboboxOption[] => {
             return opts
               .map((opt) => {
-                if (opt.hidden) return null
+                if (opt.hidden) return null;
 
                 if (opt.groupOptions?.length) {
-                  const selfMatches = opt.text.toLowerCase().includes(search)
+                  const selfMatches = opt.text.toLowerCase().includes(search);
 
                   // Parent matches — keep it with ALL children untouched
                   if (selfMatches) {
-                    return opt
+                    return opt;
                   }
 
                   // Parent doesn't match — recurse into children
                   const filteredChildren = filterOptions(
                     opt.groupOptions,
-                    search,
-                  )
+                    search
+                  );
                   if (filteredChildren.length > 0) {
-                    return { ...opt, groupOptions: filteredChildren }
+                    return { ...opt, groupOptions: filteredChildren };
                   }
 
-                  return null
+                  return null;
                 }
 
                 // Leaf node
-                return opt.text.toLowerCase().includes(search) ? opt : null
+                return opt.text.toLowerCase().includes(search) ? opt : null;
               })
-              .filter(Boolean) as ComboboxOption[]
-          }
+              .filter(Boolean) as ComboboxOption[];
+          };
 
           /**
            * filteredNavigableOptions — search-filtered navigable options passed to the drawer.
@@ -353,18 +353,18 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
                   opt?.text
                     ?.toLowerCase()
                     .includes(
-                      props?.selectedOptionsLocal?.text?.toLowerCase() ?? "",
-                    ),
+                      props?.selectedOptionsLocal?.text?.toLowerCase() ?? ""
+                    )
                 )
-              : navigableOptions
+              : navigableOptions;
 
           // Then replace the filteredForDrawer block:
           const filteredForDrawer: ComboboxOption[] = props?.hasInteracted
             ? filterOptions(
                 options ?? [],
-                props?.selectedOptionsLocal?.text?.toLowerCase() ?? "",
+                props?.selectedOptionsLocal?.text?.toLowerCase() ?? ""
               )
-            : options
+            : options;
 
           return (
             <ComboboxDrawer
@@ -390,16 +390,16 @@ const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
               openedCategoryGroup={openedCategoryGroup}
               setOpenedCategoryGroup={setOpenedCategoryGroup}
             />
-          )
+          );
         }}
       </Selectbox>
-    )
-  },
+    );
+  }
 ) as ForwardRefExoticComponent<
   ComboboxProps & RefAttributes<HTMLInputElement>
 > & {
-  Drawer: typeof ComboboxDrawer
-}
+  Drawer: typeof ComboboxDrawer;
+};
 
 function ComboboxDrawer({
   floatingStyles,
@@ -438,64 +438,64 @@ function ComboboxDrawer({
   checkbox,
   fadeEffect,
 }: ComboboxDrawerProps) {
-  const { mode, currentTheme } = useTheme()
-  const comboboxTheme = currentTheme?.combobox
-  const treeListTheme = currentTheme?.treelist
+  const { mode, currentTheme } = useTheme();
+  const comboboxTheme = currentTheme?.combobox;
+  const treeListTheme = currentTheme?.treelist;
 
-  const [hasScrolled, setHasScrolled] = useState(false)
-  const [showFadeTop, setShowFadeTop] = useState(true)
-  const [showFadeBottom, setShowFadeBottom] = useState(true)
+  const [hasScrolled, setHasScrolled] = useState(false);
+  const [showFadeTop, setShowFadeTop] = useState(true);
+  const [showFadeBottom, setShowFadeBottom] = useState(true);
 
-  const floatingRef = useRef<HTMLUListElement>(null)
+  const floatingRef = useRef<HTMLUListElement>(null);
 
-  const hasNestedOptions = options?.some((opt) => opt.groupOptions?.length)
+  const hasNestedOptions = options?.some((opt) => opt.groupOptions?.length);
 
   const finalOptions = useMemo<SelectboxOption[]>(() => {
     return (
       options?.flatMap((item) => {
-        if (item?.hidden) return []
+        if (item?.hidden) return [];
         if (item.groupOptions?.length) {
-          return [item, ...item.groupOptions.filter((o) => !o.hidden)]
+          return [item, ...item.groupOptions.filter((o) => !o.hidden)];
         }
-        return [item]
+        return [item];
       }) ?? []
-    )
-  }, [options, openedCategoryGroup])
+    );
+  }, [options, openedCategoryGroup]);
 
   const finalSelectedOptions = useMemo(() => {
     if (Array.isArray(selectedOptions)) {
-      return selectedOptions.map(String)
+      return selectedOptions.map(String);
     }
     if (selectedOptions != null) {
-      return [String(selectedOptions)]
+      return [String(selectedOptions)];
     }
-    return []
-  }, [selectedOptions])
+    return [];
+  }, [selectedOptions]);
 
   const selectedIndex = useMemo(
     () =>
       finalOptions?.findIndex((option) =>
-        finalSelectedOptions?.includes(String(option.value)),
+        finalSelectedOptions?.includes(String(option.value))
       ) + (actions?.length ?? 0),
-    [finalOptions, finalSelectedOptions, actions],
-  )
+    [finalOptions, finalSelectedOptions, actions]
+  );
 
   const handleOnChange = (values: string[]) => {
-    if (!onChange) return
+    if (!onChange) return;
 
     if (Array.isArray(selectedOptions)) {
-      onChange(castValue(values, selectedOptions))
-      return
+      onChange(castValue(values, selectedOptions));
+      return;
     }
 
-    onChange(castValue(values[0], selectedOptions))
-  }
+    onChange(castValue(values[0], selectedOptions));
+  };
 
   useEffect(() => {
     if (isOpen && selectedIndex) {
-      setHighlightedIndex(selectedIndex)
+      setHighlightedIndex(selectedIndex);
     }
-  }, [isOpen])
+  }, [isOpen]);
 
   useEffect(() => {
     if (
@@ -503,12 +503,12 @@ function ComboboxDrawer({
       finalSelectedOptions?.length > 0 &&
       finalOptions?.length > 0
     ) {
-      const selectedEl = listRef.current[selectedIndex]
+      const selectedEl = listRef.current[selectedIndex];
       if (selectedEl) {
         requestAnimationFrame(() => {
-          selectedEl.scrollIntoView({ block: "center" })
-        })
-        setHasScrolled(true)
+          selectedEl.scrollIntoView({ block: "center" });
+        });
+        setHasScrolled(true);
       }
     }
   }, [
@@ -516,7 +516,7 @@ function ComboboxDrawer({
     hasScrolled,
     finalSelectedOptions?.length,
     finalOptions?.length,
-  ])
+  ]);
 
   useEffect(() => {
     if (
@@ -525,33 +525,33 @@ function ComboboxDrawer({
       searchbox &&
       interactionMode === "keyboard"
     ) {
-      const element = listRef.current[highlightedIndex]
-      const container = floatingRef.current
+      const element = listRef.current[highlightedIndex];
+      const container = floatingRef.current;
 
       if (element && container) {
-        const searchboxHeight = 38
-        const elementTop = element.offsetTop
-        const containerScrollTop = container.scrollTop
-        const containerHeight = container.clientHeight
+        const searchboxHeight = 38;
+        const elementTop = element.offsetTop;
+        const containerScrollTop = container.scrollTop;
+        const containerHeight = container.clientHeight;
 
         if (elementTop < containerScrollTop + searchboxHeight) {
-          container.scrollTop = elementTop - searchboxHeight
+          container.scrollTop = elementTop - searchboxHeight;
         } else if (
           elementTop + element.clientHeight >
           containerScrollTop + containerHeight
         ) {
           container.scrollTop =
-            elementTop + element.clientHeight - containerHeight
+            elementTop + element.clientHeight - containerHeight;
         }
       }
     }
-  }, [highlightedIndex, searchbox, interactionMode])
+  }, [highlightedIndex, searchbox, interactionMode]);
 
   const filteredActions: TreeListAction[] = Array.isArray(actions)
     ? actions
         ?.filter((action) => !action?.hidden)
         .map((action, index) => {
-          const shouldHighlight = highlightedIndex === index
+          const shouldHighlight = highlightedIndex === index;
 
           return {
             id: action?.id,
@@ -559,12 +559,12 @@ function ComboboxDrawer({
             hidden: action?.hidden,
             icon: action?.icon,
             onClick: () => {
-              action?.onClick()
-              setIsOpen(false)
+              action?.onClick();
+              setIsOpen(false);
             },
             onMouseEnter: () => {
-              if (interactionMode !== "mouse") return
-              setHighlightedIndex(index)
+              if (interactionMode !== "mouse") return;
+              setHighlightedIndex(index);
             },
             className: shouldHighlight ? "is-highlighted" : "",
             styles: {
@@ -581,45 +581,45 @@ function ComboboxDrawer({
                 ${action?.styles?.self}
               `,
             },
-          }
+          };
         })
-    : []
+    : [];
 
-  const optionByTreeId = useRef<Record<string, ComboboxOption>>({})
+  const optionByTreeId = useRef<Record<string, ComboboxOption>>({});
 
   const flatIndexMap = useMemo(() => {
-    const map: Record<string, number> = {}
-    const offset = filteredActions.length
+    const map: Record<string, number> = {};
+    const offset = filteredActions.length;
 
     navigableOptions?.forEach((opt, i) => {
-      map[String(opt.value)] = i + offset
-    })
+      map[String(opt.value)] = i + offset;
+    });
 
-    return map
-  }, [navigableOptions, filteredActions.length])
+    return map;
+  }, [navigableOptions, filteredActions.length]);
 
-  const checkboxProps = typeof checkbox === "object" && checkbox
+  const checkboxProps = typeof checkbox === "object" && checkbox;
 
   const generateContent = (): TreeListContent[] => {
-    optionByTreeId.current = {}
+    optionByTreeId.current = {};
 
     const registerAll = (opts: ComboboxOption[]) => {
       for (const opt of opts) {
-        optionByTreeId.current[String(opt.value)] = opt
-        if (opt.groupOptions?.length) registerAll(opt.groupOptions)
+        optionByTreeId.current[String(opt.value)] = opt;
+        if (opt.groupOptions?.length) registerAll(opt.groupOptions);
       }
-    }
+    };
 
-    registerAll(finalOptions)
+    registerAll(finalOptions);
 
     const renderCaption = (opt: ComboboxOption): ReactNode => {
-      const isSelected = finalSelectedOptions.includes(String(opt.value))
+      const isSelected = finalSelectedOptions.includes(String(opt.value));
 
-      const label = opt.render ?? opt.text
-      const hasChildren = Boolean(opt?.groupOptions?.length)
+      const label = opt.render ?? opt.text;
+      const hasChildren = Boolean(opt?.groupOptions?.length);
 
       if (multiple && hasChildren) {
-        return label
+        return label;
       }
 
       return (
@@ -681,16 +681,16 @@ function ComboboxDrawer({
           )}
           {label}
         </>
-      )
-    }
+      );
+    };
 
     const mapToItem = (opt: ComboboxOption): TreeListItem => {
-      const id = String(opt.value)
+      const id = String(opt.value);
 
-      const itemIndex = flatIndexMap[id]
-      const isSelected = finalSelectedOptions.includes(id)
+      const itemIndex = flatIndexMap[id];
+      const isSelected = finalSelectedOptions.includes(id);
       const shouldHighlight =
-        highlightOnMatch && isSelected ? true : highlightedIndex === itemIndex
+        highlightOnMatch && isSelected ? true : highlightedIndex === itemIndex;
 
       return {
         id,
@@ -710,7 +710,7 @@ function ComboboxDrawer({
         })),
         onClick: ({ withoutSelection }) => {
           if (opt?.groupOptions?.length > 0) {
-            withoutSelection()
+            withoutSelection();
           }
         },
         ...(opt?.groupOptions?.length > 0
@@ -720,16 +720,16 @@ function ComboboxDrawer({
                 .map((child) => mapToItem(child)),
             }
           : {}),
-      }
-    }
+      };
+    };
 
     const mapToContent = (option: ComboboxOption): TreeListContent => {
-      const id = String(option.value)
+      const id = String(option.value);
 
-      const itemIndex = flatIndexMap[id]
-      const isSelected = finalSelectedOptions.includes(id)
+      const itemIndex = flatIndexMap[id];
+      const isSelected = finalSelectedOptions.includes(id);
       const shouldHighlight =
-        highlightOnMatch && isSelected ? true : highlightedIndex === itemIndex
+        highlightOnMatch && isSelected ? true : highlightedIndex === itemIndex;
 
       return {
         id,
@@ -755,11 +755,11 @@ function ComboboxDrawer({
                 .map((child) => mapToItem(child)),
             }
           : {}),
-      }
-    }
+      };
+    };
 
-    return (options ?? []).filter((opt) => !opt.hidden).map(mapToContent)
-  }
+    return (options ?? []).filter((opt) => !opt.hidden).map(mapToContent);
+  };
 
   const content = useMemo(
     () => generateContent(),
@@ -771,29 +771,29 @@ function ComboboxDrawer({
       flatIndexMap,
       multiple,
       mobile,
-    ],
-  )
+    ]
+  );
 
   const onMouseDown = (props: {
-    event: React.MouseEvent
-    item?: TreeListContent
+    event: React.MouseEvent;
+    item?: TreeListContent;
   }) => {
-    const { event, item } = props
-    event?.preventDefault()
-    event?.stopPropagation()
+    const { event, item } = props;
+    event?.preventDefault();
+    event?.stopPropagation();
 
-    const hasChildren = item?.items?.length > 0
+    const hasChildren = item?.items?.length > 0;
 
-    if (hasChildren) return
+    if (hasChildren) return;
 
-    const originalOption = optionByTreeId.current[item?.id]
+    const originalOption = optionByTreeId.current[item?.id];
 
     const option: ComboboxOption = {
       text: originalOption?.text ?? "",
       value: item?.id,
-    }
+    };
 
-    const optionValue = item?.id
+    const optionValue = item?.id;
 
     if (multiple) {
       if (!finalSelectedOptions.includes(item?.id)) {
@@ -801,48 +801,48 @@ function ComboboxDrawer({
           !maxSelectableItems ||
           finalSelectedOptions?.length < maxSelectableItems
         ) {
-          handleOnChange([...finalSelectedOptions, item?.id])
+          handleOnChange([...finalSelectedOptions, item?.id]);
         }
       } else {
-        handleOnChange(finalSelectedOptions.filter((val) => val !== item?.id))
+        handleOnChange(finalSelectedOptions.filter((val) => val !== item?.id));
       }
 
-      ;(inputRef as RefObject<HTMLInputElement>)?.current?.focus()
+      (inputRef as RefObject<HTMLInputElement>)?.current?.focus();
     } else {
-      const hasChildren = (item?.items?.length ?? 0) > 0
-      if (hasChildren) return
+      const hasChildren = (item?.items?.length ?? 0) > 0;
+      if (hasChildren) return;
 
-      setIsOpen(false)
-      setConfirmedValue?.(option)
-      setSelectedOptionsLocal(option)
-      handleOnChange([optionValue])
-      setHasInteracted(false)
+      setIsOpen(false);
+      setConfirmedValue?.(option);
+      setSelectedOptionsLocal(option);
+      handleOnChange([optionValue]);
+      setHasInteracted(false);
     }
 
     requestAnimationFrame(() => {
-      if (!multiple) setHighlightedIndex(null)
-    })
-    onClick?.()
-  }
+      if (!multiple) setHighlightedIndex(null);
+    });
+    onClick?.();
+  };
 
   const onMouseMove = () => {
     if (interactionMode !== "mouse") {
-      setInteractionMode("mouse")
+      setInteractionMode("mouse");
     }
-  }
+  };
 
   const onMouseEnter = (props: {
-    event: React.MouseEvent
-    item?: TreeListContent
+    event: React.MouseEvent;
+    item?: TreeListContent;
   }) => {
-    const { item } = props
-    const index = flatIndexMap[item.id]
+    const { item } = props;
+    const index = flatIndexMap[item.id];
 
-    if (interactionMode !== "mouse") return
+    if (interactionMode !== "mouse") return;
     if (typeof index === "number") {
-      setHighlightedIndex(index)
+      setHighlightedIndex(index);
     }
-  }
+  };
 
   /**
    * Dynamically show/hide the top and bottom fade overlays based on the
@@ -852,55 +852,55 @@ function ComboboxDrawer({
    * `threshold` pixels of that edge, and reappears once it scrolls past.
    */
   useEffect(() => {
-    const container = floatingRef.current
-    if (!container || !mobile) return
+    const container = floatingRef.current;
+    if (!container || !mobile) return;
 
     const updateFade = () => {
-      const selectedEl = listRef.current[selectedIndex]
+      const selectedEl = listRef.current[selectedIndex];
 
       if (!selectedEl) {
-        setShowFadeTop(true)
-        setShowFadeBottom(true)
-        return
+        setShowFadeTop(true);
+        setShowFadeBottom(true);
+        return;
       }
 
-      const containerRect = container.getBoundingClientRect()
-      const itemRect = selectedEl.getBoundingClientRect()
+      const containerRect = container.getBoundingClientRect();
+      const itemRect = selectedEl.getBoundingClientRect();
 
-      const itemMidY = itemRect.top + itemRect.height / 2
+      const itemMidY = itemRect.top + itemRect.height / 2;
 
-      const distanceFromTop = itemMidY - containerRect.top
-      const distanceFromBottom = containerRect.bottom - itemMidY
+      const distanceFromTop = itemMidY - containerRect.top;
+      const distanceFromBottom = containerRect.bottom - itemMidY;
 
-      const threshold = 40
+      const threshold = 40;
 
-      const itemNearTop = distanceFromTop >= 0 && distanceFromTop <= threshold
+      const itemNearTop = distanceFromTop >= 0 && distanceFromTop <= threshold;
       const itemNearBottom =
-        distanceFromBottom >= 0 && distanceFromBottom <= threshold
+        distanceFromBottom >= 0 && distanceFromBottom <= threshold;
 
-      setShowFadeTop(!itemNearTop)
-      setShowFadeBottom(!itemNearBottom)
-      setShowFadeBottom(!itemNearBottom)
-    }
+      setShowFadeTop(!itemNearTop);
+      setShowFadeBottom(!itemNearBottom);
+      setShowFadeBottom(!itemNearBottom);
+    };
 
-    updateFade()
-    container.addEventListener("scroll", updateFade)
+    updateFade();
+    container.addEventListener("scroll", updateFade);
 
-    return () => container.removeEventListener("scroll", updateFade)
-  }, [selectedIndex, finalOptions.length])
+    return () => container.removeEventListener("scroll", updateFade);
+  }, [selectedIndex, finalOptions.length]);
 
-  const searchboxProps = typeof searchbox === "object" && searchbox
+  const searchboxProps = typeof searchbox === "object" && searchbox;
 
-  const hasFewOptions = finalOptions?.length <= 5
+  const hasFewOptions = finalOptions?.length <= 5;
 
   const mainCombobox = (
     <DrawerWrapper
       {...getFloatingProps()}
       ref={(node) => {
         if (typeof refs?.setFloating === "function") {
-          refs?.setFloating(node)
+          refs?.setFloating(node);
         }
-        floatingRef.current = node
+        floatingRef.current = node;
       }}
       $hasFewOptions={hasFewOptions}
       $hasNestedOptions={hasNestedOptions}
@@ -919,13 +919,13 @@ function ComboboxDrawer({
         <Searchbox
           onKeyDown={handleKeyDown}
           onChange={(e) => {
-            const { value } = e.target
-            setHasInteracted(true)
-            setHighlightedIndex(0)
+            const { value } = e.target;
+            setHasInteracted(true);
+            setHighlightedIndex(0);
             setSelectedOptionsLocal({
               ...selectedOptionsLocal,
               text: value,
-            })
+            });
           }}
           autoComplete="off"
           ref={inputRef}
@@ -986,15 +986,15 @@ function ComboboxDrawer({
         <>
           <TreeList
             ref={({ el, item }) => {
-              const index = flatIndexMap[item.id]
+              const index = flatIndexMap[item.id];
               if (typeof index === "number") {
-                listRef.current[index] = el
+                listRef.current[index] = el;
               }
             }}
             refItem={({ el, item }) => {
-              const index = flatIndexMap[item.id]
+              const index = flatIndexMap[item.id];
               if (typeof index === "number") {
-                listRef.current[index] = el
+                listRef.current[index] = el;
               }
             }}
             multiple={multiple}
@@ -1009,14 +1009,14 @@ function ComboboxDrawer({
             onMouseEnterItem={onMouseEnter}
             onOpenChange={({ id }) => {
               setOpenedCategoryGroup((prev) => {
-                const next = new Set(prev)
+                const next = new Set(prev);
                 if (next.has(id)) {
-                  next.delete(id)
+                  next.delete(id);
                 } else {
-                  next.add(id)
+                  next.add(id);
                 }
-                return next
-              })
+                return next;
+              });
             }}
             arrowSize={mobile ? 18 : 14}
             maxActionsBeforeCollapsing={1}
@@ -1171,11 +1171,11 @@ function ComboboxDrawer({
         </>
       )}
     </DrawerWrapper>
-  )
+  );
 
   if (mobile) {
     const finalFadeEffect =
-      fadeEffect ?? (searchbox ? ["bottom"] : ["top", "bottom"])
+      fadeEffect ?? (searchbox ? ["bottom"] : ["top", "bottom"]);
 
     return createPortal(
       <DrawerContainer
@@ -1199,16 +1199,16 @@ function ComboboxDrawer({
         )}
         {mainCombobox}
       </DrawerContainer>,
-      document.body,
-    )
+      document.body
+    );
   }
 
-  return mainCombobox
+  return mainCombobox;
 }
 
 const DrawerContainer = styled.div<{
-  $theme?: ComboboxThemeConfig
-  $mobile?: boolean
+  $theme?: ComboboxThemeConfig;
+  $mobile?: boolean;
 }>`
   *,
   ::before,
@@ -1225,17 +1225,17 @@ const DrawerContainer = styled.div<{
   border-radius: 14px;
   background-color: ${({ $mobile, $theme }) =>
     $mobile ? $theme.mobileBackgroundColor : $theme.backgroundColor};
-`
+`;
 
 const DrawerWrapper = styled.ul<{
-  $width?: number
-  $theme: ComboboxThemeConfig
-  $style?: CSSProp
-  $mobile?: boolean
-  $searchbox?: boolean
-  $hasNestedOptions?: boolean
-  $hasFewOptions?: boolean
-  $drawerHeight?: string
+  $width?: number;
+  $theme: ComboboxThemeConfig;
+  $style?: CSSProp;
+  $mobile?: boolean;
+  $searchbox?: boolean;
+  $hasNestedOptions?: boolean;
+  $hasFewOptions?: boolean;
+  $drawerHeight?: string;
 }>`
   *,
   ::before,
@@ -1282,7 +1282,7 @@ const DrawerWrapper = styled.ul<{
     $drawerHeight,
     $hasFewOptions,
   }) => {
-    const $height = $drawerHeight ?? "220px"
+    const $height = $drawerHeight ?? "220px";
 
     return css`
       height: ${$hasFewOptions ? "fit-content" : $height};
@@ -1307,11 +1307,11 @@ const DrawerWrapper = styled.ul<{
             ? $theme.mobileBackgroundColor
             : $theme.backgroundColor};
       `}
-    `
+    `;
   }}
 
   ${({ $style }) => $style}
-`
+`;
 
 const rowStyle = ({
   interactionMode,
@@ -1321,12 +1321,12 @@ const rowStyle = ({
   hasNestedOptions,
   level,
 }: {
-  interactionMode?: "mouse" | "keyboard"
-  multiple?: boolean
-  theme?: ComboboxThemeConfig
-  mobile?: boolean
-  hasNestedOptions?: boolean
-  level?: number
+  interactionMode?: "mouse" | "keyboard";
+  multiple?: boolean;
+  theme?: ComboboxThemeConfig;
+  mobile?: boolean;
+  hasNestedOptions?: boolean;
+  level?: number;
 }) => css`
   transition: background-color 0ms;
   background-color: ${mobile
@@ -1384,12 +1384,12 @@ const rowStyle = ({
       }
     `}
   }
-`
+`;
 
 const FadeTop = styled.div<{
-  $style?: CSSProp
-  $theme: ComboboxThemeConfig
-  $visible?: boolean
+  $style?: CSSProp;
+  $theme: ComboboxThemeConfig;
+  $visible?: boolean;
 }>`
   pointer-events: none;
   position: absolute;
@@ -1407,12 +1407,12 @@ const FadeTop = styled.div<{
   z-index: 99999999;
 
   ${({ $style }) => $style}
-`
+`;
 
 const FadeBottom = styled.div<{
-  $style?: CSSProp
-  $theme: ComboboxThemeConfig
-  $visible?: boolean
+  $style?: CSSProp;
+  $theme: ComboboxThemeConfig;
+  $visible?: boolean;
 }>`
   pointer-events: none;
   position: absolute;
@@ -1430,8 +1430,8 @@ const FadeBottom = styled.div<{
   z-index: 99999999;
 
   ${({ $style }) => $style}
-`
+`;
 
-Combobox.Drawer = ComboboxDrawer
+Combobox.Drawer = ComboboxDrawer;
 
-export { Combobox }
+export { Combobox };

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -1,62 +1,61 @@
-import { RiCalendar2Line } from "@remixicon/react";
+import { RiCalendar2Line } from "@remixicon/react"
 import {
   DrawerProps,
   SelectboxOption,
   Selectbox,
   SelectboxLabels,
   SelectboxStyles,
-} from "./selectbox";
+} from "./selectbox"
 import {
   Calendar,
   BaseCalendarProps,
   CalendarSelectabilityMode,
   CalendarStyles,
-} from "./calendar";
-import styled, { css, CSSProp } from "styled-components";
-import { forwardRef, ReactNode } from "react";
-import { FieldLaneDropdownOption, FieldLaneProps } from "./field-lane";
-import { StatefulForm } from "./stateful-form";
-import { useTheme } from "./../theme/provider";
-import { applyClassName } from "./../constants/classname";
-import { CalendarThemeConfig } from "theme";
-import { createPortal } from "react-dom";
+} from "./calendar"
+import styled, { css, CSSProp } from "styled-components"
+import { forwardRef, ReactNode } from "react"
+import { FieldLaneDropdownOption, FieldLaneProps } from "./field-lane"
+import { StatefulForm } from "./stateful-form"
+import { useTheme } from "./../theme/provider"
+import { applyClassName } from "./../constants/classname"
+import { CalendarThemeConfig } from "theme"
+import { createPortal } from "react-dom"
 
 type BaseDateboxProps = Omit<BaseCalendarProps, "selectabilityMode"> & {
-  name?: string;
-  label?: string;
-  showError?: boolean;
-  errorMessage?: string;
-  disabled?: boolean;
-  calendarFooter?: ReactNode;
-  calendarTodayButtonCaption?: string;
-  calendarSelectabilityMode?: CalendarSelectabilityMode;
-  placeholder?: string;
-  styles?: DateboxStyles;
-  helper?: string;
-  id?: string;
-  isLoading?: boolean;
-  mobile?: boolean;
-  labels?: SelectboxLabels;
-};
+  name?: string
+  label?: string
+  showError?: boolean
+  errorMessage?: string
+  disabled?: boolean
+  calendarFooter?: ReactNode
+  calendarTodayButtonCaption?: string
+  calendarSelectabilityMode?: CalendarSelectabilityMode
+  placeholder?: string
+  styles?: DateboxStyles
+  id?: string
+  isLoading?: boolean
+  mobile?: boolean
+  labels?: SelectboxLabels
+}
 
 export type DateboxStyles = SelectboxStyles & {
-  calendarDrawerStyle?: CSSProp;
-};
+  calendarDrawerStyle?: CSSProp
+}
 
 type CalendarDrawerProps = BaseCalendarProps &
   Partial<
     DrawerProps & {
-      selectedOptionsLocal?: SelectboxOption;
-      mobile?: boolean;
-      setSelectedOptionsLocal?: (option: SelectboxOption) => void;
-      calendarFooter?: ReactNode;
-      calendarTodayButtonCaption?: string;
-      calendarSelectabilityMode?: CalendarSelectabilityMode;
-      showError?: boolean;
+      selectedOptionsLocal?: SelectboxOption
+      mobile?: boolean
+      setSelectedOptionsLocal?: (option: SelectboxOption) => void
+      calendarFooter?: ReactNode
+      calendarTodayButtonCaption?: string
+      calendarSelectabilityMode?: CalendarSelectabilityMode
+      showError?: boolean
     }
-  >;
+  >
 
-export type DateboxDropdownOption = FieldLaneDropdownOption;
+export type DateboxDropdownOption = FieldLaneDropdownOption
 
 export interface DateboxProps
   extends BaseDateboxProps,
@@ -85,13 +84,13 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
     labels,
     className,
     ...rest
-  } = props;
+  } = props
 
   const inputId = StatefulForm.sanitizeId({
     prefix: "datebox",
     name,
     id,
-  });
+  })
 
   const {
     bodyStyle,
@@ -101,7 +100,10 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
     containerStyle,
     self,
     calendarDrawerStyle,
-  } = styles ?? {};
+    helperArrowStyle,
+    helperDrawerStyle,
+    helperIconStyle,
+  } = styles ?? {}
 
   return (
     <Selectbox
@@ -126,6 +128,9 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
         bodyStyle,
         labelStyle,
         containerStyle,
+        helperArrowStyle,
+        helperDrawerStyle,
+        helperIconStyle,
         self: css`
           ${dropdowns &&
           css`
@@ -159,18 +164,18 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
             onChange={onChange}
             selectedDates={selectedDates}
           />
-        );
+        )
       }}
     </Selectbox>
-  );
-});
+  )
+})
 
 function CalendarDrawer(props: CalendarDrawerProps) {
-  const { mobile, styles, ...rest } = props ?? {};
-  const { currentTheme } = useTheme();
-  const calendarTheme = currentTheme?.calendar;
+  const { mobile, styles, ...rest } = props ?? {}
+  const { currentTheme } = useTheme()
+  const calendarTheme = currentTheme?.calendar
 
-  const { self, containerStyle } = styles ?? {};
+  const { self, containerStyle } = styles ?? {}
 
   const calendarStyle: CalendarStyles = {
     ...props.styles,
@@ -188,7 +193,7 @@ function CalendarDrawer(props: CalendarDrawerProps) {
         justify-content: center;
       `}
     `,
-  };
+  }
 
   return createPortal(
     <CalendarWrapper
@@ -215,27 +220,27 @@ function CalendarDrawer(props: CalendarDrawerProps) {
         footer={props.calendarFooter}
         onChange={(data: string[]) => {
           if (props.onChange) {
-            props.onChange(data);
+            props.onChange(data)
           }
           props.setSelectedOptionsLocal({
             text: data[0],
             value: data[0],
-          });
+          })
         }}
         todayButtonCaption={props.calendarTodayButtonCaption}
         selectabilityMode={props.calendarSelectabilityMode}
         label={null}
       />
     </CalendarWrapper>,
-    document.body
-  );
+    document.body,
+  )
 }
 
 const CalendarWrapper = styled.ul<{
-  $style?: CSSProp;
-  $theme?: CalendarThemeConfig;
-  $mobile?: boolean;
-  $showError?: boolean;
+  $style?: CSSProp
+  $theme?: CalendarThemeConfig
+  $mobile?: boolean
+  $showError?: boolean
 }>`
   list-style: none;
   margin: 0;
@@ -275,6 +280,6 @@ const CalendarWrapper = styled.ul<{
   `};
 
   ${({ $style }) => $style}
-`;
+`
 
-export { Datebox };
+export { Datebox }

--- a/components/datebox.tsx
+++ b/components/datebox.tsx
@@ -1,61 +1,61 @@
-import { RiCalendar2Line } from "@remixicon/react"
+import { RiCalendar2Line } from "@remixicon/react";
 import {
   DrawerProps,
   SelectboxOption,
   Selectbox,
   SelectboxLabels,
   SelectboxStyles,
-} from "./selectbox"
+} from "./selectbox";
 import {
   Calendar,
   BaseCalendarProps,
   CalendarSelectabilityMode,
   CalendarStyles,
-} from "./calendar"
-import styled, { css, CSSProp } from "styled-components"
-import { forwardRef, ReactNode } from "react"
-import { FieldLaneDropdownOption, FieldLaneProps } from "./field-lane"
-import { StatefulForm } from "./stateful-form"
-import { useTheme } from "./../theme/provider"
-import { applyClassName } from "./../constants/classname"
-import { CalendarThemeConfig } from "theme"
-import { createPortal } from "react-dom"
+} from "./calendar";
+import styled, { css, CSSProp } from "styled-components";
+import { forwardRef, ReactNode } from "react";
+import { FieldLaneDropdownOption, FieldLaneProps } from "./field-lane";
+import { StatefulForm } from "./stateful-form";
+import { useTheme } from "./../theme/provider";
+import { applyClassName } from "./../constants/classname";
+import { CalendarThemeConfig } from "theme";
+import { createPortal } from "react-dom";
 
 type BaseDateboxProps = Omit<BaseCalendarProps, "selectabilityMode"> & {
-  name?: string
-  label?: string
-  showError?: boolean
-  errorMessage?: string
-  disabled?: boolean
-  calendarFooter?: ReactNode
-  calendarTodayButtonCaption?: string
-  calendarSelectabilityMode?: CalendarSelectabilityMode
-  placeholder?: string
-  styles?: DateboxStyles
-  id?: string
-  isLoading?: boolean
-  mobile?: boolean
-  labels?: SelectboxLabels
-}
+  name?: string;
+  label?: string;
+  showError?: boolean;
+  errorMessage?: string;
+  disabled?: boolean;
+  calendarFooter?: ReactNode;
+  calendarTodayButtonCaption?: string;
+  calendarSelectabilityMode?: CalendarSelectabilityMode;
+  placeholder?: string;
+  styles?: DateboxStyles;
+  id?: string;
+  isLoading?: boolean;
+  mobile?: boolean;
+  labels?: SelectboxLabels;
+};
 
 export type DateboxStyles = SelectboxStyles & {
-  calendarDrawerStyle?: CSSProp
-}
+  calendarDrawerStyle?: CSSProp;
+};
 
 type CalendarDrawerProps = BaseCalendarProps &
   Partial<
     DrawerProps & {
-      selectedOptionsLocal?: SelectboxOption
-      mobile?: boolean
-      setSelectedOptionsLocal?: (option: SelectboxOption) => void
-      calendarFooter?: ReactNode
-      calendarTodayButtonCaption?: string
-      calendarSelectabilityMode?: CalendarSelectabilityMode
-      showError?: boolean
+      selectedOptionsLocal?: SelectboxOption;
+      mobile?: boolean;
+      setSelectedOptionsLocal?: (option: SelectboxOption) => void;
+      calendarFooter?: ReactNode;
+      calendarTodayButtonCaption?: string;
+      calendarSelectabilityMode?: CalendarSelectabilityMode;
+      showError?: boolean;
     }
-  >
+  >;
 
-export type DateboxDropdownOption = FieldLaneDropdownOption
+export type DateboxDropdownOption = FieldLaneDropdownOption;
 
 export interface DateboxProps
   extends BaseDateboxProps,
@@ -84,13 +84,13 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
     labels,
     className,
     ...rest
-  } = props
+  } = props;
 
   const inputId = StatefulForm.sanitizeId({
     prefix: "datebox",
     name,
     id,
-  })
+  });
 
   const {
     bodyStyle,
@@ -103,7 +103,7 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
     helperArrowStyle,
     helperDrawerStyle,
     helperIconStyle,
-  } = styles ?? {}
+  } = styles ?? {};
 
   return (
     <Selectbox
@@ -164,18 +164,18 @@ const Datebox = forwardRef<HTMLInputElement, DateboxProps>((props, ref) => {
             onChange={onChange}
             selectedDates={selectedDates}
           />
-        )
+        );
       }}
     </Selectbox>
-  )
-})
+  );
+});
 
 function CalendarDrawer(props: CalendarDrawerProps) {
-  const { mobile, styles, ...rest } = props ?? {}
-  const { currentTheme } = useTheme()
-  const calendarTheme = currentTheme?.calendar
+  const { mobile, styles, ...rest } = props ?? {};
+  const { currentTheme } = useTheme();
+  const calendarTheme = currentTheme?.calendar;
 
-  const { self, containerStyle } = styles ?? {}
+  const { self, containerStyle } = styles ?? {};
 
   const calendarStyle: CalendarStyles = {
     ...props.styles,
@@ -193,7 +193,7 @@ function CalendarDrawer(props: CalendarDrawerProps) {
         justify-content: center;
       `}
     `,
-  }
+  };
 
   return createPortal(
     <CalendarWrapper
@@ -220,27 +220,27 @@ function CalendarDrawer(props: CalendarDrawerProps) {
         footer={props.calendarFooter}
         onChange={(data: string[]) => {
           if (props.onChange) {
-            props.onChange(data)
+            props.onChange(data);
           }
           props.setSelectedOptionsLocal({
             text: data[0],
             value: data[0],
-          })
+          });
         }}
         todayButtonCaption={props.calendarTodayButtonCaption}
         selectabilityMode={props.calendarSelectabilityMode}
         label={null}
       />
     </CalendarWrapper>,
-    document.body,
-  )
+    document.body
+  );
 }
 
 const CalendarWrapper = styled.ul<{
-  $style?: CSSProp
-  $theme?: CalendarThemeConfig
-  $mobile?: boolean
-  $showError?: boolean
+  $style?: CSSProp;
+  $theme?: CalendarThemeConfig;
+  $mobile?: boolean;
+  $showError?: boolean;
 }>`
   list-style: none;
   margin: 0;
@@ -280,6 +280,6 @@ const CalendarWrapper = styled.ul<{
   `};
 
   ${({ $style }) => $style}
-`
+`;
 
-export { Datebox }
+export { Datebox };

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -1,89 +1,89 @@
-import { RiCheckLine, RiErrorWarningLine } from "@remixicon/react";
-import React, { ReactElement, ReactNode } from "react";
-import styled, { css, CSSProp } from "styled-components";
-import { Button } from "./button";
-import { StatefulForm } from "./stateful-form";
-import { Tooltip } from "./tooltip";
-import { Figure, FigureProps } from "./figure";
-import { useTheme } from "./../theme/provider";
-import { FieldLaneThemeConfig } from "./../theme";
-import { BaseAction } from "../constants/action";
-import { applyClassName } from "./../constants/classname";
+import { RiCheckLine, RiErrorWarningLine } from "@remixicon/react"
+import React, { ReactElement, ReactNode } from "react"
+import styled, { css, CSSProp } from "styled-components"
+import { Button } from "./button"
+import { StatefulForm, StatefulFormLabelStyles } from "./stateful-form"
+import { Tooltip } from "./tooltip"
+import { Figure, FigureProps } from "./figure"
+import { useTheme } from "./../theme/provider"
+import { FieldLaneThemeConfig } from "./../theme"
+import { BaseAction } from "../constants/action"
+import { applyClassName } from "./../constants/classname"
 
 export const FieldLaneErrorIconPosition = {
   Absolute: "absolute",
   Relative: "relative",
   None: "none",
-} as const;
+} as const
 
 export type FieldLaneErrorIconPosition =
-  (typeof FieldLaneErrorIconPosition)[keyof typeof FieldLaneErrorIconPosition];
+  (typeof FieldLaneErrorIconPosition)[keyof typeof FieldLaneErrorIconPosition]
 
 export const FieldLaneLabelPosition = {
   Top: "top",
   Left: "left",
-} as const;
+} as const
 
 export type FieldLaneLabelPosition =
-  (typeof FieldLaneLabelPosition)[keyof typeof FieldLaneLabelPosition];
+  (typeof FieldLaneLabelPosition)[keyof typeof FieldLaneLabelPosition]
 
 export interface FieldLaneProps {
-  label?: string;
-  showError?: boolean;
-  errorIconPosition?: FieldLaneErrorIconPosition;
-  errorMessage?: string;
-  dropdowns?: FieldLaneDropdown[];
-  styles?: FieldLaneStyles;
-  helper?: string;
-  disabled?: boolean;
-  children?: ReactNode;
-  actions?: FieldLaneAction[];
-  type?: string;
-  labelPosition?: FieldLaneLabelPosition;
-  labelWidth?: string;
-  labelGap?: number;
-  required?: boolean;
-  className?: string;
-  id?: string;
-  mobile?: boolean;
+  label?: string
+  showError?: boolean
+  errorIconPosition?: FieldLaneErrorIconPosition
+  errorMessage?: string
+  dropdowns?: FieldLaneDropdown[]
+  styles?: FieldLaneStyles
+  helper?: ReactNode
+  disabled?: boolean
+  children?: ReactNode
+  actions?: FieldLaneAction[]
+  type?: string
+  labelPosition?: FieldLaneLabelPosition
+  labelWidth?: string
+  labelGap?: number
+  required?: boolean
+  className?: string
+  id?: string
+  mobile?: boolean
 }
 
-export interface FieldLaneStyles {
-  containerStyle?: CSSProp;
-  labelStyle?: CSSProp;
-  controlStyle?: CSSProp;
-  bodyStyle?: CSSProp;
+export interface FieldLaneStyles extends Omit<StatefulFormLabelStyles, "self"> {
+  containerStyle?: CSSProp
+  labelStyle?: CSSProp
+  controlStyle?: CSSProp
+  bodyStyle?: CSSProp
 }
 
 export interface FieldLaneAction extends BaseAction {
-  titleShowDelay?: number;
+  titleShowDelay?: number
 }
 
 export interface FieldLaneDropdown {
-  disabled?: boolean;
-  options?: FieldLaneDropdownOption[];
-  caption?: string;
-  onChange?: (id: string) => void;
-  width?: string;
-  styles?: FieldLaneDropdownStyles;
-  withFilter?: boolean;
+  disabled?: boolean
+  options?: FieldLaneDropdownOption[]
+  caption?: string
+  onChange?: (id: string) => void
+  width?: string
+  styles?: FieldLaneDropdownStyles
+  withFilter?: boolean
   render?: (props: {
-    render?: (children?: ReactNode) => ReactNode;
-    setCaption?: (caption?: string) => void;
-  }) => ReactNode;
-  hidden?: boolean;
+    render?: (children?: ReactNode) => ReactNode
+    setCaption?: (caption?: string) => void
+  }) => ReactNode
+  hidden?: boolean
 }
 
 export interface FieldLaneDropdownStyles {
-  drawerStyle?: CSSProp;
-  containerStyle?: CSSProp;
-  self?: CSSProp;
+  drawerStyle?: CSSProp
+  containerStyle?: CSSProp
+  self?: CSSProp
 }
 
 export interface FieldLaneDropdownOption {
-  text: string;
-  value: string;
-  icon?: FigureProps;
+  text: string
+  value: string
+  icon?: FigureProps
 }
 
 function FieldLane({
@@ -106,15 +106,15 @@ function FieldLane({
   className,
   mobile,
 }: FieldLaneProps) {
-  const { currentTheme } = useTheme();
-  const fieldLaneTheme = currentTheme.fieldLane;
-  const bodyTheme = currentTheme.body;
+  const { currentTheme } = useTheme()
+  const fieldLaneTheme = currentTheme.fieldLane
+  const bodyTheme = currentTheme.body
 
   const filteredActions = Array.isArray(actions)
     ? actions?.filter((action) => !action?.hidden)
-    : [];
+    : []
 
-  const hasActions = filteredActions.length > 0;
+  const hasActions = filteredActions.length > 0
 
   const inputElement: ReactElement = (
     <InputWrapper
@@ -132,21 +132,21 @@ function FieldLane({
                 disabled={dropdown?.disabled}
                 subMenu={({ list, render }) => {
                   if (dropdown.render) {
-                    return dropdown.render({ render });
+                    return dropdown.render({ render })
                   }
 
                   const dropdownData = dropdown.options.map((prop) => ({
                     caption: prop.text,
                     icon: prop.icon,
                     onClick: () => {
-                      dropdown.onChange(prop.value);
+                      dropdown.onChange(prop.value)
                     },
                     id: prop.value,
-                  }));
+                  }))
 
                   return list(dropdownData, {
                     withFilter: dropdown.withFilter ?? false,
-                  });
+                  })
                 }}
                 showSubMenuOn="self"
                 variant="outline-default"
@@ -223,22 +223,22 @@ function FieldLane({
               >
                 {dropdown.caption}
               </Button>
-            );
+            )
           })}
 
       {children}
 
       {hasActions &&
         filteredActions.map((action, index) => {
-          const { icon, titleShowDelay = 1250 } = action;
-          const offsetBase = 8;
-          const offsetEach = 22;
-          const reverseIndex = filteredActions.length - 1 - index;
+          const { icon, titleShowDelay = 1250 } = action
+          const offsetBase = 8
+          const offsetEach = 22
+          const reverseIndex = filteredActions.length - 1 - index
           const offset =
             offsetBase +
             reverseIndex * offsetEach +
             (type === "password" ? offsetEach : 0) +
-            (showError ? offsetEach : 0);
+            (showError ? offsetEach : 0)
 
           return (
             <Button
@@ -248,9 +248,9 @@ function FieldLane({
               aria-label="action-icon"
               onMouseDown={(e) => e.preventDefault()}
               onClick={(e) => {
-                e.stopPropagation();
-                if (disabled || action?.disabled) return;
-                action?.onClick(e);
+                e.stopPropagation()
+                if (disabled || action?.disabled) return
+                action?.onClick(e)
               }}
               disabled={disabled ? disabled : action.disabled}
               styles={{
@@ -286,10 +286,10 @@ function FieldLane({
               <Tooltip
                 key={index}
                 onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
+                  e.preventDefault()
+                  e.stopPropagation()
                   if ((!disabled || !action?.disabled) && action.onClick) {
-                    action.onClick(e);
+                    action.onClick(e)
                   }
                 }}
                 styles={{
@@ -332,7 +332,7 @@ function FieldLane({
                 )}
               </Tooltip>
             </Button>
-          );
+          )
         })}
 
       {showError && (
@@ -348,7 +348,7 @@ function FieldLane({
         </ErrorIconWrapper>
       )}
     </InputWrapper>
-  );
+  )
 
   const CONETO_CLASSES = [
     "coneto-textarea",
@@ -372,11 +372,11 @@ function FieldLane({
     "coneto-toggle",
     "coneto-timebox",
     "coneto-textbox",
-  ];
+  ]
 
   const hasCustomConetoClass = CONETO_CLASSES.some((cls) =>
-    className?.includes(cls)
-  );
+    className?.includes(cls),
+  )
 
   return (
     <Container
@@ -416,6 +416,9 @@ function FieldLane({
 
                 ${styles?.labelStyle};
               `,
+              helperDrawerStyle: styles?.helperDrawerStyle,
+              helperIconStyle: styles?.helperIconStyle,
+              helperArrowStyle: styles?.helperArrowStyle,
             }}
             helper={helper}
             label={label}
@@ -429,12 +432,12 @@ function FieldLane({
         <ErrorText $theme={fieldLaneTheme}>{errorMessage}</ErrorText>
       )}
     </Container>
-  );
+  )
 }
 
 const Container = styled.div<{
-  $style?: CSSProp;
-  $disabled?: boolean;
+  $style?: CSSProp
+  $disabled?: boolean
 }>`
   *,
   ::before,
@@ -457,14 +460,14 @@ const Container = styled.div<{
     `}
 
   ${({ $style }) => $style}
-`;
+`
 
 const Body = styled.div<{
-  $style?: CSSProp;
-  $disabled?: boolean;
-  $labelPosition?: FieldLaneProps["labelPosition"];
-  $labelGap?: number;
-  $theme?: FieldLaneThemeConfig;
+  $style?: CSSProp
+  $disabled?: boolean
+  $labelPosition?: FieldLaneProps["labelPosition"]
+  $labelGap?: number
+  $theme?: FieldLaneThemeConfig
 }>`
   position: relative;
   display: flex;
@@ -485,7 +488,7 @@ const Body = styled.div<{
     `}
 
   ${({ $style }) => $style}
-`;
+`
 
 const InputWrapper = styled.label<{ $style?: CSSProp }>`
   box-sizing: border-box;
@@ -499,11 +502,11 @@ const InputWrapper = styled.label<{ $style?: CSSProp }>`
   height: fit-content;
 
   ${({ $style }) => $style}
-`;
+`
 
 const ErrorIconWrapper = styled.div<{
-  $position?: FieldLaneProps["errorIconPosition"];
-  $theme?: FieldLaneThemeConfig;
+  $position?: FieldLaneProps["errorIconPosition"]
+  $theme?: FieldLaneThemeConfig
 }>`
   ${({ $position }) =>
     $position === "absolute"
@@ -531,10 +534,10 @@ const ErrorIconWrapper = styled.div<{
     color: ${({ $theme }) => $theme?.errorForeground ?? "#fff"};
     border-radius: 9999px;
   }
-`;
+`
 
 const ErrorText = styled.span<{ $theme?: FieldLaneThemeConfig }>`
   color: ${({ $theme }) => $theme?.errorColor ?? "#dc2626"};
-`;
+`
 
-export { FieldLane };
+export { FieldLane }

--- a/components/field-lane.tsx
+++ b/components/field-lane.tsx
@@ -1,89 +1,89 @@
-import { RiCheckLine, RiErrorWarningLine } from "@remixicon/react"
-import React, { ReactElement, ReactNode } from "react"
-import styled, { css, CSSProp } from "styled-components"
-import { Button } from "./button"
-import { StatefulForm, StatefulFormLabelStyles } from "./stateful-form"
-import { Tooltip } from "./tooltip"
-import { Figure, FigureProps } from "./figure"
-import { useTheme } from "./../theme/provider"
-import { FieldLaneThemeConfig } from "./../theme"
-import { BaseAction } from "../constants/action"
-import { applyClassName } from "./../constants/classname"
+import { RiCheckLine, RiErrorWarningLine } from "@remixicon/react";
+import React, { ReactElement, ReactNode } from "react";
+import styled, { css, CSSProp } from "styled-components";
+import { Button } from "./button";
+import { StatefulForm, StatefulFormLabelStyles } from "./stateful-form";
+import { Tooltip } from "./tooltip";
+import { Figure, FigureProps } from "./figure";
+import { useTheme } from "./../theme/provider";
+import { FieldLaneThemeConfig } from "./../theme";
+import { BaseAction } from "../constants/action";
+import { applyClassName } from "./../constants/classname";
 
 export const FieldLaneErrorIconPosition = {
   Absolute: "absolute",
   Relative: "relative",
   None: "none",
-} as const
+} as const;
 
 export type FieldLaneErrorIconPosition =
-  (typeof FieldLaneErrorIconPosition)[keyof typeof FieldLaneErrorIconPosition]
+  (typeof FieldLaneErrorIconPosition)[keyof typeof FieldLaneErrorIconPosition];
 
 export const FieldLaneLabelPosition = {
   Top: "top",
   Left: "left",
-} as const
+} as const;
 
 export type FieldLaneLabelPosition =
-  (typeof FieldLaneLabelPosition)[keyof typeof FieldLaneLabelPosition]
+  (typeof FieldLaneLabelPosition)[keyof typeof FieldLaneLabelPosition];
 
 export interface FieldLaneProps {
-  label?: string
-  showError?: boolean
-  errorIconPosition?: FieldLaneErrorIconPosition
-  errorMessage?: string
-  dropdowns?: FieldLaneDropdown[]
-  styles?: FieldLaneStyles
-  helper?: ReactNode
-  disabled?: boolean
-  children?: ReactNode
-  actions?: FieldLaneAction[]
-  type?: string
-  labelPosition?: FieldLaneLabelPosition
-  labelWidth?: string
-  labelGap?: number
-  required?: boolean
-  className?: string
-  id?: string
-  mobile?: boolean
+  label?: string;
+  showError?: boolean;
+  errorIconPosition?: FieldLaneErrorIconPosition;
+  errorMessage?: string;
+  dropdowns?: FieldLaneDropdown[];
+  styles?: FieldLaneStyles;
+  helper?: ReactNode;
+  disabled?: boolean;
+  children?: ReactNode;
+  actions?: FieldLaneAction[];
+  type?: string;
+  labelPosition?: FieldLaneLabelPosition;
+  labelWidth?: string;
+  labelGap?: number;
+  required?: boolean;
+  className?: string;
+  id?: string;
+  mobile?: boolean;
 }
 
 export interface FieldLaneStyles extends Omit<StatefulFormLabelStyles, "self"> {
-  containerStyle?: CSSProp
-  labelStyle?: CSSProp
-  controlStyle?: CSSProp
-  bodyStyle?: CSSProp
+  containerStyle?: CSSProp;
+  labelStyle?: CSSProp;
+  controlStyle?: CSSProp;
+  bodyStyle?: CSSProp;
 }
 
 export interface FieldLaneAction extends BaseAction {
-  titleShowDelay?: number
+  titleShowDelay?: number;
 }
 
 export interface FieldLaneDropdown {
-  disabled?: boolean
-  options?: FieldLaneDropdownOption[]
-  caption?: string
-  onChange?: (id: string) => void
-  width?: string
-  styles?: FieldLaneDropdownStyles
-  withFilter?: boolean
+  disabled?: boolean;
+  options?: FieldLaneDropdownOption[];
+  caption?: string;
+  onChange?: (id: string) => void;
+  width?: string;
+  styles?: FieldLaneDropdownStyles;
+  withFilter?: boolean;
   render?: (props: {
-    render?: (children?: ReactNode) => ReactNode
-    setCaption?: (caption?: string) => void
-  }) => ReactNode
-  hidden?: boolean
+    render?: (children?: ReactNode) => ReactNode;
+    setCaption?: (caption?: string) => void;
+  }) => ReactNode;
+  hidden?: boolean;
 }
 
 export interface FieldLaneDropdownStyles {
-  drawerStyle?: CSSProp
-  containerStyle?: CSSProp
-  self?: CSSProp
+  drawerStyle?: CSSProp;
+  containerStyle?: CSSProp;
+  self?: CSSProp;
 }
 
 export interface FieldLaneDropdownOption {
-  text: string
-  value: string
-  icon?: FigureProps
+  text: string;
+  value: string;
+  icon?: FigureProps;
 }
 
 function FieldLane({
@@ -106,15 +106,15 @@ function FieldLane({
   className,
   mobile,
 }: FieldLaneProps) {
-  const { currentTheme } = useTheme()
-  const fieldLaneTheme = currentTheme.fieldLane
-  const bodyTheme = currentTheme.body
+  const { currentTheme } = useTheme();
+  const fieldLaneTheme = currentTheme.fieldLane;
+  const bodyTheme = currentTheme.body;
 
   const filteredActions = Array.isArray(actions)
     ? actions?.filter((action) => !action?.hidden)
-    : []
+    : [];
 
-  const hasActions = filteredActions.length > 0
+  const hasActions = filteredActions.length > 0;
 
   const inputElement: ReactElement = (
     <InputWrapper
@@ -132,21 +132,21 @@ function FieldLane({
                 disabled={dropdown?.disabled}
                 subMenu={({ list, render }) => {
                   if (dropdown.render) {
-                    return dropdown.render({ render })
+                    return dropdown.render({ render });
                   }
 
                   const dropdownData = dropdown.options.map((prop) => ({
                     caption: prop.text,
                     icon: prop.icon,
                     onClick: () => {
-                      dropdown.onChange(prop.value)
+                      dropdown.onChange(prop.value);
                     },
                     id: prop.value,
-                  }))
+                  }));
 
                   return list(dropdownData, {
                     withFilter: dropdown.withFilter ?? false,
-                  })
+                  });
                 }}
                 showSubMenuOn="self"
                 variant="outline-default"
@@ -223,22 +223,22 @@ function FieldLane({
               >
                 {dropdown.caption}
               </Button>
-            )
+            );
           })}
 
       {children}
 
       {hasActions &&
         filteredActions.map((action, index) => {
-          const { icon, titleShowDelay = 1250 } = action
-          const offsetBase = 8
-          const offsetEach = 22
-          const reverseIndex = filteredActions.length - 1 - index
+          const { icon, titleShowDelay = 1250 } = action;
+          const offsetBase = 8;
+          const offsetEach = 22;
+          const reverseIndex = filteredActions.length - 1 - index;
           const offset =
             offsetBase +
             reverseIndex * offsetEach +
             (type === "password" ? offsetEach : 0) +
-            (showError ? offsetEach : 0)
+            (showError ? offsetEach : 0);
 
           return (
             <Button
@@ -248,9 +248,9 @@ function FieldLane({
               aria-label="action-icon"
               onMouseDown={(e) => e.preventDefault()}
               onClick={(e) => {
-                e.stopPropagation()
-                if (disabled || action?.disabled) return
-                action?.onClick(e)
+                e.stopPropagation();
+                if (disabled || action?.disabled) return;
+                action?.onClick(e);
               }}
               disabled={disabled ? disabled : action.disabled}
               styles={{
@@ -286,10 +286,10 @@ function FieldLane({
               <Tooltip
                 key={index}
                 onClick={(e) => {
-                  e.preventDefault()
-                  e.stopPropagation()
+                  e.preventDefault();
+                  e.stopPropagation();
                   if ((!disabled || !action?.disabled) && action.onClick) {
-                    action.onClick(e)
+                    action.onClick(e);
                   }
                 }}
                 styles={{
@@ -332,7 +332,7 @@ function FieldLane({
                 )}
               </Tooltip>
             </Button>
-          )
+          );
         })}
 
       {showError && (
@@ -348,7 +348,7 @@ function FieldLane({
         </ErrorIconWrapper>
       )}
     </InputWrapper>
-  )
+  );
 
   const CONETO_CLASSES = [
     "coneto-textarea",
@@ -372,11 +372,11 @@ function FieldLane({
     "coneto-toggle",
     "coneto-timebox",
     "coneto-textbox",
-  ]
+  ];
 
   const hasCustomConetoClass = CONETO_CLASSES.some((cls) =>
-    className?.includes(cls),
-  )
+    className?.includes(cls)
+  );
 
   return (
     <Container
@@ -432,12 +432,12 @@ function FieldLane({
         <ErrorText $theme={fieldLaneTheme}>{errorMessage}</ErrorText>
       )}
     </Container>
-  )
+  );
 }
 
 const Container = styled.div<{
-  $style?: CSSProp
-  $disabled?: boolean
+  $style?: CSSProp;
+  $disabled?: boolean;
 }>`
   *,
   ::before,
@@ -460,14 +460,14 @@ const Container = styled.div<{
     `}
 
   ${({ $style }) => $style}
-`
+`;
 
 const Body = styled.div<{
-  $style?: CSSProp
-  $disabled?: boolean
-  $labelPosition?: FieldLaneProps["labelPosition"]
-  $labelGap?: number
-  $theme?: FieldLaneThemeConfig
+  $style?: CSSProp;
+  $disabled?: boolean;
+  $labelPosition?: FieldLaneProps["labelPosition"];
+  $labelGap?: number;
+  $theme?: FieldLaneThemeConfig;
 }>`
   position: relative;
   display: flex;
@@ -488,7 +488,7 @@ const Body = styled.div<{
     `}
 
   ${({ $style }) => $style}
-`
+`;
 
 const InputWrapper = styled.label<{ $style?: CSSProp }>`
   box-sizing: border-box;
@@ -502,11 +502,11 @@ const InputWrapper = styled.label<{ $style?: CSSProp }>`
   height: fit-content;
 
   ${({ $style }) => $style}
-`
+`;
 
 const ErrorIconWrapper = styled.div<{
-  $position?: FieldLaneProps["errorIconPosition"]
-  $theme?: FieldLaneThemeConfig
+  $position?: FieldLaneProps["errorIconPosition"];
+  $theme?: FieldLaneThemeConfig;
 }>`
   ${({ $position }) =>
     $position === "absolute"
@@ -534,10 +534,10 @@ const ErrorIconWrapper = styled.div<{
     color: ${({ $theme }) => $theme?.errorForeground ?? "#fff"};
     border-radius: 9999px;
   }
-`
+`;
 
 const ErrorText = styled.span<{ $theme?: FieldLaneThemeConfig }>`
   color: ${({ $theme }) => $theme?.errorColor ?? "#dc2626"};
-`
+`;
 
-export { FieldLane }
+export { FieldLane };

--- a/components/figure.tsx
+++ b/components/figure.tsx
@@ -1,26 +1,26 @@
-import { applyClassName } from "./../constants/classname"
-import { ComponentType, HTMLAttributes } from "react"
-import styled, { css, CSSProp } from "styled-components"
+import { applyClassName } from "./../constants/classname";
+import { ComponentType, HTMLAttributes } from "react";
+import styled, { css, CSSProp } from "styled-components";
 
 export interface FigureProps
   extends Omit<HTMLAttributes<HTMLSpanElement>, "style"> {
-  image?: ComponentType<any> | string
-  size?: number
-  color?: string
-  styles?: FigureStyles
-  notificationBadge?: FigureNotification
+  image?: ComponentType<any> | string;
+  size?: number;
+  color?: string;
+  styles?: FigureStyles;
+  notificationBadge?: FigureNotification;
 }
 
 export interface FigureNotification {
-  content?: string
-  backgroundColor?: string
-  frameSize?: string
-  fontSize?: string
+  content?: string;
+  backgroundColor?: string;
+  frameSize?: string;
+  fontSize?: string;
 }
 
 export interface FigureStyles {
-  self?: CSSProp
-  notificationBadgeStyle?: CSSProp
+  self?: CSSProp;
+  notificationBadgeStyle?: CSSProp;
 }
 
 function Figure({
@@ -33,7 +33,7 @@ function Figure({
   notificationBadge,
   ...rest
 }: FigureProps) {
-  if (!Icon) return null
+  if (!Icon) return null;
 
   return (
     <Wrapper
@@ -74,7 +74,7 @@ function Figure({
         />
       )}
     </Wrapper>
-  )
+  );
 }
 
 const Wrapper = styled.span<{ $style?: CSSProp }>`
@@ -83,15 +83,15 @@ const Wrapper = styled.span<{ $style?: CSSProp }>`
   position: relative;
 
   ${({ $style }) => $style}
-`
+`;
 
 const Notification = styled.span<{
-  $style?: CSSProp
-  $size?: number
-  $frameSize?: string
-  $fontSize?: string
-  $backgroundColor?: string
-  $contentLength?: number
+  $style?: CSSProp;
+  $size?: number;
+  $frameSize?: string;
+  $fontSize?: string;
+  $backgroundColor?: string;
+  $contentLength?: number;
 }>`
   position: absolute;
   top: 5%;
@@ -122,5 +122,5 @@ const Notification = styled.span<{
         `};
 
   ${({ $style }) => $style};
-`
-export { Figure }
+`;
+export { Figure };

--- a/components/figure.tsx
+++ b/components/figure.tsx
@@ -1,26 +1,26 @@
-import { applyClassName } from "./../constants/classname";
-import { ComponentType, HTMLAttributes } from "react";
-import styled, { css, CSSProp } from "styled-components";
+import { applyClassName } from "./../constants/classname"
+import { ComponentType, HTMLAttributes } from "react"
+import styled, { css, CSSProp } from "styled-components"
 
 export interface FigureProps
   extends Omit<HTMLAttributes<HTMLSpanElement>, "style"> {
-  image?: ComponentType<any> | string;
-  size?: number;
-  color?: string;
-  styles?: FigureStyles;
-  notificationBadge?: FigureNotification;
+  image?: ComponentType<any> | string
+  size?: number
+  color?: string
+  styles?: FigureStyles
+  notificationBadge?: FigureNotification
 }
 
 export interface FigureNotification {
-  content?: string;
-  backgroundColor?: string;
-  frameSize?: string;
-  fontSize?: string;
+  content?: string
+  backgroundColor?: string
+  frameSize?: string
+  fontSize?: string
 }
 
 export interface FigureStyles {
-  self?: CSSProp;
-  notificationBadgeStyle?: CSSProp;
+  self?: CSSProp
+  notificationBadgeStyle?: CSSProp
 }
 
 function Figure({
@@ -33,7 +33,7 @@ function Figure({
   notificationBadge,
   ...rest
 }: FigureProps) {
-  if (!Icon) return null;
+  if (!Icon) return null
 
   return (
     <Wrapper
@@ -74,7 +74,7 @@ function Figure({
         />
       )}
     </Wrapper>
-  );
+  )
 }
 
 const Wrapper = styled.span<{ $style?: CSSProp }>`
@@ -83,15 +83,15 @@ const Wrapper = styled.span<{ $style?: CSSProp }>`
   position: relative;
 
   ${({ $style }) => $style}
-`;
+`
 
 const Notification = styled.span<{
-  $style?: CSSProp;
-  $size?: number;
-  $frameSize?: string;
-  $fontSize?: string;
-  $backgroundColor?: string;
-  $contentLength?: number;
+  $style?: CSSProp
+  $size?: number
+  $frameSize?: string
+  $fontSize?: string
+  $backgroundColor?: string
+  $contentLength?: number
 }>`
   position: absolute;
   top: 5%;
@@ -122,5 +122,5 @@ const Notification = styled.span<{
         `};
 
   ${({ $style }) => $style};
-`;
-export { Figure };
+`
+export { Figure }

--- a/components/file-drop-box.tsx
+++ b/components/file-drop-box.tsx
@@ -1,4 +1,4 @@
-import { RiFile2Line, RiFileUploadLine, RiImageLine } from "@remixicon/react"
+import { RiFile2Line, RiFileUploadLine, RiImageLine } from "@remixicon/react";
 import {
   ChangeEvent,
   DragEvent,
@@ -7,64 +7,64 @@ import {
   ReactNode,
   useRef,
   useState,
-} from "react"
-import styled, { css, CSSProp } from "styled-components"
-import { LoadingSpinner } from "./loading-spinner"
-import { StatefulForm, StatefulFormLabelStyles } from "./stateful-form"
-import { Figure } from "./figure"
-import { FieldLaneProps } from "./field-lane"
-import { useTheme } from "./../theme/provider"
-import { FileDropBoxThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
+} from "react";
+import styled, { css, CSSProp } from "styled-components";
+import { LoadingSpinner } from "./loading-spinner";
+import { StatefulForm, StatefulFormLabelStyles } from "./stateful-form";
+import { Figure } from "./figure";
+import { FieldLaneProps } from "./field-lane";
+import { useTheme } from "./../theme/provider";
+import { FileDropBoxThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 
 export interface OnFileDroppedFunctionArgs {
-  files: File[]
-  succeed: (file: File) => void
-  error: (file: File, errorMessage: string) => void
-  setProgressLabel: (label: string) => void
-  progressPercentage?: number
+  files: File[];
+  succeed: (file: File) => void;
+  error: (file: File, errorMessage: string) => void;
+  setProgressLabel: (label: string) => void;
+  progressPercentage?: number;
 }
 
 export interface OnCompleteFunctionArgs {
-  succeedFiles?: File[]
-  failedFiles?: File[]
-  setProgressLabel?: (label: string) => void
-  hideProgressLabel?: () => void
-  showUploaderForm?: () => void
+  succeedFiles?: File[];
+  failedFiles?: File[];
+  setProgressLabel?: (label: string) => void;
+  hideProgressLabel?: () => void;
+  showUploaderForm?: () => void;
 }
 
 export interface FileDropBoxProps {
-  description?: ReactNode
-  placeholder?: ReactNode
-  accept?: string
-  label?: string
-  onFileDropped?: (props: OnFileDroppedFunctionArgs) => void
-  onComplete?: (props: OnCompleteFunctionArgs) => void
-  progressPercentage?: number
-  helper?: ReactNode
-  children?: ReactNode
-  styles?: FileDropBoxStyles
-  name?: string
-  id?: string
-  labelPosition?: FieldLaneProps["labelPosition"]
-  labelGap?: FieldLaneProps["labelGap"]
-  labelWidth?: FieldLaneProps["labelWidth"]
-  required?: boolean
-  disabled?: boolean
-  className?: string
+  description?: ReactNode;
+  placeholder?: ReactNode;
+  accept?: string;
+  label?: string;
+  onFileDropped?: (props: OnFileDroppedFunctionArgs) => void;
+  onComplete?: (props: OnCompleteFunctionArgs) => void;
+  progressPercentage?: number;
+  helper?: ReactNode;
+  children?: ReactNode;
+  styles?: FileDropBoxStyles;
+  name?: string;
+  id?: string;
+  labelPosition?: FieldLaneProps["labelPosition"];
+  labelGap?: FieldLaneProps["labelGap"];
+  labelWidth?: FieldLaneProps["labelWidth"];
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
 }
 
 export interface FileDropBoxStyles extends StatefulFormLabelStyles {
-  containerStyle?: CSSProp
-  dragOverStyle?: CSSProp
-  successStyle?: CSSProp
-  labelStyle?: CSSProp
-  contentStyle?: CSSProp
-  placeholderStyle?: CSSProp
-  descriptionStyle?: CSSProp
+  containerStyle?: CSSProp;
+  dragOverStyle?: CSSProp;
+  successStyle?: CSSProp;
+  labelStyle?: CSSProp;
+  contentStyle?: CSSProp;
+  placeholderStyle?: CSSProp;
+  descriptionStyle?: CSSProp;
 }
 
-type ProgressProps = "idle" | "loading" | "succeed" | null
+type ProgressProps = "idle" | "loading" | "succeed" | null;
 
 function FileDropBox({
   placeholder = "Drag and Drop Your File",
@@ -85,100 +85,100 @@ function FileDropBox({
   disabled,
   className,
 }: FileDropBoxProps) {
-  const { currentTheme } = useTheme()
-  const fileDropBoxTheme = currentTheme.fileDropBox
+  const { currentTheme } = useTheme();
+  const fileDropBoxTheme = currentTheme.fileDropBox;
 
   const FILE_ICON = [
     { id: 1, icon: RiImageLine, size: 50 },
     { id: 2, icon: RiFileUploadLine, size: 80 },
     { id: 3, icon: RiFile2Line, size: 50 },
-  ]
+  ];
 
   const inputId = StatefulForm.sanitizeId({
     prefix: "file-drop-box",
     name,
     id,
-  })
+  });
 
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const [isDragging, setIsDragging] = useState(false)
-  const [currentIndex, setCurrentIndex] = useState<number | null>(null)
-  const [progressLabel, setProgressLabel] = useState("")
-  const [progressPercentage, setProgressPercentage] = useState(0)
-  const [progress, setProgress] = useState<ProgressProps>("idle")
-  const [errorMessages, setErrorMessages] = useState<string[]>([])
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState<number | null>(null);
+  const [progressLabel, setProgressLabel] = useState("");
+  const [progressPercentage, setProgressPercentage] = useState(0);
+  const [progress, setProgress] = useState<ProgressProps>("idle");
+  const [errorMessages, setErrorMessages] = useState<string[]>([]);
 
-  const handleBrowseClick = () => fileInputRef.current?.click()
+  const handleBrowseClick = () => fileInputRef.current?.click();
   const handleErrorMessage = (msg: string) =>
-    setErrorMessages((prev) => [...prev, msg])
+    setErrorMessages((prev) => [...prev, msg]);
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
-      const files = Array.from(e.target.files)
-      handleUploadFile(files)
+      const files = Array.from(e.target.files);
+      handleUploadFile(files);
     }
-  }
+  };
 
   const handleDrop = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    setIsDragging(false)
+    e.preventDefault();
+    setIsDragging(false);
     if (e.dataTransfer.files) {
-      const files = Array.from(e.dataTransfer.files)
-      handleUploadFile(files)
+      const files = Array.from(e.dataTransfer.files);
+      handleUploadFile(files);
     }
-  }
+  };
 
   const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    setIsDragging(true)
-  }
+    e.preventDefault();
+    setIsDragging(true);
+  };
 
-  const handleDragLeave = () => setIsDragging(false)
+  const handleDragLeave = () => setIsDragging(false);
 
   const hideProgressLabel = () => {
-    setProgress(null)
-  }
+    setProgress(null);
+  };
 
   const showUploaderForm = () => {
-    setProgress("idle")
-  }
+    setProgress("idle");
+  };
 
   const handleUploadFile = async (files: File[]) => {
-    if (!onFileDropped) return
+    if (!onFileDropped) return;
 
-    await setProgress("loading")
+    await setProgress("loading");
 
-    const succeedFiles: File[] = []
-    const failedFiles: File[] = []
-    const total = files.length
+    const succeedFiles: File[] = [];
+    const failedFiles: File[] = [];
+    const total = files.length;
 
     const succeed = (file: File) => {
-      succeedFiles.push(file)
-      updateProgressBar(succeedFiles.length, total)
-    }
+      succeedFiles.push(file);
+      updateProgressBar(succeedFiles.length, total);
+    };
 
     const error = (file: File, message: string) => {
-      failedFiles.push(file)
-      handleErrorMessage(message)
-      updateProgressBar(succeedFiles.length, total)
-    }
+      failedFiles.push(file);
+      handleErrorMessage(message);
+      updateProgressBar(succeedFiles.length, total);
+    };
 
     const updateProgressBar = (succeedCount: number, totalCount: number) => {
-      const percentage = Math.round((succeedCount / totalCount) * 100)
-      setProgressPercentage(percentage)
-    }
+      const percentage = Math.round((succeedCount / totalCount) * 100);
+      setProgressPercentage(percentage);
+    };
 
     for (let i = 0; i < files.length; i++) {
-      setCurrentIndex(i)
+      setCurrentIndex(i);
       await onFileDropped({
         files: [files[i]],
         succeed,
         error,
         setProgressLabel,
         progressPercentage,
-      })
+      });
     }
-    await setProgress("succeed")
+    await setProgress("succeed");
 
     await onComplete?.({
       succeedFiles,
@@ -186,8 +186,8 @@ function FileDropBox({
       setProgressLabel,
       hideProgressLabel,
       showUploaderForm,
-    })
-  }
+    });
+  };
 
   const inputElement: ReactElement = (
     <DropArea
@@ -198,20 +198,20 @@ function FileDropBox({
       $progress={progress}
       aria-label="file-drop-box-area"
       onClick={() => {
-        if (disabled) return
-        handleBrowseClick()
+        if (disabled) return;
+        handleBrowseClick();
       }}
       onDrop={(e) => {
-        if (disabled) return
-        handleDrop(e)
+        if (disabled) return;
+        handleDrop(e);
       }}
       onDragOver={(e) => {
-        if (disabled) return
-        handleDragOver(e)
+        if (disabled) return;
+        handleDragOver(e);
       }}
       onDragLeave={() => {
-        if (disabled) return
-        handleDragLeave()
+        if (disabled) return;
+        handleDragLeave();
       }}
     >
       {progress === "loading" && currentIndex !== null ? (
@@ -295,7 +295,7 @@ function FileDropBox({
         />
       )}
     </DropArea>
-  )
+  );
 
   return (
     <InputWrapper
@@ -340,15 +340,15 @@ function FileDropBox({
         </ErrorList>
       )}
     </InputWrapper>
-  )
+  );
 }
 
 const InputWrapper = styled.div<{
-  $containerStyle?: CSSProp
-  $hide?: boolean
-  $labelPosition?: FieldLaneProps["labelPosition"]
-  $labelGap?: FieldLaneProps["labelGap"]
-  $disabled?: boolean
+  $containerStyle?: CSSProp;
+  $hide?: boolean;
+  $labelPosition?: FieldLaneProps["labelPosition"];
+  $labelGap?: FieldLaneProps["labelGap"];
+  $disabled?: boolean;
 }>`
   display: flex;
   width: 100%;
@@ -373,10 +373,10 @@ const InputWrapper = styled.div<{
     `};
 
   ${({ $containerStyle }) => $containerStyle}
-`
+`;
 
 const ContentWrapper = styled.div<{
-  $style?: CSSProp
+  $style?: CSSProp;
 }>`
   display: flex;
   width: 100%;
@@ -387,14 +387,14 @@ const ContentWrapper = styled.div<{
   cursor: default;
 
   ${({ $style }) => $style}
-`
+`;
 
 const DropArea = styled.div<{
-  $isDragging: boolean
-  $progress: ProgressProps
-  $dragOverStyle?: CSSProp
-  $successStyle?: CSSProp
-  $theme: FileDropBoxThemeConfig
+  $isDragging: boolean;
+  $progress: ProgressProps;
+  $dragOverStyle?: CSSProp;
+  $successStyle?: CSSProp;
+  $theme: FileDropBoxThemeConfig;
 }>`
   display: flex;
   flex-direction: column;
@@ -512,7 +512,7 @@ const DropArea = styled.div<{
       border: 1px solid ${$theme.borderColor};
       ${$successStyle}
     `};
-`
+`;
 
 const UploadContent = styled.div`
   font-size: 0.875rem;
@@ -522,41 +522,41 @@ const UploadContent = styled.div`
   gap: 0.5rem;
   align-items: center;
   padding: 1.5rem;
-`
+`;
 
 const IconsRow = styled.div`
   display: flex;
   flex-direction: row;
   align-items: flex-end;
   gap: 0.5rem;
-`
+`;
 
 const PlaceholderText = styled.span<{
-  $isDragging: boolean
-  $theme: FileDropBoxThemeConfig
-  $style?: CSSProp
+  $isDragging: boolean;
+  $theme: FileDropBoxThemeConfig;
+  $style?: CSSProp;
 }>`
   font-size: 1.25rem;
   color: ${({ $theme, $isDragging }) =>
     $isDragging ? $theme.dragActiveTextColor : $theme.textColor};
-`
+`;
 
 const DescriptionText = styled.span<{
-  $isDragging: boolean
-  $theme: FileDropBoxThemeConfig
-  $style?: CSSProp
+  $isDragging: boolean;
+  $theme: FileDropBoxThemeConfig;
+  $style?: CSSProp;
 }>`
   color: ${({ $theme, $isDragging }) =>
     $isDragging ? $theme.dragActiveTextColor : $theme.textColor};
-`
+`;
 
 const LinkText = styled.span<{ $theme: FileDropBoxThemeConfig }>`
   color: ${({ $theme }) => $theme.dragActiveTextColor || "#3b82f6"};
   text-decoration: underline;
-`
+`;
 
 const ProgressContainer = styled.div<{
-  $theme: FileDropBoxThemeConfig
+  $theme: FileDropBoxThemeConfig;
 }>`
   width: 100%;
   font-size: 0.875rem;
@@ -567,10 +567,10 @@ const ProgressContainer = styled.div<{
   align-items: center;
   gap: 0.5rem;
   border: 1px solid ${({ $theme }) => $theme.borderColor};
-`
+`;
 
 const ProgressBarWrapper = styled.div<{
-  $theme: FileDropBoxThemeConfig
+  $theme: FileDropBoxThemeConfig;
 }>`
   height: 4px;
   width: 100%;
@@ -578,11 +578,11 @@ const ProgressBarWrapper = styled.div<{
   left: 0;
   bottom: 0;
   background-color: ${({ $theme }) => $theme.backgroundColor || "#e5e7eb"};
-`
+`;
 
 const ProgressBar = styled.div<{
-  $width: number
-  $theme: FileDropBoxThemeConfig
+  $width: number;
+  $theme: FileDropBoxThemeConfig;
 }>`
   height: 4px;
   position: absolute;
@@ -592,7 +592,7 @@ const ProgressBar = styled.div<{
   transition: all 0.2s ease;
   width: ${({ $width }) => $width}%;
   background-color: ${({ $theme }) => $theme.progressBarColor};
-`
+`;
 
 const ErrorList = styled.ul`
   margin: 0;
@@ -600,6 +600,6 @@ const ErrorList = styled.ul`
   list-style-type: disc;
   font-size: 0.875rem;
   margin-left: 2.5rem;
-`
+`;
 
-export { FileDropBox }
+export { FileDropBox };

--- a/components/file-drop-box.tsx
+++ b/components/file-drop-box.tsx
@@ -1,4 +1,4 @@
-import { RiFile2Line, RiFileUploadLine, RiImageLine } from "@remixicon/react";
+import { RiFile2Line, RiFileUploadLine, RiImageLine } from "@remixicon/react"
 import {
   ChangeEvent,
   DragEvent,
@@ -7,64 +7,64 @@ import {
   ReactNode,
   useRef,
   useState,
-} from "react";
-import styled, { css, CSSProp } from "styled-components";
-import { LoadingSpinner } from "./loading-spinner";
-import { StatefulForm } from "./stateful-form";
-import { Figure } from "./figure";
-import { FieldLaneProps } from "./field-lane";
-import { useTheme } from "./../theme/provider";
-import { FileDropBoxThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
+} from "react"
+import styled, { css, CSSProp } from "styled-components"
+import { LoadingSpinner } from "./loading-spinner"
+import { StatefulForm, StatefulFormLabelStyles } from "./stateful-form"
+import { Figure } from "./figure"
+import { FieldLaneProps } from "./field-lane"
+import { useTheme } from "./../theme/provider"
+import { FileDropBoxThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
 
 export interface OnFileDroppedFunctionArgs {
-  files: File[];
-  succeed: (file: File) => void;
-  error: (file: File, errorMessage: string) => void;
-  setProgressLabel: (label: string) => void;
-  progressPercentage?: number;
+  files: File[]
+  succeed: (file: File) => void
+  error: (file: File, errorMessage: string) => void
+  setProgressLabel: (label: string) => void
+  progressPercentage?: number
 }
 
 export interface OnCompleteFunctionArgs {
-  succeedFiles?: File[];
-  failedFiles?: File[];
-  setProgressLabel?: (label: string) => void;
-  hideProgressLabel?: () => void;
-  showUploaderForm?: () => void;
+  succeedFiles?: File[]
+  failedFiles?: File[]
+  setProgressLabel?: (label: string) => void
+  hideProgressLabel?: () => void
+  showUploaderForm?: () => void
 }
 
 export interface FileDropBoxProps {
-  description?: ReactNode;
-  placeholder?: ReactNode;
-  accept?: string;
-  label?: string;
-  onFileDropped?: (props: OnFileDroppedFunctionArgs) => void;
-  onComplete?: (props: OnCompleteFunctionArgs) => void;
-  progressPercentage?: number;
-  helper?: string;
-  children?: ReactNode;
-  styles?: FileDropBoxStyles;
-  name?: string;
-  id?: string;
-  labelPosition?: FieldLaneProps["labelPosition"];
-  labelGap?: FieldLaneProps["labelGap"];
-  labelWidth?: FieldLaneProps["labelWidth"];
-  required?: boolean;
-  disabled?: boolean;
-  className?: string;
+  description?: ReactNode
+  placeholder?: ReactNode
+  accept?: string
+  label?: string
+  onFileDropped?: (props: OnFileDroppedFunctionArgs) => void
+  onComplete?: (props: OnCompleteFunctionArgs) => void
+  progressPercentage?: number
+  helper?: ReactNode
+  children?: ReactNode
+  styles?: FileDropBoxStyles
+  name?: string
+  id?: string
+  labelPosition?: FieldLaneProps["labelPosition"]
+  labelGap?: FieldLaneProps["labelGap"]
+  labelWidth?: FieldLaneProps["labelWidth"]
+  required?: boolean
+  disabled?: boolean
+  className?: string
 }
 
-export interface FileDropBoxStyles {
-  containerStyle?: CSSProp;
-  dragOverStyle?: CSSProp;
-  successStyle?: CSSProp;
-  labelStyle?: CSSProp;
-  contentStyle?: CSSProp;
-  placeholderStyle?: CSSProp;
-  descriptionStyle?: CSSProp;
+export interface FileDropBoxStyles extends StatefulFormLabelStyles {
+  containerStyle?: CSSProp
+  dragOverStyle?: CSSProp
+  successStyle?: CSSProp
+  labelStyle?: CSSProp
+  contentStyle?: CSSProp
+  placeholderStyle?: CSSProp
+  descriptionStyle?: CSSProp
 }
 
-type ProgressProps = "idle" | "loading" | "succeed" | null;
+type ProgressProps = "idle" | "loading" | "succeed" | null
 
 function FileDropBox({
   placeholder = "Drag and Drop Your File",
@@ -85,100 +85,100 @@ function FileDropBox({
   disabled,
   className,
 }: FileDropBoxProps) {
-  const { currentTheme } = useTheme();
-  const fileDropBoxTheme = currentTheme.fileDropBox;
+  const { currentTheme } = useTheme()
+  const fileDropBoxTheme = currentTheme.fileDropBox
 
   const FILE_ICON = [
     { id: 1, icon: RiImageLine, size: 50 },
     { id: 2, icon: RiFileUploadLine, size: 80 },
     { id: 3, icon: RiFile2Line, size: 50 },
-  ];
+  ]
 
   const inputId = StatefulForm.sanitizeId({
     prefix: "file-drop-box",
     name,
     id,
-  });
+  })
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [isDragging, setIsDragging] = useState(false);
-  const [currentIndex, setCurrentIndex] = useState<number | null>(null);
-  const [progressLabel, setProgressLabel] = useState("");
-  const [progressPercentage, setProgressPercentage] = useState(0);
-  const [progress, setProgress] = useState<ProgressProps>("idle");
-  const [errorMessages, setErrorMessages] = useState<string[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const [currentIndex, setCurrentIndex] = useState<number | null>(null)
+  const [progressLabel, setProgressLabel] = useState("")
+  const [progressPercentage, setProgressPercentage] = useState(0)
+  const [progress, setProgress] = useState<ProgressProps>("idle")
+  const [errorMessages, setErrorMessages] = useState<string[]>([])
 
-  const handleBrowseClick = () => fileInputRef.current?.click();
+  const handleBrowseClick = () => fileInputRef.current?.click()
   const handleErrorMessage = (msg: string) =>
-    setErrorMessages((prev) => [...prev, msg]);
+    setErrorMessages((prev) => [...prev, msg])
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
-      const files = Array.from(e.target.files);
-      handleUploadFile(files);
+      const files = Array.from(e.target.files)
+      handleUploadFile(files)
     }
-  };
+  }
 
   const handleDrop = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    setIsDragging(false);
+    e.preventDefault()
+    setIsDragging(false)
     if (e.dataTransfer.files) {
-      const files = Array.from(e.dataTransfer.files);
-      handleUploadFile(files);
+      const files = Array.from(e.dataTransfer.files)
+      handleUploadFile(files)
     }
-  };
+  }
 
   const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    setIsDragging(true);
-  };
+    e.preventDefault()
+    setIsDragging(true)
+  }
 
-  const handleDragLeave = () => setIsDragging(false);
+  const handleDragLeave = () => setIsDragging(false)
 
   const hideProgressLabel = () => {
-    setProgress(null);
-  };
+    setProgress(null)
+  }
 
   const showUploaderForm = () => {
-    setProgress("idle");
-  };
+    setProgress("idle")
+  }
 
   const handleUploadFile = async (files: File[]) => {
-    if (!onFileDropped) return;
+    if (!onFileDropped) return
 
-    await setProgress("loading");
+    await setProgress("loading")
 
-    const succeedFiles: File[] = [];
-    const failedFiles: File[] = [];
-    const total = files.length;
+    const succeedFiles: File[] = []
+    const failedFiles: File[] = []
+    const total = files.length
 
     const succeed = (file: File) => {
-      succeedFiles.push(file);
-      updateProgressBar(succeedFiles.length, total);
-    };
+      succeedFiles.push(file)
+      updateProgressBar(succeedFiles.length, total)
+    }
 
     const error = (file: File, message: string) => {
-      failedFiles.push(file);
-      handleErrorMessage(message);
-      updateProgressBar(succeedFiles.length, total);
-    };
+      failedFiles.push(file)
+      handleErrorMessage(message)
+      updateProgressBar(succeedFiles.length, total)
+    }
 
     const updateProgressBar = (succeedCount: number, totalCount: number) => {
-      const percentage = Math.round((succeedCount / totalCount) * 100);
-      setProgressPercentage(percentage);
-    };
+      const percentage = Math.round((succeedCount / totalCount) * 100)
+      setProgressPercentage(percentage)
+    }
 
     for (let i = 0; i < files.length; i++) {
-      setCurrentIndex(i);
+      setCurrentIndex(i)
       await onFileDropped({
         files: [files[i]],
         succeed,
         error,
         setProgressLabel,
         progressPercentage,
-      });
+      })
     }
-    await setProgress("succeed");
+    await setProgress("succeed")
 
     await onComplete?.({
       succeedFiles,
@@ -186,8 +186,8 @@ function FileDropBox({
       setProgressLabel,
       hideProgressLabel,
       showUploaderForm,
-    });
-  };
+    })
+  }
 
   const inputElement: ReactElement = (
     <DropArea
@@ -198,20 +198,20 @@ function FileDropBox({
       $progress={progress}
       aria-label="file-drop-box-area"
       onClick={() => {
-        if (disabled) return;
-        handleBrowseClick();
+        if (disabled) return
+        handleBrowseClick()
       }}
       onDrop={(e) => {
-        if (disabled) return;
-        handleDrop(e);
+        if (disabled) return
+        handleDrop(e)
       }}
       onDragOver={(e) => {
-        if (disabled) return;
-        handleDragOver(e);
+        if (disabled) return
+        handleDragOver(e)
       }}
       onDragLeave={() => {
-        if (disabled) return;
-        handleDragLeave();
+        if (disabled) return
+        handleDragLeave()
       }}
     >
       {progress === "loading" && currentIndex !== null ? (
@@ -295,7 +295,7 @@ function FileDropBox({
         />
       )}
     </DropArea>
-  );
+  )
 
   return (
     <InputWrapper
@@ -322,6 +322,9 @@ function FileDropBox({
 
               ${styles?.labelStyle};
             `,
+            helperArrowStyle: styles?.helperArrowStyle,
+            helperIconStyle: styles?.helperIconStyle,
+            helperDrawerStyle: styles?.helperDrawerStyle,
           }}
           helper={helper}
           label={label}
@@ -337,15 +340,15 @@ function FileDropBox({
         </ErrorList>
       )}
     </InputWrapper>
-  );
+  )
 }
 
 const InputWrapper = styled.div<{
-  $containerStyle?: CSSProp;
-  $hide?: boolean;
-  $labelPosition?: FieldLaneProps["labelPosition"];
-  $labelGap?: FieldLaneProps["labelGap"];
-  $disabled?: boolean;
+  $containerStyle?: CSSProp
+  $hide?: boolean
+  $labelPosition?: FieldLaneProps["labelPosition"]
+  $labelGap?: FieldLaneProps["labelGap"]
+  $disabled?: boolean
 }>`
   display: flex;
   width: 100%;
@@ -370,10 +373,10 @@ const InputWrapper = styled.div<{
     `};
 
   ${({ $containerStyle }) => $containerStyle}
-`;
+`
 
 const ContentWrapper = styled.div<{
-  $style?: CSSProp;
+  $style?: CSSProp
 }>`
   display: flex;
   width: 100%;
@@ -384,14 +387,14 @@ const ContentWrapper = styled.div<{
   cursor: default;
 
   ${({ $style }) => $style}
-`;
+`
 
 const DropArea = styled.div<{
-  $isDragging: boolean;
-  $progress: ProgressProps;
-  $dragOverStyle?: CSSProp;
-  $successStyle?: CSSProp;
-  $theme: FileDropBoxThemeConfig;
+  $isDragging: boolean
+  $progress: ProgressProps
+  $dragOverStyle?: CSSProp
+  $successStyle?: CSSProp
+  $theme: FileDropBoxThemeConfig
 }>`
   display: flex;
   flex-direction: column;
@@ -509,7 +512,7 @@ const DropArea = styled.div<{
       border: 1px solid ${$theme.borderColor};
       ${$successStyle}
     `};
-`;
+`
 
 const UploadContent = styled.div`
   font-size: 0.875rem;
@@ -519,41 +522,41 @@ const UploadContent = styled.div`
   gap: 0.5rem;
   align-items: center;
   padding: 1.5rem;
-`;
+`
 
 const IconsRow = styled.div`
   display: flex;
   flex-direction: row;
   align-items: flex-end;
   gap: 0.5rem;
-`;
+`
 
 const PlaceholderText = styled.span<{
-  $isDragging: boolean;
-  $theme: FileDropBoxThemeConfig;
-  $style?: CSSProp;
+  $isDragging: boolean
+  $theme: FileDropBoxThemeConfig
+  $style?: CSSProp
 }>`
   font-size: 1.25rem;
   color: ${({ $theme, $isDragging }) =>
     $isDragging ? $theme.dragActiveTextColor : $theme.textColor};
-`;
+`
 
 const DescriptionText = styled.span<{
-  $isDragging: boolean;
-  $theme: FileDropBoxThemeConfig;
-  $style?: CSSProp;
+  $isDragging: boolean
+  $theme: FileDropBoxThemeConfig
+  $style?: CSSProp
 }>`
   color: ${({ $theme, $isDragging }) =>
     $isDragging ? $theme.dragActiveTextColor : $theme.textColor};
-`;
+`
 
 const LinkText = styled.span<{ $theme: FileDropBoxThemeConfig }>`
   color: ${({ $theme }) => $theme.dragActiveTextColor || "#3b82f6"};
   text-decoration: underline;
-`;
+`
 
 const ProgressContainer = styled.div<{
-  $theme: FileDropBoxThemeConfig;
+  $theme: FileDropBoxThemeConfig
 }>`
   width: 100%;
   font-size: 0.875rem;
@@ -564,10 +567,10 @@ const ProgressContainer = styled.div<{
   align-items: center;
   gap: 0.5rem;
   border: 1px solid ${({ $theme }) => $theme.borderColor};
-`;
+`
 
 const ProgressBarWrapper = styled.div<{
-  $theme: FileDropBoxThemeConfig;
+  $theme: FileDropBoxThemeConfig
 }>`
   height: 4px;
   width: 100%;
@@ -575,11 +578,11 @@ const ProgressBarWrapper = styled.div<{
   left: 0;
   bottom: 0;
   background-color: ${({ $theme }) => $theme.backgroundColor || "#e5e7eb"};
-`;
+`
 
 const ProgressBar = styled.div<{
-  $width: number;
-  $theme: FileDropBoxThemeConfig;
+  $width: number
+  $theme: FileDropBoxThemeConfig
 }>`
   height: 4px;
   position: absolute;
@@ -589,7 +592,7 @@ const ProgressBar = styled.div<{
   transition: all 0.2s ease;
   width: ${({ $width }) => $width}%;
   background-color: ${({ $theme }) => $theme.progressBarColor};
-`;
+`
 
 const ErrorList = styled.ul`
   margin: 0;
@@ -597,6 +600,6 @@ const ErrorList = styled.ul`
   list-style-type: disc;
   font-size: 0.875rem;
   margin-left: 2.5rem;
-`;
+`
 
-export { FileDropBox };
+export { FileDropBox }

--- a/components/file-input-box.tsx
+++ b/components/file-input-box.tsx
@@ -1,28 +1,28 @@
-import { ChangeEvent, DragEvent, InputHTMLAttributes, useState } from "react"
-import { RiCloseLine } from "@remixicon/react"
-import styled, { css, CSSProp } from "styled-components"
-import { Button } from "./button"
-import { StatefulForm } from "./stateful-form"
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
-import { useTheme } from "./../theme/provider"
-import { FileInputBoxThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
+import { ChangeEvent, DragEvent, InputHTMLAttributes, useState } from "react";
+import { RiCloseLine } from "@remixicon/react";
+import styled, { css, CSSProp } from "styled-components";
+import { Button } from "./button";
+import { StatefulForm } from "./stateful-form";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
+import { useTheme } from "./../theme/provider";
+import { FileInputBoxThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseFileInputBoxProps extends InputHTMLAttributes<HTMLInputElement> {
-  placeholder?: string
-  accept?: string
-  multiple?: boolean
-  onFilesSelected?: (files: File[]) => void
-  label?: string
-  showError?: boolean
-  errorMessage?: string
-  styles?: BaseFileInputBoxStyles
+  placeholder?: string;
+  accept?: string;
+  multiple?: boolean;
+  onFilesSelected?: (files: File[]) => void;
+  label?: string;
+  showError?: boolean;
+  errorMessage?: string;
+  styles?: BaseFileInputBoxStyles;
 }
 
 interface BaseFileInputBoxStyles {
-  containerStyle?: CSSProp
-  labelStyle?: CSSProp
-  self?: CSSProp
+  containerStyle?: CSSProp;
+  labelStyle?: CSSProp;
+  self?: CSSProp;
 }
 
 function BaseFileInputBox({
@@ -36,52 +36,52 @@ function BaseFileInputBox({
   disabled,
   ...props
 }: BaseFileInputBoxProps) {
-  const { currentTheme } = useTheme()
-  const fileInputBoxTheme = currentTheme.fileInputBox
+  const { currentTheme } = useTheme();
+  const fileInputBoxTheme = currentTheme.fileInputBox;
 
-  const [isDragging, setIsDragging] = useState(false)
-  const [selectedFiles, setSelectedFiles] = useState<File[]>([])
+  const [isDragging, setIsDragging] = useState(false);
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
 
   const handleDeleteFile = (index: number) => {
-    const updatedFiles = selectedFiles.filter((_, i) => i !== index)
-    setSelectedFiles(updatedFiles)
+    const updatedFiles = selectedFiles.filter((_, i) => i !== index);
+    setSelectedFiles(updatedFiles);
     if (onFilesSelected) {
-      onFilesSelected(updatedFiles)
+      onFilesSelected(updatedFiles);
     }
-  }
+  };
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
-      const files = Array.from(e.target.files)
-      const updatedFiles = multiple ? [...selectedFiles, ...files] : files
-      setSelectedFiles(updatedFiles)
+      const files = Array.from(e.target.files);
+      const updatedFiles = multiple ? [...selectedFiles, ...files] : files;
+      setSelectedFiles(updatedFiles);
       if (onFilesSelected) {
-        onFilesSelected(updatedFiles)
+        onFilesSelected(updatedFiles);
       }
     }
-  }
+  };
 
   const handleDrop = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    setIsDragging(false)
+    e.preventDefault();
+    setIsDragging(false);
     if (e.dataTransfer.files) {
-      const files = Array.from(e.dataTransfer.files)
-      const updatedFiles = multiple ? [...selectedFiles, ...files] : files
-      setSelectedFiles(updatedFiles)
+      const files = Array.from(e.dataTransfer.files);
+      const updatedFiles = multiple ? [...selectedFiles, ...files] : files;
+      setSelectedFiles(updatedFiles);
       if (onFilesSelected) {
-        onFilesSelected(updatedFiles)
+        onFilesSelected(updatedFiles);
       }
     }
-  }
+  };
 
   const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    setIsDragging(true)
-  }
+    e.preventDefault();
+    setIsDragging(true);
+  };
 
   const handleDragLeave = () => {
-    setIsDragging(false)
-  }
+    setIsDragging(false);
+  };
 
   return (
     <InputBox
@@ -90,16 +90,16 @@ function BaseFileInputBox({
       $isDragging={!disabled && isDragging}
       $hasFile={selectedFiles.length > 0}
       onDrop={(e) => {
-        if (disabled) return
-        handleDrop(e)
+        if (disabled) return;
+        handleDrop(e);
       }}
       onDragOver={(e) => {
-        if (disabled) return
-        handleDragOver(e)
+        if (disabled) return;
+        handleDragOver(e);
       }}
       onDragLeave={() => {
-        if (disabled) return
-        handleDragLeave()
+        if (disabled) return;
+        handleDragLeave();
       }}
       aria-label="file-input-box-wrapper"
       $disabled={disabled}
@@ -125,8 +125,8 @@ function BaseFileInputBox({
                   `,
                 }}
                 onClick={(e) => {
-                  e.stopPropagation()
-                  handleDeleteFile(index)
+                  e.stopPropagation();
+                  handleDeleteFile(index);
                 }}
               >
                 <RiCloseLine size={14} />
@@ -149,15 +149,15 @@ function BaseFileInputBox({
         hidden
       />
     </InputBox>
-  )
+  );
 }
 
-export type FileInputBoxStyles = BaseFileInputBoxStyles & FieldLaneStyles
+export type FileInputBoxStyles = BaseFileInputBoxStyles & FieldLaneStyles;
 
 export interface FileInputBoxProps
   extends Omit<BaseFileInputBoxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: FileInputBoxStyles
+  styles?: FileInputBoxStyles;
 }
 
 function FileInputBox({
@@ -179,7 +179,7 @@ function FileInputBox({
     prefix: "file-input-box",
     name,
     id,
-  })
+  });
 
   const {
     bodyStyle,
@@ -190,7 +190,7 @@ function FileInputBox({
     helperDrawerStyle,
     helperIconStyle,
     ...baseFileInputBoxtyles
-  } = styles ?? {}
+  } = styles ?? {};
 
   return (
     <FieldLane
@@ -223,17 +223,17 @@ function FileInputBox({
         styles={baseFileInputBoxtyles}
       />
     </FieldLane>
-  )
+  );
 }
 
 const InputBox = styled.div<{
-  $isDragging: boolean
-  $hasFile: boolean
-  $isError?: boolean
-  $self?: CSSProp
-  $style?: CSSProp
-  $disabled?: boolean
-  $theme: FileInputBoxThemeConfig
+  $isDragging: boolean;
+  $hasFile: boolean;
+  $isError?: boolean;
+  $self?: CSSProp;
+  $style?: CSSProp;
+  $disabled?: boolean;
+  $theme: FileInputBoxThemeConfig;
 }>`
   padding: 12px;
   user-select: none;
@@ -298,14 +298,14 @@ const InputBox = styled.div<{
     `};
 
   ${({ $style }) => $style}
-`
+`;
 
 const FileList = styled.div`
   display: flex;
   flex-direction: column;
   gap: 4px;
   width: 100%;
-`
+`;
 
 const FileItem = styled.div`
   display: flex;
@@ -313,7 +313,7 @@ const FileItem = styled.div`
   width: 100%;
   position: relative;
   gap: 6px;
-`
+`;
 
 const FileName = styled.div<{ $theme: FileInputBoxThemeConfig }>`
   font-size: 14px;
@@ -325,7 +325,7 @@ const FileName = styled.div<{ $theme: FileInputBoxThemeConfig }>`
   ${({ $theme }) => css`
     color: ${$theme.placeholderColor};
   `}
-`
+`;
 
 const Placeholder = styled.span<{ $theme: FileInputBoxThemeConfig }>`
   font-size: 14px;
@@ -334,6 +334,6 @@ const Placeholder = styled.span<{ $theme: FileInputBoxThemeConfig }>`
   ${({ $theme }) => css`
     color: ${$theme.placeholderColor};
   `}
-`
+`;
 
-export { FileInputBox }
+export { FileInputBox };

--- a/components/file-input-box.tsx
+++ b/components/file-input-box.tsx
@@ -1,29 +1,28 @@
-import { ChangeEvent, DragEvent, InputHTMLAttributes, useState } from "react";
-import { RiCloseLine } from "@remixicon/react";
-import styled, { css, CSSProp } from "styled-components";
-import { Button } from "./button";
-import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { useTheme } from "./../theme/provider";
-import { FileInputBoxThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
+import { ChangeEvent, DragEvent, InputHTMLAttributes, useState } from "react"
+import { RiCloseLine } from "@remixicon/react"
+import styled, { css, CSSProp } from "styled-components"
+import { Button } from "./button"
+import { StatefulForm } from "./stateful-form"
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
+import { useTheme } from "./../theme/provider"
+import { FileInputBoxThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
 
 interface BaseFileInputBoxProps extends InputHTMLAttributes<HTMLInputElement> {
-  placeholder?: string;
-  accept?: string;
-  multiple?: boolean;
-  onFilesSelected?: (files: File[]) => void;
-  label?: string;
-  showError?: boolean;
-  errorMessage?: string;
-  styles?: BaseFileInputBoxStyles;
-  helper?: string;
+  placeholder?: string
+  accept?: string
+  multiple?: boolean
+  onFilesSelected?: (files: File[]) => void
+  label?: string
+  showError?: boolean
+  errorMessage?: string
+  styles?: BaseFileInputBoxStyles
 }
 
 interface BaseFileInputBoxStyles {
-  containerStyle?: CSSProp;
-  labelStyle?: CSSProp;
-  self?: CSSProp;
+  containerStyle?: CSSProp
+  labelStyle?: CSSProp
+  self?: CSSProp
 }
 
 function BaseFileInputBox({
@@ -37,52 +36,52 @@ function BaseFileInputBox({
   disabled,
   ...props
 }: BaseFileInputBoxProps) {
-  const { currentTheme } = useTheme();
-  const fileInputBoxTheme = currentTheme.fileInputBox;
+  const { currentTheme } = useTheme()
+  const fileInputBoxTheme = currentTheme.fileInputBox
 
-  const [isDragging, setIsDragging] = useState(false);
-  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [isDragging, setIsDragging] = useState(false)
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([])
 
   const handleDeleteFile = (index: number) => {
-    const updatedFiles = selectedFiles.filter((_, i) => i !== index);
-    setSelectedFiles(updatedFiles);
+    const updatedFiles = selectedFiles.filter((_, i) => i !== index)
+    setSelectedFiles(updatedFiles)
     if (onFilesSelected) {
-      onFilesSelected(updatedFiles);
+      onFilesSelected(updatedFiles)
     }
-  };
+  }
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
-      const files = Array.from(e.target.files);
-      const updatedFiles = multiple ? [...selectedFiles, ...files] : files;
-      setSelectedFiles(updatedFiles);
+      const files = Array.from(e.target.files)
+      const updatedFiles = multiple ? [...selectedFiles, ...files] : files
+      setSelectedFiles(updatedFiles)
       if (onFilesSelected) {
-        onFilesSelected(updatedFiles);
+        onFilesSelected(updatedFiles)
       }
     }
-  };
+  }
 
   const handleDrop = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    setIsDragging(false);
+    e.preventDefault()
+    setIsDragging(false)
     if (e.dataTransfer.files) {
-      const files = Array.from(e.dataTransfer.files);
-      const updatedFiles = multiple ? [...selectedFiles, ...files] : files;
-      setSelectedFiles(updatedFiles);
+      const files = Array.from(e.dataTransfer.files)
+      const updatedFiles = multiple ? [...selectedFiles, ...files] : files
+      setSelectedFiles(updatedFiles)
       if (onFilesSelected) {
-        onFilesSelected(updatedFiles);
+        onFilesSelected(updatedFiles)
       }
     }
-  };
+  }
 
   const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    setIsDragging(true);
-  };
+    e.preventDefault()
+    setIsDragging(true)
+  }
 
   const handleDragLeave = () => {
-    setIsDragging(false);
-  };
+    setIsDragging(false)
+  }
 
   return (
     <InputBox
@@ -91,16 +90,16 @@ function BaseFileInputBox({
       $isDragging={!disabled && isDragging}
       $hasFile={selectedFiles.length > 0}
       onDrop={(e) => {
-        if (disabled) return;
-        handleDrop(e);
+        if (disabled) return
+        handleDrop(e)
       }}
       onDragOver={(e) => {
-        if (disabled) return;
-        handleDragOver(e);
+        if (disabled) return
+        handleDragOver(e)
       }}
       onDragLeave={() => {
-        if (disabled) return;
-        handleDragLeave();
+        if (disabled) return
+        handleDragLeave()
       }}
       aria-label="file-input-box-wrapper"
       $disabled={disabled}
@@ -126,8 +125,8 @@ function BaseFileInputBox({
                   `,
                 }}
                 onClick={(e) => {
-                  e.stopPropagation();
-                  handleDeleteFile(index);
+                  e.stopPropagation()
+                  handleDeleteFile(index)
                 }}
               >
                 <RiCloseLine size={14} />
@@ -150,15 +149,15 @@ function BaseFileInputBox({
         hidden
       />
     </InputBox>
-  );
+  )
 }
 
-export type FileInputBoxStyles = BaseFileInputBoxStyles & FieldLaneStyles;
+export type FileInputBoxStyles = BaseFileInputBoxStyles & FieldLaneStyles
 
 export interface FileInputBoxProps
   extends Omit<BaseFileInputBoxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: FileInputBoxStyles;
+  styles?: FileInputBoxStyles
 }
 
 function FileInputBox({
@@ -180,15 +179,18 @@ function FileInputBox({
     prefix: "file-input-box",
     name,
     id,
-  });
+  })
 
   const {
     bodyStyle,
     controlStyle,
     containerStyle,
     labelStyle,
+    helperArrowStyle,
+    helperDrawerStyle,
+    helperIconStyle,
     ...baseFileInputBoxtyles
-  } = styles ?? {};
+  } = styles ?? {}
 
   return (
     <FieldLane
@@ -208,6 +210,9 @@ function FileInputBox({
         controlStyle,
         containerStyle,
         labelStyle,
+        helperArrowStyle,
+        helperDrawerStyle,
+        helperIconStyle,
       }}
     >
       <BaseFileInputBox
@@ -218,17 +223,17 @@ function FileInputBox({
         styles={baseFileInputBoxtyles}
       />
     </FieldLane>
-  );
+  )
 }
 
 const InputBox = styled.div<{
-  $isDragging: boolean;
-  $hasFile: boolean;
-  $isError?: boolean;
-  $self?: CSSProp;
-  $style?: CSSProp;
-  $disabled?: boolean;
-  $theme: FileInputBoxThemeConfig;
+  $isDragging: boolean
+  $hasFile: boolean
+  $isError?: boolean
+  $self?: CSSProp
+  $style?: CSSProp
+  $disabled?: boolean
+  $theme: FileInputBoxThemeConfig
 }>`
   padding: 12px;
   user-select: none;
@@ -293,14 +298,14 @@ const InputBox = styled.div<{
     `};
 
   ${({ $style }) => $style}
-`;
+`
 
 const FileList = styled.div`
   display: flex;
   flex-direction: column;
   gap: 4px;
   width: 100%;
-`;
+`
 
 const FileItem = styled.div`
   display: flex;
@@ -308,7 +313,7 @@ const FileItem = styled.div`
   width: 100%;
   position: relative;
   gap: 6px;
-`;
+`
 
 const FileName = styled.div<{ $theme: FileInputBoxThemeConfig }>`
   font-size: 14px;
@@ -320,7 +325,7 @@ const FileName = styled.div<{ $theme: FileInputBoxThemeConfig }>`
   ${({ $theme }) => css`
     color: ${$theme.placeholderColor};
   `}
-`;
+`
 
 const Placeholder = styled.span<{ $theme: FileInputBoxThemeConfig }>`
   font-size: 14px;
@@ -329,6 +334,6 @@ const Placeholder = styled.span<{ $theme: FileInputBoxThemeConfig }>`
   ${({ $theme }) => css`
     color: ${$theme.placeholderColor};
   `}
-`;
+`
 
-export { FileInputBox };
+export { FileInputBox }

--- a/components/helper.tsx
+++ b/components/helper.tsx
@@ -1,16 +1,31 @@
-import { css } from "styled-components";
-import { Tooltip } from "./tooltip";
-import { RiInformationLine } from "@remixicon/react";
-import { applyClassName } from "./../constants/classname";
+import { css, CSSProp } from "styled-components"
+import { Tooltip } from "./tooltip"
+import { RiInformationLine } from "@remixicon/react"
+import { applyClassName } from "./../constants/classname"
+import { ReactNode } from "react"
+import { Figure } from "./figure"
 
 export interface HelperProps {
-  value: string;
-  showDelayPeriod?: number;
-  className?: string;
-  id?: string;
+  value: ReactNode
+  showDelayPeriod?: number
+  className?: string
+  id?: string
+  styles?: HelperStyles
 }
 
-function Helper({ value, showDelayPeriod = 400, className, id }: HelperProps) {
+export interface HelperStyles {
+  self?: CSSProp
+  drawerStyle?: CSSProp
+  arrowStyle?: CSSProp
+}
+
+function Helper({
+  value,
+  showDelayPeriod = 400,
+  className,
+  id,
+  styles,
+}: HelperProps) {
   return (
     <Tooltip
       id={id}
@@ -23,24 +38,30 @@ function Helper({ value, showDelayPeriod = 400, className, id }: HelperProps) {
           ${placement?.endsWith("start") &&
           css`
             left: 5px;
-          `}
+          `};
           ${placement?.endsWith("end") &&
           css`
             right: 5px;
-          `}
+          `};
+
+          ${styles?.arrowStyle}
         `,
+        drawerStyle: styles?.drawerStyle,
       }}
       showDelayPeriod={showDelayPeriod}
       dialog={value}
     >
-      <RiInformationLine
-        style={{
-          cursor: "help",
-        }}
+      <Figure
+        image={RiInformationLine}
         size={18}
+        styles={{
+          self: css`
+            ${styles?.self}
+          `,
+        }}
       />
     </Tooltip>
-  );
+  )
 }
 
-export { Helper };
+export { Helper }

--- a/components/helper.tsx
+++ b/components/helper.tsx
@@ -1,22 +1,22 @@
-import { css, CSSProp } from "styled-components"
-import { Tooltip } from "./tooltip"
-import { RiInformationLine } from "@remixicon/react"
-import { applyClassName } from "./../constants/classname"
-import { ReactNode } from "react"
-import { Figure } from "./figure"
+import { css, CSSProp } from "styled-components";
+import { Tooltip } from "./tooltip";
+import { RiInformationLine } from "@remixicon/react";
+import { applyClassName } from "./../constants/classname";
+import { ReactNode } from "react";
+import { Figure } from "./figure";
 
 export interface HelperProps {
-  value: ReactNode
-  showDelayPeriod?: number
-  className?: string
-  id?: string
-  styles?: HelperStyles
+  value: ReactNode;
+  showDelayPeriod?: number;
+  className?: string;
+  id?: string;
+  styles?: HelperStyles;
 }
 
 export interface HelperStyles {
-  self?: CSSProp
-  drawerStyle?: CSSProp
-  arrowStyle?: CSSProp
+  self?: CSSProp;
+  drawerStyle?: CSSProp;
+  arrowStyle?: CSSProp;
 }
 
 function Helper({
@@ -59,7 +59,7 @@ function Helper({
         }}
       />
     </Tooltip>
-  )
+  );
 }
 
-export { Helper }
+export { Helper };

--- a/components/helper.tsx
+++ b/components/helper.tsx
@@ -55,9 +55,7 @@ function Helper({
         image={RiInformationLine}
         size={18}
         styles={{
-          self: css`
-            ${styles?.self}
-          `,
+          self: styles?.self,
         }}
       />
     </Tooltip>

--- a/components/imagebox.tsx
+++ b/components/imagebox.tsx
@@ -1,36 +1,36 @@
-import { ChangeEvent, DragEvent, useEffect, useRef, useState } from "react"
-import { RiAddLine, RiImageLine } from "@remixicon/react"
-import styled, { css, CSSProp } from "styled-components"
-import { StatefulForm } from "./stateful-form"
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
-import { useTheme } from "./../theme/provider"
-import { ImageboxThemeConfig } from "theme"
-import { applyClassName } from "./../constants/classname"
+import { ChangeEvent, DragEvent, useEffect, useRef, useState } from "react";
+import { RiAddLine, RiImageLine } from "@remixicon/react";
+import styled, { css, CSSProp } from "styled-components";
+import { StatefulForm } from "./stateful-form";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
+import { useTheme } from "./../theme/provider";
+import { ImageboxThemeConfig } from "theme";
+import { applyClassName } from "./../constants/classname";
 
 export const ImageboxSize = {
   ExtraSmall: "xs",
   Small: "sm",
   Medium: "md",
   Large: "lg",
-} as const
+} as const;
 
-export type ImageboxSize = (typeof ImageboxSize)[keyof typeof ImageboxSize]
+export type ImageboxSize = (typeof ImageboxSize)[keyof typeof ImageboxSize];
 
 interface BaseImageboxProps {
-  onFileSelected?: (file: File | undefined) => void
-  size?: ImageboxSize
-  name?: string
-  styles?: BaseImageboxStyles
-  value?: File | string | null
-  borderless?: boolean
-  editable?: boolean
-  url?: string
-  id?: string
-  disabled?: boolean
+  onFileSelected?: (file: File | undefined) => void;
+  size?: ImageboxSize;
+  name?: string;
+  styles?: BaseImageboxStyles;
+  value?: File | string | null;
+  borderless?: boolean;
+  editable?: boolean;
+  url?: string;
+  id?: string;
+  disabled?: boolean;
 }
 
 interface BaseImageboxStyles {
-  self?: CSSProp
+  self?: CSSProp;
 }
 
 const SIZE_STYLES = {
@@ -50,7 +50,7 @@ const SIZE_STYLES = {
     dimension: "160px",
     icon: 28,
   },
-}
+};
 
 function BaseImagebox({
   onFileSelected,
@@ -64,99 +64,99 @@ function BaseImagebox({
   url,
   id,
 }: BaseImageboxProps) {
-  const { currentTheme } = useTheme()
-  const imageboxTheme = currentTheme?.imagebox
+  const { currentTheme } = useTheme();
+  const imageboxTheme = currentTheme?.imagebox;
 
   const inputId = StatefulForm.sanitizeId({
     prefix: "imagebox",
     name,
     id,
-  })
+  });
 
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const [selectedFile, setSelectedFile] = useState<string | null>(null)
-  const [isDragging, setIsDragging] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
 
-  const { dimension, icon } = SIZE_STYLES[size]
+  const { dimension, icon } = SIZE_STYLES[size];
 
-  const isControlled = !value && !url
+  const isControlled = !value && !url;
 
   useEffect(() => {
     try {
       if (value instanceof File) {
-        const objectUrl = URL.createObjectURL(value)
-        setSelectedFile(objectUrl)
+        const objectUrl = URL.createObjectURL(value);
+        setSelectedFile(objectUrl);
 
         return () => {
-          URL.revokeObjectURL(objectUrl)
-        }
+          URL.revokeObjectURL(objectUrl);
+        };
       }
 
       if (typeof value === "string") {
-        setSelectedFile(value)
+        setSelectedFile(value);
       }
 
       if (value === null) {
-        setSelectedFile(null)
+        setSelectedFile(null);
       }
 
       if (!value && url) {
-        setSelectedFile(url)
+        setSelectedFile(url);
       }
     } catch (err) {
-      console.error("Imagebox: Failed to render value", err)
-      setSelectedFile(null)
+      console.error("Imagebox: Failed to render value", err);
+      setSelectedFile(null);
     }
-  }, [value, isControlled, url])
+  }, [value, isControlled, url]);
 
   const handleBrowseClick = () => {
-    if (editable) fileInputRef.current?.click()
-  }
+    if (editable) fileInputRef.current?.click();
+  };
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && editable) {
-      const file = e.target.files[0]
+      const file = e.target.files[0];
       if (onFileSelected) {
-        onFileSelected?.(file)
+        onFileSelected?.(file);
       }
 
       if (!isControlled) {
-        const objectUrl = URL.createObjectURL(file)
-        setSelectedFile(objectUrl)
+        const objectUrl = URL.createObjectURL(file);
+        setSelectedFile(objectUrl);
       }
     }
-  }
+  };
 
   const handleDrop = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    setIsDragging(false)
+    e.preventDefault();
+    setIsDragging(false);
     if (e.dataTransfer.files && onFileSelected) {
-      const file = e.dataTransfer.files[0]
-      if (!file) return
+      const file = e.dataTransfer.files[0];
+      if (!file) return;
 
       if (onFileSelected) {
-        onFileSelected(file)
+        onFileSelected(file);
       }
 
       if (!isControlled) {
-        const objectUrl = URL.createObjectURL(file)
-        setSelectedFile(objectUrl)
+        const objectUrl = URL.createObjectURL(file);
+        setSelectedFile(objectUrl);
       }
     }
-  }
+  };
 
   const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
     if (editable) {
-      e.preventDefault()
-      setIsDragging(true)
+      e.preventDefault();
+      setIsDragging(true);
     }
-  }
+  };
 
   const handleDragLeave = () => {
     if (editable) {
-      setIsDragging(false)
+      setIsDragging(false);
     }
-  }
+  };
 
   return (
     <InputBox
@@ -178,8 +178,8 @@ function BaseImagebox({
           src={selectedFile}
           alt="preview"
           onError={() => {
-            console.error("Imagebox: Unable to render image source")
-            setSelectedFile(null)
+            console.error("Imagebox: Unable to render image source");
+            setSelectedFile(null);
           }}
         />
       ) : (
@@ -208,15 +208,15 @@ function BaseImagebox({
         <RiAddLine size={icon} />
       </AddIconWrapper>
     </InputBox>
-  )
+  );
 }
 
-export type ImageboxStyles = BaseImageboxStyles & FieldLaneStyles
+export type ImageboxStyles = BaseImageboxStyles & FieldLaneStyles;
 
 export interface ImageboxProps
   extends Omit<BaseImageboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: ImageboxStyles
+  styles?: ImageboxStyles;
 }
 
 function Imagebox({
@@ -238,7 +238,7 @@ function Imagebox({
     prefix: "imagebox",
     name,
     id,
-  })
+  });
 
   const {
     bodyStyle,
@@ -249,7 +249,7 @@ function Imagebox({
     helperIconStyle,
     helperArrowStyle,
     ...imageboxStyles
-  } = styles ?? {}
+  } = styles ?? {};
 
   return (
     <FieldLane
@@ -282,17 +282,17 @@ function Imagebox({
         styles={imageboxStyles}
       />
     </FieldLane>
-  )
+  );
 }
 
 const InputBox = styled.div<{
-  $dimension: string
-  $isDragging: boolean
-  $style?: CSSProp
-  $editable?: boolean
-  $borderless?: boolean
-  $disabled?: boolean
-  $theme: ImageboxThemeConfig
+  $dimension: string;
+  $isDragging: boolean;
+  $style?: CSSProp;
+  $editable?: boolean;
+  $borderless?: boolean;
+  $disabled?: boolean;
+  $theme: ImageboxThemeConfig;
 }>`
   position: relative;
   width: ${({ $dimension }) => $dimension};
@@ -327,17 +327,17 @@ const InputBox = styled.div<{
     `};
 
   ${({ $style }) => $style}
-`
+`;
 
 const IconPlaceholder = styled.div<{
-  $theme: ImageboxThemeConfig
+  $theme: ImageboxThemeConfig;
 }>`
   position: absolute;
   top: 50%;
   left: 50%;
   color: ${({ $theme }) => $theme.iconColor};
   transform: translate(-50%, -50%);
-`
+`;
 
 const PreviewImage = styled.img`
   position: absolute;
@@ -345,12 +345,12 @@ const PreviewImage = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
-`
+`;
 
 const AddIconWrapper = styled.div<{
-  $isDragging: boolean
-  $editable?: boolean
-  $theme: ImageboxThemeConfig
+  $isDragging: boolean;
+  $editable?: boolean;
+  $theme: ImageboxThemeConfig;
 }>`
   position: absolute;
   bottom: -4px;
@@ -371,10 +371,10 @@ const AddIconWrapper = styled.div<{
     css`
       display: none;
     `}
-`
+`;
 
 const HiddenInput = styled.input`
   display: none;
-`
+`;
 
-export { Imagebox }
+export { Imagebox };

--- a/components/imagebox.tsx
+++ b/components/imagebox.tsx
@@ -1,36 +1,36 @@
-import { ChangeEvent, DragEvent, useEffect, useRef, useState } from "react";
-import { RiAddLine, RiImageLine } from "@remixicon/react";
-import styled, { css, CSSProp } from "styled-components";
-import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { useTheme } from "./../theme/provider";
-import { ImageboxThemeConfig } from "theme";
-import { applyClassName } from "./../constants/classname";
+import { ChangeEvent, DragEvent, useEffect, useRef, useState } from "react"
+import { RiAddLine, RiImageLine } from "@remixicon/react"
+import styled, { css, CSSProp } from "styled-components"
+import { StatefulForm } from "./stateful-form"
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
+import { useTheme } from "./../theme/provider"
+import { ImageboxThemeConfig } from "theme"
+import { applyClassName } from "./../constants/classname"
 
 export const ImageboxSize = {
   ExtraSmall: "xs",
   Small: "sm",
   Medium: "md",
   Large: "lg",
-} as const;
+} as const
 
-export type ImageboxSize = (typeof ImageboxSize)[keyof typeof ImageboxSize];
+export type ImageboxSize = (typeof ImageboxSize)[keyof typeof ImageboxSize]
 
 interface BaseImageboxProps {
-  onFileSelected?: (file: File | undefined) => void;
-  size?: ImageboxSize;
-  name?: string;
-  styles?: BaseImageboxStyles;
-  value?: File | string | null;
-  borderless?: boolean;
-  editable?: boolean;
-  url?: string;
-  id?: string;
-  disabled?: boolean;
+  onFileSelected?: (file: File | undefined) => void
+  size?: ImageboxSize
+  name?: string
+  styles?: BaseImageboxStyles
+  value?: File | string | null
+  borderless?: boolean
+  editable?: boolean
+  url?: string
+  id?: string
+  disabled?: boolean
 }
 
 interface BaseImageboxStyles {
-  self?: CSSProp;
+  self?: CSSProp
 }
 
 const SIZE_STYLES = {
@@ -50,7 +50,7 @@ const SIZE_STYLES = {
     dimension: "160px",
     icon: 28,
   },
-};
+}
 
 function BaseImagebox({
   onFileSelected,
@@ -64,99 +64,99 @@ function BaseImagebox({
   url,
   id,
 }: BaseImageboxProps) {
-  const { currentTheme } = useTheme();
-  const imageboxTheme = currentTheme?.imagebox;
+  const { currentTheme } = useTheme()
+  const imageboxTheme = currentTheme?.imagebox
 
   const inputId = StatefulForm.sanitizeId({
     prefix: "imagebox",
     name,
     id,
-  });
+  })
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [selectedFile, setSelectedFile] = useState<string | null>(null);
-  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [selectedFile, setSelectedFile] = useState<string | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
 
-  const { dimension, icon } = SIZE_STYLES[size];
+  const { dimension, icon } = SIZE_STYLES[size]
 
-  const isControlled = !value && !url;
+  const isControlled = !value && !url
 
   useEffect(() => {
     try {
       if (value instanceof File) {
-        const objectUrl = URL.createObjectURL(value);
-        setSelectedFile(objectUrl);
+        const objectUrl = URL.createObjectURL(value)
+        setSelectedFile(objectUrl)
 
         return () => {
-          URL.revokeObjectURL(objectUrl);
-        };
+          URL.revokeObjectURL(objectUrl)
+        }
       }
 
       if (typeof value === "string") {
-        setSelectedFile(value);
+        setSelectedFile(value)
       }
 
       if (value === null) {
-        setSelectedFile(null);
+        setSelectedFile(null)
       }
 
       if (!value && url) {
-        setSelectedFile(url);
+        setSelectedFile(url)
       }
     } catch (err) {
-      console.error("Imagebox: Failed to render value", err);
-      setSelectedFile(null);
+      console.error("Imagebox: Failed to render value", err)
+      setSelectedFile(null)
     }
-  }, [value, isControlled, url]);
+  }, [value, isControlled, url])
 
   const handleBrowseClick = () => {
-    if (editable) fileInputRef.current?.click();
-  };
+    if (editable) fileInputRef.current?.click()
+  }
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && editable) {
-      const file = e.target.files[0];
+      const file = e.target.files[0]
       if (onFileSelected) {
-        onFileSelected?.(file);
+        onFileSelected?.(file)
       }
 
       if (!isControlled) {
-        const objectUrl = URL.createObjectURL(file);
-        setSelectedFile(objectUrl);
+        const objectUrl = URL.createObjectURL(file)
+        setSelectedFile(objectUrl)
       }
     }
-  };
+  }
 
   const handleDrop = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    setIsDragging(false);
+    e.preventDefault()
+    setIsDragging(false)
     if (e.dataTransfer.files && onFileSelected) {
-      const file = e.dataTransfer.files[0];
-      if (!file) return;
+      const file = e.dataTransfer.files[0]
+      if (!file) return
 
       if (onFileSelected) {
-        onFileSelected(file);
+        onFileSelected(file)
       }
 
       if (!isControlled) {
-        const objectUrl = URL.createObjectURL(file);
-        setSelectedFile(objectUrl);
+        const objectUrl = URL.createObjectURL(file)
+        setSelectedFile(objectUrl)
       }
     }
-  };
+  }
 
   const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
     if (editable) {
-      e.preventDefault();
-      setIsDragging(true);
+      e.preventDefault()
+      setIsDragging(true)
     }
-  };
+  }
 
   const handleDragLeave = () => {
     if (editable) {
-      setIsDragging(false);
+      setIsDragging(false)
     }
-  };
+  }
 
   return (
     <InputBox
@@ -178,8 +178,8 @@ function BaseImagebox({
           src={selectedFile}
           alt="preview"
           onError={() => {
-            console.error("Imagebox: Unable to render image source");
-            setSelectedFile(null);
+            console.error("Imagebox: Unable to render image source")
+            setSelectedFile(null)
           }}
         />
       ) : (
@@ -208,15 +208,15 @@ function BaseImagebox({
         <RiAddLine size={icon} />
       </AddIconWrapper>
     </InputBox>
-  );
+  )
 }
 
-export type ImageboxStyles = BaseImageboxStyles & FieldLaneStyles;
+export type ImageboxStyles = BaseImageboxStyles & FieldLaneStyles
 
 export interface ImageboxProps
   extends Omit<BaseImageboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: ImageboxStyles;
+  styles?: ImageboxStyles
 }
 
 function Imagebox({
@@ -238,15 +238,18 @@ function Imagebox({
     prefix: "imagebox",
     name,
     id,
-  });
+  })
 
   const {
     bodyStyle,
     controlStyle,
     containerStyle,
     labelStyle,
-    ...ImageboxStyles
-  } = styles ?? {};
+    helperDrawerStyle,
+    helperIconStyle,
+    helperArrowStyle,
+    ...imageboxStyles
+  } = styles ?? {}
 
   return (
     <FieldLane
@@ -267,26 +270,29 @@ function Imagebox({
         controlStyle,
         containerStyle,
         labelStyle,
+        helperDrawerStyle,
+        helperIconStyle,
+        helperArrowStyle,
       }}
     >
       <BaseImagebox
         {...rest}
         id={inputId}
         disabled={disabled}
-        styles={ImageboxStyles}
+        styles={imageboxStyles}
       />
     </FieldLane>
-  );
+  )
 }
 
 const InputBox = styled.div<{
-  $dimension: string;
-  $isDragging: boolean;
-  $style?: CSSProp;
-  $editable?: boolean;
-  $borderless?: boolean;
-  $disabled?: boolean;
-  $theme: ImageboxThemeConfig;
+  $dimension: string
+  $isDragging: boolean
+  $style?: CSSProp
+  $editable?: boolean
+  $borderless?: boolean
+  $disabled?: boolean
+  $theme: ImageboxThemeConfig
 }>`
   position: relative;
   width: ${({ $dimension }) => $dimension};
@@ -321,17 +327,17 @@ const InputBox = styled.div<{
     `};
 
   ${({ $style }) => $style}
-`;
+`
 
 const IconPlaceholder = styled.div<{
-  $theme: ImageboxThemeConfig;
+  $theme: ImageboxThemeConfig
 }>`
   position: absolute;
   top: 50%;
   left: 50%;
   color: ${({ $theme }) => $theme.iconColor};
   transform: translate(-50%, -50%);
-`;
+`
 
 const PreviewImage = styled.img`
   position: absolute;
@@ -339,12 +345,12 @@ const PreviewImage = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
-`;
+`
 
 const AddIconWrapper = styled.div<{
-  $isDragging: boolean;
-  $editable?: boolean;
-  $theme: ImageboxThemeConfig;
+  $isDragging: boolean
+  $editable?: boolean
+  $theme: ImageboxThemeConfig
 }>`
   position: absolute;
   bottom: -4px;
@@ -365,10 +371,10 @@ const AddIconWrapper = styled.div<{
     css`
       display: none;
     `}
-`;
+`
 
 const HiddenInput = styled.input`
   display: none;
-`;
+`
 
-export { Imagebox };
+export { Imagebox }

--- a/components/loading-skeleton.tsx
+++ b/components/loading-skeleton.tsx
@@ -37,10 +37,8 @@ export interface LoadingSkeletonOption {
   highlightColor?: string;
 }
 
-interface LoadingSkeletonBaseProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  "style"
-> {
+interface LoadingSkeletonBaseProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "style"> {
   children?: ReactNode;
   styles?: LoadingSkeletonStyles;
 }
@@ -50,7 +48,8 @@ export interface LoadingSkeletonStyles {
 }
 
 export interface LoadingSkeletonProps
-  extends LoadingSkeletonBaseProps, LoadingSkeletonOption {
+  extends LoadingSkeletonBaseProps,
+    LoadingSkeletonOption {
   height?: number | string;
   width?: number | string;
 }
@@ -121,7 +120,8 @@ const LoadingSkeletonWrapper = styled.div<{ $style?: CSSProp }>`
 `;
 
 export interface LoadingSkeletonItemProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "style">, LoadingSkeletonOption {
+  extends Omit<HTMLAttributes<HTMLDivElement>, "style">,
+    LoadingSkeletonOption {
   styles?: LoadingSkeletonStyles;
   height?: number | string;
   width?: number | string;

--- a/components/moneybox.tsx
+++ b/components/moneybox.tsx
@@ -1,4 +1,4 @@
-import styled, { css, CSSProp } from "styled-components";
+import styled, { css, CSSProp } from "styled-components"
 import {
   ChangeEvent,
   forwardRef,
@@ -9,19 +9,19 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react";
-import { Button } from "./button";
-import { List } from "./list";
+} from "react"
+import { Button } from "./button"
+import { List } from "./list"
 import {
   FieldLane,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane";
-import { StatefulForm } from "./stateful-form";
-import { useTheme } from "./../theme/provider";
-import { MoneyboxThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
+} from "./field-lane"
+import { StatefulForm } from "./stateful-form"
+import { useTheme } from "./../theme/provider"
+import { MoneyboxThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
 import {
   autoUpdate,
   flip,
@@ -31,22 +31,22 @@ import {
   useDismiss,
   useFloating,
   useInteractions,
-} from "@floating-ui/react";
-import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox";
-import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox";
+} from "@floating-ui/react"
+import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox"
+import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox"
 
 export const MoneyboxSeparator = {
   Dot: "dot",
   Comma: "comma",
-} as const;
+} as const
 
 export type MoneyboxSeparator =
-  (typeof MoneyboxSeparator)[keyof typeof MoneyboxSeparator];
+  (typeof MoneyboxSeparator)[keyof typeof MoneyboxSeparator]
 
 export interface MoneyboxCurrencyOption {
-  id: string;
-  name: string;
-  symbol: string;
+  id: string
+  name: string
+  symbol: string
 }
 
 interface BaseMoneyboxProps
@@ -54,30 +54,30 @@ interface BaseMoneyboxProps
     InputHTMLAttributes<HTMLInputElement>,
     "name" | "placeholder" | "style"
   > {
-  value?: string;
-  currency?: string;
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-  name?: string;
-  placeholder?: string;
-  separator?: MoneyboxSeparator;
-  showError?: boolean;
-  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
-  styles?: MoneyboxStyles;
-  editableCurrency?: boolean;
-  currencyOptions?: MoneyboxCurrencyOption[];
-  mobile?: boolean;
-  drawerHeight?: string;
-  id?: string;
+  value?: string
+  currency?: string
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
+  name?: string
+  placeholder?: string
+  separator?: MoneyboxSeparator
+  showError?: boolean
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
+  styles?: MoneyboxStyles
+  editableCurrency?: boolean
+  currencyOptions?: MoneyboxCurrencyOption[]
+  mobile?: boolean
+  drawerHeight?: string
+  id?: string
 }
 
 export interface MoneyboxStyles {
-  self?: CSSProp;
-  toggleStyle?: CSSProp;
-  inputWrapperStyle?: CSSProp;
-  drawerStyle?: CSSProp;
+  self?: CSSProp
+  toggleStyle?: CSSProp
+  inputWrapperStyle?: CSSProp
+  drawerStyle?: CSSProp
 }
 
-export type MoneyboxDropdownOption = FieldLaneDropdownOption;
+export type MoneyboxDropdownOption = FieldLaneDropdownOption
 
 const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
   (
@@ -101,24 +101,24 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
       drawerHeight,
       ...props
     },
-    ref
+    ref,
   ) => {
-    const { currentTheme } = useTheme();
-    const moneyboxTheme = currentTheme.moneybox;
+    const { currentTheme } = useTheme()
+    const moneyboxTheme = currentTheme.moneybox
 
-    const moneyInputRef = useRef<HTMLInputElement>(null);
-    const currencyInputRef = useRef<HTMLInputElement>(null);
+    const moneyInputRef = useRef<HTMLInputElement>(null)
+    const currencyInputRef = useRef<HTMLInputElement>(null)
 
-    useImperativeHandle(ref, () => moneyInputRef.current!);
+    useImperativeHandle(ref, () => moneyInputRef.current!)
 
-    const [selectedCurrency, setSelectedCurrency] = useState<string>(currency);
-    const [searchTerm, setSearchTerm] = useState("");
-    const [isOpen, setIsOpen] = useState(false);
-    const [highlightedIndex, setHighlightedIndex] = useState(0);
+    const [selectedCurrency, setSelectedCurrency] = useState<string>(currency)
+    const [searchTerm, setSearchTerm] = useState("")
+    const [isOpen, setIsOpen] = useState(false)
+    const [highlightedIndex, setHighlightedIndex] = useState(0)
     const [interactionMode, setInteractionMode] = useState<
       "mouse" | "keyboard"
-    >("keyboard");
-    const [hasInteracted, setHasInteracted] = useState(false);
+    >("keyboard")
+    const [hasInteracted, setHasInteracted] = useState(false)
 
     const { refs, floatingStyles, context } = useFloating({
       placement: "bottom-start" as Placement,
@@ -126,10 +126,10 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
       onOpenChange: setIsOpen,
       middleware: [offset(4), flip(), shift()],
       whileElementsMounted: autoUpdate,
-    });
+    })
 
-    const dismiss = useDismiss(context);
-    const { getFloatingProps, getReferenceProps } = useInteractions([dismiss]);
+    const dismiss = useDismiss(context)
+    const { getFloatingProps, getReferenceProps } = useInteractions([dismiss])
 
     const FINAL_CURRENCY_OPTIONS: ComboboxOption[] = useMemo(
       () =>
@@ -143,126 +143,126 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
             </>
           ),
         })),
-      []
-    );
+      [],
+    )
 
     const FILTERED_CURRENCY_OPTIONS: ComboboxOption[] = useMemo(() => {
-      if (!hasInteracted || !searchTerm) return FINAL_CURRENCY_OPTIONS;
+      if (!hasInteracted || !searchTerm) return FINAL_CURRENCY_OPTIONS
 
       return FINAL_CURRENCY_OPTIONS.filter((option) => {
         const currency = currencyOptions.find(
-          (currency) => currency.id === option.value
-        );
-        if (!currency) return false;
+          (currency) => currency.id === option.value,
+        )
+        if (!currency) return false
         return (
           currency.id.toLowerCase().includes(searchTerm.toLowerCase()) ||
           currency.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
           currency.symbol.toLowerCase().includes(searchTerm.toLowerCase())
-        );
-      });
-    }, [searchTerm, FINAL_CURRENCY_OPTIONS]);
+        )
+      })
+    }, [searchTerm, FINAL_CURRENCY_OPTIONS])
 
-    const listRef = useRef<(HTMLLIElement | null)[]>([]);
+    const listRef = useRef<(HTMLLIElement | null)[]>([])
 
     // Keep the highlighted option visible while navigating the list.
     useEffect(() => {
       if (isOpen && listRef.current[highlightedIndex]) {
-        listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });
+        listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" })
       }
-    }, [highlightedIndex, isOpen]);
+    }, [highlightedIndex, isOpen])
 
     const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (disabled) return;
+      if (disabled) return
 
-      setInteractionMode("keyboard");
+      setInteractionMode("keyboard")
 
       if (e.key === "ArrowDown") {
-        e.preventDefault();
-        if (!isOpen) await setIsOpen(true);
+        e.preventDefault()
+        if (!isOpen) await setIsOpen(true)
         await setHighlightedIndex((prev) =>
-          Math.min(prev + 1, FILTERED_CURRENCY_OPTIONS.length - 1)
-        );
+          Math.min(prev + 1, FILTERED_CURRENCY_OPTIONS.length - 1),
+        )
       } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        if (!isOpen) await setIsOpen(true);
-        await setHighlightedIndex((prev) => Math.max(prev - 1, 0));
+        e.preventDefault()
+        if (!isOpen) await setIsOpen(true)
+        await setHighlightedIndex((prev) => Math.max(prev - 1, 0))
       } else if (e.key === "Enter") {
-        e.preventDefault();
-        const selectedOption = FILTERED_CURRENCY_OPTIONS[highlightedIndex];
+        e.preventDefault()
+        const selectedOption = FILTERED_CURRENCY_OPTIONS[highlightedIndex]
         const selectedCurrency = currencyOptions.find(
-          (currency) => currency.id === selectedOption.value
-        );
+          (currency) => currency.id === selectedOption.value,
+        )
         if (selectedCurrency) {
-          await handleSelectCurrency(selectedCurrency.id);
+          await handleSelectCurrency(selectedCurrency.id)
         }
       } else if (e.key === "Escape") {
-        e.preventDefault();
-        await setIsOpen(false);
+        e.preventDefault()
+        await setIsOpen(false)
       }
-    };
+    }
 
     const handleToggleDropdown = () => {
-      if (disabled) return;
-      setSearchTerm("");
+      if (disabled) return
+      setSearchTerm("")
       setIsOpen((prev) => {
-        const newState = !prev;
+        const newState = !prev
         if (newState) {
-          setTimeout(() => currencyInputRef.current?.focus(), 0);
+          setTimeout(() => currencyInputRef.current?.focus(), 0)
         }
-        return newState;
-      });
-    };
+        return newState
+      })
+    }
 
-    const [focus, setFocus] = useState(false);
+    const [focus, setFocus] = useState(false)
 
     const [inputValue, setInputValue] = useState(() =>
       formatMoneyboxNumber(
         unformatMoneyboxNumber(value ?? "", separator),
-        separator
-      )
-    );
+        separator,
+      ),
+    )
 
     useEffect(() => {
       if (!focus && value !== undefined) {
         const formatted = formatMoneyboxNumber(
           unformatMoneyboxNumber(value, separator),
-          separator
-        );
+          separator,
+        )
         if (formatted !== inputValue) {
-          setInputValue(formatted);
+          setInputValue(formatted)
         }
       }
-    }, [value, focus]);
+    }, [value, focus])
 
     const selectionCurrency = editableCurrency
       ? currencyOptions.find((props) => props.id === currency)?.symbol
-      : currency;
+      : currency
 
-    const boxRef = useRef<HTMLDivElement>(null);
+    const boxRef = useRef<HTMLDivElement>(null)
 
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-      const raw = e.target.value;
-      setInputValue(raw);
+      const raw = e.target.value
+      setInputValue(raw)
 
-      const cleaned = unformatMoneyboxNumber(raw, separator);
+      const cleaned = unformatMoneyboxNumber(raw, separator)
       if (onChange) {
         const syntheticEvent = {
           target: {
             name,
             value: cleaned,
           },
-        };
-        onChange(syntheticEvent as ChangeEvent<HTMLInputElement>);
+        }
+        onChange(syntheticEvent as ChangeEvent<HTMLInputElement>)
       }
-    };
+    }
 
     const handleSelectCurrency = async (currency: string) => {
-      if (disabled) return;
+      if (disabled) return
 
-      await setSelectedCurrency(currency);
-      await setIsOpen(false);
-      await setSearchTerm("");
-      await setHighlightedIndex(0);
+      await setSelectedCurrency(currency)
+      await setIsOpen(false)
+      await setSearchTerm("")
+      await setHighlightedIndex(0)
 
       if (onChange) {
         const syntheticEvent = {
@@ -270,12 +270,12 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
             name: "currency",
             value: currency,
           },
-        } as ChangeEvent<HTMLInputElement>;
-        await onChange(syntheticEvent);
+        } as ChangeEvent<HTMLInputElement>
+        await onChange(syntheticEvent)
       }
 
-      await moneyInputRef?.current?.focus();
-    };
+      await moneyInputRef?.current?.focus()
+    }
 
     return (
       <Box
@@ -377,17 +377,17 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
             }}
             onChange={async (selectedOptions?: SelectboxSelectedOptions) => {
               const selectedCurrency = await currencyOptions.find(
-                (currency) => currency.id === selectedOptions
-              );
+                (currency) => currency.id === selectedOptions,
+              )
               if (selectedCurrency) {
-                await handleSelectCurrency(selectedCurrency.id);
+                await handleSelectCurrency(selectedCurrency.id)
               }
-              moneyInputRef.current?.focus();
+              moneyInputRef.current?.focus()
             }}
             setSelectedOptionsLocal={(
-              selectedOptionsLocal?: SelectboxOption
+              selectedOptionsLocal?: SelectboxOption,
             ) => {
-              setSearchTerm(selectedOptionsLocal?.text);
+              setSearchTerm(selectedOptionsLocal?.text)
             }}
             setHasInteracted={setHasInteracted}
             options={FILTERED_CURRENCY_OPTIONS}
@@ -402,14 +402,14 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
           />
         )}
       </Box>
-    );
-  }
-);
+    )
+  },
+)
 
 export interface MoneyboxProps
   extends Omit<BaseMoneyboxProps, "styles" | "actions">,
     Omit<FieldLaneProps, "styles" | "type" | "actions"> {
-  styles?: MoneyboxStyles & FieldLaneStyles;
+  styles?: MoneyboxStyles & FieldLaneStyles
 }
 
 const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
@@ -428,21 +428,24 @@ const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
       labelPosition,
       className,
       ...rest
-    } = props ?? {};
+    } = props ?? {}
 
     const {
       bodyStyle,
       containerStyle,
       controlStyle,
       labelStyle,
+      helperIconStyle,
+      helperDrawerStyle,
+      helperArrowStyle,
       ...moneyboxStyle
-    } = styles ?? {};
+    } = styles ?? {}
 
     const inputId = StatefulForm.sanitizeId({
       prefix: "moneybox",
       name: props.name,
       id: props.id,
-    });
+    })
 
     return (
       <FieldLane
@@ -465,6 +468,9 @@ const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
           controlStyle,
           containerStyle,
           labelStyle,
+          helperDrawerStyle,
+          helperIconStyle,
+          helperArrowStyle,
         }}
       >
         <BaseMoneybox
@@ -487,16 +493,16 @@ const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
           ref={ref}
         />
       </FieldLane>
-    );
-  }
-);
+    )
+  },
+)
 
 const Box = styled.div<{
-  $error?: boolean;
-  $focus?: boolean;
-  $style?: CSSProp;
-  $disabled?: boolean;
-  $theme: MoneyboxThemeConfig;
+  $error?: boolean
+  $focus?: boolean
+  $style?: CSSProp
+  $disabled?: boolean
+  $theme: MoneyboxThemeConfig
 }>`
   display: flex;
   align-items: center;
@@ -528,12 +534,12 @@ const Box = styled.div<{
     `}
 
   ${({ $style }) => $style}
-`;
+`
 
 const MoneyboxInput = styled.input<{
-  $disabled?: boolean;
-  $style?: CSSProp;
-  $theme: MoneyboxThemeConfig;
+  $disabled?: boolean
+  $style?: CSSProp
+  $theme: MoneyboxThemeConfig
 }>`
   background: transparent;
   text-align: right;
@@ -559,68 +565,68 @@ const MoneyboxInput = styled.input<{
     `}
 
   ${({ $style }) => $style}
-`;
+`
 
 const unformatMoneyboxNumber = (
   val: string,
-  separator: MoneyboxSeparator
+  separator: MoneyboxSeparator,
 ): string => {
-  if (!val) return "";
+  if (!val) return ""
 
   if (separator === "dot") {
-    const lastCommaIndex = val.lastIndexOf(",");
+    const lastCommaIndex = val.lastIndexOf(",")
 
     if (lastCommaIndex === -1) {
-      return val.replace(/\./g, "").replace(/[^\d]/g, "");
+      return val.replace(/\./g, "").replace(/[^\d]/g, "")
     } else {
       const integerPart = val
         .substring(0, lastCommaIndex)
         .replace(/\./g, "")
-        .replace(/[^\d]/g, "");
+        .replace(/[^\d]/g, "")
       const decimalPart = val
         .substring(lastCommaIndex + 1)
-        .replace(/[^\d]/g, "");
-      return decimalPart ? `${integerPart}.${decimalPart}` : integerPart;
+        .replace(/[^\d]/g, "")
+      return decimalPart ? `${integerPart}.${decimalPart}` : integerPart
     }
   } else {
-    const lastDotIndex = val.lastIndexOf(".");
+    const lastDotIndex = val.lastIndexOf(".")
 
     if (lastDotIndex === -1) {
-      return val.replace(/,/g, "").replace(/[^\d]/g, "");
+      return val.replace(/,/g, "").replace(/[^\d]/g, "")
     } else {
       const integerPart = val
         .substring(0, lastDotIndex)
         .replace(/,/g, "")
-        .replace(/[^\d]/g, "");
-      const decimalPart = val.substring(lastDotIndex + 1).replace(/[^\d]/g, "");
-      return decimalPart ? `${integerPart}.${decimalPart}` : integerPart;
+        .replace(/[^\d]/g, "")
+      const decimalPart = val.substring(lastDotIndex + 1).replace(/[^\d]/g, "")
+      return decimalPart ? `${integerPart}.${decimalPart}` : integerPart
     }
   }
-};
+}
 
 const formatMoneyboxNumber = (
   val: string,
-  separator: MoneyboxSeparator
+  separator: MoneyboxSeparator,
 ): string => {
-  if (!val) return "";
+  if (!val) return ""
 
-  const [intPart, decimalPart = ""] = val.split(".");
+  const [intPart, decimalPart = ""] = val.split(".")
 
   if (separator === "dot") {
-    const thousandSep = ".";
-    const decimalSep = ",";
-    const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSep);
+    const thousandSep = "."
+    const decimalSep = ","
+    const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSep)
     return decimalPart
       ? `${intFormatted}${decimalSep}${decimalPart}`
-      : intFormatted;
+      : intFormatted
   } else {
-    const thousandSep = ",";
-    const decimalSep = ".";
-    const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSep);
+    const thousandSep = ","
+    const decimalSep = "."
+    const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSep)
     return decimalPart
       ? `${intFormatted}${decimalSep}${decimalPart}`
-      : intFormatted;
+      : intFormatted
   }
-};
+}
 
-export { Moneybox, formatMoneyboxNumber };
+export { Moneybox, formatMoneyboxNumber }

--- a/components/moneybox.tsx
+++ b/components/moneybox.tsx
@@ -1,4 +1,4 @@
-import styled, { css, CSSProp } from "styled-components"
+import styled, { css, CSSProp } from "styled-components";
 import {
   ChangeEvent,
   forwardRef,
@@ -9,19 +9,19 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react"
-import { Button } from "./button"
-import { List } from "./list"
+} from "react";
+import { Button } from "./button";
+import { List } from "./list";
 import {
   FieldLane,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane"
-import { StatefulForm } from "./stateful-form"
-import { useTheme } from "./../theme/provider"
-import { MoneyboxThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
+} from "./field-lane";
+import { StatefulForm } from "./stateful-form";
+import { useTheme } from "./../theme/provider";
+import { MoneyboxThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 import {
   autoUpdate,
   flip,
@@ -31,22 +31,22 @@ import {
   useDismiss,
   useFloating,
   useInteractions,
-} from "@floating-ui/react"
-import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox"
-import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox"
+} from "@floating-ui/react";
+import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox";
+import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox";
 
 export const MoneyboxSeparator = {
   Dot: "dot",
   Comma: "comma",
-} as const
+} as const;
 
 export type MoneyboxSeparator =
-  (typeof MoneyboxSeparator)[keyof typeof MoneyboxSeparator]
+  (typeof MoneyboxSeparator)[keyof typeof MoneyboxSeparator];
 
 export interface MoneyboxCurrencyOption {
-  id: string
-  name: string
-  symbol: string
+  id: string;
+  name: string;
+  symbol: string;
 }
 
 interface BaseMoneyboxProps
@@ -54,30 +54,30 @@ interface BaseMoneyboxProps
     InputHTMLAttributes<HTMLInputElement>,
     "name" | "placeholder" | "style"
   > {
-  value?: string
-  currency?: string
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
-  name?: string
-  placeholder?: string
-  separator?: MoneyboxSeparator
-  showError?: boolean
-  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
-  styles?: MoneyboxStyles
-  editableCurrency?: boolean
-  currencyOptions?: MoneyboxCurrencyOption[]
-  mobile?: boolean
-  drawerHeight?: string
-  id?: string
+  value?: string;
+  currency?: string;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  name?: string;
+  placeholder?: string;
+  separator?: MoneyboxSeparator;
+  showError?: boolean;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+  styles?: MoneyboxStyles;
+  editableCurrency?: boolean;
+  currencyOptions?: MoneyboxCurrencyOption[];
+  mobile?: boolean;
+  drawerHeight?: string;
+  id?: string;
 }
 
 export interface MoneyboxStyles {
-  self?: CSSProp
-  toggleStyle?: CSSProp
-  inputWrapperStyle?: CSSProp
-  drawerStyle?: CSSProp
+  self?: CSSProp;
+  toggleStyle?: CSSProp;
+  inputWrapperStyle?: CSSProp;
+  drawerStyle?: CSSProp;
 }
 
-export type MoneyboxDropdownOption = FieldLaneDropdownOption
+export type MoneyboxDropdownOption = FieldLaneDropdownOption;
 
 const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
   (
@@ -101,24 +101,24 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
       drawerHeight,
       ...props
     },
-    ref,
+    ref
   ) => {
-    const { currentTheme } = useTheme()
-    const moneyboxTheme = currentTheme.moneybox
+    const { currentTheme } = useTheme();
+    const moneyboxTheme = currentTheme.moneybox;
 
-    const moneyInputRef = useRef<HTMLInputElement>(null)
-    const currencyInputRef = useRef<HTMLInputElement>(null)
+    const moneyInputRef = useRef<HTMLInputElement>(null);
+    const currencyInputRef = useRef<HTMLInputElement>(null);
 
-    useImperativeHandle(ref, () => moneyInputRef.current!)
+    useImperativeHandle(ref, () => moneyInputRef.current!);
 
-    const [selectedCurrency, setSelectedCurrency] = useState<string>(currency)
-    const [searchTerm, setSearchTerm] = useState("")
-    const [isOpen, setIsOpen] = useState(false)
-    const [highlightedIndex, setHighlightedIndex] = useState(0)
+    const [selectedCurrency, setSelectedCurrency] = useState<string>(currency);
+    const [searchTerm, setSearchTerm] = useState("");
+    const [isOpen, setIsOpen] = useState(false);
+    const [highlightedIndex, setHighlightedIndex] = useState(0);
     const [interactionMode, setInteractionMode] = useState<
       "mouse" | "keyboard"
-    >("keyboard")
-    const [hasInteracted, setHasInteracted] = useState(false)
+    >("keyboard");
+    const [hasInteracted, setHasInteracted] = useState(false);
 
     const { refs, floatingStyles, context } = useFloating({
       placement: "bottom-start" as Placement,
@@ -126,10 +126,10 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
       onOpenChange: setIsOpen,
       middleware: [offset(4), flip(), shift()],
       whileElementsMounted: autoUpdate,
-    })
+    });
 
-    const dismiss = useDismiss(context)
-    const { getFloatingProps, getReferenceProps } = useInteractions([dismiss])
+    const dismiss = useDismiss(context);
+    const { getFloatingProps, getReferenceProps } = useInteractions([dismiss]);
 
     const FINAL_CURRENCY_OPTIONS: ComboboxOption[] = useMemo(
       () =>
@@ -143,126 +143,126 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
             </>
           ),
         })),
-      [],
-    )
+      []
+    );
 
     const FILTERED_CURRENCY_OPTIONS: ComboboxOption[] = useMemo(() => {
-      if (!hasInteracted || !searchTerm) return FINAL_CURRENCY_OPTIONS
+      if (!hasInteracted || !searchTerm) return FINAL_CURRENCY_OPTIONS;
 
       return FINAL_CURRENCY_OPTIONS.filter((option) => {
         const currency = currencyOptions.find(
-          (currency) => currency.id === option.value,
-        )
-        if (!currency) return false
+          (currency) => currency.id === option.value
+        );
+        if (!currency) return false;
         return (
           currency.id.toLowerCase().includes(searchTerm.toLowerCase()) ||
           currency.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
           currency.symbol.toLowerCase().includes(searchTerm.toLowerCase())
-        )
-      })
-    }, [searchTerm, FINAL_CURRENCY_OPTIONS])
+        );
+      });
+    }, [searchTerm, FINAL_CURRENCY_OPTIONS]);
 
-    const listRef = useRef<(HTMLLIElement | null)[]>([])
+    const listRef = useRef<(HTMLLIElement | null)[]>([]);
 
     // Keep the highlighted option visible while navigating the list.
     useEffect(() => {
       if (isOpen && listRef.current[highlightedIndex]) {
-        listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" })
+        listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });
       }
-    }, [highlightedIndex, isOpen])
+    }, [highlightedIndex, isOpen]);
 
     const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (disabled) return
+      if (disabled) return;
 
-      setInteractionMode("keyboard")
+      setInteractionMode("keyboard");
 
       if (e.key === "ArrowDown") {
-        e.preventDefault()
-        if (!isOpen) await setIsOpen(true)
+        e.preventDefault();
+        if (!isOpen) await setIsOpen(true);
         await setHighlightedIndex((prev) =>
-          Math.min(prev + 1, FILTERED_CURRENCY_OPTIONS.length - 1),
-        )
+          Math.min(prev + 1, FILTERED_CURRENCY_OPTIONS.length - 1)
+        );
       } else if (e.key === "ArrowUp") {
-        e.preventDefault()
-        if (!isOpen) await setIsOpen(true)
-        await setHighlightedIndex((prev) => Math.max(prev - 1, 0))
+        e.preventDefault();
+        if (!isOpen) await setIsOpen(true);
+        await setHighlightedIndex((prev) => Math.max(prev - 1, 0));
       } else if (e.key === "Enter") {
-        e.preventDefault()
-        const selectedOption = FILTERED_CURRENCY_OPTIONS[highlightedIndex]
+        e.preventDefault();
+        const selectedOption = FILTERED_CURRENCY_OPTIONS[highlightedIndex];
         const selectedCurrency = currencyOptions.find(
-          (currency) => currency.id === selectedOption.value,
-        )
+          (currency) => currency.id === selectedOption.value
+        );
         if (selectedCurrency) {
-          await handleSelectCurrency(selectedCurrency.id)
+          await handleSelectCurrency(selectedCurrency.id);
         }
       } else if (e.key === "Escape") {
-        e.preventDefault()
-        await setIsOpen(false)
+        e.preventDefault();
+        await setIsOpen(false);
       }
-    }
+    };
 
     const handleToggleDropdown = () => {
-      if (disabled) return
-      setSearchTerm("")
+      if (disabled) return;
+      setSearchTerm("");
       setIsOpen((prev) => {
-        const newState = !prev
+        const newState = !prev;
         if (newState) {
-          setTimeout(() => currencyInputRef.current?.focus(), 0)
+          setTimeout(() => currencyInputRef.current?.focus(), 0);
         }
-        return newState
-      })
-    }
+        return newState;
+      });
+    };
 
-    const [focus, setFocus] = useState(false)
+    const [focus, setFocus] = useState(false);
 
     const [inputValue, setInputValue] = useState(() =>
       formatMoneyboxNumber(
         unformatMoneyboxNumber(value ?? "", separator),
-        separator,
-      ),
-    )
+        separator
+      )
+    );
 
     useEffect(() => {
       if (!focus && value !== undefined) {
         const formatted = formatMoneyboxNumber(
           unformatMoneyboxNumber(value, separator),
-          separator,
-        )
+          separator
+        );
         if (formatted !== inputValue) {
-          setInputValue(formatted)
+          setInputValue(formatted);
         }
       }
-    }, [value, focus])
+    }, [value, focus]);
 
     const selectionCurrency = editableCurrency
       ? currencyOptions.find((props) => props.id === currency)?.symbol
-      : currency
+      : currency;
 
-    const boxRef = useRef<HTMLDivElement>(null)
+    const boxRef = useRef<HTMLDivElement>(null);
 
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-      const raw = e.target.value
-      setInputValue(raw)
+      const raw = e.target.value;
+      setInputValue(raw);
 
-      const cleaned = unformatMoneyboxNumber(raw, separator)
+      const cleaned = unformatMoneyboxNumber(raw, separator);
       if (onChange) {
         const syntheticEvent = {
           target: {
             name,
             value: cleaned,
           },
-        }
-        onChange(syntheticEvent as ChangeEvent<HTMLInputElement>)
+        };
+        onChange(syntheticEvent as ChangeEvent<HTMLInputElement>);
       }
-    }
+    };
 
     const handleSelectCurrency = async (currency: string) => {
-      if (disabled) return
+      if (disabled) return;
 
-      await setSelectedCurrency(currency)
-      await setIsOpen(false)
-      await setSearchTerm("")
-      await setHighlightedIndex(0)
+      await setSelectedCurrency(currency);
+      await setIsOpen(false);
+      await setSearchTerm("");
+      await setHighlightedIndex(0);
 
       if (onChange) {
         const syntheticEvent = {
@@ -270,12 +270,12 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
             name: "currency",
             value: currency,
           },
-        } as ChangeEvent<HTMLInputElement>
-        await onChange(syntheticEvent)
+        } as ChangeEvent<HTMLInputElement>;
+        await onChange(syntheticEvent);
       }
 
-      await moneyInputRef?.current?.focus()
-    }
+      await moneyInputRef?.current?.focus();
+    };
 
     return (
       <Box
@@ -377,17 +377,17 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
             }}
             onChange={async (selectedOptions?: SelectboxSelectedOptions) => {
               const selectedCurrency = await currencyOptions.find(
-                (currency) => currency.id === selectedOptions,
-              )
+                (currency) => currency.id === selectedOptions
+              );
               if (selectedCurrency) {
-                await handleSelectCurrency(selectedCurrency.id)
+                await handleSelectCurrency(selectedCurrency.id);
               }
-              moneyInputRef.current?.focus()
+              moneyInputRef.current?.focus();
             }}
             setSelectedOptionsLocal={(
-              selectedOptionsLocal?: SelectboxOption,
+              selectedOptionsLocal?: SelectboxOption
             ) => {
-              setSearchTerm(selectedOptionsLocal?.text)
+              setSearchTerm(selectedOptionsLocal?.text);
             }}
             setHasInteracted={setHasInteracted}
             options={FILTERED_CURRENCY_OPTIONS}
@@ -402,14 +402,14 @@ const BaseMoneybox = forwardRef<HTMLInputElement, BaseMoneyboxProps>(
           />
         )}
       </Box>
-    )
-  },
-)
+    );
+  }
+);
 
 export interface MoneyboxProps
   extends Omit<BaseMoneyboxProps, "styles" | "actions">,
     Omit<FieldLaneProps, "styles" | "type" | "actions"> {
-  styles?: MoneyboxStyles & FieldLaneStyles
+  styles?: MoneyboxStyles & FieldLaneStyles;
 }
 
 const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
@@ -428,7 +428,7 @@ const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
       labelPosition,
       className,
       ...rest
-    } = props ?? {}
+    } = props ?? {};
 
     const {
       bodyStyle,
@@ -439,13 +439,13 @@ const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
       helperDrawerStyle,
       helperArrowStyle,
       ...moneyboxStyle
-    } = styles ?? {}
+    } = styles ?? {};
 
     const inputId = StatefulForm.sanitizeId({
       prefix: "moneybox",
       name: props.name,
       id: props.id,
-    })
+    });
 
     return (
       <FieldLane
@@ -493,16 +493,16 @@ const Moneybox = forwardRef<HTMLInputElement, MoneyboxProps>(
           ref={ref}
         />
       </FieldLane>
-    )
-  },
-)
+    );
+  }
+);
 
 const Box = styled.div<{
-  $error?: boolean
-  $focus?: boolean
-  $style?: CSSProp
-  $disabled?: boolean
-  $theme: MoneyboxThemeConfig
+  $error?: boolean;
+  $focus?: boolean;
+  $style?: CSSProp;
+  $disabled?: boolean;
+  $theme: MoneyboxThemeConfig;
 }>`
   display: flex;
   align-items: center;
@@ -534,12 +534,12 @@ const Box = styled.div<{
     `}
 
   ${({ $style }) => $style}
-`
+`;
 
 const MoneyboxInput = styled.input<{
-  $disabled?: boolean
-  $style?: CSSProp
-  $theme: MoneyboxThemeConfig
+  $disabled?: boolean;
+  $style?: CSSProp;
+  $theme: MoneyboxThemeConfig;
 }>`
   background: transparent;
   text-align: right;
@@ -565,68 +565,68 @@ const MoneyboxInput = styled.input<{
     `}
 
   ${({ $style }) => $style}
-`
+`;
 
 const unformatMoneyboxNumber = (
   val: string,
-  separator: MoneyboxSeparator,
+  separator: MoneyboxSeparator
 ): string => {
-  if (!val) return ""
+  if (!val) return "";
 
   if (separator === "dot") {
-    const lastCommaIndex = val.lastIndexOf(",")
+    const lastCommaIndex = val.lastIndexOf(",");
 
     if (lastCommaIndex === -1) {
-      return val.replace(/\./g, "").replace(/[^\d]/g, "")
+      return val.replace(/\./g, "").replace(/[^\d]/g, "");
     } else {
       const integerPart = val
         .substring(0, lastCommaIndex)
         .replace(/\./g, "")
-        .replace(/[^\d]/g, "")
+        .replace(/[^\d]/g, "");
       const decimalPart = val
         .substring(lastCommaIndex + 1)
-        .replace(/[^\d]/g, "")
-      return decimalPart ? `${integerPart}.${decimalPart}` : integerPart
+        .replace(/[^\d]/g, "");
+      return decimalPart ? `${integerPart}.${decimalPart}` : integerPart;
     }
   } else {
-    const lastDotIndex = val.lastIndexOf(".")
+    const lastDotIndex = val.lastIndexOf(".");
 
     if (lastDotIndex === -1) {
-      return val.replace(/,/g, "").replace(/[^\d]/g, "")
+      return val.replace(/,/g, "").replace(/[^\d]/g, "");
     } else {
       const integerPart = val
         .substring(0, lastDotIndex)
         .replace(/,/g, "")
-        .replace(/[^\d]/g, "")
-      const decimalPart = val.substring(lastDotIndex + 1).replace(/[^\d]/g, "")
-      return decimalPart ? `${integerPart}.${decimalPart}` : integerPart
+        .replace(/[^\d]/g, "");
+      const decimalPart = val.substring(lastDotIndex + 1).replace(/[^\d]/g, "");
+      return decimalPart ? `${integerPart}.${decimalPart}` : integerPart;
     }
   }
-}
+};
 
 const formatMoneyboxNumber = (
   val: string,
-  separator: MoneyboxSeparator,
+  separator: MoneyboxSeparator
 ): string => {
-  if (!val) return ""
+  if (!val) return "";
 
-  const [intPart, decimalPart = ""] = val.split(".")
+  const [intPart, decimalPart = ""] = val.split(".");
 
   if (separator === "dot") {
-    const thousandSep = "."
-    const decimalSep = ","
-    const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSep)
+    const thousandSep = ".";
+    const decimalSep = ",";
+    const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSep);
     return decimalPart
       ? `${intFormatted}${decimalSep}${decimalPart}`
-      : intFormatted
+      : intFormatted;
   } else {
-    const thousandSep = ","
-    const decimalSep = "."
-    const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSep)
+    const thousandSep = ",";
+    const decimalSep = ".";
+    const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSep);
     return decimalPart
       ? `${intFormatted}${decimalSep}${decimalPart}`
-      : intFormatted
+      : intFormatted;
   }
-}
+};
 
-export { Moneybox, formatMoneyboxNumber }
+export { Moneybox, formatMoneyboxNumber };

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -7,7 +7,7 @@ import React, {
   useMemo,
   useRef,
   useState,
-} from "react";
+} from "react"
 import {
   useFloating,
   offset,
@@ -17,70 +17,69 @@ import {
   useDismiss,
   useInteractions,
   Placement,
-} from "@floating-ui/react";
-import { RiArrowDownSLine, RiArrowUpSLine } from "@remixicon/react";
-import { COUNTRY_CODES } from "../constants/countries";
-import { CountryCode, groupDigits } from "../lib/phone";
-import styled, { css, CSSProp } from "styled-components";
+} from "@floating-ui/react"
+import { RiArrowDownSLine, RiArrowUpSLine } from "@remixicon/react"
+import { COUNTRY_CODES } from "../constants/countries"
+import { CountryCode, groupDigits } from "../lib/phone"
+import styled, { css, CSSProp } from "styled-components"
 import {
   FieldLane,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane";
-import { Figure } from "./figure";
-import { StatefulForm } from "./stateful-form";
-import { PhoneboxThemeConfig } from "./../theme";
-import { useTheme } from "./../theme/provider";
-import { applyClassName } from "./../constants/classname";
-import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox";
-import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox";
+} from "./field-lane"
+import { Figure } from "./figure"
+import { StatefulForm } from "./stateful-form"
+import { PhoneboxThemeConfig } from "./../theme"
+import { useTheme } from "./../theme/provider"
+import { applyClassName } from "./../constants/classname"
+import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox"
+import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox"
 
 export interface PhoneboxCountryCode {
-  id: string;
-  code: string;
-  name: string;
-  flag: string;
+  id: string
+  code: string
+  name: string
+  flag: string
 }
 
 export type PhoneboxComponent = React.ForwardRefExoticComponent<
   PhoneboxProps & React.RefAttributes<HTMLInputElement>
 > & {
-  formatPhoneNumber: typeof formatPhoneboxNumber;
-};
+  formatPhoneNumber: typeof formatPhoneboxNumber
+}
 
 interface BasePhoneboxProps {
-  label?: string;
-  name?: string;
-  value?: string;
+  label?: string
+  name?: string
+  value?: string
   onChange?: (
     e:
       | { target: { name: string; value: PhoneboxCountryCode } }
-      | ChangeEvent<HTMLInputElement>
-  ) => void;
-  placeholder?: string;
-  helper?: string;
-  disabled?: boolean;
-  showError?: boolean;
-  errorMessage?: string;
-  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
-  onBlur?: () => void;
-  countryCodeValue?: PhoneboxCountryCode;
-  styles?: PhoneboxStyles;
-  id?: string;
-  required?: boolean;
-  mobile?: boolean;
-  drawerHeight?: string;
+      | ChangeEvent<HTMLInputElement>,
+  ) => void
+  placeholder?: string
+  disabled?: boolean
+  showError?: boolean
+  errorMessage?: string
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
+  onBlur?: () => void
+  countryCodeValue?: PhoneboxCountryCode
+  styles?: PhoneboxStyles
+  id?: string
+  required?: boolean
+  mobile?: boolean
+  drawerHeight?: string
 }
 
 export interface PhoneboxStyles {
-  self?: CSSProp;
-  inputWrapperStyle?: CSSProp;
-  toggleStyle?: CSSProp;
-  drawerStyle?: CSSProp;
+  self?: CSSProp
+  inputWrapperStyle?: CSSProp
+  toggleStyle?: CSSProp
+  drawerStyle?: CSSProp
 }
 
-export type PhoneboxDropdownOption = FieldLaneDropdownOption;
+export type PhoneboxDropdownOption = FieldLaneDropdownOption
 
 const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
   (
@@ -99,30 +98,30 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
       mobile,
       drawerHeight,
     },
-    ref
+    ref,
   ) => {
-    const { currentTheme } = useTheme();
-    const phoneboxTheme = currentTheme?.phonebox;
+    const { currentTheme } = useTheme()
+    const phoneboxTheme = currentTheme?.phonebox
 
-    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES[205];
-    const countryCodeState = countryCodeValue ?? DEFAULT_COUNTRY_CODES;
+    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES[205]
+    const countryCodeState = countryCodeValue ?? DEFAULT_COUNTRY_CODES
 
-    const [isOpen, setIsOpen] = useState(false);
-    const [searchTerm, setSearchTerm] = useState("");
+    const [isOpen, setIsOpen] = useState(false)
+    const [searchTerm, setSearchTerm] = useState("")
     const [selectedCountry, setSelectedCountry] =
-      useState<PhoneboxCountryCode>(countryCodeState);
-    const [phoneNumber, setPhoneNumber] = useState("");
+      useState<PhoneboxCountryCode>(countryCodeState)
+    const [phoneNumber, setPhoneNumber] = useState("")
 
-    const [highlightedIndex, setHighlightedIndex] = useState(0);
+    const [highlightedIndex, setHighlightedIndex] = useState(0)
     const [interactionMode, setInteractionMode] = useState<
       "mouse" | "keyboard"
-    >("keyboard");
-    const [hasInteracted, setHasInteracted] = useState(false);
+    >("keyboard")
+    const [hasInteracted, setHasInteracted] = useState(false)
 
-    const searchInputRef = useRef<HTMLInputElement>(null);
-    const phoneInputRef = useRef<HTMLInputElement>(null);
+    const searchInputRef = useRef<HTMLInputElement>(null)
+    const phoneInputRef = useRef<HTMLInputElement>(null)
 
-    useImperativeHandle(ref, () => phoneInputRef.current!);
+    useImperativeHandle(ref, () => phoneInputRef.current!)
 
     const FINAL_COUNTRY_OPTIONS: ComboboxOption[] = useMemo(
       () =>
@@ -139,25 +138,25 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
             </>
           ),
         })),
-      []
-    );
+      [],
+    )
 
     const FILTERED_COUNTRY_OPTIONS: ComboboxOption[] = useMemo(() => {
-      if (!hasInteracted || !searchTerm) return FINAL_COUNTRY_OPTIONS;
+      if (!hasInteracted || !searchTerm) return FINAL_COUNTRY_OPTIONS
 
-      const search = searchTerm.toLowerCase();
+      const search = searchTerm.toLowerCase()
 
       return FINAL_COUNTRY_OPTIONS.filter((option) => {
         const country = COUNTRY_CODES.find(
-          (country) => country.id === option.value
-        );
-        if (!country) return false;
+          (country) => country.id === option.value,
+        )
+        if (!country) return false
         return (
           country.name.toLowerCase().includes(search) ||
           country.code.includes(searchTerm)
-        );
-      });
-    }, [hasInteracted, searchTerm, FINAL_COUNTRY_OPTIONS]);
+        )
+      })
+    }, [hasInteracted, searchTerm, FINAL_COUNTRY_OPTIONS])
 
     const { refs, floatingStyles, context } = useFloating({
       placement: "bottom-start" as Placement,
@@ -165,98 +164,98 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
       onOpenChange: setIsOpen,
       middleware: [offset(4), flip(), shift()],
       whileElementsMounted: autoUpdate,
-    });
+    })
 
-    const dismiss = useDismiss(context);
-    const { getFloatingProps, getReferenceProps } = useInteractions([dismiss]);
+    const dismiss = useDismiss(context)
+    const { getFloatingProps, getReferenceProps } = useInteractions([dismiss])
 
     useEffect(() => {
       if (!isOpen) {
-        setSearchTerm("");
-        setHighlightedIndex(0);
+        setSearchTerm("")
+        setHighlightedIndex(0)
       }
-    }, [isOpen]);
+    }, [isOpen])
 
     useEffect(() => {
       if (!value) {
-        setPhoneNumber("");
-        return;
+        setPhoneNumber("")
+        return
       }
 
       const formatted = formatPhoneboxNumber(
         value,
-        selectedCountry.id as CountryCode
-      );
-      setPhoneNumber(formatted);
-    }, [value]);
+        selectedCountry.id as CountryCode,
+      )
+      setPhoneNumber(formatted)
+    }, [value])
 
-    const listRef = useRef<(HTMLLIElement | null)[]>([]);
+    const listRef = useRef<(HTMLLIElement | null)[]>([])
 
     // Keep the highlighted option visible while navigating the list.
     useEffect(() => {
       if (isOpen && listRef.current[highlightedIndex]) {
-        listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });
+        listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" })
       }
-    }, [highlightedIndex, isOpen]);
+    }, [highlightedIndex, isOpen])
 
     const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (disabled) return;
+      if (disabled) return
 
-      setInteractionMode("keyboard");
+      setInteractionMode("keyboard")
 
       if (e.key === "ArrowDown") {
-        e.preventDefault();
-        if (!isOpen) await setIsOpen(true);
+        e.preventDefault()
+        if (!isOpen) await setIsOpen(true)
         await setHighlightedIndex((prev) =>
-          Math.min(prev + 1, FILTERED_COUNTRY_OPTIONS.length - 1)
-        );
+          Math.min(prev + 1, FILTERED_COUNTRY_OPTIONS.length - 1),
+        )
       } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        if (!isOpen) await setIsOpen(true);
-        await setHighlightedIndex((prev) => Math.max(prev - 1, 0));
+        e.preventDefault()
+        if (!isOpen) await setIsOpen(true)
+        await setHighlightedIndex((prev) => Math.max(prev - 1, 0))
       } else if (e.key === "Enter") {
-        e.preventDefault();
-        const selectedOption = FILTERED_COUNTRY_OPTIONS[highlightedIndex];
+        e.preventDefault()
+        const selectedOption = FILTERED_COUNTRY_OPTIONS[highlightedIndex]
         const selectedCountry = COUNTRY_CODES.find(
-          (country) => country.id === selectedOption.value
-        );
+          (country) => country.id === selectedOption.value,
+        )
         if (selectedCountry) {
-          await handleSelectCountry(selectedCountry);
+          await handleSelectCountry(selectedCountry)
         }
       } else if (e.key === "Escape") {
-        e.preventDefault();
-        await setIsOpen(false);
+        e.preventDefault()
+        await setIsOpen(false)
       }
-    };
+    }
 
     const handlePhoneChange = (e: ChangeEvent<HTMLInputElement>) => {
-      if (disabled) return;
+      if (disabled) return
 
-      const raw = e.target.value;
-      const trimmed = trimPhone(raw);
+      const raw = e.target.value
+      const trimmed = trimPhone(raw)
       const formatted = formatPhoneboxNumber(
         trimmed,
-        selectedCountry.id as CountryCode
-      );
-      setPhoneNumber(formatted);
+        selectedCountry.id as CountryCode,
+      )
+      setPhoneNumber(formatted)
       if (onChange) {
         const syntheticEvent = {
           target: {
             name: "phone",
             value: trimmed,
           },
-        } as ChangeEvent<HTMLInputElement>;
-        onChange?.(syntheticEvent);
+        } as ChangeEvent<HTMLInputElement>
+        onChange?.(syntheticEvent)
       }
-    };
+    }
 
     const handleSelectCountry = async (country: PhoneboxCountryCode) => {
-      if (disabled) return;
+      if (disabled) return
 
-      await setSelectedCountry(country);
-      await setIsOpen(false);
-      await setSearchTerm("");
-      await setHighlightedIndex(0);
+      await setSelectedCountry(country)
+      await setIsOpen(false)
+      await setSearchTerm("")
+      await setHighlightedIndex(0)
 
       if (onChange) {
         const syntheticEvent = {
@@ -264,23 +263,23 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
             name: "country_code",
             value: country,
           },
-        };
-        await onChange(syntheticEvent);
+        }
+        await onChange(syntheticEvent)
       }
 
-      phoneInputRef.current?.focus();
-    };
+      phoneInputRef.current?.focus()
+    }
 
     const handleToggleDropdown = () => {
-      if (disabled) return;
+      if (disabled) return
       setIsOpen((prev) => {
-        const newState = !prev;
+        const newState = !prev
         if (newState) {
-          setTimeout(() => searchInputRef.current?.focus(), 0);
+          setTimeout(() => searchInputRef.current?.focus(), 0)
         }
-        return newState;
-      });
-    };
+        return newState
+      })
+    }
 
     return (
       <>
@@ -361,16 +360,16 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
             }}
             onChange={async (selectedOptions?: SelectboxSelectedOptions) => {
               const selectedCountry = await COUNTRY_CODES.find(
-                (country) => country.id === selectedOptions
-              );
+                (country) => country.id === selectedOptions,
+              )
               if (selectedCountry) {
-                await handleSelectCountry(selectedCountry);
+                await handleSelectCountry(selectedCountry)
               }
             }}
             setSelectedOptionsLocal={(
-              selectedOptionsLocal?: SelectboxOption
+              selectedOptionsLocal?: SelectboxOption,
             ) => {
-              setSearchTerm(selectedOptionsLocal?.text);
+              setSearchTerm(selectedOptionsLocal?.text)
             }}
             setHasInteracted={setHasInteracted}
             options={FILTERED_COUNTRY_OPTIONS}
@@ -387,14 +386,14 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
           />
         )}
       </>
-    );
-  }
-);
+    )
+  },
+)
 
 export interface PhoneboxProps
   extends Omit<BasePhoneboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "onChange" | "actions"> {
-  styles?: PhoneboxStyles & FieldLaneStyles;
+  styles?: PhoneboxStyles & FieldLaneStyles
 }
 
 const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
@@ -414,21 +413,24 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
       labelPosition,
       className,
       ...rest
-    } = props;
+    } = props
 
     const {
       bodyStyle,
       containerStyle,
       controlStyle,
       labelStyle,
+      helperArrowStyle,
+      helperDrawerStyle,
+      helperIconStyle,
       ...phoneboxStyle
-    } = styles ?? {};
+    } = styles ?? {}
 
     const inputId = StatefulForm.sanitizeId({
       prefix: "phonebox",
       name: props.name,
       id: props.id,
-    });
+    })
 
     return (
       <FieldLane
@@ -450,6 +452,9 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
           controlStyle,
           containerStyle,
           labelStyle,
+          helperArrowStyle,
+          helperDrawerStyle,
+          helperIconStyle,
         }}
       >
         <BasePhonebox
@@ -472,16 +477,16 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
           ref={ref}
         />
       </FieldLane>
-    );
-  }
-) as PhoneboxComponent;
+    )
+  },
+) as PhoneboxComponent
 
 const InputWrapper = styled.div<{
-  $hasError?: boolean;
-  $isOpen?: boolean;
-  $disabled?: boolean;
-  $style?: CSSProp;
-  $theme: PhoneboxThemeConfig;
+  $hasError?: boolean
+  $isOpen?: boolean
+  $disabled?: boolean
+  $style?: CSSProp
+  $theme: PhoneboxThemeConfig
 }>`
   *,
   ::before,
@@ -521,14 +526,14 @@ const InputWrapper = styled.div<{
   border-radius: 2px;
 
   ${({ $style }) => $style};
-`;
+`
 
 const CountryButton = styled.button<{
-  $disabled?: boolean;
-  $hasError?: boolean;
-  $style?: CSSProp;
-  $theme?: PhoneboxThemeConfig;
-  $isOpen?: boolean;
+  $disabled?: boolean
+  $hasError?: boolean
+  $style?: CSSProp
+  $theme?: PhoneboxThemeConfig
+  $isOpen?: boolean
 }>`
   display: flex;
   flex-direction: row;
@@ -570,12 +575,12 @@ const CountryButton = styled.button<{
           `}
 
   ${({ $style }) => $style}
-`;
+`
 
 const PhoneInput = styled.input<{
-  $disabled?: boolean;
-  $style?: CSSProp;
-  $theme: PhoneboxThemeConfig;
+  $disabled?: boolean
+  $style?: CSSProp
+  $theme: PhoneboxThemeConfig
 }>`
   width: 100%;
   padding: 0 12px;
@@ -596,11 +601,11 @@ const PhoneInput = styled.input<{
   }
 
   ${({ $style }) => $style}
-`;
+`
 
 function trimPhone(input: string): string {
-  const onlyNumber = input.replace(/[^0-9]/g, "");
-  return onlyNumber.startsWith("0") ? onlyNumber.slice(1) : onlyNumber;
+  const onlyNumber = input.replace(/[^0-9]/g, "")
+  return onlyNumber.startsWith("0") ? onlyNumber.slice(1) : onlyNumber
 }
 
 /**
@@ -618,15 +623,15 @@ function trimPhone(input: string): string {
  */
 function formatPhoneboxNumber(
   phone: string,
-  countryCode: CountryCode = "ID"
+  countryCode: CountryCode = "ID",
 ): string {
   // Keep digits only — no dial code, no +
-  const digits = phone.replace(/\D/g, "");
-  if (!digits) return "";
+  const digits = phone.replace(/\D/g, "")
+  if (!digits) return ""
 
-  return groupDigits(digits, countryCode).replace(/ /g, "-");
+  return groupDigits(digits, countryCode).replace(/ /g, "-")
 }
 
-Phonebox.formatPhoneNumber = formatPhoneboxNumber;
+Phonebox.formatPhoneNumber = formatPhoneboxNumber
 
-export { Phonebox };
+export { Phonebox }

--- a/components/phonebox.tsx
+++ b/components/phonebox.tsx
@@ -7,7 +7,7 @@ import React, {
   useMemo,
   useRef,
   useState,
-} from "react"
+} from "react";
 import {
   useFloating,
   offset,
@@ -17,69 +17,69 @@ import {
   useDismiss,
   useInteractions,
   Placement,
-} from "@floating-ui/react"
-import { RiArrowDownSLine, RiArrowUpSLine } from "@remixicon/react"
-import { COUNTRY_CODES } from "../constants/countries"
-import { CountryCode, groupDigits } from "../lib/phone"
-import styled, { css, CSSProp } from "styled-components"
+} from "@floating-ui/react";
+import { RiArrowDownSLine, RiArrowUpSLine } from "@remixicon/react";
+import { COUNTRY_CODES } from "../constants/countries";
+import { CountryCode, groupDigits } from "../lib/phone";
+import styled, { css, CSSProp } from "styled-components";
 import {
   FieldLane,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane"
-import { Figure } from "./figure"
-import { StatefulForm } from "./stateful-form"
-import { PhoneboxThemeConfig } from "./../theme"
-import { useTheme } from "./../theme/provider"
-import { applyClassName } from "./../constants/classname"
-import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox"
-import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox"
+} from "./field-lane";
+import { Figure } from "./figure";
+import { StatefulForm } from "./stateful-form";
+import { PhoneboxThemeConfig } from "./../theme";
+import { useTheme } from "./../theme/provider";
+import { applyClassName } from "./../constants/classname";
+import { Combobox, ComboboxDrawerProps, ComboboxOption } from "./combobox";
+import { SelectboxOption, SelectboxSelectedOptions } from "./selectbox";
 
 export interface PhoneboxCountryCode {
-  id: string
-  code: string
-  name: string
-  flag: string
+  id: string;
+  code: string;
+  name: string;
+  flag: string;
 }
 
 export type PhoneboxComponent = React.ForwardRefExoticComponent<
   PhoneboxProps & React.RefAttributes<HTMLInputElement>
 > & {
-  formatPhoneNumber: typeof formatPhoneboxNumber
-}
+  formatPhoneNumber: typeof formatPhoneboxNumber;
+};
 
 interface BasePhoneboxProps {
-  label?: string
-  name?: string
-  value?: string
+  label?: string;
+  name?: string;
+  value?: string;
   onChange?: (
     e:
       | { target: { name: string; value: PhoneboxCountryCode } }
-      | ChangeEvent<HTMLInputElement>,
-  ) => void
-  placeholder?: string
-  disabled?: boolean
-  showError?: boolean
-  errorMessage?: string
-  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
-  onBlur?: () => void
-  countryCodeValue?: PhoneboxCountryCode
-  styles?: PhoneboxStyles
-  id?: string
-  required?: boolean
-  mobile?: boolean
-  drawerHeight?: string
+      | ChangeEvent<HTMLInputElement>
+  ) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  showError?: boolean;
+  errorMessage?: string;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+  onBlur?: () => void;
+  countryCodeValue?: PhoneboxCountryCode;
+  styles?: PhoneboxStyles;
+  id?: string;
+  required?: boolean;
+  mobile?: boolean;
+  drawerHeight?: string;
 }
 
 export interface PhoneboxStyles {
-  self?: CSSProp
-  inputWrapperStyle?: CSSProp
-  toggleStyle?: CSSProp
-  drawerStyle?: CSSProp
+  self?: CSSProp;
+  inputWrapperStyle?: CSSProp;
+  toggleStyle?: CSSProp;
+  drawerStyle?: CSSProp;
 }
 
-export type PhoneboxDropdownOption = FieldLaneDropdownOption
+export type PhoneboxDropdownOption = FieldLaneDropdownOption;
 
 const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
   (
@@ -98,30 +98,30 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
       mobile,
       drawerHeight,
     },
-    ref,
+    ref
   ) => {
-    const { currentTheme } = useTheme()
-    const phoneboxTheme = currentTheme?.phonebox
+    const { currentTheme } = useTheme();
+    const phoneboxTheme = currentTheme?.phonebox;
 
-    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES[205]
-    const countryCodeState = countryCodeValue ?? DEFAULT_COUNTRY_CODES
+    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES[205];
+    const countryCodeState = countryCodeValue ?? DEFAULT_COUNTRY_CODES;
 
-    const [isOpen, setIsOpen] = useState(false)
-    const [searchTerm, setSearchTerm] = useState("")
+    const [isOpen, setIsOpen] = useState(false);
+    const [searchTerm, setSearchTerm] = useState("");
     const [selectedCountry, setSelectedCountry] =
-      useState<PhoneboxCountryCode>(countryCodeState)
-    const [phoneNumber, setPhoneNumber] = useState("")
+      useState<PhoneboxCountryCode>(countryCodeState);
+    const [phoneNumber, setPhoneNumber] = useState("");
 
-    const [highlightedIndex, setHighlightedIndex] = useState(0)
+    const [highlightedIndex, setHighlightedIndex] = useState(0);
     const [interactionMode, setInteractionMode] = useState<
       "mouse" | "keyboard"
-    >("keyboard")
-    const [hasInteracted, setHasInteracted] = useState(false)
+    >("keyboard");
+    const [hasInteracted, setHasInteracted] = useState(false);
 
-    const searchInputRef = useRef<HTMLInputElement>(null)
-    const phoneInputRef = useRef<HTMLInputElement>(null)
+    const searchInputRef = useRef<HTMLInputElement>(null);
+    const phoneInputRef = useRef<HTMLInputElement>(null);
 
-    useImperativeHandle(ref, () => phoneInputRef.current!)
+    useImperativeHandle(ref, () => phoneInputRef.current!);
 
     const FINAL_COUNTRY_OPTIONS: ComboboxOption[] = useMemo(
       () =>
@@ -138,25 +138,25 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
             </>
           ),
         })),
-      [],
-    )
+      []
+    );
 
     const FILTERED_COUNTRY_OPTIONS: ComboboxOption[] = useMemo(() => {
-      if (!hasInteracted || !searchTerm) return FINAL_COUNTRY_OPTIONS
+      if (!hasInteracted || !searchTerm) return FINAL_COUNTRY_OPTIONS;
 
-      const search = searchTerm.toLowerCase()
+      const search = searchTerm.toLowerCase();
 
       return FINAL_COUNTRY_OPTIONS.filter((option) => {
         const country = COUNTRY_CODES.find(
-          (country) => country.id === option.value,
-        )
-        if (!country) return false
+          (country) => country.id === option.value
+        );
+        if (!country) return false;
         return (
           country.name.toLowerCase().includes(search) ||
           country.code.includes(searchTerm)
-        )
-      })
-    }, [hasInteracted, searchTerm, FINAL_COUNTRY_OPTIONS])
+        );
+      });
+    }, [hasInteracted, searchTerm, FINAL_COUNTRY_OPTIONS]);
 
     const { refs, floatingStyles, context } = useFloating({
       placement: "bottom-start" as Placement,
@@ -164,98 +164,98 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
       onOpenChange: setIsOpen,
       middleware: [offset(4), flip(), shift()],
       whileElementsMounted: autoUpdate,
-    })
+    });
 
-    const dismiss = useDismiss(context)
-    const { getFloatingProps, getReferenceProps } = useInteractions([dismiss])
+    const dismiss = useDismiss(context);
+    const { getFloatingProps, getReferenceProps } = useInteractions([dismiss]);
 
     useEffect(() => {
       if (!isOpen) {
-        setSearchTerm("")
-        setHighlightedIndex(0)
+        setSearchTerm("");
+        setHighlightedIndex(0);
       }
-    }, [isOpen])
+    }, [isOpen]);
 
     useEffect(() => {
       if (!value) {
-        setPhoneNumber("")
-        return
+        setPhoneNumber("");
+        return;
       }
 
       const formatted = formatPhoneboxNumber(
         value,
-        selectedCountry.id as CountryCode,
-      )
-      setPhoneNumber(formatted)
-    }, [value])
+        selectedCountry.id as CountryCode
+      );
+      setPhoneNumber(formatted);
+    }, [value]);
 
-    const listRef = useRef<(HTMLLIElement | null)[]>([])
+    const listRef = useRef<(HTMLLIElement | null)[]>([]);
 
     // Keep the highlighted option visible while navigating the list.
     useEffect(() => {
       if (isOpen && listRef.current[highlightedIndex]) {
-        listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" })
+        listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });
       }
-    }, [highlightedIndex, isOpen])
+    }, [highlightedIndex, isOpen]);
 
     const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (disabled) return
+      if (disabled) return;
 
-      setInteractionMode("keyboard")
+      setInteractionMode("keyboard");
 
       if (e.key === "ArrowDown") {
-        e.preventDefault()
-        if (!isOpen) await setIsOpen(true)
+        e.preventDefault();
+        if (!isOpen) await setIsOpen(true);
         await setHighlightedIndex((prev) =>
-          Math.min(prev + 1, FILTERED_COUNTRY_OPTIONS.length - 1),
-        )
+          Math.min(prev + 1, FILTERED_COUNTRY_OPTIONS.length - 1)
+        );
       } else if (e.key === "ArrowUp") {
-        e.preventDefault()
-        if (!isOpen) await setIsOpen(true)
-        await setHighlightedIndex((prev) => Math.max(prev - 1, 0))
+        e.preventDefault();
+        if (!isOpen) await setIsOpen(true);
+        await setHighlightedIndex((prev) => Math.max(prev - 1, 0));
       } else if (e.key === "Enter") {
-        e.preventDefault()
-        const selectedOption = FILTERED_COUNTRY_OPTIONS[highlightedIndex]
+        e.preventDefault();
+        const selectedOption = FILTERED_COUNTRY_OPTIONS[highlightedIndex];
         const selectedCountry = COUNTRY_CODES.find(
-          (country) => country.id === selectedOption.value,
-        )
+          (country) => country.id === selectedOption.value
+        );
         if (selectedCountry) {
-          await handleSelectCountry(selectedCountry)
+          await handleSelectCountry(selectedCountry);
         }
       } else if (e.key === "Escape") {
-        e.preventDefault()
-        await setIsOpen(false)
+        e.preventDefault();
+        await setIsOpen(false);
       }
-    }
+    };
 
     const handlePhoneChange = (e: ChangeEvent<HTMLInputElement>) => {
-      if (disabled) return
+      if (disabled) return;
 
-      const raw = e.target.value
-      const trimmed = trimPhone(raw)
+      const raw = e.target.value;
+      const trimmed = trimPhone(raw);
       const formatted = formatPhoneboxNumber(
         trimmed,
-        selectedCountry.id as CountryCode,
-      )
-      setPhoneNumber(formatted)
+        selectedCountry.id as CountryCode
+      );
+      setPhoneNumber(formatted);
       if (onChange) {
         const syntheticEvent = {
           target: {
             name: "phone",
             value: trimmed,
           },
-        } as ChangeEvent<HTMLInputElement>
-        onChange?.(syntheticEvent)
+        } as ChangeEvent<HTMLInputElement>;
+        onChange?.(syntheticEvent);
       }
-    }
+    };
 
     const handleSelectCountry = async (country: PhoneboxCountryCode) => {
-      if (disabled) return
+      if (disabled) return;
 
-      await setSelectedCountry(country)
-      await setIsOpen(false)
-      await setSearchTerm("")
-      await setHighlightedIndex(0)
+      await setSelectedCountry(country);
+      await setIsOpen(false);
+      await setSearchTerm("");
+      await setHighlightedIndex(0);
 
       if (onChange) {
         const syntheticEvent = {
@@ -263,23 +263,23 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
             name: "country_code",
             value: country,
           },
-        }
-        await onChange(syntheticEvent)
+        };
+        await onChange(syntheticEvent);
       }
 
-      phoneInputRef.current?.focus()
-    }
+      phoneInputRef.current?.focus();
+    };
 
     const handleToggleDropdown = () => {
-      if (disabled) return
+      if (disabled) return;
       setIsOpen((prev) => {
-        const newState = !prev
+        const newState = !prev;
         if (newState) {
-          setTimeout(() => searchInputRef.current?.focus(), 0)
+          setTimeout(() => searchInputRef.current?.focus(), 0);
         }
-        return newState
-      })
-    }
+        return newState;
+      });
+    };
 
     return (
       <>
@@ -360,16 +360,16 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
             }}
             onChange={async (selectedOptions?: SelectboxSelectedOptions) => {
               const selectedCountry = await COUNTRY_CODES.find(
-                (country) => country.id === selectedOptions,
-              )
+                (country) => country.id === selectedOptions
+              );
               if (selectedCountry) {
-                await handleSelectCountry(selectedCountry)
+                await handleSelectCountry(selectedCountry);
               }
             }}
             setSelectedOptionsLocal={(
-              selectedOptionsLocal?: SelectboxOption,
+              selectedOptionsLocal?: SelectboxOption
             ) => {
-              setSearchTerm(selectedOptionsLocal?.text)
+              setSearchTerm(selectedOptionsLocal?.text);
             }}
             setHasInteracted={setHasInteracted}
             options={FILTERED_COUNTRY_OPTIONS}
@@ -386,14 +386,14 @@ const BasePhonebox = forwardRef<HTMLInputElement, BasePhoneboxProps>(
           />
         )}
       </>
-    )
-  },
-)
+    );
+  }
+);
 
 export interface PhoneboxProps
   extends Omit<BasePhoneboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "onChange" | "actions"> {
-  styles?: PhoneboxStyles & FieldLaneStyles
+  styles?: PhoneboxStyles & FieldLaneStyles;
 }
 
 const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
@@ -413,7 +413,7 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
       labelPosition,
       className,
       ...rest
-    } = props
+    } = props;
 
     const {
       bodyStyle,
@@ -424,13 +424,13 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
       helperDrawerStyle,
       helperIconStyle,
       ...phoneboxStyle
-    } = styles ?? {}
+    } = styles ?? {};
 
     const inputId = StatefulForm.sanitizeId({
       prefix: "phonebox",
       name: props.name,
       id: props.id,
-    })
+    });
 
     return (
       <FieldLane
@@ -477,16 +477,16 @@ const Phonebox = forwardRef<HTMLInputElement, PhoneboxProps>(
           ref={ref}
         />
       </FieldLane>
-    )
-  },
-) as PhoneboxComponent
+    );
+  }
+) as PhoneboxComponent;
 
 const InputWrapper = styled.div<{
-  $hasError?: boolean
-  $isOpen?: boolean
-  $disabled?: boolean
-  $style?: CSSProp
-  $theme: PhoneboxThemeConfig
+  $hasError?: boolean;
+  $isOpen?: boolean;
+  $disabled?: boolean;
+  $style?: CSSProp;
+  $theme: PhoneboxThemeConfig;
 }>`
   *,
   ::before,
@@ -526,14 +526,14 @@ const InputWrapper = styled.div<{
   border-radius: 2px;
 
   ${({ $style }) => $style};
-`
+`;
 
 const CountryButton = styled.button<{
-  $disabled?: boolean
-  $hasError?: boolean
-  $style?: CSSProp
-  $theme?: PhoneboxThemeConfig
-  $isOpen?: boolean
+  $disabled?: boolean;
+  $hasError?: boolean;
+  $style?: CSSProp;
+  $theme?: PhoneboxThemeConfig;
+  $isOpen?: boolean;
 }>`
   display: flex;
   flex-direction: row;
@@ -575,12 +575,12 @@ const CountryButton = styled.button<{
           `}
 
   ${({ $style }) => $style}
-`
+`;
 
 const PhoneInput = styled.input<{
-  $disabled?: boolean
-  $style?: CSSProp
-  $theme: PhoneboxThemeConfig
+  $disabled?: boolean;
+  $style?: CSSProp;
+  $theme: PhoneboxThemeConfig;
 }>`
   width: 100%;
   padding: 0 12px;
@@ -601,11 +601,11 @@ const PhoneInput = styled.input<{
   }
 
   ${({ $style }) => $style}
-`
+`;
 
 function trimPhone(input: string): string {
-  const onlyNumber = input.replace(/[^0-9]/g, "")
-  return onlyNumber.startsWith("0") ? onlyNumber.slice(1) : onlyNumber
+  const onlyNumber = input.replace(/[^0-9]/g, "");
+  return onlyNumber.startsWith("0") ? onlyNumber.slice(1) : onlyNumber;
 }
 
 /**
@@ -623,15 +623,15 @@ function trimPhone(input: string): string {
  */
 function formatPhoneboxNumber(
   phone: string,
-  countryCode: CountryCode = "ID",
+  countryCode: CountryCode = "ID"
 ): string {
   // Keep digits only — no dial code, no +
-  const digits = phone.replace(/\D/g, "")
-  if (!digits) return ""
+  const digits = phone.replace(/\D/g, "");
+  if (!digits) return "";
 
-  return groupDigits(digits, countryCode).replace(/ /g, "-")
+  return groupDigits(digits, countryCode).replace(/ /g, "-");
 }
 
-Phonebox.formatPhoneNumber = formatPhoneboxNumber
+Phonebox.formatPhoneNumber = formatPhoneboxNumber;
 
-export { Phonebox }
+export { Phonebox };

--- a/components/pinbox.tsx
+++ b/components/pinbox.tsx
@@ -1,46 +1,46 @@
-import { RiErrorWarningLine } from "@remixicon/react"
+import { RiErrorWarningLine } from "@remixicon/react";
 import React, {
   ChangeEvent,
   forwardRef,
   useEffect,
   useRef,
   useState,
-} from "react"
-import styled, { css, CSSProp } from "styled-components"
-import { StatefulForm } from "./stateful-form"
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
-import { useTheme } from "./../theme/provider"
-import { PinboxThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
+} from "react";
+import styled, { css, CSSProp } from "styled-components";
+import { StatefulForm } from "./stateful-form";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
+import { useTheme } from "./../theme/provider";
+import { PinboxThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 
 interface BasePinboxProps {
-  fontSize?: number
-  label?: string
-  showError?: boolean
-  errorMessage?: string
-  masked?: boolean
-  parts?: PinboxParts[]
-  name?: string
-  onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
-  onBlur?: () => void
-  value?: string
-  disabled?: boolean
-  id?: string
-  showIconError?: boolean
-  required?: boolean
-  styles?: BasePinboxStyles
+  fontSize?: number;
+  label?: string;
+  showError?: boolean;
+  errorMessage?: string;
+  masked?: boolean;
+  parts?: PinboxParts[];
+  name?: string;
+  onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onBlur?: () => void;
+  value?: string;
+  disabled?: boolean;
+  id?: string;
+  showIconError?: boolean;
+  required?: boolean;
+  styles?: BasePinboxStyles;
 }
 
 interface BasePinboxStyles {
-  self?: CSSProp
+  self?: CSSProp;
 }
 
 export interface PinboxParts {
-  type?: PinboxTypeState
-  text?: string
+  type?: PinboxTypeState;
+  text?: string;
 }
 
-type PinboxTypeState = "static" | "digit" | "alphabet" | "alphanumeric"
+type PinboxTypeState = "static" | "digit" | "alphabet" | "alphanumeric";
 
 const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
   (
@@ -60,16 +60,16 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
       styles,
       showIconError = true,
     },
-    ref,
+    ref
   ) => {
-    const { currentTheme } = useTheme()
-    const pinboxTheme = currentTheme?.pinbox
+    const { currentTheme } = useTheme();
+    const pinboxTheme = currentTheme?.pinbox;
 
     const getDefaultValue = () => {
-      let valIndex = 0
+      let valIndex = 0;
       return parts.map((p) => {
         if (p.type === "static") {
-          return p.text ?? ""
+          return p.text ?? "";
         }
 
         while (
@@ -77,70 +77,70 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
           valIndex < value.length &&
           parts[valIndex]?.type === "static"
         ) {
-          valIndex++
+          valIndex++;
         }
 
-        const char = value?.[valIndex] ?? ""
-        valIndex++
-        return char.toUpperCase()
-      })
-    }
+        const char = value?.[valIndex] ?? "";
+        valIndex++;
+        return char.toUpperCase();
+      });
+    };
 
-    const [valueLocal, setValueLocal] = useState<string[]>(getDefaultValue())
+    const [valueLocal, setValueLocal] = useState<string[]>(getDefaultValue());
 
-    const inputsRef = useRef<(HTMLInputElement | null)[]>([])
-    const [maskedIndices, setMaskedIndices] = useState<Set<number>>(new Set())
+    const inputsRef = useRef<(HTMLInputElement | null)[]>([]);
+    const [maskedIndices, setMaskedIndices] = useState<Set<number>>(new Set());
     const maskTimeoutsRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(
-      new Map(),
-    )
+      new Map()
+    );
 
-    const wrapperRef = useRef<HTMLDivElement>(null)
+    const wrapperRef = useRef<HTMLDivElement>(null);
 
     const handleBlurCapture = (e: React.FocusEvent) => {
-      const next = e.relatedTarget as Node
+      const next = e.relatedTarget as Node;
 
       if (!wrapperRef.current?.contains(next)) {
-        onBlur?.()
+        onBlur?.();
       }
-    }
+    };
 
     const moveToNextInput = (currentIndex: number) => {
-      let nextIndex = currentIndex + 1
+      let nextIndex = currentIndex + 1;
       while (parts[nextIndex] && parts[nextIndex].type === "static") {
-        nextIndex++
+        nextIndex++;
       }
       if (parts[nextIndex]) {
-        inputsRef.current[nextIndex]?.focus()
+        inputsRef.current[nextIndex]?.focus();
       }
-    }
+    };
 
     const moveToPrevInput = (currentIndex: number) => {
-      let prevIndex = currentIndex - 1
+      let prevIndex = currentIndex - 1;
       while (parts[prevIndex] && parts[prevIndex].type === "static") {
-        prevIndex--
+        prevIndex--;
       }
       if (inputsRef.current[prevIndex]) {
-        inputsRef.current[prevIndex]?.focus()
+        inputsRef.current[prevIndex]?.focus();
       }
-    }
+    };
 
     useEffect(() => {
       return () => {
-        maskTimeoutsRef.current.forEach((timeout) => clearTimeout(timeout))
-      }
-    }, [])
+        maskTimeoutsRef.current.forEach((timeout) => clearTimeout(timeout));
+      };
+    }, []);
 
     /** Check whether a character is valid for a given part type */
     const isCharValidForType = (
       char: string,
-      type: PinboxTypeState,
+      type: PinboxTypeState
     ): boolean => {
-      if (type === "static") return false
-      if (type === "digit") return /^[0-9]$/.test(char)
-      if (type === "alphabet") return /^[A-Za-z]$/.test(char)
-      if (type === "alphanumeric") return /^[A-Za-z0-9]$/.test(char)
-      return true
-    }
+      if (type === "static") return false;
+      if (type === "digit") return /^[0-9]$/.test(char);
+      if (type === "alphabet") return /^[A-Za-z]$/.test(char);
+      if (type === "alphanumeric") return /^[A-Za-z0-9]$/.test(char);
+      return true;
+    };
 
     /**
      * Handle paste event on any input box.
@@ -149,114 +149,114 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
      */
     const handlePaste = (
       e: React.ClipboardEvent<HTMLInputElement>,
-      startIndex: number,
+      startIndex: number
     ) => {
-      e.preventDefault()
+      e.preventDefault();
 
-      const pasted = e.clipboardData.getData("text")
-      if (!pasted) return
+      const pasted = e.clipboardData.getData("text");
+      if (!pasted) return;
 
-      const finalValue = [...valueLocal]
-      let pastePos = 0
+      const finalValue = [...valueLocal];
+      let pastePos = 0;
 
       // Walk parts from startIndex, aligning pasted chars.
       // For static parts: if the pasted string includes the static char (case-insensitive),
       // consume it. If it omits it (e.g. pasting "A2DL" skipping the leading "S"),
       // just skip the static slot without consuming a pasted char.
       // Either way, a mismatch where the user pastes a *different* char in a static slot aborts.
-      let index = startIndex
+      let index = startIndex;
 
       while (index < parts.length && pastePos < pasted.length) {
-        const part = parts[index]
+        const part = parts[index];
 
         if (part.type === "static") {
-          const pastedChar = pasted[pastePos]
-          const staticChar = part.text ?? ""
+          const pastedChar = pasted[pastePos];
+          const staticChar = part.text ?? "";
 
           if (pastedChar.toUpperCase() === staticChar.toUpperCase()) {
             // Pasted string includes the static char — consume it and move on.
-            pastePos++
+            pastePos++;
           }
           // Static slot is always skipped regardless.
-          index++
-          continue
+          index++;
+          continue;
         }
 
-        const char = pasted[pastePos]
+        const char = pasted[pastePos];
         if (isCharValidForType(char, part.type!)) {
           const normalized =
             part.type === "alphabet" || part.type === "alphanumeric"
               ? char.toUpperCase()
-              : char
-          finalValue[index] = normalized
+              : char;
+          finalValue[index] = normalized;
 
           if (masked) {
-            const existingTimeout = maskTimeoutsRef.current.get(index)
-            if (existingTimeout) clearTimeout(existingTimeout)
+            const existingTimeout = maskTimeoutsRef.current.get(index);
+            if (existingTimeout) clearTimeout(existingTimeout);
 
             setMaskedIndices((prev) => {
-              const next = new Set(prev)
-              next.delete(index)
-              return next
-            })
+              const next = new Set(prev);
+              next.delete(index);
+              return next;
+            });
 
             const timeout = setTimeout(() => {
               setMaskedIndices((prev) => {
-                const next = new Set(prev)
-                next.add(index)
-                return next
-              })
-              maskTimeoutsRef.current.delete(index)
-            }, 500)
+                const next = new Set(prev);
+                next.add(index);
+                return next;
+              });
+              maskTimeoutsRef.current.delete(index);
+            }, 500);
 
-            maskTimeoutsRef.current.set(index, timeout)
+            maskTimeoutsRef.current.set(index, timeout);
           }
 
-          pastePos++
-          index++
+          pastePos++;
+          index++;
         } else {
           // Invalid char for this editable slot — drop it and retry with the
           // next pasted char, staying on the same slot.
-          pastePos++
+          pastePos++;
         }
       }
 
-      setValueLocal(finalValue)
+      setValueLocal(finalValue);
 
       // Focus the next unfilled editable slot after the paste.
-      while (index < parts.length && parts[index].type === "static") index++
-      if (index < parts.length) inputsRef.current[index]?.focus()
+      while (index < parts.length && parts[index].type === "static") index++;
+      if (index < parts.length) inputsRef.current[index]?.focus();
 
       if (onChange) {
         onChange({
           target: { name, value: finalValue.join("") },
-        } as ChangeEvent<HTMLInputElement>)
+        } as ChangeEvent<HTMLInputElement>);
       }
-    }
+    };
 
     const handleKeyDown = (
       e: React.KeyboardEvent<HTMLInputElement>,
-      index: number,
+      index: number
     ) => {
-      const key = e.key
-      const type = parts[index].type
+      const key = e.key;
+      const type = parts[index].type;
 
       if (type === "static") {
         const isSystemShortcut =
-          (e.ctrlKey || e.metaKey) && ["v", "a"].includes(key.toLowerCase())
-        if (isSystemShortcut) return
-        if (key === "ArrowLeft") moveToPrevInput(index)
-        if (key === "Backspace") moveToPrevInput(index)
-        if (key === "ArrowRight") moveToNextInput(index)
-        if (key === "Tab") moveToNextInput(index)
-        e.preventDefault()
-        return
+          (e.ctrlKey || e.metaKey) && ["v", "a"].includes(key.toLowerCase());
+        if (isSystemShortcut) return;
+        if (key === "ArrowLeft") moveToPrevInput(index);
+        if (key === "Backspace") moveToPrevInput(index);
+        if (key === "ArrowRight") moveToNextInput(index);
+        if (key === "Tab") moveToNextInput(index);
+        e.preventDefault();
+        return;
       }
 
       // Allow browser paste (Ctrl+V / Meta+V) and select-all (Ctrl+A) to
       // pass through so the native onPaste event fires correctly.
       const isSystemShortcut =
-        (e.ctrlKey || e.metaKey) && ["v", "a"].includes(key.toLowerCase())
+        (e.ctrlKey || e.metaKey) && ["v", "a"].includes(key.toLowerCase());
 
       if (
         type === "digit" &&
@@ -264,8 +264,8 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
         !["Backspace", "Tab", "ArrowLeft", "ArrowRight"].includes(key) &&
         !isSystemShortcut
       ) {
-        e.preventDefault()
-        return
+        e.preventDefault();
+        return;
       }
       if (
         type === "alphabet" &&
@@ -273,8 +273,8 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
         !["Backspace", "Tab", "ArrowLeft", "ArrowRight"].includes(key) &&
         !isSystemShortcut
       ) {
-        e.preventDefault()
-        return
+        e.preventDefault();
+        return;
       }
       if (
         type === "alphanumeric" &&
@@ -282,99 +282,99 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
         !["Backspace", "Tab", "ArrowLeft", "ArrowRight"].includes(key) &&
         !isSystemShortcut
       ) {
-        e.preventDefault()
-        return
+        e.preventDefault();
+        return;
       }
 
       if (key.length === 1 && !e.ctrlKey && !e.metaKey) {
-        e.preventDefault()
-        updateValue(index, key)
-        moveToNextInput(index)
+        e.preventDefault();
+        updateValue(index, key);
+        moveToNextInput(index);
       }
 
       if (key === "Backspace") {
         if (valueLocal[index]) {
-          updateValue(index, "")
+          updateValue(index, "");
         } else {
-          moveToPrevInput(index)
+          moveToPrevInput(index);
         }
       }
 
       if (key === "Tab" && !e.shiftKey) {
-        e.preventDefault()
-        moveToNextInput(index)
+        e.preventDefault();
+        moveToNextInput(index);
       }
 
       if (key === "Tab" && e.shiftKey) {
-        e.preventDefault()
-        moveToPrevInput(index)
+        e.preventDefault();
+        moveToPrevInput(index);
       }
 
       if (key === "ArrowLeft") {
-        moveToPrevInput(index)
+        moveToPrevInput(index);
       }
 
       if (key === "ArrowRight") {
-        moveToNextInput(index)
+        moveToNextInput(index);
       }
-    }
+    };
 
     const updateValue = (index: number, newChar: string) => {
-      const type = parts[index].type
+      const type = parts[index].type;
       if (type === "alphabet" || type === "alphanumeric") {
         if (/[a-z]/.test(newChar)) {
-          newChar = newChar.toUpperCase()
+          newChar = newChar.toUpperCase();
         }
       }
 
-      const finalValue = [...valueLocal]
-      finalValue[index] = newChar
-      setValueLocal(finalValue)
+      const finalValue = [...valueLocal];
+      finalValue[index] = newChar;
+      setValueLocal(finalValue);
 
       if (masked && newChar) {
-        const existingTimeout = maskTimeoutsRef.current.get(index)
+        const existingTimeout = maskTimeoutsRef.current.get(index);
         if (existingTimeout) {
-          clearTimeout(existingTimeout)
+          clearTimeout(existingTimeout);
         }
 
         setMaskedIndices((prev) => {
-          const newSet = new Set(prev)
-          newSet.delete(index)
-          return newSet
-        })
+          const newSet = new Set(prev);
+          newSet.delete(index);
+          return newSet;
+        });
 
         const timeout = setTimeout(() => {
           setMaskedIndices((prev) => {
-            const newSet = new Set(prev)
-            newSet.add(index)
-            return newSet
-          })
-          maskTimeoutsRef.current.delete(index)
-        }, 500)
+            const newSet = new Set(prev);
+            newSet.add(index);
+            return newSet;
+          });
+          maskTimeoutsRef.current.delete(index);
+        }, 500);
 
-        maskTimeoutsRef.current.set(index, timeout)
+        maskTimeoutsRef.current.set(index, timeout);
       }
 
       const outputValue = finalValue
         .map((char, i) => (parts[i].type === "static" ? char : char))
-        .join("")
+        .join("");
 
       if (onChange) {
         onChange({
           target: { name, value: outputValue },
-        } as ChangeEvent<HTMLInputElement>)
+        } as ChangeEvent<HTMLInputElement>);
       }
-    }
+    };
 
     const getDisplayChar = (index: number) => {
-      const char = valueLocal[index] || ""
+      const char = valueLocal[index] || "";
 
       if (!masked || !char || parts[index].type === "static") {
-        return char
+        return char;
       }
 
-      return maskedIndices.has(index) ? "•" : char
-    }
+      return maskedIndices.has(index) ? "•" : char;
+    };
 
     return (
       <PinboxInputWrapper
@@ -383,18 +383,20 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
         $disabled={disabled}
       >
         {parts.map((part, index) => {
-          const isStatic = part.type === "static"
+          const isStatic = part.type === "static";
 
-          const displayChar = getDisplayChar(index)
-          const { type, pattern } = switchInputBox(part.type)
+          const displayChar = getDisplayChar(index);
+          const { type, pattern } = switchInputBox(part.type);
           const isAnimate = Boolean(
             masked &&
               !isStatic &&
               !maskedIndices.has(index) &&
-              valueLocal[index],
-          )
+              valueLocal[index]
+          );
 
-          const firstEditableIndex = parts.findIndex((p) => p.type !== "static")
+          const firstEditableIndex = parts.findIndex(
+            (p) => p.type !== "static"
+          );
 
           return (
             <PinboxInputContent
@@ -410,14 +412,14 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
                 $error={showError}
                 $style={styles?.self}
                 ref={(el: HTMLInputElement) => {
-                  inputsRef.current[index] = el
+                  inputsRef.current[index] = el;
 
                   if (index === 0 && typeof ref === "function") {
-                    ref(el)
+                    ref(el);
                   } else if (index === 0 && ref) {
-                    ;(
+                    (
                       ref as React.MutableRefObject<HTMLInputElement | null>
-                    ).current = el
+                    ).current = el;
                   }
                 }}
                 onPaste={(e) => handlePaste(e, index)}
@@ -439,7 +441,7 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
                 $error={showError}
               />
             </PinboxInputContent>
-          )
+          );
         })}
         {showError && errorMessage && showIconError && (
           <RiErrorWarningLine
@@ -454,16 +456,16 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
           />
         )}
       </PinboxInputWrapper>
-    )
-  },
-)
+    );
+  }
+);
 
-export type PinboxStyles = BasePinboxStyles & FieldLaneStyles
+export type PinboxStyles = BasePinboxStyles & FieldLaneStyles;
 
 export interface PinboxProps
   extends Omit<BasePinboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: PinboxStyles
+  styles?: PinboxStyles;
 }
 
 const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
@@ -483,13 +485,13 @@ const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
       className,
       ...rest
     },
-    ref,
+    ref
   ) => {
     const inputId = StatefulForm.sanitizeId({
       prefix: "pinbox",
       name,
       id,
-    })
+    });
 
     const {
       bodyStyle,
@@ -500,7 +502,7 @@ const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
       helperDrawerStyle,
       helperIconStyle,
       ...pinboxStyles
-    } = styles ?? {}
+    } = styles ?? {};
 
     return (
       <FieldLane
@@ -537,9 +539,9 @@ const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
           label={label}
         />
       </FieldLane>
-    )
-  },
-)
+    );
+  }
+);
 
 const PinboxInputWrapper = styled.div<{ $disabled?: boolean }>`
   display: flex;
@@ -557,11 +559,11 @@ const PinboxInputWrapper = styled.div<{ $disabled?: boolean }>`
       user-select: none;
       cursor: not-allowed;
     `}
-`
+`;
 
 const PinboxInputContent = styled.div<{
-  $fontSize?: number
-  $isStatic?: boolean
+  $fontSize?: number;
+  $isStatic?: boolean;
 }>`
   ${({ $fontSize }) =>
     $fontSize &&
@@ -572,11 +574,11 @@ const PinboxInputContent = styled.div<{
 
   display: flex;
   position: relative;
-`
+`;
 
 const PinboxIndicator = styled.div<{
-  $error?: boolean
-  $theme: PinboxThemeConfig
+  $error?: boolean;
+  $theme: PinboxThemeConfig;
 }>`
   width: 70%;
   bottom: 3px;
@@ -591,15 +593,15 @@ const PinboxIndicator = styled.div<{
   color: ${({ $theme, $error }) =>
     $error ? $theme.errorTextColor : $theme.textColor};
   z-index: 9999;
-`
+`;
 
 const PinboxInput = styled.input<{
-  $fontSize?: number
-  $error?: boolean
-  $isStatic?: boolean
-  $isAnimate?: boolean
-  $theme: PinboxThemeConfig
-  $style?: CSSProp
+  $fontSize?: number;
+  $error?: boolean;
+  $isStatic?: boolean;
+  $isAnimate?: boolean;
+  $theme: PinboxThemeConfig;
+  $style?: CSSProp;
 }>`
   ${({ $fontSize, $isStatic }) =>
     $isStatic
@@ -667,38 +669,38 @@ const PinboxInput = styled.input<{
         `};
 
   ${({ $style }) => $style}
-`
+`;
 
 const switchInputBox = (type: PinboxTypeState) => {
   switch (type) {
     case "static":
       return {
         type: "text",
-      }
+      };
 
     case "digit":
       return {
         type: "tel",
         pattern: "[0-9]",
-      }
+      };
 
     case "alphabet":
       return {
         type: "text",
         pattern: "[A-Za-z]",
-      }
+      };
 
     case "alphanumeric":
       return {
         type: "text",
         pattern: "[A-Za-z0-9]",
-      }
+      };
 
     default:
       return {
         type: "text",
-      }
+      };
   }
-}
+};
 
-export { Pinbox }
+export { Pinbox };

--- a/components/pinbox.tsx
+++ b/components/pinbox.tsx
@@ -1,47 +1,46 @@
-import { RiErrorWarningLine } from "@remixicon/react";
+import { RiErrorWarningLine } from "@remixicon/react"
 import React, {
   ChangeEvent,
   forwardRef,
   useEffect,
   useRef,
   useState,
-} from "react";
-import styled, { css, CSSProp } from "styled-components";
-import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { useTheme } from "./../theme/provider";
-import { PinboxThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
+} from "react"
+import styled, { css, CSSProp } from "styled-components"
+import { StatefulForm } from "./stateful-form"
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
+import { useTheme } from "./../theme/provider"
+import { PinboxThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
 
 interface BasePinboxProps {
-  fontSize?: number;
-  label?: string;
-  helper?: string;
-  showError?: boolean;
-  errorMessage?: string;
-  masked?: boolean;
-  parts?: PinboxParts[];
-  name?: string;
-  onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
-  onBlur?: () => void;
-  value?: string;
-  disabled?: boolean;
-  id?: string;
-  showIconError?: boolean;
-  required?: boolean;
-  styles?: BasePinboxStyles;
+  fontSize?: number
+  label?: string
+  showError?: boolean
+  errorMessage?: string
+  masked?: boolean
+  parts?: PinboxParts[]
+  name?: string
+  onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
+  onBlur?: () => void
+  value?: string
+  disabled?: boolean
+  id?: string
+  showIconError?: boolean
+  required?: boolean
+  styles?: BasePinboxStyles
 }
 
 interface BasePinboxStyles {
-  self?: CSSProp;
+  self?: CSSProp
 }
 
 export interface PinboxParts {
-  type?: PinboxTypeState;
-  text?: string;
+  type?: PinboxTypeState
+  text?: string
 }
 
-type PinboxTypeState = "static" | "digit" | "alphabet" | "alphanumeric";
+type PinboxTypeState = "static" | "digit" | "alphabet" | "alphanumeric"
 
 const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
   (
@@ -61,16 +60,16 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
       styles,
       showIconError = true,
     },
-    ref
+    ref,
   ) => {
-    const { currentTheme } = useTheme();
-    const pinboxTheme = currentTheme?.pinbox;
+    const { currentTheme } = useTheme()
+    const pinboxTheme = currentTheme?.pinbox
 
     const getDefaultValue = () => {
-      let valIndex = 0;
+      let valIndex = 0
       return parts.map((p) => {
         if (p.type === "static") {
-          return p.text ?? "";
+          return p.text ?? ""
         }
 
         while (
@@ -78,70 +77,70 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
           valIndex < value.length &&
           parts[valIndex]?.type === "static"
         ) {
-          valIndex++;
+          valIndex++
         }
 
-        const char = value?.[valIndex] ?? "";
-        valIndex++;
-        return char.toUpperCase();
-      });
-    };
+        const char = value?.[valIndex] ?? ""
+        valIndex++
+        return char.toUpperCase()
+      })
+    }
 
-    const [valueLocal, setValueLocal] = useState<string[]>(getDefaultValue());
+    const [valueLocal, setValueLocal] = useState<string[]>(getDefaultValue())
 
-    const inputsRef = useRef<(HTMLInputElement | null)[]>([]);
-    const [maskedIndices, setMaskedIndices] = useState<Set<number>>(new Set());
+    const inputsRef = useRef<(HTMLInputElement | null)[]>([])
+    const [maskedIndices, setMaskedIndices] = useState<Set<number>>(new Set())
     const maskTimeoutsRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(
-      new Map()
-    );
+      new Map(),
+    )
 
-    const wrapperRef = useRef<HTMLDivElement>(null);
+    const wrapperRef = useRef<HTMLDivElement>(null)
 
     const handleBlurCapture = (e: React.FocusEvent) => {
-      const next = e.relatedTarget as Node;
+      const next = e.relatedTarget as Node
 
       if (!wrapperRef.current?.contains(next)) {
-        onBlur?.();
+        onBlur?.()
       }
-    };
+    }
 
     const moveToNextInput = (currentIndex: number) => {
-      let nextIndex = currentIndex + 1;
+      let nextIndex = currentIndex + 1
       while (parts[nextIndex] && parts[nextIndex].type === "static") {
-        nextIndex++;
+        nextIndex++
       }
       if (parts[nextIndex]) {
-        inputsRef.current[nextIndex]?.focus();
+        inputsRef.current[nextIndex]?.focus()
       }
-    };
+    }
 
     const moveToPrevInput = (currentIndex: number) => {
-      let prevIndex = currentIndex - 1;
+      let prevIndex = currentIndex - 1
       while (parts[prevIndex] && parts[prevIndex].type === "static") {
-        prevIndex--;
+        prevIndex--
       }
       if (inputsRef.current[prevIndex]) {
-        inputsRef.current[prevIndex]?.focus();
+        inputsRef.current[prevIndex]?.focus()
       }
-    };
+    }
 
     useEffect(() => {
       return () => {
-        maskTimeoutsRef.current.forEach((timeout) => clearTimeout(timeout));
-      };
-    }, []);
+        maskTimeoutsRef.current.forEach((timeout) => clearTimeout(timeout))
+      }
+    }, [])
 
     /** Check whether a character is valid for a given part type */
     const isCharValidForType = (
       char: string,
-      type: PinboxTypeState
+      type: PinboxTypeState,
     ): boolean => {
-      if (type === "static") return false;
-      if (type === "digit") return /^[0-9]$/.test(char);
-      if (type === "alphabet") return /^[A-Za-z]$/.test(char);
-      if (type === "alphanumeric") return /^[A-Za-z0-9]$/.test(char);
-      return true;
-    };
+      if (type === "static") return false
+      if (type === "digit") return /^[0-9]$/.test(char)
+      if (type === "alphabet") return /^[A-Za-z]$/.test(char)
+      if (type === "alphanumeric") return /^[A-Za-z0-9]$/.test(char)
+      return true
+    }
 
     /**
      * Handle paste event on any input box.
@@ -150,114 +149,114 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
      */
     const handlePaste = (
       e: React.ClipboardEvent<HTMLInputElement>,
-      startIndex: number
+      startIndex: number,
     ) => {
-      e.preventDefault();
+      e.preventDefault()
 
-      const pasted = e.clipboardData.getData("text");
-      if (!pasted) return;
+      const pasted = e.clipboardData.getData("text")
+      if (!pasted) return
 
-      const finalValue = [...valueLocal];
-      let pastePos = 0;
+      const finalValue = [...valueLocal]
+      let pastePos = 0
 
       // Walk parts from startIndex, aligning pasted chars.
       // For static parts: if the pasted string includes the static char (case-insensitive),
       // consume it. If it omits it (e.g. pasting "A2DL" skipping the leading "S"),
       // just skip the static slot without consuming a pasted char.
       // Either way, a mismatch where the user pastes a *different* char in a static slot aborts.
-      let index = startIndex;
+      let index = startIndex
 
       while (index < parts.length && pastePos < pasted.length) {
-        const part = parts[index];
+        const part = parts[index]
 
         if (part.type === "static") {
-          const pastedChar = pasted[pastePos];
-          const staticChar = part.text ?? "";
+          const pastedChar = pasted[pastePos]
+          const staticChar = part.text ?? ""
 
           if (pastedChar.toUpperCase() === staticChar.toUpperCase()) {
             // Pasted string includes the static char — consume it and move on.
-            pastePos++;
+            pastePos++
           }
           // Static slot is always skipped regardless.
-          index++;
-          continue;
+          index++
+          continue
         }
 
-        const char = pasted[pastePos];
+        const char = pasted[pastePos]
         if (isCharValidForType(char, part.type!)) {
           const normalized =
             part.type === "alphabet" || part.type === "alphanumeric"
               ? char.toUpperCase()
-              : char;
-          finalValue[index] = normalized;
+              : char
+          finalValue[index] = normalized
 
           if (masked) {
-            const existingTimeout = maskTimeoutsRef.current.get(index);
-            if (existingTimeout) clearTimeout(existingTimeout);
+            const existingTimeout = maskTimeoutsRef.current.get(index)
+            if (existingTimeout) clearTimeout(existingTimeout)
 
             setMaskedIndices((prev) => {
-              const next = new Set(prev);
-              next.delete(index);
-              return next;
-            });
+              const next = new Set(prev)
+              next.delete(index)
+              return next
+            })
 
             const timeout = setTimeout(() => {
               setMaskedIndices((prev) => {
-                const next = new Set(prev);
-                next.add(index);
-                return next;
-              });
-              maskTimeoutsRef.current.delete(index);
-            }, 500);
+                const next = new Set(prev)
+                next.add(index)
+                return next
+              })
+              maskTimeoutsRef.current.delete(index)
+            }, 500)
 
-            maskTimeoutsRef.current.set(index, timeout);
+            maskTimeoutsRef.current.set(index, timeout)
           }
 
-          pastePos++;
-          index++;
+          pastePos++
+          index++
         } else {
           // Invalid char for this editable slot — drop it and retry with the
           // next pasted char, staying on the same slot.
-          pastePos++;
+          pastePos++
         }
       }
 
-      setValueLocal(finalValue);
+      setValueLocal(finalValue)
 
       // Focus the next unfilled editable slot after the paste.
-      while (index < parts.length && parts[index].type === "static") index++;
-      if (index < parts.length) inputsRef.current[index]?.focus();
+      while (index < parts.length && parts[index].type === "static") index++
+      if (index < parts.length) inputsRef.current[index]?.focus()
 
       if (onChange) {
         onChange({
           target: { name, value: finalValue.join("") },
-        } as ChangeEvent<HTMLInputElement>);
+        } as ChangeEvent<HTMLInputElement>)
       }
-    };
+    }
 
     const handleKeyDown = (
       e: React.KeyboardEvent<HTMLInputElement>,
-      index: number
+      index: number,
     ) => {
-      const key = e.key;
-      const type = parts[index].type;
+      const key = e.key
+      const type = parts[index].type
 
       if (type === "static") {
         const isSystemShortcut =
-          (e.ctrlKey || e.metaKey) && ["v", "a"].includes(key.toLowerCase());
-        if (isSystemShortcut) return;
-        if (key === "ArrowLeft") moveToPrevInput(index);
-        if (key === "Backspace") moveToPrevInput(index);
-        if (key === "ArrowRight") moveToNextInput(index);
-        if (key === "Tab") moveToNextInput(index);
-        e.preventDefault();
-        return;
+          (e.ctrlKey || e.metaKey) && ["v", "a"].includes(key.toLowerCase())
+        if (isSystemShortcut) return
+        if (key === "ArrowLeft") moveToPrevInput(index)
+        if (key === "Backspace") moveToPrevInput(index)
+        if (key === "ArrowRight") moveToNextInput(index)
+        if (key === "Tab") moveToNextInput(index)
+        e.preventDefault()
+        return
       }
 
       // Allow browser paste (Ctrl+V / Meta+V) and select-all (Ctrl+A) to
       // pass through so the native onPaste event fires correctly.
       const isSystemShortcut =
-        (e.ctrlKey || e.metaKey) && ["v", "a"].includes(key.toLowerCase());
+        (e.ctrlKey || e.metaKey) && ["v", "a"].includes(key.toLowerCase())
 
       if (
         type === "digit" &&
@@ -265,8 +264,8 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
         !["Backspace", "Tab", "ArrowLeft", "ArrowRight"].includes(key) &&
         !isSystemShortcut
       ) {
-        e.preventDefault();
-        return;
+        e.preventDefault()
+        return
       }
       if (
         type === "alphabet" &&
@@ -274,8 +273,8 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
         !["Backspace", "Tab", "ArrowLeft", "ArrowRight"].includes(key) &&
         !isSystemShortcut
       ) {
-        e.preventDefault();
-        return;
+        e.preventDefault()
+        return
       }
       if (
         type === "alphanumeric" &&
@@ -283,99 +282,99 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
         !["Backspace", "Tab", "ArrowLeft", "ArrowRight"].includes(key) &&
         !isSystemShortcut
       ) {
-        e.preventDefault();
-        return;
+        e.preventDefault()
+        return
       }
 
       if (key.length === 1 && !e.ctrlKey && !e.metaKey) {
-        e.preventDefault();
-        updateValue(index, key);
-        moveToNextInput(index);
+        e.preventDefault()
+        updateValue(index, key)
+        moveToNextInput(index)
       }
 
       if (key === "Backspace") {
         if (valueLocal[index]) {
-          updateValue(index, "");
+          updateValue(index, "")
         } else {
-          moveToPrevInput(index);
+          moveToPrevInput(index)
         }
       }
 
       if (key === "Tab" && !e.shiftKey) {
-        e.preventDefault();
-        moveToNextInput(index);
+        e.preventDefault()
+        moveToNextInput(index)
       }
 
       if (key === "Tab" && e.shiftKey) {
-        e.preventDefault();
-        moveToPrevInput(index);
+        e.preventDefault()
+        moveToPrevInput(index)
       }
 
       if (key === "ArrowLeft") {
-        moveToPrevInput(index);
+        moveToPrevInput(index)
       }
 
       if (key === "ArrowRight") {
-        moveToNextInput(index);
+        moveToNextInput(index)
       }
-    };
+    }
 
     const updateValue = (index: number, newChar: string) => {
-      const type = parts[index].type;
+      const type = parts[index].type
       if (type === "alphabet" || type === "alphanumeric") {
         if (/[a-z]/.test(newChar)) {
-          newChar = newChar.toUpperCase();
+          newChar = newChar.toUpperCase()
         }
       }
 
-      const finalValue = [...valueLocal];
-      finalValue[index] = newChar;
-      setValueLocal(finalValue);
+      const finalValue = [...valueLocal]
+      finalValue[index] = newChar
+      setValueLocal(finalValue)
 
       if (masked && newChar) {
-        const existingTimeout = maskTimeoutsRef.current.get(index);
+        const existingTimeout = maskTimeoutsRef.current.get(index)
         if (existingTimeout) {
-          clearTimeout(existingTimeout);
+          clearTimeout(existingTimeout)
         }
 
         setMaskedIndices((prev) => {
-          const newSet = new Set(prev);
-          newSet.delete(index);
-          return newSet;
-        });
+          const newSet = new Set(prev)
+          newSet.delete(index)
+          return newSet
+        })
 
         const timeout = setTimeout(() => {
           setMaskedIndices((prev) => {
-            const newSet = new Set(prev);
-            newSet.add(index);
-            return newSet;
-          });
-          maskTimeoutsRef.current.delete(index);
-        }, 500);
+            const newSet = new Set(prev)
+            newSet.add(index)
+            return newSet
+          })
+          maskTimeoutsRef.current.delete(index)
+        }, 500)
 
-        maskTimeoutsRef.current.set(index, timeout);
+        maskTimeoutsRef.current.set(index, timeout)
       }
 
       const outputValue = finalValue
         .map((char, i) => (parts[i].type === "static" ? char : char))
-        .join("");
+        .join("")
 
       if (onChange) {
         onChange({
           target: { name, value: outputValue },
-        } as ChangeEvent<HTMLInputElement>);
+        } as ChangeEvent<HTMLInputElement>)
       }
-    };
+    }
 
     const getDisplayChar = (index: number) => {
-      const char = valueLocal[index] || "";
+      const char = valueLocal[index] || ""
 
       if (!masked || !char || parts[index].type === "static") {
-        return char;
+        return char
       }
 
-      return maskedIndices.has(index) ? "•" : char;
-    };
+      return maskedIndices.has(index) ? "•" : char
+    }
 
     return (
       <PinboxInputWrapper
@@ -384,20 +383,18 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
         $disabled={disabled}
       >
         {parts.map((part, index) => {
-          const isStatic = part.type === "static";
+          const isStatic = part.type === "static"
 
-          const displayChar = getDisplayChar(index);
-          const { type, pattern } = switchInputBox(part.type);
+          const displayChar = getDisplayChar(index)
+          const { type, pattern } = switchInputBox(part.type)
           const isAnimate = Boolean(
             masked &&
               !isStatic &&
               !maskedIndices.has(index) &&
-              valueLocal[index]
-          );
+              valueLocal[index],
+          )
 
-          const firstEditableIndex = parts.findIndex(
-            (p) => p.type !== "static"
-          );
+          const firstEditableIndex = parts.findIndex((p) => p.type !== "static")
 
           return (
             <PinboxInputContent
@@ -413,14 +410,14 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
                 $error={showError}
                 $style={styles?.self}
                 ref={(el: HTMLInputElement) => {
-                  inputsRef.current[index] = el;
+                  inputsRef.current[index] = el
 
                   if (index === 0 && typeof ref === "function") {
-                    ref(el);
+                    ref(el)
                   } else if (index === 0 && ref) {
-                    (
+                    ;(
                       ref as React.MutableRefObject<HTMLInputElement | null>
-                    ).current = el;
+                    ).current = el
                   }
                 }}
                 onPaste={(e) => handlePaste(e, index)}
@@ -442,7 +439,7 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
                 $error={showError}
               />
             </PinboxInputContent>
-          );
+          )
         })}
         {showError && errorMessage && showIconError && (
           <RiErrorWarningLine
@@ -457,16 +454,16 @@ const BasePinbox = forwardRef<HTMLInputElement, BasePinboxProps>(
           />
         )}
       </PinboxInputWrapper>
-    );
-  }
-);
+    )
+  },
+)
 
-export type PinboxStyles = BasePinboxStyles & FieldLaneStyles;
+export type PinboxStyles = BasePinboxStyles & FieldLaneStyles
 
 export interface PinboxProps
   extends Omit<BasePinboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: PinboxStyles;
+  styles?: PinboxStyles
 }
 
 const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
@@ -486,21 +483,24 @@ const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
       className,
       ...rest
     },
-    ref
+    ref,
   ) => {
     const inputId = StatefulForm.sanitizeId({
       prefix: "pinbox",
       name,
       id,
-    });
+    })
 
     const {
       bodyStyle,
       controlStyle,
       containerStyle,
       labelStyle,
+      helperArrowStyle,
+      helperDrawerStyle,
+      helperIconStyle,
       ...pinboxStyles
-    } = styles ?? {};
+    } = styles ?? {}
 
     return (
       <FieldLane
@@ -521,6 +521,9 @@ const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
           controlStyle,
           containerStyle,
           labelStyle,
+          helperArrowStyle,
+          helperDrawerStyle,
+          helperIconStyle,
         }}
       >
         <BasePinbox
@@ -534,9 +537,9 @@ const Pinbox = forwardRef<HTMLInputElement, PinboxProps>(
           label={label}
         />
       </FieldLane>
-    );
-  }
-);
+    )
+  },
+)
 
 const PinboxInputWrapper = styled.div<{ $disabled?: boolean }>`
   display: flex;
@@ -554,11 +557,11 @@ const PinboxInputWrapper = styled.div<{ $disabled?: boolean }>`
       user-select: none;
       cursor: not-allowed;
     `}
-`;
+`
 
 const PinboxInputContent = styled.div<{
-  $fontSize?: number;
-  $isStatic?: boolean;
+  $fontSize?: number
+  $isStatic?: boolean
 }>`
   ${({ $fontSize }) =>
     $fontSize &&
@@ -569,11 +572,11 @@ const PinboxInputContent = styled.div<{
 
   display: flex;
   position: relative;
-`;
+`
 
 const PinboxIndicator = styled.div<{
-  $error?: boolean;
-  $theme: PinboxThemeConfig;
+  $error?: boolean
+  $theme: PinboxThemeConfig
 }>`
   width: 70%;
   bottom: 3px;
@@ -588,15 +591,15 @@ const PinboxIndicator = styled.div<{
   color: ${({ $theme, $error }) =>
     $error ? $theme.errorTextColor : $theme.textColor};
   z-index: 9999;
-`;
+`
 
 const PinboxInput = styled.input<{
-  $fontSize?: number;
-  $error?: boolean;
-  $isStatic?: boolean;
-  $isAnimate?: boolean;
-  $theme: PinboxThemeConfig;
-  $style?: CSSProp;
+  $fontSize?: number
+  $error?: boolean
+  $isStatic?: boolean
+  $isAnimate?: boolean
+  $theme: PinboxThemeConfig
+  $style?: CSSProp
 }>`
   ${({ $fontSize, $isStatic }) =>
     $isStatic
@@ -664,38 +667,38 @@ const PinboxInput = styled.input<{
         `};
 
   ${({ $style }) => $style}
-`;
+`
 
 const switchInputBox = (type: PinboxTypeState) => {
   switch (type) {
     case "static":
       return {
         type: "text",
-      };
+      }
 
     case "digit":
       return {
         type: "tel",
         pattern: "[0-9]",
-      };
+      }
 
     case "alphabet":
       return {
         type: "text",
         pattern: "[A-Za-z]",
-      };
+      }
 
     case "alphanumeric":
       return {
         type: "text",
         pattern: "[A-Za-z0-9]",
-      };
+      }
 
     default:
       return {
         type: "text",
-      };
+      }
   }
-};
+}
 
-export { Pinbox };
+export { Pinbox }

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -1,50 +1,49 @@
-import styled, { css, CSSProp } from "styled-components";
-import { ChangeEvent, InputHTMLAttributes } from "react";
-import { StatefulForm } from "./stateful-form";
-import { Figure, FigureProps } from "./figure";
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { useTheme } from "./../theme/provider";
-import { RadioThemeConfig } from "theme";
-import { applyClassName } from "./../constants/classname";
+import styled, { css, CSSProp } from "styled-components"
+import { ChangeEvent, InputHTMLAttributes } from "react"
+import { StatefulForm } from "./stateful-form"
+import { Figure, FigureProps } from "./figure"
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
+import { useTheme } from "./../theme/provider"
+import { RadioThemeConfig } from "theme"
+import { applyClassName } from "./../constants/classname"
 
 export const RadioMode = {
   Radio: "radio",
   Button: "button",
-} as const;
+} as const
 
-export type RadioMode = (typeof RadioMode)[keyof typeof RadioMode];
+export type RadioMode = (typeof RadioMode)[keyof typeof RadioMode]
 
 interface BaseRadioProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "style"> {
-  value?: string;
-  label?: string;
-  description?: string;
-  checked?: boolean;
-  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
-  name?: string;
-  highlightOnChecked?: boolean;
-  styles?: BaseRadioStyles;
-  showError?: boolean;
-  errorMessage?: string;
-  mode?: RadioMode;
-  helper?: string;
-  icon?: FigureProps;
+  value?: string
+  label?: string
+  description?: string
+  checked?: boolean
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void
+  name?: string
+  highlightOnChecked?: boolean
+  styles?: BaseRadioStyles
+  showError?: boolean
+  errorMessage?: string
+  mode?: RadioMode
+  icon?: FigureProps
 }
 
 interface BaseRadioStyles {
-  descriptionStyle?: CSSProp;
-  self?: CSSProp;
-  titleStyle?: CSSProp;
-  inputWrapperStyle?: CSSProp;
-  labelStyle?: CSSProp;
-  textWrapperStyle?: CSSProp;
+  descriptionStyle?: CSSProp
+  self?: CSSProp
+  titleStyle?: CSSProp
+  inputWrapperStyle?: CSSProp
+  labelStyle?: CSSProp
+  textWrapperStyle?: CSSProp
 }
 
 export interface RadioOption {
-  value?: string;
-  label?: string;
-  description?: string;
-  icon?: FigureProps;
+  value?: string
+  label?: string
+  description?: string
+  icon?: FigureProps
 }
 
 function BaseRadio({
@@ -62,10 +61,10 @@ function BaseRadio({
   id,
   ...props
 }: BaseRadioProps) {
-  const { currentTheme } = useTheme();
-  const radioTheme = currentTheme.radio;
+  const { currentTheme } = useTheme()
+  const radioTheme = currentTheme.radio
 
-  const resolvediconSize = icon?.size ?? (mode === "button" ? 25 : 16);
+  const resolvediconSize = icon?.size ?? (mode === "button" ? 25 : 16)
 
   return (
     <Label
@@ -132,15 +131,15 @@ function BaseRadio({
         </DescriptionText>
       )}
     </Label>
-  );
+  )
 }
 
-export type RadioStyles = BaseRadioStyles & FieldLaneStyles;
+export type RadioStyles = BaseRadioStyles & FieldLaneStyles
 
 export interface RadioProps
   extends Omit<BaseRadioProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: RadioStyles;
+  styles?: RadioStyles
 }
 
 function Radio({
@@ -164,15 +163,18 @@ function Radio({
     id: id ? `${id}-${rest.value ?? "value"}` : null,
     prefix: `radio-${rest.value ?? "value"}`,
     name,
-  });
+  })
 
   const {
     bodyStyle,
     controlStyle,
     containerStyle,
     titleStyle,
+    helperArrowStyle,
+    helperDrawerStyle,
+    helperIconStyle,
     ...baseRadiotyles
-  } = styles ?? {};
+  } = styles ?? {}
 
   return (
     <FieldLane
@@ -195,6 +197,9 @@ function Radio({
         controlStyle,
         containerStyle,
         labelStyle: titleStyle,
+        helperArrowStyle,
+        helperDrawerStyle,
+        helperIconStyle,
       }}
     >
       <BaseRadio
@@ -208,17 +213,17 @@ function Radio({
         styles={baseRadiotyles}
       />
     </FieldLane>
-  );
+  )
 }
 
 const Label = styled.label<{
-  $highlight?: boolean;
-  $checked?: boolean;
-  $style?: CSSProp;
-  $hasDescription?: boolean;
-  $disabled?: boolean;
-  $isRadio?: boolean;
-  $theme: RadioThemeConfig;
+  $highlight?: boolean
+  $checked?: boolean
+  $style?: CSSProp
+  $hasDescription?: boolean
+  $disabled?: boolean
+  $isRadio?: boolean
+  $theme: RadioThemeConfig
 }>`
   display: flex;
   align-items: flex-start;
@@ -234,9 +239,9 @@ const Label = styled.label<{
         $theme?.highlightCheckedBackgroundColor ||
         $theme?.checkedBackgroundColor ||
         "transparent"
-      );
+      )
 
-    return "transparent";
+    return "transparent"
   }};
 
   ${({ $highlight, $checked, $isRadio, $theme }) =>
@@ -271,11 +276,11 @@ const Label = styled.label<{
 
         background-color: ${(() => {
           if ($highlight && $checked) {
-            return $theme?.highlightCheckedBackgroundColor;
+            return $theme?.highlightCheckedBackgroundColor
           } else if ($highlight) {
-            return $theme?.highlightBackgroundColor;
+            return $theme?.highlightBackgroundColor
           }
-          return "transparent";
+          return "transparent"
         })()};
       }
     `};
@@ -296,7 +301,7 @@ const Label = styled.label<{
     `}
 
   ${({ $style }) => $style}
-`;
+`
 
 const HiddenRadio = styled.input<{ $disabled?: boolean; $style?: CSSProp }>`
   position: absolute;
@@ -315,13 +320,13 @@ const HiddenRadio = styled.input<{ $disabled?: boolean; $style?: CSSProp }>`
     `}
 
   ${({ $style }) => $style}
-`;
+`
 
 const Circle = styled.div<{
-  $style?: CSSProp;
-  $error?: boolean;
-  $isRadio?: boolean;
-  $theme: RadioThemeConfig;
+  $style?: CSSProp
+  $error?: boolean
+  $isRadio?: boolean
+  $theme: RadioThemeConfig
 }>`
   width: 16px;
   height: 16px;
@@ -352,7 +357,7 @@ const Circle = styled.div<{
     `}
 
   ${({ $style }) => $style}
-`;
+`
 
 const InputWrapper = styled.div<{ $style?: CSSProp; $isRadio?: boolean }>`
   display: flex;
@@ -370,19 +375,19 @@ const InputWrapper = styled.div<{ $style?: CSSProp; $isRadio?: boolean }>`
         `}
 
   ${({ $style }) => $style}
-`;
+`
 
 const LabelText = styled.div<{ $style?: CSSProp; $theme: RadioThemeConfig }>`
   font-size: 14px;
   color: ${({ $theme }) => $theme.textColor || "#000"};
   ${({ $style }) => $style}
-`;
+`
 
 const DescriptionText = styled.span<{
-  $highlight?: boolean;
-  $style?: CSSProp;
-  $isRadio?: boolean;
-  $descriptionColor?: string;
+  $highlight?: boolean
+  $style?: CSSProp
+  $isRadio?: boolean
+  $descriptionColor?: string
 }>`
   ${({ $highlight }) =>
     $highlight &&
@@ -397,6 +402,6 @@ const DescriptionText = styled.span<{
       margin-left: 24px;
     `}
   ${({ $style }) => $style};
-`;
+`
 
-export { Radio };
+export { Radio }

--- a/components/radio.tsx
+++ b/components/radio.tsx
@@ -1,49 +1,49 @@
-import styled, { css, CSSProp } from "styled-components"
-import { ChangeEvent, InputHTMLAttributes } from "react"
-import { StatefulForm } from "./stateful-form"
-import { Figure, FigureProps } from "./figure"
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
-import { useTheme } from "./../theme/provider"
-import { RadioThemeConfig } from "theme"
-import { applyClassName } from "./../constants/classname"
+import styled, { css, CSSProp } from "styled-components";
+import { ChangeEvent, InputHTMLAttributes } from "react";
+import { StatefulForm } from "./stateful-form";
+import { Figure, FigureProps } from "./figure";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
+import { useTheme } from "./../theme/provider";
+import { RadioThemeConfig } from "theme";
+import { applyClassName } from "./../constants/classname";
 
 export const RadioMode = {
   Radio: "radio",
   Button: "button",
-} as const
+} as const;
 
-export type RadioMode = (typeof RadioMode)[keyof typeof RadioMode]
+export type RadioMode = (typeof RadioMode)[keyof typeof RadioMode];
 
 interface BaseRadioProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "style"> {
-  value?: string
-  label?: string
-  description?: string
-  checked?: boolean
-  onChange?: (event: ChangeEvent<HTMLInputElement>) => void
-  name?: string
-  highlightOnChecked?: boolean
-  styles?: BaseRadioStyles
-  showError?: boolean
-  errorMessage?: string
-  mode?: RadioMode
-  icon?: FigureProps
+  value?: string;
+  label?: string;
+  description?: string;
+  checked?: boolean;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  name?: string;
+  highlightOnChecked?: boolean;
+  styles?: BaseRadioStyles;
+  showError?: boolean;
+  errorMessage?: string;
+  mode?: RadioMode;
+  icon?: FigureProps;
 }
 
 interface BaseRadioStyles {
-  descriptionStyle?: CSSProp
-  self?: CSSProp
-  titleStyle?: CSSProp
-  inputWrapperStyle?: CSSProp
-  labelStyle?: CSSProp
-  textWrapperStyle?: CSSProp
+  descriptionStyle?: CSSProp;
+  self?: CSSProp;
+  titleStyle?: CSSProp;
+  inputWrapperStyle?: CSSProp;
+  labelStyle?: CSSProp;
+  textWrapperStyle?: CSSProp;
 }
 
 export interface RadioOption {
-  value?: string
-  label?: string
-  description?: string
-  icon?: FigureProps
+  value?: string;
+  label?: string;
+  description?: string;
+  icon?: FigureProps;
 }
 
 function BaseRadio({
@@ -61,10 +61,10 @@ function BaseRadio({
   id,
   ...props
 }: BaseRadioProps) {
-  const { currentTheme } = useTheme()
-  const radioTheme = currentTheme.radio
+  const { currentTheme } = useTheme();
+  const radioTheme = currentTheme.radio;
 
-  const resolvediconSize = icon?.size ?? (mode === "button" ? 25 : 16)
+  const resolvediconSize = icon?.size ?? (mode === "button" ? 25 : 16);
 
   return (
     <Label
@@ -131,15 +131,15 @@ function BaseRadio({
         </DescriptionText>
       )}
     </Label>
-  )
+  );
 }
 
-export type RadioStyles = BaseRadioStyles & FieldLaneStyles
+export type RadioStyles = BaseRadioStyles & FieldLaneStyles;
 
 export interface RadioProps
   extends Omit<BaseRadioProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: RadioStyles
+  styles?: RadioStyles;
 }
 
 function Radio({
@@ -163,7 +163,7 @@ function Radio({
     id: id ? `${id}-${rest.value ?? "value"}` : null,
     prefix: `radio-${rest.value ?? "value"}`,
     name,
-  })
+  });
 
   const {
     bodyStyle,
@@ -174,7 +174,7 @@ function Radio({
     helperDrawerStyle,
     helperIconStyle,
     ...baseRadiotyles
-  } = styles ?? {}
+  } = styles ?? {};
 
   return (
     <FieldLane
@@ -213,17 +213,17 @@ function Radio({
         styles={baseRadiotyles}
       />
     </FieldLane>
-  )
+  );
 }
 
 const Label = styled.label<{
-  $highlight?: boolean
-  $checked?: boolean
-  $style?: CSSProp
-  $hasDescription?: boolean
-  $disabled?: boolean
-  $isRadio?: boolean
-  $theme: RadioThemeConfig
+  $highlight?: boolean;
+  $checked?: boolean;
+  $style?: CSSProp;
+  $hasDescription?: boolean;
+  $disabled?: boolean;
+  $isRadio?: boolean;
+  $theme: RadioThemeConfig;
 }>`
   display: flex;
   align-items: flex-start;
@@ -239,9 +239,9 @@ const Label = styled.label<{
         $theme?.highlightCheckedBackgroundColor ||
         $theme?.checkedBackgroundColor ||
         "transparent"
-      )
+      );
 
-    return "transparent"
+    return "transparent";
   }};
 
   ${({ $highlight, $checked, $isRadio, $theme }) =>
@@ -276,11 +276,11 @@ const Label = styled.label<{
 
         background-color: ${(() => {
           if ($highlight && $checked) {
-            return $theme?.highlightCheckedBackgroundColor
+            return $theme?.highlightCheckedBackgroundColor;
           } else if ($highlight) {
-            return $theme?.highlightBackgroundColor
+            return $theme?.highlightBackgroundColor;
           }
-          return "transparent"
+          return "transparent";
         })()};
       }
     `};
@@ -301,7 +301,7 @@ const Label = styled.label<{
     `}
 
   ${({ $style }) => $style}
-`
+`;
 
 const HiddenRadio = styled.input<{ $disabled?: boolean; $style?: CSSProp }>`
   position: absolute;
@@ -320,13 +320,13 @@ const HiddenRadio = styled.input<{ $disabled?: boolean; $style?: CSSProp }>`
     `}
 
   ${({ $style }) => $style}
-`
+`;
 
 const Circle = styled.div<{
-  $style?: CSSProp
-  $error?: boolean
-  $isRadio?: boolean
-  $theme: RadioThemeConfig
+  $style?: CSSProp;
+  $error?: boolean;
+  $isRadio?: boolean;
+  $theme: RadioThemeConfig;
 }>`
   width: 16px;
   height: 16px;
@@ -357,7 +357,7 @@ const Circle = styled.div<{
     `}
 
   ${({ $style }) => $style}
-`
+`;
 
 const InputWrapper = styled.div<{ $style?: CSSProp; $isRadio?: boolean }>`
   display: flex;
@@ -375,19 +375,19 @@ const InputWrapper = styled.div<{ $style?: CSSProp; $isRadio?: boolean }>`
         `}
 
   ${({ $style }) => $style}
-`
+`;
 
 const LabelText = styled.div<{ $style?: CSSProp; $theme: RadioThemeConfig }>`
   font-size: 14px;
   color: ${({ $theme }) => $theme.textColor || "#000"};
   ${({ $style }) => $style}
-`
+`;
 
 const DescriptionText = styled.span<{
-  $highlight?: boolean
-  $style?: CSSProp
-  $isRadio?: boolean
-  $descriptionColor?: string
+  $highlight?: boolean;
+  $style?: CSSProp;
+  $isRadio?: boolean;
+  $descriptionColor?: string;
 }>`
   ${({ $highlight }) =>
     $highlight &&
@@ -402,6 +402,6 @@ const DescriptionText = styled.span<{
       margin-left: 24px;
     `}
   ${({ $style }) => $style};
-`
+`;
 
-export { Radio }
+export { Radio };

--- a/components/rating.tsx
+++ b/components/rating.tsx
@@ -1,25 +1,26 @@
-import { ChangeEvent, MouseEvent, ReactNode, useState } from "react";
-import styled, { css, CSSProp } from "styled-components";
-import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { useTheme } from "./../theme/provider";
-import { RatingThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
+import { ChangeEvent, MouseEvent, ReactNode, useState } from "react"
+import styled, { css, CSSProp } from "styled-components"
+import { StatefulForm } from "./stateful-form"
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
+import { useTheme } from "./../theme/provider"
+import { RatingThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
 
 export const RatingSize = {
   Small: "sm",
   Medium: "md",
   Large: "lg",
-} as const;
+} as const
 
-export type RatingSize = (typeof RatingSize)[keyof typeof RatingSize];
+export type RatingSize = (typeof RatingSize)[keyof typeof RatingSize]
 
 export type RatingScoreLabelRender =
-  ReactNode | ((props?: { value?: number; maxValue?: number }) => ReactNode);
+  | ReactNode
+  | ((props?: { value?: number; maxValue?: number }) => ReactNode)
 
 export interface RatingScoreLabel {
-  text?: RatingScoreLabelRender;
-  position?: RatingScoreLabelPosition;
+  text?: RatingScoreLabelRender
+  position?: RatingScoreLabelPosition
 }
 
 export const RatingScoreLabelPosition = {
@@ -27,25 +28,25 @@ export const RatingScoreLabelPosition = {
   Right: "right",
   Bottom: "bottom",
   Left: "left",
-} as const;
+} as const
 
 export type RatingScoreLabelPosition =
-  (typeof RatingScoreLabelPosition)[keyof typeof RatingScoreLabelPosition];
+  (typeof RatingScoreLabelPosition)[keyof typeof RatingScoreLabelPosition]
 
 interface BaseRatingProps {
-  rating?: string;
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-  scoreLabel?: RatingScoreLabel;
-  size?: RatingSize;
-  disabled?: boolean;
-  name?: string;
-  styles?: BaseRatingStyles;
-  id?: string;
+  rating?: string
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
+  scoreLabel?: RatingScoreLabel
+  size?: RatingSize
+  disabled?: boolean
+  name?: string
+  styles?: BaseRatingStyles
+  id?: string
 }
 interface BaseRatingStyles {
-  ratingWrapperStyle?: CSSProp;
-  starsWrapperStyle?: CSSProp;
-  ratingLabelStyle?: CSSProp;
+  ratingWrapperStyle?: CSSProp
+  starsWrapperStyle?: CSSProp
+  ratingLabelStyle?: CSSProp
 }
 
 function BaseRating({
@@ -58,62 +59,62 @@ function BaseRating({
   disabled,
   styles,
 }: BaseRatingProps) {
-  const { currentTheme } = useTheme();
-  const ratingTheme = currentTheme?.rating;
+  const { currentTheme } = useTheme()
+  const ratingTheme = currentTheme?.rating
 
   const { position = RatingScoreLabelPosition.Right, text: scoreText } =
-    scoreLabel ?? {};
+    scoreLabel ?? {}
 
-  const [hoverRating, setHoverRating] = useState(0);
+  const [hoverRating, setHoverRating] = useState(0)
 
-  const maxValue = 5;
-  const rawValue = Number(rating || 0);
+  const maxValue = 5
+  const rawValue = Number(rating || 0)
 
-  const value = rawValue > maxValue ? (rawValue / 10) * maxValue : rawValue;
+  const value = rawValue > maxValue ? (rawValue / 10) * maxValue : rawValue
 
   const handleMouseMove = (e: MouseEvent<HTMLSpanElement>, index: number) => {
-    const { left, width } = e.currentTarget.getBoundingClientRect();
-    const x = e.clientX - left;
-    const isHalf = x < width / 2;
-    setHoverRating(isHalf ? index + 0.5 : index + 1);
-  };
+    const { left, width } = e.currentTarget.getBoundingClientRect()
+    const x = e.clientX - left
+    const isHalf = x < width / 2
+    setHoverRating(isHalf ? index + 0.5 : index + 1)
+  }
 
   const handleClick = (e: MouseEvent<HTMLSpanElement>, index: number) => {
-    const { left, width } = e.currentTarget.getBoundingClientRect();
-    const x = e.clientX - left;
-    const isHalf = x < width / 2;
-    const newRating = isHalf ? index + 0.5 : index + 1;
+    const { left, width } = e.currentTarget.getBoundingClientRect()
+    const x = e.clientX - left
+    const isHalf = x < width / 2
+    const newRating = isHalf ? index + 0.5 : index + 1
     const inputRatingEvent = {
       target: {
         name: name ?? "rating",
         value: String(newRating),
       },
-    } as ChangeEvent<HTMLInputElement>;
-    onChange?.(inputRatingEvent);
-  };
+    } as ChangeEvent<HTMLInputElement>
+    onChange?.(inputRatingEvent)
+  }
 
   const getStarType = (index: number) => {
-    const current = hoverRating || value;
-    if (current >= index + 1) return "full";
-    if (current >= index + 0.5) return "half";
-    return "empty";
-  };
+    const current = hoverRating || value
+    if (current >= index + 1) return "full"
+    if (current >= index + 0.5) return "half"
+    return "empty"
+  }
 
   const sizeMap = {
     sm: 16,
     md: 24,
     lg: 32,
-  };
+  }
 
-  const starSize = sizeMap[size];
+  const starSize = sizeMap[size]
 
   const renderStar = (type: "full" | "half" | "empty") => {
-    const STAR_COLOR = ratingTheme?.starFullColor;
-    const EMPTY_COLOR = ratingTheme?.starEmptyColor;
-    const BORDER_COLOR = ratingTheme?.starBorderColor;
+    const STAR_COLOR = ratingTheme?.starFullColor
+    const EMPTY_COLOR = ratingTheme?.starEmptyColor
+    const BORDER_COLOR = ratingTheme?.starBorderColor
 
     const pathD =
-      "M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z";
+      "M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
 
     const fullStar = (
       <svg
@@ -124,7 +125,7 @@ function BaseRating({
       >
         <path d={pathD} stroke={BORDER_COLOR} strokeWidth={1} />
       </svg>
-    );
+    )
 
     const halfStar = (
       <svg viewBox="0 0 24 24" width={starSize} height={starSize}>
@@ -141,7 +142,7 @@ function BaseRating({
           strokeWidth={1}
         />
       </svg>
-    );
+    )
 
     const emptyStar = (
       <svg
@@ -152,19 +153,17 @@ function BaseRating({
       >
         <path d={pathD} stroke={BORDER_COLOR} strokeWidth={1} />
       </svg>
-    );
+    )
 
-    if (type === "full") return fullStar;
-    if (type === "half") return halfStar;
-    return emptyStar;
-  };
+    if (type === "full") return fullStar
+    if (type === "half") return halfStar
+    return emptyStar
+  }
 
-  const editable = !disabled && !!onChange;
+  const editable = !disabled && !!onChange
 
   const scoreTextNode =
-    typeof scoreText === "function"
-      ? scoreText({ value, maxValue })
-      : scoreText;
+    typeof scoreText === "function" ? scoreText({ value, maxValue }) : scoreText
 
   return (
     <RatingWrapper
@@ -213,36 +212,35 @@ function BaseRating({
         </RatingLabel>
       )}
     </RatingWrapper>
-  );
+  )
 }
 
 function getPositionStyle(position: RatingScoreLabelPosition) {
   if (position === RatingScoreLabelPosition.Right) {
     return css`
       flex-direction: row;
-    `;
+    `
   } else if (position === RatingScoreLabelPosition.Left) {
     return css`
       flex-direction: row-reverse;
-    `;
+    `
   } else if (position === RatingScoreLabelPosition.Bottom) {
     return css`
       flex-direction: column;
-    `;
+    `
   } else {
     return css`
       flex-direction: column-reverse;
-    `;
+    `
   }
 }
 
-export type RatingStyles = BaseRatingStyles & FieldLaneStyles;
+export type RatingStyles = BaseRatingStyles & FieldLaneStyles
 
 export interface RatingProps
-  extends
-    Omit<BaseRatingProps, "styles">,
+  extends Omit<BaseRatingProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: RatingStyles;
+  styles?: RatingStyles
 }
 
 function Rating({
@@ -264,15 +262,18 @@ function Rating({
     prefix: "rating",
     name,
     id,
-  });
+  })
 
   const {
     bodyStyle,
     controlStyle,
     containerStyle,
     labelStyle,
+    helperDrawerStyle,
+    helperIconStyle,
+    helperArrowStyle,
     ...ratingStyles
-  } = styles ?? {};
+  } = styles ?? {}
 
   return (
     <FieldLane
@@ -293,6 +294,9 @@ function Rating({
         controlStyle,
         containerStyle,
         labelStyle,
+        helperDrawerStyle,
+        helperIconStyle,
+        helperArrowStyle,
       }}
     >
       <BaseRating
@@ -303,7 +307,7 @@ function Rating({
         styles={ratingStyles}
       />
     </FieldLane>
-  );
+  )
 }
 
 const RatingWrapper = styled.div<{ $style?: CSSProp }>`
@@ -311,14 +315,14 @@ const RatingWrapper = styled.div<{ $style?: CSSProp }>`
   align-items: center;
   gap: 8px;
   ${({ $style }) => $style}
-`;
+`
 
 const StarsWrapper = styled.div<{ $style?: CSSProp }>`
   display: flex;
   flex-direction: row;
   gap: 2px;
   ${({ $style }) => $style}
-`;
+`
 
 const StarSpan = styled.span<{ $editable?: boolean; $disabled?: boolean }>`
   ${({ $editable, $disabled }) =>
@@ -332,13 +336,13 @@ const StarSpan = styled.span<{ $editable?: boolean; $disabled?: boolean }>`
         css`
           cursor: pointer;
         `}
-`;
+`
 
 const RatingLabel = styled.span<{
-  $size: "sm" | "md" | "lg";
-  $theme: RatingThemeConfig;
-  $disabled?: boolean;
-  $style?: CSSProp;
+  $size: "sm" | "md" | "lg"
+  $theme: RatingThemeConfig
+  $disabled?: boolean
+  $style?: CSSProp
 }>`
   font-weight: 500;
   color: ${({ $disabled, $theme }) =>
@@ -348,19 +352,19 @@ const RatingLabel = styled.span<{
       case "sm":
         return css`
           font-size: 0.875rem;
-        `;
+        `
       case "lg":
         return css`
           font-size: 1.25rem;
-        `;
+        `
       default:
         return css`
           font-size: 1rem;
-        `;
+        `
     }
   }}
 
   ${({ $style }) => $style}
-`;
+`
 
-export { Rating };
+export { Rating }

--- a/components/rating.tsx
+++ b/components/rating.tsx
@@ -1,26 +1,26 @@
-import { ChangeEvent, MouseEvent, ReactNode, useState } from "react"
-import styled, { css, CSSProp } from "styled-components"
-import { StatefulForm } from "./stateful-form"
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
-import { useTheme } from "./../theme/provider"
-import { RatingThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
+import { ChangeEvent, MouseEvent, ReactNode, useState } from "react";
+import styled, { css, CSSProp } from "styled-components";
+import { StatefulForm } from "./stateful-form";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
+import { useTheme } from "./../theme/provider";
+import { RatingThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 
 export const RatingSize = {
   Small: "sm",
   Medium: "md",
   Large: "lg",
-} as const
+} as const;
 
-export type RatingSize = (typeof RatingSize)[keyof typeof RatingSize]
+export type RatingSize = (typeof RatingSize)[keyof typeof RatingSize];
 
 export type RatingScoreLabelRender =
   | ReactNode
-  | ((props?: { value?: number; maxValue?: number }) => ReactNode)
+  | ((props?: { value?: number; maxValue?: number }) => ReactNode);
 
 export interface RatingScoreLabel {
-  text?: RatingScoreLabelRender
-  position?: RatingScoreLabelPosition
+  text?: RatingScoreLabelRender;
+  position?: RatingScoreLabelPosition;
 }
 
 export const RatingScoreLabelPosition = {
@@ -28,25 +28,25 @@ export const RatingScoreLabelPosition = {
   Right: "right",
   Bottom: "bottom",
   Left: "left",
-} as const
+} as const;
 
 export type RatingScoreLabelPosition =
-  (typeof RatingScoreLabelPosition)[keyof typeof RatingScoreLabelPosition]
+  (typeof RatingScoreLabelPosition)[keyof typeof RatingScoreLabelPosition];
 
 interface BaseRatingProps {
-  rating?: string
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
-  scoreLabel?: RatingScoreLabel
-  size?: RatingSize
-  disabled?: boolean
-  name?: string
-  styles?: BaseRatingStyles
-  id?: string
+  rating?: string;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  scoreLabel?: RatingScoreLabel;
+  size?: RatingSize;
+  disabled?: boolean;
+  name?: string;
+  styles?: BaseRatingStyles;
+  id?: string;
 }
 interface BaseRatingStyles {
-  ratingWrapperStyle?: CSSProp
-  starsWrapperStyle?: CSSProp
-  ratingLabelStyle?: CSSProp
+  ratingWrapperStyle?: CSSProp;
+  starsWrapperStyle?: CSSProp;
+  ratingLabelStyle?: CSSProp;
 }
 
 function BaseRating({
@@ -59,62 +59,62 @@ function BaseRating({
   disabled,
   styles,
 }: BaseRatingProps) {
-  const { currentTheme } = useTheme()
-  const ratingTheme = currentTheme?.rating
+  const { currentTheme } = useTheme();
+  const ratingTheme = currentTheme?.rating;
 
   const { position = RatingScoreLabelPosition.Right, text: scoreText } =
-    scoreLabel ?? {}
+    scoreLabel ?? {};
 
-  const [hoverRating, setHoverRating] = useState(0)
+  const [hoverRating, setHoverRating] = useState(0);
 
-  const maxValue = 5
-  const rawValue = Number(rating || 0)
+  const maxValue = 5;
+  const rawValue = Number(rating || 0);
 
-  const value = rawValue > maxValue ? (rawValue / 10) * maxValue : rawValue
+  const value = rawValue > maxValue ? (rawValue / 10) * maxValue : rawValue;
 
   const handleMouseMove = (e: MouseEvent<HTMLSpanElement>, index: number) => {
-    const { left, width } = e.currentTarget.getBoundingClientRect()
-    const x = e.clientX - left
-    const isHalf = x < width / 2
-    setHoverRating(isHalf ? index + 0.5 : index + 1)
-  }
+    const { left, width } = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - left;
+    const isHalf = x < width / 2;
+    setHoverRating(isHalf ? index + 0.5 : index + 1);
+  };
 
   const handleClick = (e: MouseEvent<HTMLSpanElement>, index: number) => {
-    const { left, width } = e.currentTarget.getBoundingClientRect()
-    const x = e.clientX - left
-    const isHalf = x < width / 2
-    const newRating = isHalf ? index + 0.5 : index + 1
+    const { left, width } = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - left;
+    const isHalf = x < width / 2;
+    const newRating = isHalf ? index + 0.5 : index + 1;
     const inputRatingEvent = {
       target: {
         name: name ?? "rating",
         value: String(newRating),
       },
-    } as ChangeEvent<HTMLInputElement>
-    onChange?.(inputRatingEvent)
-  }
+    } as ChangeEvent<HTMLInputElement>;
+    onChange?.(inputRatingEvent);
+  };
 
   const getStarType = (index: number) => {
-    const current = hoverRating || value
-    if (current >= index + 1) return "full"
-    if (current >= index + 0.5) return "half"
-    return "empty"
-  }
+    const current = hoverRating || value;
+    if (current >= index + 1) return "full";
+    if (current >= index + 0.5) return "half";
+    return "empty";
+  };
 
   const sizeMap = {
     sm: 16,
     md: 24,
     lg: 32,
-  }
+  };
 
-  const starSize = sizeMap[size]
+  const starSize = sizeMap[size];
 
   const renderStar = (type: "full" | "half" | "empty") => {
-    const STAR_COLOR = ratingTheme?.starFullColor
-    const EMPTY_COLOR = ratingTheme?.starEmptyColor
-    const BORDER_COLOR = ratingTheme?.starBorderColor
+    const STAR_COLOR = ratingTheme?.starFullColor;
+    const EMPTY_COLOR = ratingTheme?.starEmptyColor;
+    const BORDER_COLOR = ratingTheme?.starBorderColor;
 
     const pathD =
-      "M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+      "M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z";
 
     const fullStar = (
       <svg
@@ -125,7 +125,7 @@ function BaseRating({
       >
         <path d={pathD} stroke={BORDER_COLOR} strokeWidth={1} />
       </svg>
-    )
+    );
 
     const halfStar = (
       <svg viewBox="0 0 24 24" width={starSize} height={starSize}>
@@ -142,7 +142,7 @@ function BaseRating({
           strokeWidth={1}
         />
       </svg>
-    )
+    );
 
     const emptyStar = (
       <svg
@@ -153,17 +153,19 @@ function BaseRating({
       >
         <path d={pathD} stroke={BORDER_COLOR} strokeWidth={1} />
       </svg>
-    )
+    );
 
-    if (type === "full") return fullStar
-    if (type === "half") return halfStar
-    return emptyStar
-  }
+    if (type === "full") return fullStar;
+    if (type === "half") return halfStar;
+    return emptyStar;
+  };
 
-  const editable = !disabled && !!onChange
+  const editable = !disabled && !!onChange;
 
   const scoreTextNode =
-    typeof scoreText === "function" ? scoreText({ value, maxValue }) : scoreText
+    typeof scoreText === "function"
+      ? scoreText({ value, maxValue })
+      : scoreText;
 
   return (
     <RatingWrapper
@@ -212,35 +214,35 @@ function BaseRating({
         </RatingLabel>
       )}
     </RatingWrapper>
-  )
+  );
 }
 
 function getPositionStyle(position: RatingScoreLabelPosition) {
   if (position === RatingScoreLabelPosition.Right) {
     return css`
       flex-direction: row;
-    `
+    `;
   } else if (position === RatingScoreLabelPosition.Left) {
     return css`
       flex-direction: row-reverse;
-    `
+    `;
   } else if (position === RatingScoreLabelPosition.Bottom) {
     return css`
       flex-direction: column;
-    `
+    `;
   } else {
     return css`
       flex-direction: column-reverse;
-    `
+    `;
   }
 }
 
-export type RatingStyles = BaseRatingStyles & FieldLaneStyles
+export type RatingStyles = BaseRatingStyles & FieldLaneStyles;
 
 export interface RatingProps
   extends Omit<BaseRatingProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: RatingStyles
+  styles?: RatingStyles;
 }
 
 function Rating({
@@ -262,7 +264,7 @@ function Rating({
     prefix: "rating",
     name,
     id,
-  })
+  });
 
   const {
     bodyStyle,
@@ -273,7 +275,7 @@ function Rating({
     helperIconStyle,
     helperArrowStyle,
     ...ratingStyles
-  } = styles ?? {}
+  } = styles ?? {};
 
   return (
     <FieldLane
@@ -307,7 +309,7 @@ function Rating({
         styles={ratingStyles}
       />
     </FieldLane>
-  )
+  );
 }
 
 const RatingWrapper = styled.div<{ $style?: CSSProp }>`
@@ -315,14 +317,14 @@ const RatingWrapper = styled.div<{ $style?: CSSProp }>`
   align-items: center;
   gap: 8px;
   ${({ $style }) => $style}
-`
+`;
 
 const StarsWrapper = styled.div<{ $style?: CSSProp }>`
   display: flex;
   flex-direction: row;
   gap: 2px;
   ${({ $style }) => $style}
-`
+`;
 
 const StarSpan = styled.span<{ $editable?: boolean; $disabled?: boolean }>`
   ${({ $editable, $disabled }) =>
@@ -336,13 +338,13 @@ const StarSpan = styled.span<{ $editable?: boolean; $disabled?: boolean }>`
         css`
           cursor: pointer;
         `}
-`
+`;
 
 const RatingLabel = styled.span<{
-  $size: "sm" | "md" | "lg"
-  $theme: RatingThemeConfig
-  $disabled?: boolean
-  $style?: CSSProp
+  $size: "sm" | "md" | "lg";
+  $theme: RatingThemeConfig;
+  $disabled?: boolean;
+  $style?: CSSProp;
 }>`
   font-weight: 500;
   color: ${({ $disabled, $theme }) =>
@@ -352,19 +354,19 @@ const RatingLabel = styled.span<{
       case "sm":
         return css`
           font-size: 0.875rem;
-        `
+        `;
       case "lg":
         return css`
           font-size: 1.25rem;
-        `
+        `;
       default:
         return css`
           font-size: 1rem;
-        `
+        `;
     }
   }}
 
   ${({ $style }) => $style}
-`
+`;
 
-export { Rating }
+export { Rating };

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -12,7 +12,7 @@ import {
   forwardRef,
   InputHTMLAttributes,
   useMemo,
-} from "react";
+} from "react"
 import {
   useFloating,
   offset,
@@ -22,99 +22,93 @@ import {
   Placement,
   useDismiss,
   useInteractions,
-} from "@floating-ui/react";
-import {
-  RiArrowDownSLine,
-  RiArrowUpSLine,
-  RiCloseLine,
-} from "@remixicon/react";
-import styled, { css, CSSProp } from "styled-components";
-import { isValidDateString } from "../lib/date";
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { FigureProps } from "./figure";
-import { StatefulForm } from "./stateful-form";
-import { LoadingSpinner } from "./loading-spinner";
-import { useTheme } from "./../theme/provider";
-import { SelectboxThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
+} from "@floating-ui/react"
+import { RiArrowDownSLine, RiArrowUpSLine, RiCloseLine } from "@remixicon/react"
+import styled, { css, CSSProp } from "styled-components"
+import { isValidDateString } from "../lib/date"
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
+import { FigureProps } from "./figure"
+import { StatefulForm } from "./stateful-form"
+import { LoadingSpinner } from "./loading-spinner"
+import { useTheme } from "./../theme/provider"
+import { SelectboxThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
 
-export type SelectboxSelectedOptions = number | string | number[] | string[];
+export type SelectboxSelectedOptions = number | string | number[] | string[]
 
 interface BaseSelectboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "children"> {
-  options?: SelectboxOption[];
-  navigableOptions?: SelectboxOption[];
-  selectedOptions?: SelectboxSelectedOptions;
-  onChange?: (selectedOptions: SelectboxSelectedOptions) => void;
-  placeholder?: string;
-  iconOpened?: FigureProps["image"];
-  iconClosed?: FigureProps["image"];
-  type?: "calendar" | "default";
-  clearable?: boolean;
-  highlightOnMatch?: boolean;
-  strict?: boolean;
-  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
-  onClick?: () => void;
-  multiple?: boolean;
-  actions?: any[];
-  id?: string;
-  showError?: boolean;
-  maxSelectableItems?: number | undefined;
-  isLoading?: boolean;
-  mobile?: boolean;
+  options?: SelectboxOption[]
+  navigableOptions?: SelectboxOption[]
+  selectedOptions?: SelectboxSelectedOptions
+  onChange?: (selectedOptions: SelectboxSelectedOptions) => void
+  placeholder?: string
+  iconOpened?: FigureProps["image"]
+  iconClosed?: FigureProps["image"]
+  type?: "calendar" | "default"
+  clearable?: boolean
+  highlightOnMatch?: boolean
+  strict?: boolean
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
+  onClick?: () => void
+  multiple?: boolean
+  actions?: any[]
+  id?: string
+  showError?: boolean
+  maxSelectableItems?: number | undefined
+  isLoading?: boolean
+  mobile?: boolean
   children?: (
     props: DrawerProps &
       InteractionModeProps & {
-        options: SelectboxOption[];
-        handleKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
-        selectedOptionsLocal: SelectboxOption;
-        setSelectedOptionsLocal: (value: SelectboxOption) => void;
-        hasInteracted?: boolean;
-        setHasInteracted?: (value: boolean) => void;
-        ref?: Ref<HTMLInputElement>;
-        setConfirmedValue?: (option: SelectboxOption | null) => void;
-      }
-  ) => ReactNode;
-  styles?: SelectboxStyles;
-  labels?: SelectboxLabels;
+        options: SelectboxOption[]
+        handleKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
+        selectedOptionsLocal: SelectboxOption
+        setSelectedOptionsLocal: (value: SelectboxOption) => void
+        hasInteracted?: boolean
+        setHasInteracted?: (value: boolean) => void
+        ref?: Ref<HTMLInputElement>
+        setConfirmedValue?: (option: SelectboxOption | null) => void
+      },
+  ) => ReactNode
+  styles?: BaseSelectboxStyles
+  labels?: SelectboxLabels
 }
 
 export interface SelectboxLabels {
-  loadingText?: string;
+  loadingText?: string
 }
 
 interface BaseSelectboxStyles {
-  selectboxStyle?: CSSProp;
-  self?: CSSProp;
+  selectboxStyle?: CSSProp
+  self?: CSSProp
 }
 
-export type SelectboxStyles = FieldLaneStyles & BaseSelectboxStyles;
-
 export interface DrawerProps extends InteractionModeProps {
-  highlightedIndex: number | null;
-  setHighlightedIndex: (index: number | null) => void;
-  setIsOpen: (open: boolean) => void;
-  multiple?: boolean;
+  highlightedIndex: number | null
+  setHighlightedIndex: (index: number | null) => void
+  setIsOpen: (open: boolean) => void
+  multiple?: boolean
   getFloatingProps: (
-    userProps?: HTMLAttributes<HTMLUListElement>
-  ) => HTMLAttributes<HTMLUListElement>;
-  refs: { setFloating: Ref<HTMLUListElement>; setReference: Ref<HTMLElement> };
-  listRef: MutableRefObject<(HTMLLIElement | null)[]>;
-  isOpen: boolean;
-  floatingStyles: CSSProperties;
-  onClick?: () => void;
+    userProps?: HTMLAttributes<HTMLUListElement>,
+  ) => HTMLAttributes<HTMLUListElement>
+  refs: { setFloating: Ref<HTMLUListElement>; setReference: Ref<HTMLElement> }
+  listRef: MutableRefObject<(HTMLLIElement | null)[]>
+  isOpen: boolean
+  floatingStyles: CSSProperties
+  onClick?: () => void
 }
 
 interface InteractionModeProps {
-  interactionMode: "keyboard" | "mouse";
-  setInteractionMode: (props: "keyboard" | "mouse") => void;
+  interactionMode: "keyboard" | "mouse"
+  setInteractionMode: (props: "keyboard" | "mouse") => void
 }
 
 export interface SelectboxOption {
-  text: string;
-  render?: ReactNode;
-  value: string | number;
-  hidden?: boolean;
+  text: string
+  render?: ReactNode
+  value: string | number
+  hidden?: boolean
 }
 
 const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
@@ -148,104 +142,104 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
       mobile,
       ...props
     },
-    ref
+    ref,
   ) => {
-    const { currentTheme } = useTheme();
-    const selectboxTheme = currentTheme?.selectbox;
+    const { currentTheme } = useTheme()
+    const selectboxTheme = currentTheme?.selectbox
 
     const finalOptions = useMemo(
       () => (Array.isArray(options) ? options : []),
-      [options]
-    );
+      [options],
+    )
 
     const finalSelectedOptions = useMemo(() => {
       if (Array.isArray(selectedOptions)) {
-        return selectedOptions.map(String);
+        return selectedOptions.map(String)
       }
       if (selectedOptions != null) {
-        return [String(selectedOptions)];
+        return [String(selectedOptions)]
       }
-      return [];
-    }, [selectedOptions]);
+      return []
+    }, [selectedOptions])
 
     // Sync local display state and confirmed value when selectedOptions prop changes
     // from outside (e.g. form reset, parent-controlled value update).
     // Only updates confirmedValue in strict mode to avoid overriding user's
     // in-progress input in non-strict (free-text) mode.
     useEffect(() => {
-      if (multiple) return;
+      if (multiple) return
       const matched = finalOptions.find(
-        (opt) => String(opt.value) === finalSelectedOptions?.[0]
-      );
+        (opt) => String(opt.value) === finalSelectedOptions?.[0],
+      )
       if (matched) {
-        setSelectedOptionsLocal(matched);
+        setSelectedOptionsLocal(matched)
         if (strict) {
-          setConfirmedValue(matched);
+          setConfirmedValue(matched)
         }
       }
-    }, [finalSelectedOptions?.[0], finalOptions, strict, multiple]);
+    }, [finalSelectedOptions?.[0], finalOptions, strict, multiple])
 
     const initialState = useMemo(
       () =>
         finalOptions.find(
-          (opt) => String(opt.value) === finalSelectedOptions?.[0]
+          (opt) => String(opt.value) === finalSelectedOptions?.[0],
         ) ?? {
           text: isValidDateString(finalSelectedOptions?.[0])
             ? finalSelectedOptions?.[0]
             : "",
           value: typeof selectedOptions === "number" ? 0 : "0",
         },
-      [finalOptions, finalSelectedOptions, selectedOptions]
-    );
+      [finalOptions, finalSelectedOptions, selectedOptions],
+    )
 
     const handleOnChange = (values: string[]) => {
-      if (!onChange) return;
+      if (!onChange) return
 
       if (Array.isArray(selectedOptions)) {
-        onChange(castValue(values, selectedOptions));
-        return;
+        onChange(castValue(values, selectedOptions))
+        return
       }
 
-      onChange(castValue(values[0], selectedOptions));
-    };
+      onChange(castValue(values[0], selectedOptions))
+    }
 
     const [selectedOptionsLocal, setSelectedOptionsLocal] =
-      useState<SelectboxOption>(initialState);
+      useState<SelectboxOption>(initialState)
 
-    const [isOpen, setIsOpen] = useState(false);
-    const [highlightedIndex, setHighlightedIndex] = useState<number | null>(0);
-    const [hasInteracted, setHasInteracted] = useState(false);
-    const [isHovered, setIsHovered] = useState(false);
-    const [isFocused, setIsFocused] = useState(false);
+    const [isOpen, setIsOpen] = useState(false)
+    const [highlightedIndex, setHighlightedIndex] = useState<number | null>(0)
+    const [hasInteracted, setHasInteracted] = useState(false)
+    const [isHovered, setIsHovered] = useState(false)
+    const [isFocused, setIsFocused] = useState(false)
     const [interactionMode, setInteractionMode] = useState<
       "keyboard" | "mouse"
-    >("mouse");
+    >("mouse")
 
     const [confirmedValue, setConfirmedValue] =
-      useState<SelectboxOption | null>(null);
+      useState<SelectboxOption | null>(null)
 
-    const inputRef = useRef<HTMLInputElement>(null);
-    const listRef = useRef<(HTMLLIElement | null)[]>([]);
+    const inputRef = useRef<HTMLInputElement>(null)
+    const listRef = useRef<(HTMLLIElement | null)[]>([])
 
     const FILTERED_OPTIONS = hasInteracted
       ? finalOptions.filter((opt) =>
           opt.text
             .toLowerCase()
-            .includes(selectedOptionsLocal.text.toLowerCase())
+            .includes(selectedOptionsLocal.text.toLowerCase()),
         )
-      : finalOptions;
+      : finalOptions
 
     const FILTERED_ACTIVE = finalOptions.some(
-      (opt) => opt.text === selectedOptionsLocal.text
-    );
+      (opt) => opt.text === selectedOptionsLocal.text,
+    )
 
     const FILTERED_NAVIGABLE_OPTIONS = hasInteracted
       ? navigableOptions.filter((opt) =>
           opt.text
             .toLowerCase()
-            .includes(selectedOptionsLocal.text.toLowerCase())
+            .includes(selectedOptionsLocal.text.toLowerCase()),
         )
-      : navigableOptions;
+      : navigableOptions
 
     const { refs, floatingStyles, context } = useFloating({
       placement: "bottom-start" as Placement,
@@ -253,122 +247,120 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
       onOpenChange: setIsOpen,
       middleware: [offset(4), flip(), shift()],
       whileElementsMounted: autoUpdate,
-    });
+    })
 
-    const dismiss = useDismiss(context);
-    const { getFloatingProps, getReferenceProps } = useInteractions([dismiss]);
+    const dismiss = useDismiss(context)
+    const { getFloatingProps, getReferenceProps } = useInteractions([dismiss])
 
     const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-      setHasInteracted(true);
-      let value = e.target.value;
+      setHasInteracted(true)
+      let value = e.target.value
       if (type === "calendar") {
-        value = value.replace(/\D/g, "");
+        value = value.replace(/\D/g, "")
         if (value.length > 2 && value.length <= 4) {
-          value = value.slice(0, 2) + "/" + value.slice(2);
+          value = value.slice(0, 2) + "/" + value.slice(2)
         } else if (value.length > 4) {
           value =
             value.slice(0, 2) +
             "/" +
             value.slice(2, 4) +
             "/" +
-            value.slice(4, 8);
+            value.slice(4, 8)
         }
-        handleOnChange([value]);
+        handleOnChange([value])
       }
-      setSelectedOptionsLocal({ ...selectedOptionsLocal, text: value });
-      setIsOpen(value.length > 0);
+      setSelectedOptionsLocal({ ...selectedOptionsLocal, text: value })
+      setIsOpen(value.length > 0)
 
       const hasMatch = finalOptions.some((opt) =>
-        opt.text.toLowerCase().includes(value.toLowerCase())
-      );
-      setHighlightedIndex(hasMatch ? 0 : null);
-    };
+        opt.text.toLowerCase().includes(value.toLowerCase()),
+      )
+      setHighlightedIndex(hasMatch ? 0 : null)
+    }
 
-    const justCommittedRef = useRef(false);
+    const justCommittedRef = useRef(false)
 
     const commitOrRevert = (
       selectedOption?: SelectboxOption,
       currentLocal: SelectboxOption = selectedOptionsLocal,
-      currentConfirmed: SelectboxOption | null = confirmedValue
+      currentConfirmed: SelectboxOption | null = confirmedValue,
     ) => {
       if (selectedOption) {
-        const val = String(selectedOption.value);
-        setConfirmedValue(selectedOption);
-        setSelectedOptionsLocal(selectedOption);
-        handleOnChange?.([val]);
-        setIsOpen(false);
-        return;
+        const val = String(selectedOption.value)
+        setConfirmedValue(selectedOption)
+        setSelectedOptionsLocal(selectedOption)
+        handleOnChange?.([val])
+        setIsOpen(false)
+        return
       }
 
-      const matched = finalOptions.find(
-        (opt) => opt.text === currentLocal.text
-      );
+      const matched = finalOptions.find((opt) => opt.text === currentLocal.text)
 
       if (matched) {
-        const val = String(matched.value);
-        setConfirmedValue(matched);
-        setSelectedOptionsLocal(matched);
-        handleOnChange?.([val]);
-        setIsOpen(false);
-        return;
+        const val = String(matched.value)
+        setConfirmedValue(matched)
+        setSelectedOptionsLocal(matched)
+        handleOnChange?.([val])
+        setIsOpen(false)
+        return
       }
 
       if (currentConfirmed && strict) {
-        setSelectedOptionsLocal(currentConfirmed);
-        handleOnChange?.([String(currentConfirmed.value)]);
-        return;
+        setSelectedOptionsLocal(currentConfirmed)
+        handleOnChange?.([String(currentConfirmed.value)])
+        return
       }
 
       if (strict) {
-        setSelectedOptionsLocal({ text: "", value: "0" });
-        handleOnChange?.([]);
+        setSelectedOptionsLocal({ text: "", value: "0" })
+        handleOnChange?.([])
       } else {
-        handleOnChange?.([currentLocal.text]);
+        handleOnChange?.([currentLocal.text])
       }
-    };
+    }
 
     const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-      onKeyDown?.(e);
+      onKeyDown?.(e)
 
       const totalItems =
-        (actions?.length ?? 0) + FILTERED_NAVIGABLE_OPTIONS.length - 1;
+        (actions?.length ?? 0) + FILTERED_NAVIGABLE_OPTIONS.length - 1
 
       if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-        setInteractionMode("keyboard");
+        setInteractionMode("keyboard")
 
         if (!isOpen) {
-          setIsOpen(true);
+          setIsOpen(true)
         }
 
-        e.preventDefault();
+        e.preventDefault()
       }
 
       if (e.key === "ArrowDown") {
         if (highlightedIndex < totalItems) {
-          setHighlightedIndex(highlightedIndex + 1);
+          setHighlightedIndex(highlightedIndex + 1)
         }
-        e.preventDefault();
+        e.preventDefault()
       }
 
       if (e.key === "ArrowUp") {
         if (highlightedIndex > 0) {
-          setHighlightedIndex(highlightedIndex - 1);
+          setHighlightedIndex(highlightedIndex - 1)
         }
-        e.preventDefault();
+        e.preventDefault()
       }
 
       if (e.key === "Enter") {
         if (!multiple) {
-          setHasInteracted(false);
+          setHasInteracted(false)
         }
 
         if (
           highlightedIndex !== null &&
           highlightedIndex < (actions?.length || 0)
         ) {
-          actions?.[highlightedIndex]?.onClick?.();
-          setIsOpen(false);
-          return;
+          actions?.[highlightedIndex]?.onClick?.()
+          setIsOpen(false)
+          return
         }
 
         const selectedOption =
@@ -376,69 +368,69 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
             ? FILTERED_NAVIGABLE_OPTIONS[
                 highlightedIndex - (actions?.length ?? 0)
               ]
-            : undefined;
+            : undefined
 
         if (multiple) {
           if (selectedOption) {
-            const val = String(selectedOption.value);
+            const val = String(selectedOption.value)
             if (!finalSelectedOptions.includes(val)) {
               if (
                 !maxSelectableItems ||
                 finalSelectedOptions.length < maxSelectableItems
               ) {
-                handleOnChange([...finalSelectedOptions, val]);
+                handleOnChange([...finalSelectedOptions, val])
               }
             } else {
-              handleOnChange(finalSelectedOptions.filter((v) => v !== val));
+              handleOnChange(finalSelectedOptions.filter((v) => v !== val))
             }
           }
         } else {
-          justCommittedRef.current = true;
-          commitOrRevert(selectedOption, selectedOptionsLocal, confirmedValue);
+          justCommittedRef.current = true
+          commitOrRevert(selectedOption, selectedOptionsLocal, confirmedValue)
         }
 
         requestAnimationFrame(() => {
           if (!multiple) {
-            setHighlightedIndex(null);
+            setHighlightedIndex(null)
           }
-        });
+        })
       }
 
       if (e.key === "Escape") {
-        setIsOpen(false);
-        setHasInteracted(false);
-        setIsFocused(false);
+        setIsOpen(false)
+        setHasInteracted(false)
+        setIsFocused(false)
 
         if (strict && confirmedValue) {
-          setSelectedOptionsLocal(confirmedValue);
+          setSelectedOptionsLocal(confirmedValue)
         }
 
         if (!isOpen) {
-          inputRef.current?.blur();
+          inputRef.current?.blur()
         }
 
         requestAnimationFrame(() => {
           if (!multiple) {
-            setHighlightedIndex(null);
+            setHighlightedIndex(null)
           }
-        });
+        })
       }
-    };
+    }
 
     // Sync highlightedIndex to the selected option's position when the dropdown open
     useEffect(() => {
       if (isOpen) {
         if (finalSelectedOptions.length > 0) {
-          const offset = actions?.length ?? 0;
+          const offset = actions?.length ?? 0
           const idx = (navigableOptions ?? finalOptions).findIndex(
-            (opt) => String(opt.value) === finalSelectedOptions[0]
-          );
-          setHighlightedIndex(idx !== -1 ? idx + offset : 0);
+            (opt) => String(opt.value) === finalSelectedOptions[0],
+          )
+          setHighlightedIndex(idx !== -1 ? idx + offset : 0)
         } else {
-          setHighlightedIndex(0);
+          setHighlightedIndex(0)
         }
       }
-    }, [isOpen]);
+    }, [isOpen])
 
     // Scroll the highlighted item into view on keyboard navigation
     useEffect(() => {
@@ -447,9 +439,9 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
         listRef.current[highlightedIndex] &&
         finalSelectedOptions?.length > 0
       ) {
-        listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });
+        listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" })
       }
-    }, [highlightedIndex, isOpen, finalSelectedOptions]);
+    }, [highlightedIndex, isOpen, finalSelectedOptions])
 
     // Reset search text when the dropdown closes in multiple mode
     useEffect(() => {
@@ -457,45 +449,45 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
         setSelectedOptionsLocal({
           text: "",
           value: "",
-        });
+        })
       }
-    }, [isOpen]);
+    }, [isOpen])
 
     const multipleOptionsJoinedText = finalSelectedOptions
       ?.map((val) => finalOptions.find((o) => o.value === val)?.text)
       .filter(Boolean)
-      .join(", ");
+      .join(", ")
 
     const inputValue = multiple
       ? multipleOptionsJoinedText
-      : selectedOptionsLocal.text;
+      : selectedOptionsLocal.text
 
     const isClearable =
       clearable &&
       (multiple
         ? finalSelectedOptions?.length
-        : selectedOptionsLocal?.text.length) !== 0;
+        : selectedOptionsLocal?.text.length) !== 0
 
-    const { loadingText = "Loading..." } = labels ?? {};
+    const { loadingText = "Loading..." } = labels ?? {}
 
     return (
       <Container
         $isLoading={isLoading}
         onBlur={() => {
-          if (!isLoading) setIsHovered(false);
+          if (!isLoading) setIsHovered(false)
         }}
         onMouseEnter={() => {
-          if (!isLoading) setIsHovered(true);
+          if (!isLoading) setIsHovered(true)
         }}
         onMouseLeave={() => {
-          if (!isLoading) setIsHovered(false);
+          if (!isLoading) setIsHovered(false)
         }}
         role="combobox"
         $style={styles?.selectboxStyle}
         aria-expanded={isOpen}
         $disabled={disabled}
         onClick={() => {
-          inputRef.current?.focus();
+          inputRef.current?.focus()
         }}
       >
         {isLoading && (
@@ -529,50 +521,50 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           disabled={disabled || isLoading}
           $disabled={disabled || isLoading}
           ref={(el) => {
-            refs.setReference(el);
+            refs.setReference(el)
             if (!multiple) {
-              inputRef.current = el;
+              inputRef.current = el
             }
-            if (typeof ref === "function") ref(el);
+            if (typeof ref === "function") ref(el)
             else if (ref)
-              (ref as MutableRefObject<HTMLInputElement | null>).current = el;
+              (ref as MutableRefObject<HTMLInputElement | null>).current = el
           }}
           type="text"
           value={isLoading ? "" : inputValue}
           onChange={handleInputChange}
           onKeyDown={(e) => {
-            handleKeyDown(e);
+            handleKeyDown(e)
           }}
           readOnly={multiple || mobile}
           onMouseDown={() => {
             if (strict || mobile) {
               if (!isOpen) {
-                setIsOpen(true);
+                setIsOpen(true)
               }
             } else {
               if (!isOpen && !isFocused) {
-                setIsOpen(true);
+                setIsOpen(true)
               }
             }
           }}
           onFocus={() => {
-            if (type === "calendar" || selectedOptionsLocal) setIsFocused(true);
+            if (type === "calendar" || selectedOptionsLocal) setIsFocused(true)
 
-            setIsOpen(true);
+            setIsOpen(true)
           }}
           onBlur={() => {
-            setIsFocused(false);
+            setIsFocused(false)
 
             if (!multiple) {
-              setHasInteracted(false);
+              setHasInteracted(false)
             }
 
             if (strict && !multiple) {
               if (justCommittedRef.current) {
-                justCommittedRef.current = false;
-                return;
+                justCommittedRef.current = false
+                return
               }
-              commitOrRevert(undefined, selectedOptionsLocal, confirmedValue);
+              commitOrRevert(undefined, selectedOptionsLocal, confirmedValue)
             }
           }}
           placeholder={isLoading ? "" : placeholder || "Search your item..."}
@@ -587,10 +579,10 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
               $theme={selectboxTheme}
               aria-label="clearable-content"
               onMouseDown={() => {
-                handleOnChange?.([]);
-                setSelectedOptionsLocal({ text: "", value: "0" });
-                setConfirmedValue(null);
-                setHasInteracted(false);
+                handleOnChange?.([])
+                setSelectedOptionsLocal({ text: "", value: "0" })
+                setConfirmedValue(null)
+                setHasInteracted(false)
               }}
               $highlight={highlightOnMatch && FILTERED_ACTIVE}
               size={16}
@@ -604,12 +596,12 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           aria-label="selectbox-opener"
           onClick={async () => {
             await setIsOpen((prev) => {
-              const newState = !prev;
-              if (newState && inputRef.current) inputRef.current?.focus();
-              return newState;
-            });
+              const newState = !prev
+              if (newState && inputRef.current) inputRef.current?.focus()
+              return newState
+            })
             if (multiple) {
-              await inputRef.current?.focus();
+              await inputRef.current?.focus()
             }
           }}
         >
@@ -657,14 +649,16 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
             ref: multiple ? inputRef : undefined,
           })}
       </Container>
-    );
-  }
-);
+    )
+  },
+)
+
+export type SelectboxStyles = FieldLaneStyles & BaseSelectboxStyles
 
 export interface SelectboxProps
   extends Omit<BaseSelectboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "actions" | "children"> {
-  styles?: SelectboxStyles;
+  styles?: SelectboxStyles
 }
 
 const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
@@ -688,15 +682,27 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
       className,
       mobile,
       ...rest
-    } = props;
+    } = props
+
     const inputId = StatefulForm.sanitizeId({
       prefix: "selectbox",
       name,
       id,
-    });
+    })
 
-    const hasCombo = className?.includes("coneto-combobox");
-    const hasDatebox = className?.includes("coneto-datebox");
+    const hasCombo = className?.includes("coneto-combobox")
+    const hasDatebox = className?.includes("coneto-datebox")
+
+    const {
+      bodyStyle,
+      containerStyle,
+      controlStyle,
+      labelStyle,
+      helperIconStyle,
+      helperDrawerStyle,
+      helperArrowStyle,
+      ...selectboxStyles
+    } = styles ?? {}
 
     return (
       <FieldLane
@@ -720,10 +726,13 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
         errorIconPosition={errorIconPosition}
         required={rest.required}
         styles={{
-          bodyStyle: styles?.bodyStyle,
-          controlStyle: styles?.controlStyle,
-          containerStyle: styles?.containerStyle,
-          labelStyle: styles?.labelStyle,
+          bodyStyle,
+          controlStyle,
+          containerStyle,
+          labelStyle,
+          helperDrawerStyle,
+          helperIconStyle,
+          helperArrowStyle,
         }}
       >
         <BaseSelectbox
@@ -734,47 +743,48 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
           mobile={mobile}
           disabled={disabled}
           styles={{
+            ...selectboxStyles,
             self: css`
               ${dropdowns &&
               css`
                 border-top-left-radius: 0px;
                 border-bottom-left-radius: 0px;
               `}
-              ${styles?.self}
+              ${selectboxStyles?.self}
             `,
           }}
           type={type}
           ref={ref}
         />
       </FieldLane>
-    );
-  }
-);
+    )
+  },
+)
 
 export function castValue<T extends SelectboxSelectedOptions>(
   value: any,
-  original: T
+  original: T,
 ): T {
   if (Array.isArray(original)) {
     if (Array.isArray(value)) {
       return value.map((v) =>
-        typeof original[0] === "number" ? Number(v) : String(v)
-      ) as T;
+        typeof original[0] === "number" ? Number(v) : String(v),
+      ) as T
     }
-    return [value] as T;
+    return [value] as T
   }
 
   if (typeof original === "number") {
-    return Number(value) as T;
+    return Number(value) as T
   }
 
-  return String(value) as T;
+  return String(value) as T
 }
 
 const Container = styled.div<{
-  $style?: CSSProp;
-  $isLoading?: boolean;
-  $disabled?: boolean;
+  $style?: CSSProp
+  $isLoading?: boolean
+  $disabled?: boolean
 }>`
   position: relative;
   width: 100%;
@@ -796,17 +806,17 @@ const Container = styled.div<{
     `};
 
   ${({ $style }) => $style}
-`;
+`
 
 const Input = styled.input<{
-  $highlight?: boolean;
-  $focused?: boolean;
-  $hovered?: boolean;
-  $style?: CSSProp;
-  $clearable?: boolean;
-  $hasError?: boolean;
-  $disabled?: boolean;
-  $theme: SelectboxThemeConfig;
+  $highlight?: boolean
+  $focused?: boolean
+  $hovered?: boolean
+  $style?: CSSProp
+  $clearable?: boolean
+  $hasError?: boolean
+  $disabled?: boolean
+  $theme: SelectboxThemeConfig
 }>`
   width: 100%;
   border-radius: 2px;
@@ -855,11 +865,11 @@ const Input = styled.input<{
     `}
 
   ${({ $style }) => $style}
-`;
+`
 
 const ClearIcon = styled(RiCloseLine)<{
-  $highlight?: boolean;
-  $theme: SelectboxThemeConfig;
+  $highlight?: boolean
+  $theme: SelectboxThemeConfig
 }>`
   position: absolute;
   top: 50%;
@@ -883,10 +893,10 @@ const ClearIcon = styled(RiCloseLine)<{
     background-color: ${({ $theme }) =>
       $theme.clearIconHoverBackground || "#e5e7eb"};
   }
-`;
+`
 
 const Divider = styled.span<{
-  $theme: SelectboxThemeConfig;
+  $theme: SelectboxThemeConfig
 }>`
   position: absolute;
   top: 50%;
@@ -895,7 +905,7 @@ const Divider = styled.span<{
   width: 1px;
   min-height: 15px;
   border-right: 1px solid ${({ $theme }) => $theme.dividerColor || "#9ca3af"};
-`;
+`
 
 const IconWrapper = styled.div<{ $isLoading?: boolean }>`
   position: absolute;
@@ -909,6 +919,6 @@ const IconWrapper = styled.div<{ $isLoading?: boolean }>`
     css`
       opacity: 0.5;
     `}
-`;
+`
 
-export { Selectbox };
+export { Selectbox }

--- a/components/selectbox.tsx
+++ b/components/selectbox.tsx
@@ -12,7 +12,7 @@ import {
   forwardRef,
   InputHTMLAttributes,
   useMemo,
-} from "react"
+} from "react";
 import {
   useFloating,
   offset,
@@ -22,93 +22,97 @@ import {
   Placement,
   useDismiss,
   useInteractions,
-} from "@floating-ui/react"
-import { RiArrowDownSLine, RiArrowUpSLine, RiCloseLine } from "@remixicon/react"
-import styled, { css, CSSProp } from "styled-components"
-import { isValidDateString } from "../lib/date"
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
-import { FigureProps } from "./figure"
-import { StatefulForm } from "./stateful-form"
-import { LoadingSpinner } from "./loading-spinner"
-import { useTheme } from "./../theme/provider"
-import { SelectboxThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
+} from "@floating-ui/react";
+import {
+  RiArrowDownSLine,
+  RiArrowUpSLine,
+  RiCloseLine,
+} from "@remixicon/react";
+import styled, { css, CSSProp } from "styled-components";
+import { isValidDateString } from "../lib/date";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
+import { FigureProps } from "./figure";
+import { StatefulForm } from "./stateful-form";
+import { LoadingSpinner } from "./loading-spinner";
+import { useTheme } from "./../theme/provider";
+import { SelectboxThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 
-export type SelectboxSelectedOptions = number | string | number[] | string[]
+export type SelectboxSelectedOptions = number | string | number[] | string[];
 
 interface BaseSelectboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "children"> {
-  options?: SelectboxOption[]
-  navigableOptions?: SelectboxOption[]
-  selectedOptions?: SelectboxSelectedOptions
-  onChange?: (selectedOptions: SelectboxSelectedOptions) => void
-  placeholder?: string
-  iconOpened?: FigureProps["image"]
-  iconClosed?: FigureProps["image"]
-  type?: "calendar" | "default"
-  clearable?: boolean
-  highlightOnMatch?: boolean
-  strict?: boolean
-  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
-  onClick?: () => void
-  multiple?: boolean
-  actions?: any[]
-  id?: string
-  showError?: boolean
-  maxSelectableItems?: number | undefined
-  isLoading?: boolean
-  mobile?: boolean
+  options?: SelectboxOption[];
+  navigableOptions?: SelectboxOption[];
+  selectedOptions?: SelectboxSelectedOptions;
+  onChange?: (selectedOptions: SelectboxSelectedOptions) => void;
+  placeholder?: string;
+  iconOpened?: FigureProps["image"];
+  iconClosed?: FigureProps["image"];
+  type?: "calendar" | "default";
+  clearable?: boolean;
+  highlightOnMatch?: boolean;
+  strict?: boolean;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+  onClick?: () => void;
+  multiple?: boolean;
+  actions?: any[];
+  id?: string;
+  showError?: boolean;
+  maxSelectableItems?: number | undefined;
+  isLoading?: boolean;
+  mobile?: boolean;
   children?: (
     props: DrawerProps &
       InteractionModeProps & {
-        options: SelectboxOption[]
-        handleKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void
-        selectedOptionsLocal: SelectboxOption
-        setSelectedOptionsLocal: (value: SelectboxOption) => void
-        hasInteracted?: boolean
-        setHasInteracted?: (value: boolean) => void
-        ref?: Ref<HTMLInputElement>
-        setConfirmedValue?: (option: SelectboxOption | null) => void
-      },
-  ) => ReactNode
-  styles?: BaseSelectboxStyles
-  labels?: SelectboxLabels
+        options: SelectboxOption[];
+        handleKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+        selectedOptionsLocal: SelectboxOption;
+        setSelectedOptionsLocal: (value: SelectboxOption) => void;
+        hasInteracted?: boolean;
+        setHasInteracted?: (value: boolean) => void;
+        ref?: Ref<HTMLInputElement>;
+        setConfirmedValue?: (option: SelectboxOption | null) => void;
+      }
+  ) => ReactNode;
+  styles?: BaseSelectboxStyles;
+  labels?: SelectboxLabels;
 }
 
 export interface SelectboxLabels {
-  loadingText?: string
+  loadingText?: string;
 }
 
 interface BaseSelectboxStyles {
-  selectboxStyle?: CSSProp
-  self?: CSSProp
+  selectboxStyle?: CSSProp;
+  self?: CSSProp;
 }
 
 export interface DrawerProps extends InteractionModeProps {
-  highlightedIndex: number | null
-  setHighlightedIndex: (index: number | null) => void
-  setIsOpen: (open: boolean) => void
-  multiple?: boolean
+  highlightedIndex: number | null;
+  setHighlightedIndex: (index: number | null) => void;
+  setIsOpen: (open: boolean) => void;
+  multiple?: boolean;
   getFloatingProps: (
-    userProps?: HTMLAttributes<HTMLUListElement>,
-  ) => HTMLAttributes<HTMLUListElement>
-  refs: { setFloating: Ref<HTMLUListElement>; setReference: Ref<HTMLElement> }
-  listRef: MutableRefObject<(HTMLLIElement | null)[]>
-  isOpen: boolean
-  floatingStyles: CSSProperties
-  onClick?: () => void
+    userProps?: HTMLAttributes<HTMLUListElement>
+  ) => HTMLAttributes<HTMLUListElement>;
+  refs: { setFloating: Ref<HTMLUListElement>; setReference: Ref<HTMLElement> };
+  listRef: MutableRefObject<(HTMLLIElement | null)[]>;
+  isOpen: boolean;
+  floatingStyles: CSSProperties;
+  onClick?: () => void;
 }
 
 interface InteractionModeProps {
-  interactionMode: "keyboard" | "mouse"
-  setInteractionMode: (props: "keyboard" | "mouse") => void
+  interactionMode: "keyboard" | "mouse";
+  setInteractionMode: (props: "keyboard" | "mouse") => void;
 }
 
 export interface SelectboxOption {
-  text: string
-  render?: ReactNode
-  value: string | number
-  hidden?: boolean
+  text: string;
+  render?: ReactNode;
+  value: string | number;
+  hidden?: boolean;
 }
 
 const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
@@ -142,104 +146,104 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
       mobile,
       ...props
     },
-    ref,
+    ref
   ) => {
-    const { currentTheme } = useTheme()
-    const selectboxTheme = currentTheme?.selectbox
+    const { currentTheme } = useTheme();
+    const selectboxTheme = currentTheme?.selectbox;
 
     const finalOptions = useMemo(
       () => (Array.isArray(options) ? options : []),
-      [options],
-    )
+      [options]
+    );
 
     const finalSelectedOptions = useMemo(() => {
       if (Array.isArray(selectedOptions)) {
-        return selectedOptions.map(String)
+        return selectedOptions.map(String);
       }
       if (selectedOptions != null) {
-        return [String(selectedOptions)]
+        return [String(selectedOptions)];
       }
-      return []
-    }, [selectedOptions])
+      return [];
+    }, [selectedOptions]);
 
     // Sync local display state and confirmed value when selectedOptions prop changes
     // from outside (e.g. form reset, parent-controlled value update).
     // Only updates confirmedValue in strict mode to avoid overriding user's
     // in-progress input in non-strict (free-text) mode.
     useEffect(() => {
-      if (multiple) return
+      if (multiple) return;
       const matched = finalOptions.find(
-        (opt) => String(opt.value) === finalSelectedOptions?.[0],
-      )
+        (opt) => String(opt.value) === finalSelectedOptions?.[0]
+      );
       if (matched) {
-        setSelectedOptionsLocal(matched)
+        setSelectedOptionsLocal(matched);
         if (strict) {
-          setConfirmedValue(matched)
+          setConfirmedValue(matched);
         }
       }
-    }, [finalSelectedOptions?.[0], finalOptions, strict, multiple])
+    }, [finalSelectedOptions?.[0], finalOptions, strict, multiple]);
 
     const initialState = useMemo(
       () =>
         finalOptions.find(
-          (opt) => String(opt.value) === finalSelectedOptions?.[0],
+          (opt) => String(opt.value) === finalSelectedOptions?.[0]
         ) ?? {
           text: isValidDateString(finalSelectedOptions?.[0])
             ? finalSelectedOptions?.[0]
             : "",
           value: typeof selectedOptions === "number" ? 0 : "0",
         },
-      [finalOptions, finalSelectedOptions, selectedOptions],
-    )
+      [finalOptions, finalSelectedOptions, selectedOptions]
+    );
 
     const handleOnChange = (values: string[]) => {
-      if (!onChange) return
+      if (!onChange) return;
 
       if (Array.isArray(selectedOptions)) {
-        onChange(castValue(values, selectedOptions))
-        return
+        onChange(castValue(values, selectedOptions));
+        return;
       }
 
-      onChange(castValue(values[0], selectedOptions))
-    }
+      onChange(castValue(values[0], selectedOptions));
+    };
 
     const [selectedOptionsLocal, setSelectedOptionsLocal] =
-      useState<SelectboxOption>(initialState)
+      useState<SelectboxOption>(initialState);
 
-    const [isOpen, setIsOpen] = useState(false)
-    const [highlightedIndex, setHighlightedIndex] = useState<number | null>(0)
-    const [hasInteracted, setHasInteracted] = useState(false)
-    const [isHovered, setIsHovered] = useState(false)
-    const [isFocused, setIsFocused] = useState(false)
+    const [isOpen, setIsOpen] = useState(false);
+    const [highlightedIndex, setHighlightedIndex] = useState<number | null>(0);
+    const [hasInteracted, setHasInteracted] = useState(false);
+    const [isHovered, setIsHovered] = useState(false);
+    const [isFocused, setIsFocused] = useState(false);
     const [interactionMode, setInteractionMode] = useState<
       "keyboard" | "mouse"
-    >("mouse")
+    >("mouse");
 
     const [confirmedValue, setConfirmedValue] =
-      useState<SelectboxOption | null>(null)
+      useState<SelectboxOption | null>(null);
 
-    const inputRef = useRef<HTMLInputElement>(null)
-    const listRef = useRef<(HTMLLIElement | null)[]>([])
+    const inputRef = useRef<HTMLInputElement>(null);
+    const listRef = useRef<(HTMLLIElement | null)[]>([]);
 
     const FILTERED_OPTIONS = hasInteracted
       ? finalOptions.filter((opt) =>
           opt.text
             .toLowerCase()
-            .includes(selectedOptionsLocal.text.toLowerCase()),
+            .includes(selectedOptionsLocal.text.toLowerCase())
         )
-      : finalOptions
+      : finalOptions;
 
     const FILTERED_ACTIVE = finalOptions.some(
-      (opt) => opt.text === selectedOptionsLocal.text,
-    )
+      (opt) => opt.text === selectedOptionsLocal.text
+    );
 
     const FILTERED_NAVIGABLE_OPTIONS = hasInteracted
       ? navigableOptions.filter((opt) =>
           opt.text
             .toLowerCase()
-            .includes(selectedOptionsLocal.text.toLowerCase()),
+            .includes(selectedOptionsLocal.text.toLowerCase())
         )
-      : navigableOptions
+      : navigableOptions;
 
     const { refs, floatingStyles, context } = useFloating({
       placement: "bottom-start" as Placement,
@@ -247,120 +251,122 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
       onOpenChange: setIsOpen,
       middleware: [offset(4), flip(), shift()],
       whileElementsMounted: autoUpdate,
-    })
+    });
 
-    const dismiss = useDismiss(context)
-    const { getFloatingProps, getReferenceProps } = useInteractions([dismiss])
+    const dismiss = useDismiss(context);
+    const { getFloatingProps, getReferenceProps } = useInteractions([dismiss]);
 
     const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-      setHasInteracted(true)
-      let value = e.target.value
+      setHasInteracted(true);
+      let value = e.target.value;
       if (type === "calendar") {
-        value = value.replace(/\D/g, "")
+        value = value.replace(/\D/g, "");
         if (value.length > 2 && value.length <= 4) {
-          value = value.slice(0, 2) + "/" + value.slice(2)
+          value = value.slice(0, 2) + "/" + value.slice(2);
         } else if (value.length > 4) {
           value =
             value.slice(0, 2) +
             "/" +
             value.slice(2, 4) +
             "/" +
-            value.slice(4, 8)
+            value.slice(4, 8);
         }
-        handleOnChange([value])
+        handleOnChange([value]);
       }
-      setSelectedOptionsLocal({ ...selectedOptionsLocal, text: value })
-      setIsOpen(value.length > 0)
+      setSelectedOptionsLocal({ ...selectedOptionsLocal, text: value });
+      setIsOpen(value.length > 0);
 
       const hasMatch = finalOptions.some((opt) =>
-        opt.text.toLowerCase().includes(value.toLowerCase()),
-      )
-      setHighlightedIndex(hasMatch ? 0 : null)
-    }
+        opt.text.toLowerCase().includes(value.toLowerCase())
+      );
+      setHighlightedIndex(hasMatch ? 0 : null);
+    };
 
-    const justCommittedRef = useRef(false)
+    const justCommittedRef = useRef(false);
 
     const commitOrRevert = (
       selectedOption?: SelectboxOption,
       currentLocal: SelectboxOption = selectedOptionsLocal,
-      currentConfirmed: SelectboxOption | null = confirmedValue,
+      currentConfirmed: SelectboxOption | null = confirmedValue
     ) => {
       if (selectedOption) {
-        const val = String(selectedOption.value)
-        setConfirmedValue(selectedOption)
-        setSelectedOptionsLocal(selectedOption)
-        handleOnChange?.([val])
-        setIsOpen(false)
-        return
+        const val = String(selectedOption.value);
+        setConfirmedValue(selectedOption);
+        setSelectedOptionsLocal(selectedOption);
+        handleOnChange?.([val]);
+        setIsOpen(false);
+        return;
       }
 
-      const matched = finalOptions.find((opt) => opt.text === currentLocal.text)
+      const matched = finalOptions.find(
+        (opt) => opt.text === currentLocal.text
+      );
 
       if (matched) {
-        const val = String(matched.value)
-        setConfirmedValue(matched)
-        setSelectedOptionsLocal(matched)
-        handleOnChange?.([val])
-        setIsOpen(false)
-        return
+        const val = String(matched.value);
+        setConfirmedValue(matched);
+        setSelectedOptionsLocal(matched);
+        handleOnChange?.([val]);
+        setIsOpen(false);
+        return;
       }
 
       if (currentConfirmed && strict) {
-        setSelectedOptionsLocal(currentConfirmed)
-        handleOnChange?.([String(currentConfirmed.value)])
-        return
+        setSelectedOptionsLocal(currentConfirmed);
+        handleOnChange?.([String(currentConfirmed.value)]);
+        return;
       }
 
       if (strict) {
-        setSelectedOptionsLocal({ text: "", value: "0" })
-        handleOnChange?.([])
+        setSelectedOptionsLocal({ text: "", value: "0" });
+        handleOnChange?.([]);
       } else {
-        handleOnChange?.([currentLocal.text])
+        handleOnChange?.([currentLocal.text]);
       }
-    }
+    };
 
     const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-      onKeyDown?.(e)
+      onKeyDown?.(e);
 
       const totalItems =
-        (actions?.length ?? 0) + FILTERED_NAVIGABLE_OPTIONS.length - 1
+        (actions?.length ?? 0) + FILTERED_NAVIGABLE_OPTIONS.length - 1;
 
       if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-        setInteractionMode("keyboard")
+        setInteractionMode("keyboard");
 
         if (!isOpen) {
-          setIsOpen(true)
+          setIsOpen(true);
         }
 
-        e.preventDefault()
+        e.preventDefault();
       }
 
       if (e.key === "ArrowDown") {
         if (highlightedIndex < totalItems) {
-          setHighlightedIndex(highlightedIndex + 1)
+          setHighlightedIndex(highlightedIndex + 1);
         }
-        e.preventDefault()
+        e.preventDefault();
       }
 
       if (e.key === "ArrowUp") {
         if (highlightedIndex > 0) {
-          setHighlightedIndex(highlightedIndex - 1)
+          setHighlightedIndex(highlightedIndex - 1);
         }
-        e.preventDefault()
+        e.preventDefault();
       }
 
       if (e.key === "Enter") {
         if (!multiple) {
-          setHasInteracted(false)
+          setHasInteracted(false);
         }
 
         if (
           highlightedIndex !== null &&
           highlightedIndex < (actions?.length || 0)
         ) {
-          actions?.[highlightedIndex]?.onClick?.()
-          setIsOpen(false)
-          return
+          actions?.[highlightedIndex]?.onClick?.();
+          setIsOpen(false);
+          return;
         }
 
         const selectedOption =
@@ -368,69 +374,69 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
             ? FILTERED_NAVIGABLE_OPTIONS[
                 highlightedIndex - (actions?.length ?? 0)
               ]
-            : undefined
+            : undefined;
 
         if (multiple) {
           if (selectedOption) {
-            const val = String(selectedOption.value)
+            const val = String(selectedOption.value);
             if (!finalSelectedOptions.includes(val)) {
               if (
                 !maxSelectableItems ||
                 finalSelectedOptions.length < maxSelectableItems
               ) {
-                handleOnChange([...finalSelectedOptions, val])
+                handleOnChange([...finalSelectedOptions, val]);
               }
             } else {
-              handleOnChange(finalSelectedOptions.filter((v) => v !== val))
+              handleOnChange(finalSelectedOptions.filter((v) => v !== val));
             }
           }
         } else {
-          justCommittedRef.current = true
-          commitOrRevert(selectedOption, selectedOptionsLocal, confirmedValue)
+          justCommittedRef.current = true;
+          commitOrRevert(selectedOption, selectedOptionsLocal, confirmedValue);
         }
 
         requestAnimationFrame(() => {
           if (!multiple) {
-            setHighlightedIndex(null)
+            setHighlightedIndex(null);
           }
-        })
+        });
       }
 
       if (e.key === "Escape") {
-        setIsOpen(false)
-        setHasInteracted(false)
-        setIsFocused(false)
+        setIsOpen(false);
+        setHasInteracted(false);
+        setIsFocused(false);
 
         if (strict && confirmedValue) {
-          setSelectedOptionsLocal(confirmedValue)
+          setSelectedOptionsLocal(confirmedValue);
         }
 
         if (!isOpen) {
-          inputRef.current?.blur()
+          inputRef.current?.blur();
         }
 
         requestAnimationFrame(() => {
           if (!multiple) {
-            setHighlightedIndex(null)
+            setHighlightedIndex(null);
           }
-        })
+        });
       }
-    }
+    };
 
     // Sync highlightedIndex to the selected option's position when the dropdown open
     useEffect(() => {
       if (isOpen) {
         if (finalSelectedOptions.length > 0) {
-          const offset = actions?.length ?? 0
+          const offset = actions?.length ?? 0;
           const idx = (navigableOptions ?? finalOptions).findIndex(
-            (opt) => String(opt.value) === finalSelectedOptions[0],
-          )
-          setHighlightedIndex(idx !== -1 ? idx + offset : 0)
+            (opt) => String(opt.value) === finalSelectedOptions[0]
+          );
+          setHighlightedIndex(idx !== -1 ? idx + offset : 0);
         } else {
-          setHighlightedIndex(0)
+          setHighlightedIndex(0);
         }
       }
-    }, [isOpen])
+    }, [isOpen]);
 
     // Scroll the highlighted item into view on keyboard navigation
     useEffect(() => {
@@ -439,9 +445,9 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
         listRef.current[highlightedIndex] &&
         finalSelectedOptions?.length > 0
       ) {
-        listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" })
+        listRef.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });
       }
-    }, [highlightedIndex, isOpen, finalSelectedOptions])
+    }, [highlightedIndex, isOpen, finalSelectedOptions]);
 
     // Reset search text when the dropdown closes in multiple mode
     useEffect(() => {
@@ -449,45 +455,45 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
         setSelectedOptionsLocal({
           text: "",
           value: "",
-        })
+        });
       }
-    }, [isOpen])
+    }, [isOpen]);
 
     const multipleOptionsJoinedText = finalSelectedOptions
       ?.map((val) => finalOptions.find((o) => o.value === val)?.text)
       .filter(Boolean)
-      .join(", ")
+      .join(", ");
 
     const inputValue = multiple
       ? multipleOptionsJoinedText
-      : selectedOptionsLocal.text
+      : selectedOptionsLocal.text;
 
     const isClearable =
       clearable &&
       (multiple
         ? finalSelectedOptions?.length
-        : selectedOptionsLocal?.text.length) !== 0
+        : selectedOptionsLocal?.text.length) !== 0;
 
-    const { loadingText = "Loading..." } = labels ?? {}
+    const { loadingText = "Loading..." } = labels ?? {};
 
     return (
       <Container
         $isLoading={isLoading}
         onBlur={() => {
-          if (!isLoading) setIsHovered(false)
+          if (!isLoading) setIsHovered(false);
         }}
         onMouseEnter={() => {
-          if (!isLoading) setIsHovered(true)
+          if (!isLoading) setIsHovered(true);
         }}
         onMouseLeave={() => {
-          if (!isLoading) setIsHovered(false)
+          if (!isLoading) setIsHovered(false);
         }}
         role="combobox"
         $style={styles?.selectboxStyle}
         aria-expanded={isOpen}
         $disabled={disabled}
         onClick={() => {
-          inputRef.current?.focus()
+          inputRef.current?.focus();
         }}
       >
         {isLoading && (
@@ -521,50 +527,50 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           disabled={disabled || isLoading}
           $disabled={disabled || isLoading}
           ref={(el) => {
-            refs.setReference(el)
+            refs.setReference(el);
             if (!multiple) {
-              inputRef.current = el
+              inputRef.current = el;
             }
-            if (typeof ref === "function") ref(el)
+            if (typeof ref === "function") ref(el);
             else if (ref)
-              (ref as MutableRefObject<HTMLInputElement | null>).current = el
+              (ref as MutableRefObject<HTMLInputElement | null>).current = el;
           }}
           type="text"
           value={isLoading ? "" : inputValue}
           onChange={handleInputChange}
           onKeyDown={(e) => {
-            handleKeyDown(e)
+            handleKeyDown(e);
           }}
           readOnly={multiple || mobile}
           onMouseDown={() => {
             if (strict || mobile) {
               if (!isOpen) {
-                setIsOpen(true)
+                setIsOpen(true);
               }
             } else {
               if (!isOpen && !isFocused) {
-                setIsOpen(true)
+                setIsOpen(true);
               }
             }
           }}
           onFocus={() => {
-            if (type === "calendar" || selectedOptionsLocal) setIsFocused(true)
+            if (type === "calendar" || selectedOptionsLocal) setIsFocused(true);
 
-            setIsOpen(true)
+            setIsOpen(true);
           }}
           onBlur={() => {
-            setIsFocused(false)
+            setIsFocused(false);
 
             if (!multiple) {
-              setHasInteracted(false)
+              setHasInteracted(false);
             }
 
             if (strict && !multiple) {
               if (justCommittedRef.current) {
-                justCommittedRef.current = false
-                return
+                justCommittedRef.current = false;
+                return;
               }
-              commitOrRevert(undefined, selectedOptionsLocal, confirmedValue)
+              commitOrRevert(undefined, selectedOptionsLocal, confirmedValue);
             }
           }}
           placeholder={isLoading ? "" : placeholder || "Search your item..."}
@@ -579,10 +585,10 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
               $theme={selectboxTheme}
               aria-label="clearable-content"
               onMouseDown={() => {
-                handleOnChange?.([])
-                setSelectedOptionsLocal({ text: "", value: "0" })
-                setConfirmedValue(null)
-                setHasInteracted(false)
+                handleOnChange?.([]);
+                setSelectedOptionsLocal({ text: "", value: "0" });
+                setConfirmedValue(null);
+                setHasInteracted(false);
               }}
               $highlight={highlightOnMatch && FILTERED_ACTIVE}
               size={16}
@@ -596,12 +602,12 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
           aria-label="selectbox-opener"
           onClick={async () => {
             await setIsOpen((prev) => {
-              const newState = !prev
-              if (newState && inputRef.current) inputRef.current?.focus()
-              return newState
-            })
+              const newState = !prev;
+              if (newState && inputRef.current) inputRef.current?.focus();
+              return newState;
+            });
             if (multiple) {
-              await inputRef.current?.focus()
+              await inputRef.current?.focus();
             }
           }}
         >
@@ -649,16 +655,16 @@ const BaseSelectbox = forwardRef<HTMLInputElement, BaseSelectboxProps>(
             ref: multiple ? inputRef : undefined,
           })}
       </Container>
-    )
-  },
-)
+    );
+  }
+);
 
-export type SelectboxStyles = FieldLaneStyles & BaseSelectboxStyles
+export type SelectboxStyles = FieldLaneStyles & BaseSelectboxStyles;
 
 export interface SelectboxProps
   extends Omit<BaseSelectboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "actions" | "children"> {
-  styles?: SelectboxStyles
+  styles?: SelectboxStyles;
 }
 
 const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
@@ -682,16 +688,16 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
       className,
       mobile,
       ...rest
-    } = props
+    } = props;
 
     const inputId = StatefulForm.sanitizeId({
       prefix: "selectbox",
       name,
       id,
-    })
+    });
 
-    const hasCombo = className?.includes("coneto-combobox")
-    const hasDatebox = className?.includes("coneto-datebox")
+    const hasCombo = className?.includes("coneto-combobox");
+    const hasDatebox = className?.includes("coneto-datebox");
 
     const {
       bodyStyle,
@@ -702,7 +708,7 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
       helperDrawerStyle,
       helperArrowStyle,
       ...selectboxStyles
-    } = styles ?? {}
+    } = styles ?? {};
 
     return (
       <FieldLane
@@ -757,34 +763,34 @@ const Selectbox = forwardRef<HTMLInputElement, SelectboxProps>(
           ref={ref}
         />
       </FieldLane>
-    )
-  },
-)
+    );
+  }
+);
 
 export function castValue<T extends SelectboxSelectedOptions>(
   value: any,
-  original: T,
+  original: T
 ): T {
   if (Array.isArray(original)) {
     if (Array.isArray(value)) {
       return value.map((v) =>
-        typeof original[0] === "number" ? Number(v) : String(v),
-      ) as T
+        typeof original[0] === "number" ? Number(v) : String(v)
+      ) as T;
     }
-    return [value] as T
+    return [value] as T;
   }
 
   if (typeof original === "number") {
-    return Number(value) as T
+    return Number(value) as T;
   }
 
-  return String(value) as T
+  return String(value) as T;
 }
 
 const Container = styled.div<{
-  $style?: CSSProp
-  $isLoading?: boolean
-  $disabled?: boolean
+  $style?: CSSProp;
+  $isLoading?: boolean;
+  $disabled?: boolean;
 }>`
   position: relative;
   width: 100%;
@@ -806,17 +812,17 @@ const Container = styled.div<{
     `};
 
   ${({ $style }) => $style}
-`
+`;
 
 const Input = styled.input<{
-  $highlight?: boolean
-  $focused?: boolean
-  $hovered?: boolean
-  $style?: CSSProp
-  $clearable?: boolean
-  $hasError?: boolean
-  $disabled?: boolean
-  $theme: SelectboxThemeConfig
+  $highlight?: boolean;
+  $focused?: boolean;
+  $hovered?: boolean;
+  $style?: CSSProp;
+  $clearable?: boolean;
+  $hasError?: boolean;
+  $disabled?: boolean;
+  $theme: SelectboxThemeConfig;
 }>`
   width: 100%;
   border-radius: 2px;
@@ -865,11 +871,11 @@ const Input = styled.input<{
     `}
 
   ${({ $style }) => $style}
-`
+`;
 
 const ClearIcon = styled(RiCloseLine)<{
-  $highlight?: boolean
-  $theme: SelectboxThemeConfig
+  $highlight?: boolean;
+  $theme: SelectboxThemeConfig;
 }>`
   position: absolute;
   top: 50%;
@@ -893,10 +899,10 @@ const ClearIcon = styled(RiCloseLine)<{
     background-color: ${({ $theme }) =>
       $theme.clearIconHoverBackground || "#e5e7eb"};
   }
-`
+`;
 
 const Divider = styled.span<{
-  $theme: SelectboxThemeConfig
+  $theme: SelectboxThemeConfig;
 }>`
   position: absolute;
   top: 50%;
@@ -905,7 +911,7 @@ const Divider = styled.span<{
   width: 1px;
   min-height: 15px;
   border-right: 1px solid ${({ $theme }) => $theme.dividerColor || "#9ca3af"};
-`
+`;
 
 const IconWrapper = styled.div<{ $isLoading?: boolean }>`
   position: absolute;
@@ -919,6 +925,6 @@ const IconWrapper = styled.div<{ $isLoading?: boolean }>`
     css`
       opacity: 0.5;
     `}
-`
+`;
 
-export { Selectbox }
+export { Selectbox };

--- a/components/separator.tsx
+++ b/components/separator.tsx
@@ -62,10 +62,7 @@ function Separator({
             $grow={textFloat === "right"}
             $basis={textFloat === "left" ? depth : undefined}
           />
-          <Title
-            $style={styles?.titleStyle}
-            $color={separatorTheme.titleColor}
-          >
+          <Title $style={styles?.titleStyle} $color={separatorTheme.titleColor}>
             {title}
           </Title>
           <Line
@@ -160,7 +157,8 @@ const Line = styled.span<{
   border-radius: 0.125rem;
   background-color: ${({ $color }) => $color};
   box-shadow: ${({ $lineShadow }) => $lineShadow};
-  flex: ${({ $grow, $basis }) => ($grow ? "1 1 auto" : `0 0 ${$basis ?? "0px"}`)};
+  flex: ${({ $grow, $basis }) =>
+    $grow ? "1 1 auto" : `0 0 ${$basis ?? "0px"}`};
 
   ${({ $style }) => $style}
 `;

--- a/components/signbox.tsx
+++ b/components/signbox.tsx
@@ -1,38 +1,38 @@
-import { RiEraserLine } from "@remixicon/react"
-import React, { useRef, useEffect, ChangeEvent } from "react"
-import styled, { css, CSSProp } from "styled-components"
+import { RiEraserLine } from "@remixicon/react";
+import React, { useRef, useEffect, ChangeEvent } from "react";
+import styled, { css, CSSProp } from "styled-components";
 import {
   FieldLane,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane"
-import { StatefulForm } from "./stateful-form"
-import { useTheme } from "./../theme/provider"
-import { SignboxThemeConfig } from "./../theme"
-import { Button } from "./button"
-import { applyClassName } from "./../constants/classname"
+} from "./field-lane";
+import { StatefulForm } from "./stateful-form";
+import { useTheme } from "./../theme/provider";
+import { SignboxThemeConfig } from "./../theme";
+import { Button } from "./button";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseSignboxProps {
-  name?: string
-  value?: string
-  clearable?: boolean
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
-  disabled?: boolean
-  label?: string
-  showError?: boolean
-  errorMessage?: string
-  height?: string
-  width?: string
-  styles?: SignboxStyles
-  id?: string
+  name?: string;
+  value?: string;
+  clearable?: boolean;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
+  label?: string;
+  showError?: boolean;
+  errorMessage?: string;
+  height?: string;
+  width?: string;
+  styles?: SignboxStyles;
+  id?: string;
 }
 
 export interface SignboxStyles {
-  self?: CSSProp
+  self?: CSSProp;
 }
 
-export type SignboxDropdownOption = FieldLaneDropdownOption
+export type SignboxDropdownOption = FieldLaneDropdownOption;
 
 function BaseSignbox({
   name = "signature",
@@ -46,48 +46,48 @@ function BaseSignbox({
   id,
   disabled,
 }: BaseSignboxProps) {
-  const { currentTheme } = useTheme()
-  const signboxTheme = currentTheme?.signbox
+  const { currentTheme } = useTheme();
+  const signboxTheme = currentTheme?.signbox;
 
-  const canvasRef = useRef<HTMLCanvasElement>(null)
-  const isDrawing = useRef(false)
-  const lastPoint = useRef<{ x: number; y: number } | null>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const isDrawing = useRef(false);
+  const lastPoint = useRef<{ x: number; y: number } | null>(null);
 
-  const valueRef = useRef(value)
-
-  useEffect(() => {
-    valueRef.current = value
-  }, [value])
+  const valueRef = useRef(value);
 
   useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) return
+    valueRef.current = value;
+  }, [value]);
 
-    const ctx = canvas.getContext("2d")
-    if (!ctx) return
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
 
     const resizeCanvas = () => {
-      const rect = canvas.getBoundingClientRect()
-      const scale = window.devicePixelRatio || 1
+      const rect = canvas.getBoundingClientRect();
+      const scale = window.devicePixelRatio || 1;
 
-      canvas.width = rect.width * scale
-      canvas.height = rect.height * scale
-      ctx.scale(scale, scale)
+      canvas.width = rect.width * scale;
+      canvas.height = rect.height * scale;
+      ctx.scale(scale, scale);
 
-      ctx.strokeStyle = signboxTheme?.textColor || "#111827"
-      ctx.lineWidth = 2
-      ctx.lineCap = "round"
+      ctx.strokeStyle = signboxTheme?.textColor || "#111827";
+      ctx.lineWidth = 2;
+      ctx.lineCap = "round";
 
-      const currentValue = valueRef.current
+      const currentValue = valueRef.current;
       if (currentValue) {
-        const img = new Image()
+        const img = new Image();
         img.onload = () => {
           const ratio = Math.min(
             rect.width / img.width,
-            rect.height / img.height,
-          )
-          const x = (rect.width - img.width * ratio) / 2
-          const y = (rect.height - img.height * ratio) / 2
+            rect.height / img.height
+          );
+          const x = (rect.width - img.width * ratio) / 2;
+          const y = (rect.height - img.height * ratio) / 2;
           ctx.drawImage(
             img,
             0,
@@ -97,40 +97,43 @@ function BaseSignbox({
             x,
             y,
             img.width * ratio,
-            img.height * ratio,
-          )
-        }
-        img.src = currentValue
+            img.height * ratio
+          );
+        };
+        img.src = currentValue;
       }
-    }
+    };
 
-    resizeCanvas()
-    window.addEventListener("resize", resizeCanvas)
-    return () => window.removeEventListener("resize", resizeCanvas)
-  }, [signboxTheme])
+    resizeCanvas();
+    window.addEventListener("resize", resizeCanvas);
+    return () => window.removeEventListener("resize", resizeCanvas);
+  }, [signboxTheme]);
 
   useEffect(() => {
-    if (!value) return
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const ctx = canvas.getContext("2d")
-    if (!ctx) return
+    if (!value) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
 
     const drawValue = () => {
-      const rect = canvas.getBoundingClientRect()
-      const scale = window.devicePixelRatio || 1
+      const rect = canvas.getBoundingClientRect();
+      const scale = window.devicePixelRatio || 1;
 
-      canvas.width = rect.width * scale
-      canvas.height = rect.height * scale
-      ctx.scale(scale, scale)
+      canvas.width = rect.width * scale;
+      canvas.height = rect.height * scale;
+      ctx.scale(scale, scale);
 
-      const img = new Image()
+      const img = new Image();
       img.onload = () => {
-        ctx.clearRect(0, 0, rect.width, rect.height)
+        ctx.clearRect(0, 0, rect.width, rect.height);
 
-        const ratio = Math.min(rect.width / img.width, rect.height / img.height)
-        const x = (rect.width - img.width * ratio) / 2
-        const y = (rect.height - img.height * ratio) / 2
+        const ratio = Math.min(
+          rect.width / img.width,
+          rect.height / img.height
+        );
+        const x = (rect.width - img.width * ratio) / 2;
+        const y = (rect.height - img.height * ratio) / 2;
         ctx.drawImage(
           img,
           0,
@@ -140,89 +143,89 @@ function BaseSignbox({
           x,
           y,
           img.width * ratio,
-          img.height * ratio,
-        )
-      }
-      img.src = value
-    }
+          img.height * ratio
+        );
+      };
+      img.src = value;
+    };
 
-    drawValue()
-  }, [signboxTheme])
+    drawValue();
+  }, [signboxTheme]);
 
   const getCoordinates = (e: MouseEvent | TouchEvent) => {
-    const canvas = canvasRef.current
-    if (!canvas) return { x: 0, y: 0 }
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
 
-    const rect = canvas.getBoundingClientRect()
+    const rect = canvas.getBoundingClientRect();
 
     if (e instanceof TouchEvent) {
       return {
         x: e.touches[0].clientX - rect.left,
         y: e.touches[0].clientY - rect.top,
-      }
+      };
     } else {
       return {
         x: (e as MouseEvent).clientX - rect.left,
         y: (e as MouseEvent).clientY - rect.top,
-      }
+      };
     }
-  }
+  };
 
   const startDrawing = (e: MouseEvent | TouchEvent) => {
-    isDrawing.current = true
-    lastPoint.current = getCoordinates(e)
-  }
+    isDrawing.current = true;
+    lastPoint.current = getCoordinates(e);
+  };
 
   const draw = (e: MouseEvent | TouchEvent) => {
-    if (!isDrawing.current) return
+    if (!isDrawing.current) return;
 
-    const ctx = canvasRef.current?.getContext("2d")
-    if (!ctx) return
+    const ctx = canvasRef.current?.getContext("2d");
+    if (!ctx) return;
 
-    const { x, y } = getCoordinates(e)
-    const last = lastPoint.current
+    const { x, y } = getCoordinates(e);
+    const last = lastPoint.current;
     if (last) {
-      ctx.beginPath()
-      ctx.moveTo(last.x, last.y)
-      ctx.lineTo(x, y)
-      ctx.stroke()
-      ctx.strokeStyle = signboxTheme?.textColor || "#111827"
-      ctx.lineWidth = 2
-      ctx.lineCap = "round"
+      ctx.beginPath();
+      ctx.moveTo(last.x, last.y);
+      ctx.lineTo(x, y);
+      ctx.stroke();
+      ctx.strokeStyle = signboxTheme?.textColor || "#111827";
+      ctx.lineWidth = 2;
+      ctx.lineCap = "round";
     }
-    lastPoint.current = { x, y }
+    lastPoint.current = { x, y };
 
     if (canvasRef.current) {
-      const dataURL = canvasRef.current.toDataURL("image/png")
+      const dataURL = canvasRef.current.toDataURL("image/png");
       if (onChange) {
         onChange({
           target: { name: name ?? "signature", value: dataURL },
-        } as ChangeEvent<HTMLInputElement>)
+        } as ChangeEvent<HTMLInputElement>);
       }
     }
-  }
+  };
 
   const stopDrawing = () => {
-    isDrawing.current = false
-    lastPoint.current = null
-  }
+    isDrawing.current = false;
+    lastPoint.current = null;
+  };
 
   const clearCanvas = (e?: React.MouseEvent) => {
-    e?.stopPropagation()
-    const canvas = canvasRef.current
-    const ctx = canvas?.getContext("2d")
+    e?.stopPropagation();
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
     if (canvas && ctx) {
-      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
     }
 
     if (onChange) {
       onChange({
         target: { name: name ?? "signature", value: "" },
-      } as ChangeEvent<HTMLInputElement>)
+      } as ChangeEvent<HTMLInputElement>);
     }
-  }
+  };
 
-  const cursor = createCursor(signboxTheme?.textColor || "#111827")
+  const cursor = createCursor(signboxTheme?.textColor || "#111827");
 
   return (
     <SignatureWrapper
@@ -239,32 +242,32 @@ function BaseSignbox({
         ref={canvasRef}
         id={id}
         onMouseDown={(e) => {
-          if (disabled) return
-          startDrawing(e.nativeEvent)
+          if (disabled) return;
+          startDrawing(e.nativeEvent);
         }}
         onMouseMove={(e) => {
-          if (disabled) return
-          draw(e.nativeEvent)
+          if (disabled) return;
+          draw(e.nativeEvent);
         }}
         onMouseUp={() => {
-          if (disabled) return
-          stopDrawing()
+          if (disabled) return;
+          stopDrawing();
         }}
         onMouseLeave={() => {
-          if (disabled) return
-          stopDrawing()
+          if (disabled) return;
+          stopDrawing();
         }}
         onTouchStart={(e) => {
-          if (disabled) return
-          startDrawing(e.nativeEvent)
+          if (disabled) return;
+          startDrawing(e.nativeEvent);
         }}
         onTouchMove={(e) => {
-          if (disabled) return
-          draw(e.nativeEvent)
+          if (disabled) return;
+          draw(e.nativeEvent);
         }}
         onTouchEnd={() => {
-          if (disabled) return
-          stopDrawing()
+          if (disabled) return;
+          stopDrawing();
         }}
       />
       {clearable && (
@@ -288,8 +291,8 @@ function BaseSignbox({
           }}
           aria-label="signbox-clearable"
           onClick={(e) => {
-            if (disabled) return
-            clearCanvas(e)
+            if (disabled) return;
+            clearCanvas(e);
           }}
           disabled={disabled}
           variant="ghost"
@@ -300,13 +303,13 @@ function BaseSignbox({
         />
       )}
     </SignatureWrapper>
-  )
+  );
 }
 
 export interface SignboxProps
   extends Omit<BaseSignboxProps, "styles" | "children">,
     Omit<FieldLaneProps, "styles" | "type" | "children"> {
-  styles?: SignboxStyles & FieldLaneStyles
+  styles?: SignboxStyles & FieldLaneStyles;
 }
 
 function Signbox({
@@ -336,7 +339,7 @@ function Signbox({
     prefix: "signbox",
     name,
     id,
-  })
+  });
 
   const {
     bodyStyle,
@@ -347,7 +350,7 @@ function Signbox({
     helperDrawerStyle,
     helperIconStyle,
     self,
-  } = styles ?? {}
+  } = styles ?? {};
 
   return (
     <FieldLane
@@ -396,26 +399,26 @@ function Signbox({
         }}
       />
     </FieldLane>
-  )
+  );
 }
 
 const createCursor = (color: string) => {
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="${color}">
     <path d="M15.7279 9.57627L14.3137 8.16206L5 17.4758V18.89H6.41421L15.7279 9.57627ZM17.1421 8.16206L18.5563 6.74785L17.1421 5.33363L15.7279 6.74785L17.1421 8.16206ZM7.24264 20.89H3V16.6473L16.435 3.21231C16.8256 2.82179 17.4587 2.82179 17.8492 3.21231L20.6777 6.04074C21.0682 6.43126 21.0682 7.06443 20.6777 7.45495L7.24264 20.89Z"/>
-  </svg>`
+  </svg>`;
 
-  const base64 = btoa(svg)
-  return `url("data:image/svg+xml;base64,${base64}") 2 16, auto`
-}
+  const base64 = btoa(svg);
+  return `url("data:image/svg+xml;base64,${base64}") 2 16, auto`;
+};
 
 const SignatureWrapper = styled.div<{
-  $width?: string
-  $height?: string
-  $canvasStyle?: CSSProp
-  $error?: boolean
-  $disabled?: boolean
-  $theme: SignboxThemeConfig
-  $cursor: string
+  $width?: string;
+  $height?: string;
+  $canvasStyle?: CSSProp;
+  $error?: boolean;
+  $disabled?: boolean;
+  $theme: SignboxThemeConfig;
+  $cursor: string;
 }>`
   position: relative;
   width: ${({ $width }) => $width ?? "100%"};
@@ -442,12 +445,12 @@ const SignatureWrapper = styled.div<{
     `}
 
   ${({ $canvasStyle }) => $canvasStyle};
-`
+`;
 
 const SignatureCanvas = styled.canvas`
   position: relative;
   width: 100%;
   height: 100%;
-`
+`;
 
-export { Signbox }
+export { Signbox };

--- a/components/signbox.tsx
+++ b/components/signbox.tsx
@@ -1,39 +1,38 @@
-import { RiEraserLine } from "@remixicon/react";
-import React, { useRef, useEffect, ChangeEvent } from "react";
-import styled, { css, CSSProp } from "styled-components";
+import { RiEraserLine } from "@remixicon/react"
+import React, { useRef, useEffect, ChangeEvent } from "react"
+import styled, { css, CSSProp } from "styled-components"
 import {
   FieldLane,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane";
-import { StatefulForm } from "./stateful-form";
-import { useTheme } from "./../theme/provider";
-import { SignboxThemeConfig } from "./../theme";
-import { Button } from "./button";
-import { applyClassName } from "./../constants/classname";
+} from "./field-lane"
+import { StatefulForm } from "./stateful-form"
+import { useTheme } from "./../theme/provider"
+import { SignboxThemeConfig } from "./../theme"
+import { Button } from "./button"
+import { applyClassName } from "./../constants/classname"
 
 interface BaseSignboxProps {
-  name?: string;
-  value?: string;
-  clearable?: boolean;
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-  disabled?: boolean;
-  label?: string;
-  showError?: boolean;
-  errorMessage?: string;
-  height?: string;
-  width?: string;
-  styles?: SignboxStyles;
-  helper?: string;
-  id?: string;
+  name?: string
+  value?: string
+  clearable?: boolean
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
+  disabled?: boolean
+  label?: string
+  showError?: boolean
+  errorMessage?: string
+  height?: string
+  width?: string
+  styles?: SignboxStyles
+  id?: string
 }
 
 export interface SignboxStyles {
-  self?: CSSProp;
+  self?: CSSProp
 }
 
-export type SignboxDropdownOption = FieldLaneDropdownOption;
+export type SignboxDropdownOption = FieldLaneDropdownOption
 
 function BaseSignbox({
   name = "signature",
@@ -47,48 +46,48 @@ function BaseSignbox({
   id,
   disabled,
 }: BaseSignboxProps) {
-  const { currentTheme } = useTheme();
-  const signboxTheme = currentTheme?.signbox;
+  const { currentTheme } = useTheme()
+  const signboxTheme = currentTheme?.signbox
 
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const isDrawing = useRef(false);
-  const lastPoint = useRef<{ x: number; y: number } | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const isDrawing = useRef(false)
+  const lastPoint = useRef<{ x: number; y: number } | null>(null)
 
-  const valueRef = useRef(value);
-
-  useEffect(() => {
-    valueRef.current = value;
-  }, [value]);
+  const valueRef = useRef(value)
 
   useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
+    valueRef.current = value
+  }, [value])
 
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
 
     const resizeCanvas = () => {
-      const rect = canvas.getBoundingClientRect();
-      const scale = window.devicePixelRatio || 1;
+      const rect = canvas.getBoundingClientRect()
+      const scale = window.devicePixelRatio || 1
 
-      canvas.width = rect.width * scale;
-      canvas.height = rect.height * scale;
-      ctx.scale(scale, scale);
+      canvas.width = rect.width * scale
+      canvas.height = rect.height * scale
+      ctx.scale(scale, scale)
 
-      ctx.strokeStyle = signboxTheme?.textColor || "#111827";
-      ctx.lineWidth = 2;
-      ctx.lineCap = "round";
+      ctx.strokeStyle = signboxTheme?.textColor || "#111827"
+      ctx.lineWidth = 2
+      ctx.lineCap = "round"
 
-      const currentValue = valueRef.current;
+      const currentValue = valueRef.current
       if (currentValue) {
-        const img = new Image();
+        const img = new Image()
         img.onload = () => {
           const ratio = Math.min(
             rect.width / img.width,
-            rect.height / img.height
-          );
-          const x = (rect.width - img.width * ratio) / 2;
-          const y = (rect.height - img.height * ratio) / 2;
+            rect.height / img.height,
+          )
+          const x = (rect.width - img.width * ratio) / 2
+          const y = (rect.height - img.height * ratio) / 2
           ctx.drawImage(
             img,
             0,
@@ -98,43 +97,40 @@ function BaseSignbox({
             x,
             y,
             img.width * ratio,
-            img.height * ratio
-          );
-        };
-        img.src = currentValue;
+            img.height * ratio,
+          )
+        }
+        img.src = currentValue
       }
-    };
+    }
 
-    resizeCanvas();
-    window.addEventListener("resize", resizeCanvas);
-    return () => window.removeEventListener("resize", resizeCanvas);
-  }, [signboxTheme]);
+    resizeCanvas()
+    window.addEventListener("resize", resizeCanvas)
+    return () => window.removeEventListener("resize", resizeCanvas)
+  }, [signboxTheme])
 
   useEffect(() => {
-    if (!value) return;
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
+    if (!value) return
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
 
     const drawValue = () => {
-      const rect = canvas.getBoundingClientRect();
-      const scale = window.devicePixelRatio || 1;
+      const rect = canvas.getBoundingClientRect()
+      const scale = window.devicePixelRatio || 1
 
-      canvas.width = rect.width * scale;
-      canvas.height = rect.height * scale;
-      ctx.scale(scale, scale);
+      canvas.width = rect.width * scale
+      canvas.height = rect.height * scale
+      ctx.scale(scale, scale)
 
-      const img = new Image();
+      const img = new Image()
       img.onload = () => {
-        ctx.clearRect(0, 0, rect.width, rect.height);
+        ctx.clearRect(0, 0, rect.width, rect.height)
 
-        const ratio = Math.min(
-          rect.width / img.width,
-          rect.height / img.height
-        );
-        const x = (rect.width - img.width * ratio) / 2;
-        const y = (rect.height - img.height * ratio) / 2;
+        const ratio = Math.min(rect.width / img.width, rect.height / img.height)
+        const x = (rect.width - img.width * ratio) / 2
+        const y = (rect.height - img.height * ratio) / 2
         ctx.drawImage(
           img,
           0,
@@ -144,89 +140,89 @@ function BaseSignbox({
           x,
           y,
           img.width * ratio,
-          img.height * ratio
-        );
-      };
-      img.src = value;
-    };
+          img.height * ratio,
+        )
+      }
+      img.src = value
+    }
 
-    drawValue();
-  }, [signboxTheme]);
+    drawValue()
+  }, [signboxTheme])
 
   const getCoordinates = (e: MouseEvent | TouchEvent) => {
-    const canvas = canvasRef.current;
-    if (!canvas) return { x: 0, y: 0 };
+    const canvas = canvasRef.current
+    if (!canvas) return { x: 0, y: 0 }
 
-    const rect = canvas.getBoundingClientRect();
+    const rect = canvas.getBoundingClientRect()
 
     if (e instanceof TouchEvent) {
       return {
         x: e.touches[0].clientX - rect.left,
         y: e.touches[0].clientY - rect.top,
-      };
+      }
     } else {
       return {
         x: (e as MouseEvent).clientX - rect.left,
         y: (e as MouseEvent).clientY - rect.top,
-      };
+      }
     }
-  };
+  }
 
   const startDrawing = (e: MouseEvent | TouchEvent) => {
-    isDrawing.current = true;
-    lastPoint.current = getCoordinates(e);
-  };
+    isDrawing.current = true
+    lastPoint.current = getCoordinates(e)
+  }
 
   const draw = (e: MouseEvent | TouchEvent) => {
-    if (!isDrawing.current) return;
+    if (!isDrawing.current) return
 
-    const ctx = canvasRef.current?.getContext("2d");
-    if (!ctx) return;
+    const ctx = canvasRef.current?.getContext("2d")
+    if (!ctx) return
 
-    const { x, y } = getCoordinates(e);
-    const last = lastPoint.current;
+    const { x, y } = getCoordinates(e)
+    const last = lastPoint.current
     if (last) {
-      ctx.beginPath();
-      ctx.moveTo(last.x, last.y);
-      ctx.lineTo(x, y);
-      ctx.stroke();
-      ctx.strokeStyle = signboxTheme?.textColor || "#111827";
-      ctx.lineWidth = 2;
-      ctx.lineCap = "round";
+      ctx.beginPath()
+      ctx.moveTo(last.x, last.y)
+      ctx.lineTo(x, y)
+      ctx.stroke()
+      ctx.strokeStyle = signboxTheme?.textColor || "#111827"
+      ctx.lineWidth = 2
+      ctx.lineCap = "round"
     }
-    lastPoint.current = { x, y };
+    lastPoint.current = { x, y }
 
     if (canvasRef.current) {
-      const dataURL = canvasRef.current.toDataURL("image/png");
+      const dataURL = canvasRef.current.toDataURL("image/png")
       if (onChange) {
         onChange({
           target: { name: name ?? "signature", value: dataURL },
-        } as ChangeEvent<HTMLInputElement>);
+        } as ChangeEvent<HTMLInputElement>)
       }
     }
-  };
+  }
 
   const stopDrawing = () => {
-    isDrawing.current = false;
-    lastPoint.current = null;
-  };
+    isDrawing.current = false
+    lastPoint.current = null
+  }
 
   const clearCanvas = (e?: React.MouseEvent) => {
-    e?.stopPropagation();
-    const canvas = canvasRef.current;
-    const ctx = canvas?.getContext("2d");
+    e?.stopPropagation()
+    const canvas = canvasRef.current
+    const ctx = canvas?.getContext("2d")
     if (canvas && ctx) {
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
     }
 
     if (onChange) {
       onChange({
         target: { name: name ?? "signature", value: "" },
-      } as ChangeEvent<HTMLInputElement>);
+      } as ChangeEvent<HTMLInputElement>)
     }
-  };
+  }
 
-  const cursor = createCursor(signboxTheme?.textColor || "#111827");
+  const cursor = createCursor(signboxTheme?.textColor || "#111827")
 
   return (
     <SignatureWrapper
@@ -243,32 +239,32 @@ function BaseSignbox({
         ref={canvasRef}
         id={id}
         onMouseDown={(e) => {
-          if (disabled) return;
-          startDrawing(e.nativeEvent);
+          if (disabled) return
+          startDrawing(e.nativeEvent)
         }}
         onMouseMove={(e) => {
-          if (disabled) return;
-          draw(e.nativeEvent);
+          if (disabled) return
+          draw(e.nativeEvent)
         }}
         onMouseUp={() => {
-          if (disabled) return;
-          stopDrawing();
+          if (disabled) return
+          stopDrawing()
         }}
         onMouseLeave={() => {
-          if (disabled) return;
-          stopDrawing();
+          if (disabled) return
+          stopDrawing()
         }}
         onTouchStart={(e) => {
-          if (disabled) return;
-          startDrawing(e.nativeEvent);
+          if (disabled) return
+          startDrawing(e.nativeEvent)
         }}
         onTouchMove={(e) => {
-          if (disabled) return;
-          draw(e.nativeEvent);
+          if (disabled) return
+          draw(e.nativeEvent)
         }}
         onTouchEnd={() => {
-          if (disabled) return;
-          stopDrawing();
+          if (disabled) return
+          stopDrawing()
         }}
       />
       {clearable && (
@@ -292,8 +288,8 @@ function BaseSignbox({
           }}
           aria-label="signbox-clearable"
           onClick={(e) => {
-            if (disabled) return;
-            clearCanvas(e);
+            if (disabled) return
+            clearCanvas(e)
           }}
           disabled={disabled}
           variant="ghost"
@@ -304,13 +300,13 @@ function BaseSignbox({
         />
       )}
     </SignatureWrapper>
-  );
+  )
 }
 
 export interface SignboxProps
   extends Omit<BaseSignboxProps, "styles" | "children">,
     Omit<FieldLaneProps, "styles" | "type" | "children"> {
-  styles?: SignboxStyles & FieldLaneStyles;
+  styles?: SignboxStyles & FieldLaneStyles
 }
 
 function Signbox({
@@ -340,7 +336,18 @@ function Signbox({
     prefix: "signbox",
     name,
     id,
-  });
+  })
+
+  const {
+    bodyStyle,
+    controlStyle,
+    containerStyle,
+    labelStyle,
+    helperArrowStyle,
+    helperDrawerStyle,
+    helperIconStyle,
+    self,
+  } = styles ?? {}
 
   return (
     <FieldLane
@@ -359,10 +366,13 @@ function Signbox({
       required={required}
       className={applyClassName("signbox", className)}
       styles={{
-        bodyStyle: styles?.bodyStyle,
-        controlStyle: styles?.controlStyle,
-        containerStyle: styles?.containerStyle,
-        labelStyle: styles?.labelStyle,
+        bodyStyle,
+        controlStyle,
+        containerStyle,
+        labelStyle,
+        helperArrowStyle,
+        helperDrawerStyle,
+        helperIconStyle,
       }}
     >
       <BaseSignbox
@@ -380,32 +390,32 @@ function Signbox({
             css`
               border-top-left-radius: 0px;
               border-bottom-left-radius: 0px;
-            `}
-            ${styles?.self}
+            `};
+            ${self}
           `,
         }}
       />
     </FieldLane>
-  );
+  )
 }
 
 const createCursor = (color: string) => {
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="${color}">
     <path d="M15.7279 9.57627L14.3137 8.16206L5 17.4758V18.89H6.41421L15.7279 9.57627ZM17.1421 8.16206L18.5563 6.74785L17.1421 5.33363L15.7279 6.74785L17.1421 8.16206ZM7.24264 20.89H3V16.6473L16.435 3.21231C16.8256 2.82179 17.4587 2.82179 17.8492 3.21231L20.6777 6.04074C21.0682 6.43126 21.0682 7.06443 20.6777 7.45495L7.24264 20.89Z"/>
-  </svg>`;
+  </svg>`
 
-  const base64 = btoa(svg);
-  return `url("data:image/svg+xml;base64,${base64}") 2 16, auto`;
-};
+  const base64 = btoa(svg)
+  return `url("data:image/svg+xml;base64,${base64}") 2 16, auto`
+}
 
 const SignatureWrapper = styled.div<{
-  $width?: string;
-  $height?: string;
-  $canvasStyle?: CSSProp;
-  $error?: boolean;
-  $disabled?: boolean;
-  $theme: SignboxThemeConfig;
-  $cursor: string;
+  $width?: string
+  $height?: string
+  $canvasStyle?: CSSProp
+  $error?: boolean
+  $disabled?: boolean
+  $theme: SignboxThemeConfig
+  $cursor: string
 }>`
   position: relative;
   width: ${({ $width }) => $width ?? "100%"};
@@ -432,12 +442,12 @@ const SignatureWrapper = styled.div<{
     `}
 
   ${({ $canvasStyle }) => $canvasStyle};
-`;
+`
 
 const SignatureCanvas = styled.canvas`
   position: relative;
   width: 100%;
   height: 100%;
-`;
+`
 
-export { Signbox };
+export { Signbox }

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -1,25 +1,25 @@
-import { Meta, StoryObj } from "@storybook/react/"
-import { useMemo, useState } from "react"
-import styled, { css } from "styled-components"
-import { z } from "zod"
-import { COUNTRY_CODES } from "./../constants/countries"
-import { BadgeProps } from "./badge"
-import { Button } from "./button"
-import { CapsuleTab } from "./capsule"
-import { Card } from "./card"
+import { Meta, StoryObj } from "@storybook/react/";
+import { useMemo, useState } from "react";
+import styled, { css } from "styled-components";
+import { z } from "zod";
+import { COUNTRY_CODES } from "./../constants/countries";
+import { BadgeProps } from "./badge";
+import { Button } from "./button";
+import { CapsuleTab } from "./capsule";
+import { Card } from "./card";
 import {
   OnCompleteFunctionArgs,
   OnFileDroppedFunctionArgs,
-} from "./file-drop-box"
-import { Messagebox } from "./messagebox"
-import { MoneyboxCurrencyOption } from "./moneybox"
-import { PhoneboxCountryCode } from "./phonebox"
-import { PinboxParts } from "./pinbox"
-import { SelectboxOption } from "./selectbox"
-import { FormFieldGroup, StatefulForm } from "./stateful-form"
-import { BodyThemeConfig, ThemeMode } from "./../theme"
-import { useTheme } from "./../theme/provider"
-import { darkenColor, lightenColor } from "./../lib/color"
+} from "./file-drop-box";
+import { Messagebox } from "./messagebox";
+import { MoneyboxCurrencyOption } from "./moneybox";
+import { PhoneboxCountryCode } from "./phonebox";
+import { PinboxParts } from "./pinbox";
+import { SelectboxOption } from "./selectbox";
+import { FormFieldGroup, StatefulForm } from "./stateful-form";
+import { BodyThemeConfig, ThemeMode } from "./../theme";
+import { useTheme } from "./../theme/provider";
+import { darkenColor, lightenColor } from "./../lib/color";
 
 const meta: Meta<typeof StatefulForm> = {
   title: "Input Elements/StatefulForm",
@@ -177,18 +177,20 @@ Custom styles for form components:
       table: { type: { summary: "StatefulFormStyles" } },
     },
   },
-}
+};
 
-export default meta
+export default meta;
 
-type Story = StoryObj<typeof StatefulForm>
+type Story = StoryObj<typeof StatefulForm>;
 
 export const Default: Story = {
   render: () => {
-    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find((data) => data.id === "US")
+    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
+      (data) => data.id === "US"
+    );
 
     if (!DEFAULT_COUNTRY_CODES) {
-      throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
+      throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
     }
 
     const [value, setValue] = useState({
@@ -200,15 +202,15 @@ export const Default: Story = {
       note: "",
       access: false,
       country_code: DEFAULT_COUNTRY_CODES,
-    })
+    });
 
     const SALUTATION_OPTIONS: SelectboxOption[] = [
       { text: "Mr.", value: "1" },
       { text: "Mrs.", value: "2" },
       { text: "Ms.", value: "3" },
-    ]
+    ];
 
-    const [isFormValid, setIsFormValid] = useState(false)
+    const [isFormValid, setIsFormValid] = useState(false);
 
     const employeeSchema = z.object({
       salutation: z
@@ -217,9 +219,9 @@ export const Default: Story = {
         .refine(
           (arr) =>
             arr.every((val) =>
-              SALUTATION_OPTIONS.some((opt) => opt.value === val),
+              SALUTATION_OPTIONS.some((opt) => opt.value === val)
             ),
-          "Invalid value in combo",
+          "Invalid value in combo"
         ),
       first_name: z
         .string()
@@ -234,7 +236,7 @@ export const Default: Story = {
       access: z.boolean().refine((val) => val === true, {
         message: "Access must be true",
       }),
-    })
+    });
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
@@ -350,7 +352,7 @@ export const Default: Story = {
         placeholder: "Enter text",
         rowJustifyPosition: "end",
       },
-    ]
+    ];
 
     return (
       <div
@@ -368,7 +370,7 @@ export const Default: Story = {
       >
         <StatefulForm
           onChange={({ currentState }) => {
-            setValue((prev) => ({ ...prev, ...currentState }))
+            setValue((prev) => ({ ...prev, ...currentState }));
           }}
           fields={EMPLOYEE_FIELDS}
           formValues={value}
@@ -378,13 +380,13 @@ export const Default: Story = {
           mode="onChange"
         />
       </div>
-    )
+    );
   },
-}
+};
 
 export const WithFrame: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false)
+    const [isFormValid, setIsFormValid] = useState(false);
     const [value, setValue] = useState({
       name: "",
       department: "",
@@ -392,13 +394,13 @@ export const WithFrame: Story = {
       start_date: [""],
       end_date: [""],
       purpose: "",
-    })
+    });
 
     const dateArraySchema = z
       .array(
-        z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date"),
+        z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date")
       )
-      .min(1, "At least one date is required")
+      .min(1, "At least one date is required");
 
     const employeeSchema = z.object({
       name: z.string().min(3, "Name is required"),
@@ -407,17 +409,17 @@ export const WithFrame: Story = {
       start_date: dateArraySchema,
       end_date: dateArraySchema,
       purpose: z.string().min(10, "Business purpose is required"),
-    })
+    });
 
     const MANAGER_NAME_OPTIONS: SelectboxOption[] = [
       { text: "Alim Naufal", value: "1" },
       { text: "Soekarno", value: "2" },
-    ]
+    ];
 
     const DEPARTMENT_OPTIONS: SelectboxOption[] = [
       { text: "HR", value: "1" },
       { text: "IT", value: "2" },
-    ]
+    ];
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       {
@@ -486,7 +488,7 @@ export const WithFrame: Story = {
         disabled: !isFormValid,
         rowJustifyPosition: "end",
       },
-    ]
+    ];
 
     return (
       <div
@@ -504,7 +506,7 @@ export const WithFrame: Story = {
       >
         <StatefulForm
           onChange={({ currentState }) => {
-            setValue((prev) => ({ ...prev, ...currentState }))
+            setValue((prev) => ({ ...prev, ...currentState }));
           }}
           validationSchema={employeeSchema}
           onValidityChange={setIsFormValid}
@@ -513,20 +515,20 @@ export const WithFrame: Story = {
           mode="onChange"
         />
       </div>
-    )
+    );
   },
-}
+};
 
 export const ConditionalElement: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false)
+    const [isFormValid, setIsFormValid] = useState(false);
     const [formFields, setFormFields] = useState({
       quantType: "",
       compEffort: "",
       scheIterations: "",
       target: "",
       hostArch: "",
-    })
+    });
 
     const schema = z.object({
       quantType: z.string().optional(),
@@ -537,46 +539,46 @@ export const ConditionalElement: Story = {
         .optional(),
       target: z.string().min(1, "Target is required"),
       hostArch: z.string().optional(),
-    })
+    });
 
     const HostArchitecture = {
       x86: 0,
       x64: 1,
       ARM: 2,
       ARM64: 3,
-    } as const
+    } as const;
 
     const CompilationTarget = {
       Interpreter: 0,
       Simulator: 1,
       IP: 2,
-    } as const
+    } as const;
 
     const CompilationEffort = {
       SimpleScheduling: 0,
       Performance: 1,
       Aggressive: 2,
-    } as const
+    } as const;
 
     const Quantization = {
       Int8: 0,
       Bf16: 1,
       Fp16: 2,
       Fp32: 3,
-    } as const
+    } as const;
 
     const HOST_ARCHITECTURE_OPTIONS: SelectboxOption[] = [
       { value: String(HostArchitecture.x86), text: "x86" },
       { value: String(HostArchitecture.x64), text: "x64" },
       { value: String(HostArchitecture.ARM), text: "ARM" },
       { value: String(HostArchitecture.ARM64), text: "ARM64" },
-    ]
+    ];
 
     const COMPILATION_TARGET_OPTIONS: SelectboxOption[] = [
       { value: String(CompilationTarget.Interpreter), text: "Interpreter" },
       { value: String(CompilationTarget.Simulator), text: "Simulator" },
       { value: String(CompilationTarget.IP), text: "IP" },
-    ]
+    ];
 
     const COMPILATION_EFFORT_OPTIONS: SelectboxOption[] = [
       {
@@ -591,21 +593,21 @@ export const ConditionalElement: Story = {
         value: String(CompilationEffort.Aggressive),
         text: "Aggressive",
       },
-    ]
+    ];
 
     const QUANTIZATION_TYPE_OPTIONS: SelectboxOption[] = [
       { value: String(Quantization.Int8), text: "INT8" },
       { value: String(Quantization.Bf16), text: "BF16" },
       { value: String(Quantization.Fp16), text: "FP16" },
       { value: String(Quantization.Fp32), text: "FP32" },
-    ]
+    ];
 
     const COMPILATION_FIELDS: FormFieldGroup[] = useMemo(() => {
       const isInt8Quantization =
-        formFields.quantType === String(Quantization.Int8)
+        formFields.quantType === String(Quantization.Int8);
 
       const isPerfCompilation =
-        formFields.compEffort === String(CompilationEffort.Performance)
+        formFields.compEffort === String(CompilationEffort.Performance);
 
       return [
         {
@@ -666,13 +668,13 @@ export const ConditionalElement: Story = {
           disabled: !isFormValid,
           rowJustifyPosition: "end",
         },
-      ] as FormFieldGroup[]
-    }, [formFields.compEffort, formFields.quantType, isFormValid])
+      ] as FormFieldGroup[];
+    }, [formFields.compEffort, formFields.quantType, isFormValid]);
 
     return (
       <StatefulForm
         onChange={({ currentState }) => {
-          setFormFields((prev) => ({ ...prev, ...currentState }))
+          setFormFields((prev) => ({ ...prev, ...currentState }));
         }}
         onValidityChange={setIsFormValid}
         validationSchema={schema}
@@ -680,33 +682,33 @@ export const ConditionalElement: Story = {
         formValues={formFields}
         mode="onChange"
       />
-    )
+    );
   },
-}
+};
 
 export const LeftLabeled: Story = {
   render: () => {
-    const { currentTheme, mode } = useTheme()
-    const bodyTheme = currentTheme?.body
+    const { currentTheme, mode } = useTheme();
+    const bodyTheme = currentTheme?.body;
 
     const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-      (country) => country.id === "US",
-    )
+      (country) => country.id === "US"
+    );
 
-    const [isFormValid, setIsFormValid] = useState(false)
+    const [isFormValid, setIsFormValid] = useState(false);
     const [value, setValue] = useState<{
-      name: string
-      email: string
-      phone: string
-      country_code: PhoneboxCountryCode
-      password: string
+      name: string;
+      email: string;
+      phone: string;
+      country_code: PhoneboxCountryCode;
+      password: string;
     }>({
       name: "",
       email: "",
       phone: "",
       country_code: DEFAULT_COUNTRY_CODES,
       password: "",
-    })
+    });
 
     const SIGN_UP_FIELDS: FormFieldGroup[] = [
       {
@@ -744,14 +746,14 @@ export const LeftLabeled: Story = {
         required: true,
         labelPosition: "left",
       },
-    ]
+    ];
 
     const signUpSchema = z.object({
       name: z.string().min(3, "Name must be at least 3 characters"),
       phone: z.string().min(8, "Phone number must be 8 digits"),
       email: z.string().email("Please enter a valid email"),
       password: z.string().min(8, "Password must be at least 8 characters"),
-    })
+    });
 
     return (
       <Card
@@ -802,14 +804,14 @@ export const LeftLabeled: Story = {
           </div>
         </Footer>
       </Card>
-    )
+    );
   },
-}
+};
 
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-`
+`;
 
 const Title = styled.h3`
   font-family: monospace;
@@ -821,7 +823,7 @@ const Title = styled.h3`
   @media (min-width: 768px) {
     font-size: 1.5rem;
   }
-`
+`;
 
 const Description = styled.span`
   font-size: 0.625rem;
@@ -830,18 +832,18 @@ const Description = styled.span`
   @media (min-width: 768px) {
     font-size: 0.75rem;
   }
-`
+`;
 
 const FormBody = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
   padding: 2rem;
-`
+`;
 
 const Footer = styled.div<{
-  $theme?: BodyThemeConfig
-  $mode: ThemeMode | string
+  $theme?: BodyThemeConfig;
+  $mode: ThemeMode | string;
 }>`
   display: flex;
   flex-direction: row;
@@ -869,7 +871,7 @@ const Footer = styled.div<{
   .loader {
     margin-left: 0.5rem;
   }
-`
+`;
 
 const ScrollBox = styled.div`
   max-height: 120px;
@@ -894,17 +896,17 @@ const ScrollBox = styled.div`
 
   scrollbar-width: thin;
   scrollbar-color: #ccc transparent;
-`
+`;
 
 export const Mobile: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false)
+    const [isFormValid, setIsFormValid] = useState(false);
     const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-      (data) => data.id === "US" || COUNTRY_CODES[206],
-    )
+      (data) => data.id === "US" || COUNTRY_CODES[206]
+    );
 
     if (!DEFAULT_COUNTRY_CODES) {
-      throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
+      throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
     }
 
     const FRUIT_OPTIONS: SelectboxOption[] = [
@@ -915,7 +917,7 @@ export const Mobile: Story = {
       { text: "Pineapple", value: "5" },
       { text: "Strawberry", value: "6" },
       { text: "Watermelon", value: "7" },
-    ]
+    ];
 
     const BADGE_OPTIONS: BadgeProps[] = [
       {
@@ -958,7 +960,7 @@ export const Mobile: Story = {
         id: "10",
         caption: "Webtoons",
       },
-    ]
+    ];
 
     const CURRENCY_OPTIONS: MoneyboxCurrencyOption[] = [
       { id: "IDR", name: "Indonesian Rupiah", symbol: "Rp" },
@@ -971,36 +973,36 @@ export const Mobile: Story = {
       { id: "MYR", name: "Malaysian Ringgit", symbol: "RM" },
       { id: "KRW", name: "South Korean Won", symbol: "₩" },
       { id: "CNY", name: "Chinese Yuan", symbol: "¥" },
-    ]
+    ];
 
     interface AllCaseValueProps {
-      text: string
-      time: string
-      email: string
-      number: string
-      password: string
-      textarea: string
-      rating: string
-      check: boolean
+      text: string;
+      time: string;
+      email: string;
+      number: string;
+      password: string;
+      textarea: string;
+      rating: string;
+      check: boolean;
       chips?: {
-        searchText: string
-        selectedOptions: string[]
-      }
-      color: string
-      combo: string[]
-      date: string[]
-      file_drop_box?: File[]
-      file: File[] | undefined
-      image: File | undefined
-      money: string
-      phone: string
-      thumb_field: boolean
-      toggle: boolean
-      signature: string
-      capsule: string
-      country_code?: PhoneboxCountryCode
-      currency: string
-      pin: string
+        searchText: string;
+        selectedOptions: string[];
+      };
+      color: string;
+      combo: string[];
+      date: string[];
+      file_drop_box?: File[];
+      file: File[] | undefined;
+      image: File | undefined;
+      money: string;
+      phone: string;
+      thumb_field: boolean;
+      toggle: boolean;
+      signature: string;
+      capsule: string;
+      country_code?: PhoneboxCountryCode;
+      currency: string;
+      pin: string;
     }
 
     const [value, setValue] = useState<AllCaseValueProps>({
@@ -1031,7 +1033,7 @@ export const Mobile: Story = {
       country_code: DEFAULT_COUNTRY_CODES,
       currency: "USD",
       pin: "",
-    })
+    });
 
     const CAPSULE_TABS: CapsuleTab[] = [
       {
@@ -1042,7 +1044,7 @@ export const Mobile: Story = {
         id: "unpaid",
         title: "Unpaid",
       },
-    ]
+    ];
 
     const PARTS_INPUT: PinboxParts[] = [
       {
@@ -1065,7 +1067,7 @@ export const Mobile: Story = {
       {
         type: "alphabet",
       },
-    ]
+    ];
 
     const schema = z.object({
       text: z.string().min(3, "Text must be at least 3 characters"),
@@ -1089,10 +1091,10 @@ export const Mobile: Story = {
           (arr) =>
             arr.every((val) =>
               FRUIT_OPTIONS.some((opt) => {
-                return opt.value === val
-              }),
+                return opt.value === val;
+              })
             ),
-          "Invalid value in combo",
+          "Invalid value in combo"
         ),
       date: z.array(
         z
@@ -1103,15 +1105,15 @@ export const Mobile: Story = {
               /^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/\d{4}$/.test(val),
             {
               message: "Invalid date",
-            },
-          ),
+            }
+          )
       ),
       file_drop_box: z.any().optional(),
       file: z
         .preprocess((value) => {
-          if (value instanceof FileList) return Array.from(value)
-          if (Array.isArray(value)) return value
-          return []
+          if (value instanceof FileList) return Array.from(value);
+          if (Array.isArray(value)) return value;
+          return [];
         }, z.array(z.any()))
         .refine((files) => files.length > 0, {
           message: "At least one file is required",
@@ -1123,17 +1125,17 @@ export const Mobile: Story = {
           (files) => files.every((file) => file.size <= 5 * 1024 * 1024),
           {
             message: "Each file must be 5MB or less",
-          },
+          }
         ),
       image: z
         .any()
         .refine(
           (file) => {
-            return file?.type === "image/jpeg"
+            return file?.type === "image/jpeg";
           },
           {
             message: "Only JPEG file are allowed",
-          },
+          }
         )
         .refine((file) => file?.size <= 5 * 1024 * 1024, {
           message: "File size must be 5MB or less",
@@ -1154,7 +1156,7 @@ export const Mobile: Story = {
           code: z.string(),
         })
         .optional(),
-    })
+    });
 
     const onFileDropped = async ({
       error,
@@ -1162,27 +1164,27 @@ export const Mobile: Story = {
       setProgressLabel,
       succeed,
     }: OnFileDroppedFunctionArgs) => {
-      const file = files[0]
-      setProgressLabel(`Uploading ${file.name}`)
+      const file = files[0];
+      setProgressLabel(`Uploading ${file.name}`);
 
       return new Promise<void>((resolve) => {
-        let progress = 0
+        let progress = 0;
         const interval = setInterval(() => {
-          progress += 20
+          progress += 20;
 
           if (progress >= 100) {
-            clearInterval(interval)
+            clearInterval(interval);
             if (file === null) {
-              error(file, `file ${files[0].name} is not uploaded`)
+              error(file, `file ${files[0].name} is not uploaded`);
             } else {
-              succeed(file)
+              succeed(file);
             }
-            setProgressLabel(`Uploaded ${files[0].name}`)
-            resolve()
+            setProgressLabel(`Uploaded ${files[0].name}`);
+            resolve();
           }
-        }, 300)
-      })
-    }
+        }, 300);
+      });
+    };
 
     const onComplete = ({
       failedFiles,
@@ -1192,13 +1194,13 @@ export const Mobile: Story = {
       setValue((prev) => ({
         ...prev,
         file_drop_box: succeedFiles,
-      }))
-      console.log(succeedFiles, "This is succeedFiles")
-      console.log(failedFiles, "This is failedFiles")
+      }));
+      console.log(succeedFiles, "This is succeedFiles");
+      console.log(failedFiles, "This is failedFiles");
       setProgressLabel(
-        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`,
-      )
-    }
+        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`
+      );
+    };
 
     const MONTH_NAMES = [
       { text: "JAN", value: "1" },
@@ -1213,7 +1215,7 @@ export const Mobile: Story = {
       { text: "OCT", value: "10" },
       { text: "NOV", value: "11" },
       { text: "DEC", value: "12" },
-    ]
+    ];
 
     const FIELDS: FormFieldGroup[] = [
       [
@@ -1417,7 +1419,7 @@ export const Mobile: Story = {
           },
         },
       ],
-    ]
+    ];
 
     return (
       <StatefulForm
@@ -1433,7 +1435,7 @@ export const Mobile: Story = {
           `,
         }}
         onChange={({ currentState }) => {
-          const [[key, value]] = Object.entries(currentState)
+          const [[key, value]] = Object.entries(currentState);
 
           setValue((prev) => ({
             ...prev,
@@ -1446,7 +1448,7 @@ export const Mobile: Story = {
                   },
                 }
               : currentState),
-          }))
+          }));
         }}
         onValidityChange={setIsFormValid}
         labelSize="14px"
@@ -1456,19 +1458,19 @@ export const Mobile: Story = {
         validationSchema={schema}
         mode="onChange"
       />
-    )
+    );
   },
-}
+};
 
 export const AllCase: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false)
+    const [isFormValid, setIsFormValid] = useState(false);
     const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-      (data) => data.id === "US" || COUNTRY_CODES[206],
-    )
+      (data) => data.id === "US" || COUNTRY_CODES[206]
+    );
 
     if (!DEFAULT_COUNTRY_CODES) {
-      throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
+      throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
     }
 
     const FRUIT_OPTIONS: SelectboxOption[] = [
@@ -1479,7 +1481,7 @@ export const AllCase: Story = {
       { text: "Pineapple", value: "5" },
       { text: "Strawberry", value: "6" },
       { text: "Watermelon", value: "7" },
-    ]
+    ];
 
     const BADGE_OPTIONS: BadgeProps[] = [
       {
@@ -1522,7 +1524,7 @@ export const AllCase: Story = {
         id: "10",
         caption: "Webtoons",
       },
-    ]
+    ];
 
     const CURRENCY_OPTIONS: MoneyboxCurrencyOption[] = [
       { id: "IDR", name: "Indonesian Rupiah", symbol: "Rp" },
@@ -1535,36 +1537,36 @@ export const AllCase: Story = {
       { id: "MYR", name: "Malaysian Ringgit", symbol: "RM" },
       { id: "KRW", name: "South Korean Won", symbol: "₩" },
       { id: "CNY", name: "Chinese Yuan", symbol: "¥" },
-    ]
+    ];
 
     interface AllCaseValueProps {
-      text: string
-      time: string
-      email: string
-      number: string
-      password: string
-      textarea: string
-      rating: string
-      check: boolean
+      text: string;
+      time: string;
+      email: string;
+      number: string;
+      password: string;
+      textarea: string;
+      rating: string;
+      check: boolean;
       chips?: {
-        searchText: string
-        selectedOptions: string[]
-      }
-      color: string
-      combo: string[]
-      date: string[]
-      file_drop_box?: File[]
-      file: File[] | undefined
-      image: File | undefined
-      money: string
-      phone: string
-      thumb_field: boolean
-      toggle: boolean
-      signature: string
-      capsule: string
-      country_code?: PhoneboxCountryCode
-      currency: string
-      pin: string
+        searchText: string;
+        selectedOptions: string[];
+      };
+      color: string;
+      combo: string[];
+      date: string[];
+      file_drop_box?: File[];
+      file: File[] | undefined;
+      image: File | undefined;
+      money: string;
+      phone: string;
+      thumb_field: boolean;
+      toggle: boolean;
+      signature: string;
+      capsule: string;
+      country_code?: PhoneboxCountryCode;
+      currency: string;
+      pin: string;
     }
 
     const [value, setValue] = useState<AllCaseValueProps>({
@@ -1595,7 +1597,7 @@ export const AllCase: Story = {
       country_code: DEFAULT_COUNTRY_CODES,
       currency: "USD",
       pin: "",
-    })
+    });
 
     const CAPSULE_TABS: CapsuleTab[] = [
       {
@@ -1606,7 +1608,7 @@ export const AllCase: Story = {
         id: "unpaid",
         title: "Unpaid",
       },
-    ]
+    ];
 
     const PARTS_INPUT: PinboxParts[] = [
       {
@@ -1629,7 +1631,7 @@ export const AllCase: Story = {
       {
         type: "alphabet",
       },
-    ]
+    ];
 
     const schema = z.object({
       text: z.string().min(3, "Text must be at least 3 characters"),
@@ -1653,10 +1655,10 @@ export const AllCase: Story = {
           (arr) =>
             arr.every((val) =>
               FRUIT_OPTIONS.some((opt) => {
-                return opt.value === val
-              }),
+                return opt.value === val;
+              })
             ),
-          "Invalid value in combo",
+          "Invalid value in combo"
         ),
       date: z.array(
         z
@@ -1667,15 +1669,15 @@ export const AllCase: Story = {
               /^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/\d{4}$/.test(val),
             {
               message: "Invalid date",
-            },
-          ),
+            }
+          )
       ),
       file_drop_box: z.any().optional(),
       file: z
         .preprocess((value) => {
-          if (value instanceof FileList) return Array.from(value)
-          if (Array.isArray(value)) return value
-          return []
+          if (value instanceof FileList) return Array.from(value);
+          if (Array.isArray(value)) return value;
+          return [];
         }, z.array(z.any()))
         .refine((files) => files.length > 0, {
           message: "At least one file is required",
@@ -1687,17 +1689,17 @@ export const AllCase: Story = {
           (files) => files.every((file) => file.size <= 5 * 1024 * 1024),
           {
             message: "Each file must be 5MB or less",
-          },
+          }
         ),
       image: z
         .any()
         .refine(
           (file) => {
-            return file?.type === "image/jpeg"
+            return file?.type === "image/jpeg";
           },
           {
             message: "Only JPEG file are allowed",
-          },
+          }
         )
         .refine((file) => file?.size <= 5 * 1024 * 1024, {
           message: "File size must be 5MB or less",
@@ -1718,7 +1720,7 @@ export const AllCase: Story = {
           code: z.string(),
         })
         .optional(),
-    })
+    });
 
     const onFileDropped = async ({
       error,
@@ -1726,27 +1728,27 @@ export const AllCase: Story = {
       setProgressLabel,
       succeed,
     }: OnFileDroppedFunctionArgs) => {
-      const file = files[0]
-      setProgressLabel(`Uploading ${file.name}`)
+      const file = files[0];
+      setProgressLabel(`Uploading ${file.name}`);
 
       return new Promise<void>((resolve) => {
-        let progress = 0
+        let progress = 0;
         const interval = setInterval(() => {
-          progress += 20
+          progress += 20;
 
           if (progress >= 100) {
-            clearInterval(interval)
+            clearInterval(interval);
             if (file === null) {
-              error(file, `file ${files[0].name} is not uploaded`)
+              error(file, `file ${files[0].name} is not uploaded`);
             } else {
-              succeed(file)
+              succeed(file);
             }
-            setProgressLabel(`Uploaded ${files[0].name}`)
-            resolve()
+            setProgressLabel(`Uploaded ${files[0].name}`);
+            resolve();
           }
-        }, 300)
-      })
-    }
+        }, 300);
+      });
+    };
 
     const onComplete = ({
       failedFiles,
@@ -1756,13 +1758,13 @@ export const AllCase: Story = {
       setValue((prev) => ({
         ...prev,
         file_drop_box: succeedFiles,
-      }))
-      console.log(succeedFiles, "This is succeedFiles")
-      console.log(failedFiles, "This is failedFiles")
+      }));
+      console.log(succeedFiles, "This is succeedFiles");
+      console.log(failedFiles, "This is failedFiles");
       setProgressLabel(
-        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`,
-      )
-    }
+        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`
+      );
+    };
 
     const MONTH_NAMES = [
       { text: "JAN", value: "1" },
@@ -1777,7 +1779,7 @@ export const AllCase: Story = {
       { text: "OCT", value: "10" },
       { text: "NOV", value: "11" },
       { text: "DEC", value: "12" },
-    ]
+    ];
 
     const FIELDS: FormFieldGroup[] = [
       {
@@ -1786,7 +1788,44 @@ export const AllCase: Story = {
         type: "text",
         required: true,
         placeholder: "Enter text",
-        helper: "This field is used to enter a single line of text",
+        helper: (
+          <StatefulForm.FieldTooltip
+            items={[
+              {
+                title: "Work Email Preferred",
+                description:
+                  "Use your company email address if you're registering for an organization.",
+              },
+              {
+                title: "Verification Required",
+                description:
+                  "We'll send a verification email before your account becomes active.",
+              },
+              {
+                title: "Password Recovery",
+                description:
+                  "This email address will be used to recover your account if you forget your password.",
+              },
+              {
+                title: "Notifications",
+                description:
+                  "Important security alerts and account updates will be sent to this address.",
+              },
+              {
+                title: "Double-check Spelling",
+                description:
+                  "Make sure your email address is correct to avoid missing verification emails.",
+              },
+            ]}
+          />
+        ),
+        textbox: {
+          styles: {
+            helperDrawerStyle: css`
+              padding: 0px;
+            `,
+          },
+        },
       },
       {
         name: "email",
@@ -1991,9 +2030,9 @@ export const AllCase: Story = {
         disabled: !isFormValid,
         rowJustifyPosition: "end",
       },
-    ]
+    ];
 
-    console.log(value.chips.searchText)
+    console.log(value.chips.searchText);
 
     return (
       <StatefulForm
@@ -2008,7 +2047,7 @@ export const AllCase: Story = {
           `,
         }}
         onChange={({ currentState }) => {
-          const [[key, value]] = Object.entries(currentState)
+          const [[key, value]] = Object.entries(currentState);
 
           setValue((prev) => ({
             ...prev,
@@ -2021,7 +2060,7 @@ export const AllCase: Story = {
                   },
                 }
               : currentState),
-          }))
+          }));
         }}
         onValidityChange={setIsFormValid}
         labelSize="14px"
@@ -2031,40 +2070,40 @@ export const AllCase: Story = {
         validationSchema={schema}
         mode="onChange"
       />
-    )
+    );
   },
-}
+};
 
 export const AllCaseDisabled: Story = {
   render: () => {
     interface AllCaseValueProps {
-      text: string
-      time: string
-      email: string
-      number: string
-      password: string
-      textarea: string
-      rating: string
-      check: boolean
+      text: string;
+      time: string;
+      email: string;
+      number: string;
+      password: string;
+      textarea: string;
+      rating: string;
+      check: boolean;
       chips?: {
-        searchText: string
-        selectedOptions: string[]
-      }
-      color: string
-      combo: string[]
-      date: string[]
-      file_drop_box?: File[]
-      file: File[] | undefined
-      image: File | undefined
-      money: string
-      phone: string
-      thumb_field: boolean
-      togglebox: boolean
-      signature: string
-      capsule: string
-      country_code?: PhoneboxCountryCode
-      currency: string
-      pin: string
+        searchText: string;
+        selectedOptions: string[];
+      };
+      color: string;
+      combo: string[];
+      date: string[];
+      file_drop_box?: File[];
+      file: File[] | undefined;
+      image: File | undefined;
+      money: string;
+      phone: string;
+      thumb_field: boolean;
+      togglebox: boolean;
+      signature: string;
+      capsule: string;
+      country_code?: PhoneboxCountryCode;
+      currency: string;
+      pin: string;
     }
 
     const [value, setValue] = useState<AllCaseValueProps>({
@@ -2095,7 +2134,7 @@ export const AllCaseDisabled: Story = {
       country_code: undefined,
       currency: "USD",
       pin: "",
-    })
+    });
 
     const CAPSULE_TABS: CapsuleTab[] = [
       {
@@ -2106,7 +2145,7 @@ export const AllCaseDisabled: Story = {
         id: "unpaid",
         title: "Unpaid",
       },
-    ]
+    ];
 
     const PARTS_INPUT: PinboxParts[] = [
       {
@@ -2129,7 +2168,7 @@ export const AllCaseDisabled: Story = {
       {
         type: "alphabet",
       },
-    ]
+    ];
 
     const FIELDS: FormFieldGroup[] = [
       {
@@ -2344,7 +2383,7 @@ export const AllCaseDisabled: Story = {
         required: true,
         rowJustifyPosition: "end",
       },
-    ]
+    ];
 
     return (
       <StatefulForm
@@ -2360,13 +2399,13 @@ export const AllCaseDisabled: Story = {
         }}
         disabled
         onChange={({ currentState }) => {
-          const { chips, ...rest } = currentState
-          void chips
+          const { chips, ...rest } = currentState;
+          void chips;
 
           setValue((prev) => ({
             ...prev,
             ...rest,
-          }))
+          }));
         }}
         labelSize="14px"
         fieldSize="14px"
@@ -2374,6 +2413,6 @@ export const AllCaseDisabled: Story = {
         formValues={value}
         mode="onChange"
       />
-    )
+    );
   },
-}
+};

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -99,6 +99,50 @@ const fields = [
 - Listen to \`onChange\` for live updates and \`onValidityChange\` to track form validity.
 - Customize appearance and spacing using \`styles\`.
 - Render fully custom inputs using \`type="custom"\` and the \`render\` prop.
+
+---
+
+### 💡 StatefulForm.FieldTooltip
+
+\`StatefulForm.FieldTooltip\` provides a structured way to display contextual guidance for a form field. Unlike a plain helper string, it supports multiple titled sections, making it ideal for explaining requirements, best practices, or additional information.
+
+Use it by passing the component to a field's \`helper\` property.
+
+\`\`\`tsx
+helper: (
+  <StatefulForm.FieldTooltip
+    items={[
+      {
+        title: "Purpose",
+        description:
+          "Use this field to enter a short, descriptive title.",
+      },
+      {
+        title: "Best Practice",
+        description:
+          "Choose a clear and concise value that is easy to understand.",
+      },
+      {
+        title: "Requirements",
+        description:
+          "Avoid using special characters unless they are required.",
+      },
+    ]}
+  />
+)
+\`\`\`
+
+For simple helper text, you can continue using a string:
+
+\`\`\`tsx
+helper: "Enter a unique title."
+\`\`\`
+
+Use \`StatefulForm.FieldTooltip\` when:
+- 📖 You need to explain multiple rules or requirements.
+- 💡 You want to provide additional context or guidance.
+- 📋 You want to organize helper content into titled sections.
+- 🎨 You need to customize the tooltip appearance using the \`styles\` prop.
 `,
       },
     },
@@ -1792,29 +1836,29 @@ export const AllCase: Story = {
           <StatefulForm.FieldTooltip
             items={[
               {
-                title: "Work Email Preferred",
+                title: "Purpose",
                 description:
-                  "Use your company email address if you're registering for an organization.",
+                  "Use this field to enter short text such as a name, title, or label.",
               },
               {
-                title: "Verification Required",
+                title: "Keep It Concise",
                 description:
-                  "We'll send a verification email before your account becomes active.",
+                  "Enter clear and meaningful text that is easy for others to understand.",
               },
               {
-                title: "Password Recovery",
+                title: "Required Field",
                 description:
-                  "This email address will be used to recover your account if you forget your password.",
+                  "Fields marked with an asterisk (*) must be completed before submitting the form.",
               },
               {
-                title: "Notifications",
+                title: "Supported Characters",
                 description:
-                  "Important security alerts and account updates will be sent to this address.",
+                  "Letters, numbers, spaces, and common punctuation are accepted unless otherwise specified.",
               },
               {
-                title: "Double-check Spelling",
+                title: "Review Before Continuing",
                 description:
-                  "Make sure your email address is correct to avoid missing verification emails.",
+                  "Double-check your input for spelling or typing mistakes before proceeding.",
               },
             ]}
           />

--- a/components/stateful-form.stories.tsx
+++ b/components/stateful-form.stories.tsx
@@ -1,25 +1,25 @@
-import { Meta, StoryObj } from "@storybook/react/";
-import { useMemo, useState } from "react";
-import styled, { css } from "styled-components";
-import { z } from "zod";
-import { COUNTRY_CODES } from "./../constants/countries";
-import { BadgeProps } from "./badge";
-import { Button } from "./button";
-import { CapsuleTab } from "./capsule";
-import { Card } from "./card";
+import { Meta, StoryObj } from "@storybook/react/"
+import { useMemo, useState } from "react"
+import styled, { css } from "styled-components"
+import { z } from "zod"
+import { COUNTRY_CODES } from "./../constants/countries"
+import { BadgeProps } from "./badge"
+import { Button } from "./button"
+import { CapsuleTab } from "./capsule"
+import { Card } from "./card"
 import {
   OnCompleteFunctionArgs,
   OnFileDroppedFunctionArgs,
-} from "./file-drop-box";
-import { Messagebox } from "./messagebox";
-import { MoneyboxCurrencyOption } from "./moneybox";
-import { PhoneboxCountryCode } from "./phonebox";
-import { PinboxParts } from "./pinbox";
-import { SelectboxOption } from "./selectbox";
-import { FormFieldGroup, StatefulForm } from "./stateful-form";
-import { BodyThemeConfig, ThemeMode } from "./../theme";
-import { useTheme } from "./../theme/provider";
-import { darkenColor, lightenColor } from "./../lib/color";
+} from "./file-drop-box"
+import { Messagebox } from "./messagebox"
+import { MoneyboxCurrencyOption } from "./moneybox"
+import { PhoneboxCountryCode } from "./phonebox"
+import { PinboxParts } from "./pinbox"
+import { SelectboxOption } from "./selectbox"
+import { FormFieldGroup, StatefulForm } from "./stateful-form"
+import { BodyThemeConfig, ThemeMode } from "./../theme"
+import { useTheme } from "./../theme/provider"
+import { darkenColor, lightenColor } from "./../lib/color"
 
 const meta: Meta<typeof StatefulForm> = {
   title: "Input Elements/StatefulForm",
@@ -29,12 +29,13 @@ const meta: Meta<typeof StatefulForm> = {
     docs: {
       description: {
         component: `
-**StatefulForm** is a form renderer capable to handle complex scenarios involving data validation,
-nested fields, custom input rendering, and state management. It works seamlessly with Zod.
+**StatefulForm** is a flexible form renderer designed to handle complex forms with data validation, 
+nested layouts, custom field rendering, and controlled state management. It integrates seamlessly with Zod.
 
 ---
 
 ### ✨ Features
+- 🎛 **Controlled by design**: The form is driven by the \`formValues\` prop, making it easy to synchronize with React state, Zustand, Redux, or any external store.
 - 🖊 **Flexible input types**: Supports text, email, password, textarea, checkbox, radio, phone, file, image, color, date, money, rating, toggle, pin, and fully custom fields.
 - 📦 **Nested/grouped fields**: Organize fields in groups or frames for complex layouts.
 - ⚠️ **Validation**: Integrates with Zod schemas, supporting \`onChange\`, \`onBlur\`, or \`onSubmit\` validation modes.
@@ -43,6 +44,20 @@ nested fields, custom input rendering, and state management. It works seamlessly
 - 🔍 **Error handling**: Automatically shows validation errors for touched fields.
 - 🖌 **Custom render**: For fields with \`type="custom"\`, you can render any JSX/component.
 - 🎯 **AutoFocus**: Focus on a specific field when the form mounts.
+
+---
+
+### 🔄 Controlled State
+
+\`StatefulForm\` follows the controlled component pattern.
+
+1. The parent owns the form state.
+2. The parent passes the latest state through \`formValues\`.
+3. User interactions trigger \`onChange\`.
+4. The parent updates its state.
+5. The updated \`formValues\` are passed back to \`StatefulForm\`.
+
+Because the component always renders from \`formValues\`, external updates (such as API responses, resetting a form, or loading draft data) are reflected automatically.
 
 ---
 
@@ -162,20 +177,18 @@ Custom styles for form components:
       table: { type: { summary: "StatefulFormStyles" } },
     },
   },
-};
+}
 
-export default meta;
+export default meta
 
-type Story = StoryObj<typeof StatefulForm>;
+type Story = StoryObj<typeof StatefulForm>
 
 export const Default: Story = {
   render: () => {
-    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-      (data) => data.id === "US"
-    );
+    const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find((data) => data.id === "US")
 
     if (!DEFAULT_COUNTRY_CODES) {
-      throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
+      throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
     }
 
     const [value, setValue] = useState({
@@ -187,15 +200,15 @@ export const Default: Story = {
       note: "",
       access: false,
       country_code: DEFAULT_COUNTRY_CODES,
-    });
+    })
 
     const SALUTATION_OPTIONS: SelectboxOption[] = [
       { text: "Mr.", value: "1" },
       { text: "Mrs.", value: "2" },
       { text: "Ms.", value: "3" },
-    ];
+    ]
 
-    const [isFormValid, setIsFormValid] = useState(false);
+    const [isFormValid, setIsFormValid] = useState(false)
 
     const employeeSchema = z.object({
       salutation: z
@@ -204,9 +217,9 @@ export const Default: Story = {
         .refine(
           (arr) =>
             arr.every((val) =>
-              SALUTATION_OPTIONS.some((opt) => opt.value === val)
+              SALUTATION_OPTIONS.some((opt) => opt.value === val),
             ),
-          "Invalid value in combo"
+          "Invalid value in combo",
         ),
       first_name: z
         .string()
@@ -221,7 +234,7 @@ export const Default: Story = {
       access: z.boolean().refine((val) => val === true, {
         message: "Access must be true",
       }),
-    });
+    })
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
@@ -337,7 +350,7 @@ export const Default: Story = {
         placeholder: "Enter text",
         rowJustifyPosition: "end",
       },
-    ];
+    ]
 
     return (
       <div
@@ -355,7 +368,7 @@ export const Default: Story = {
       >
         <StatefulForm
           onChange={({ currentState }) => {
-            setValue((prev) => ({ ...prev, ...currentState }));
+            setValue((prev) => ({ ...prev, ...currentState }))
           }}
           fields={EMPLOYEE_FIELDS}
           formValues={value}
@@ -365,13 +378,13 @@ export const Default: Story = {
           mode="onChange"
         />
       </div>
-    );
+    )
   },
-};
+}
 
 export const WithFrame: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false);
+    const [isFormValid, setIsFormValid] = useState(false)
     const [value, setValue] = useState({
       name: "",
       department: "",
@@ -379,13 +392,13 @@ export const WithFrame: Story = {
       start_date: [""],
       end_date: [""],
       purpose: "",
-    });
+    })
 
     const dateArraySchema = z
       .array(
-        z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date")
+        z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date"),
       )
-      .min(1, "At least one date is required");
+      .min(1, "At least one date is required")
 
     const employeeSchema = z.object({
       name: z.string().min(3, "Name is required"),
@@ -394,17 +407,17 @@ export const WithFrame: Story = {
       start_date: dateArraySchema,
       end_date: dateArraySchema,
       purpose: z.string().min(10, "Business purpose is required"),
-    });
+    })
 
     const MANAGER_NAME_OPTIONS: SelectboxOption[] = [
       { text: "Alim Naufal", value: "1" },
       { text: "Soekarno", value: "2" },
-    ];
+    ]
 
     const DEPARTMENT_OPTIONS: SelectboxOption[] = [
       { text: "HR", value: "1" },
       { text: "IT", value: "2" },
-    ];
+    ]
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       {
@@ -473,7 +486,7 @@ export const WithFrame: Story = {
         disabled: !isFormValid,
         rowJustifyPosition: "end",
       },
-    ];
+    ]
 
     return (
       <div
@@ -491,7 +504,7 @@ export const WithFrame: Story = {
       >
         <StatefulForm
           onChange={({ currentState }) => {
-            setValue((prev) => ({ ...prev, ...currentState }));
+            setValue((prev) => ({ ...prev, ...currentState }))
           }}
           validationSchema={employeeSchema}
           onValidityChange={setIsFormValid}
@@ -500,20 +513,20 @@ export const WithFrame: Story = {
           mode="onChange"
         />
       </div>
-    );
+    )
   },
-};
+}
 
 export const ConditionalElement: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false);
+    const [isFormValid, setIsFormValid] = useState(false)
     const [formFields, setFormFields] = useState({
       quantType: "",
       compEffort: "",
       scheIterations: "",
       target: "",
       hostArch: "",
-    });
+    })
 
     const schema = z.object({
       quantType: z.string().optional(),
@@ -524,46 +537,46 @@ export const ConditionalElement: Story = {
         .optional(),
       target: z.string().min(1, "Target is required"),
       hostArch: z.string().optional(),
-    });
+    })
 
     const HostArchitecture = {
       x86: 0,
       x64: 1,
       ARM: 2,
       ARM64: 3,
-    } as const;
+    } as const
 
     const CompilationTarget = {
       Interpreter: 0,
       Simulator: 1,
       IP: 2,
-    } as const;
+    } as const
 
     const CompilationEffort = {
       SimpleScheduling: 0,
       Performance: 1,
       Aggressive: 2,
-    } as const;
+    } as const
 
     const Quantization = {
       Int8: 0,
       Bf16: 1,
       Fp16: 2,
       Fp32: 3,
-    } as const;
+    } as const
 
     const HOST_ARCHITECTURE_OPTIONS: SelectboxOption[] = [
       { value: String(HostArchitecture.x86), text: "x86" },
       { value: String(HostArchitecture.x64), text: "x64" },
       { value: String(HostArchitecture.ARM), text: "ARM" },
       { value: String(HostArchitecture.ARM64), text: "ARM64" },
-    ];
+    ]
 
     const COMPILATION_TARGET_OPTIONS: SelectboxOption[] = [
       { value: String(CompilationTarget.Interpreter), text: "Interpreter" },
       { value: String(CompilationTarget.Simulator), text: "Simulator" },
       { value: String(CompilationTarget.IP), text: "IP" },
-    ];
+    ]
 
     const COMPILATION_EFFORT_OPTIONS: SelectboxOption[] = [
       {
@@ -578,21 +591,21 @@ export const ConditionalElement: Story = {
         value: String(CompilationEffort.Aggressive),
         text: "Aggressive",
       },
-    ];
+    ]
 
     const QUANTIZATION_TYPE_OPTIONS: SelectboxOption[] = [
       { value: String(Quantization.Int8), text: "INT8" },
       { value: String(Quantization.Bf16), text: "BF16" },
       { value: String(Quantization.Fp16), text: "FP16" },
       { value: String(Quantization.Fp32), text: "FP32" },
-    ];
+    ]
 
     const COMPILATION_FIELDS: FormFieldGroup[] = useMemo(() => {
       const isInt8Quantization =
-        formFields.quantType === String(Quantization.Int8);
+        formFields.quantType === String(Quantization.Int8)
 
       const isPerfCompilation =
-        formFields.compEffort === String(CompilationEffort.Performance);
+        formFields.compEffort === String(CompilationEffort.Performance)
 
       return [
         {
@@ -653,13 +666,13 @@ export const ConditionalElement: Story = {
           disabled: !isFormValid,
           rowJustifyPosition: "end",
         },
-      ] as FormFieldGroup[];
-    }, [formFields.compEffort, formFields.quantType, isFormValid]);
+      ] as FormFieldGroup[]
+    }, [formFields.compEffort, formFields.quantType, isFormValid])
 
     return (
       <StatefulForm
         onChange={({ currentState }) => {
-          setFormFields((prev) => ({ ...prev, ...currentState }));
+          setFormFields((prev) => ({ ...prev, ...currentState }))
         }}
         onValidityChange={setIsFormValid}
         validationSchema={schema}
@@ -667,33 +680,33 @@ export const ConditionalElement: Story = {
         formValues={formFields}
         mode="onChange"
       />
-    );
+    )
   },
-};
+}
 
 export const LeftLabeled: Story = {
   render: () => {
-    const { currentTheme, mode } = useTheme();
-    const bodyTheme = currentTheme?.body;
+    const { currentTheme, mode } = useTheme()
+    const bodyTheme = currentTheme?.body
 
     const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-      (country) => country.id === "US"
-    );
+      (country) => country.id === "US",
+    )
 
-    const [isFormValid, setIsFormValid] = useState(false);
+    const [isFormValid, setIsFormValid] = useState(false)
     const [value, setValue] = useState<{
-      name: string;
-      email: string;
-      phone: string;
-      country_code: PhoneboxCountryCode;
-      password: string;
+      name: string
+      email: string
+      phone: string
+      country_code: PhoneboxCountryCode
+      password: string
     }>({
       name: "",
       email: "",
       phone: "",
       country_code: DEFAULT_COUNTRY_CODES,
       password: "",
-    });
+    })
 
     const SIGN_UP_FIELDS: FormFieldGroup[] = [
       {
@@ -731,14 +744,14 @@ export const LeftLabeled: Story = {
         required: true,
         labelPosition: "left",
       },
-    ];
+    ]
 
     const signUpSchema = z.object({
       name: z.string().min(3, "Name must be at least 3 characters"),
       phone: z.string().min(8, "Phone number must be 8 digits"),
       email: z.string().email("Please enter a valid email"),
       password: z.string().min(8, "Password must be at least 8 characters"),
-    });
+    })
 
     return (
       <Card
@@ -789,14 +802,14 @@ export const LeftLabeled: Story = {
           </div>
         </Footer>
       </Card>
-    );
+    )
   },
-};
+}
 
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-`;
+`
 
 const Title = styled.h3`
   font-family: monospace;
@@ -808,7 +821,7 @@ const Title = styled.h3`
   @media (min-width: 768px) {
     font-size: 1.5rem;
   }
-`;
+`
 
 const Description = styled.span`
   font-size: 0.625rem;
@@ -817,18 +830,18 @@ const Description = styled.span`
   @media (min-width: 768px) {
     font-size: 0.75rem;
   }
-`;
+`
 
 const FormBody = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
   padding: 2rem;
-`;
+`
 
 const Footer = styled.div<{
-  $theme?: BodyThemeConfig;
-  $mode: ThemeMode | string;
+  $theme?: BodyThemeConfig
+  $mode: ThemeMode | string
 }>`
   display: flex;
   flex-direction: row;
@@ -856,7 +869,7 @@ const Footer = styled.div<{
   .loader {
     margin-left: 0.5rem;
   }
-`;
+`
 
 const ScrollBox = styled.div`
   max-height: 120px;
@@ -881,17 +894,17 @@ const ScrollBox = styled.div`
 
   scrollbar-width: thin;
   scrollbar-color: #ccc transparent;
-`;
+`
 
 export const Mobile: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false);
+    const [isFormValid, setIsFormValid] = useState(false)
     const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-      (data) => data.id === "US" || COUNTRY_CODES[206]
-    );
+      (data) => data.id === "US" || COUNTRY_CODES[206],
+    )
 
     if (!DEFAULT_COUNTRY_CODES) {
-      throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
+      throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
     }
 
     const FRUIT_OPTIONS: SelectboxOption[] = [
@@ -902,7 +915,7 @@ export const Mobile: Story = {
       { text: "Pineapple", value: "5" },
       { text: "Strawberry", value: "6" },
       { text: "Watermelon", value: "7" },
-    ];
+    ]
 
     const BADGE_OPTIONS: BadgeProps[] = [
       {
@@ -945,7 +958,7 @@ export const Mobile: Story = {
         id: "10",
         caption: "Webtoons",
       },
-    ];
+    ]
 
     const CURRENCY_OPTIONS: MoneyboxCurrencyOption[] = [
       { id: "IDR", name: "Indonesian Rupiah", symbol: "Rp" },
@@ -958,36 +971,36 @@ export const Mobile: Story = {
       { id: "MYR", name: "Malaysian Ringgit", symbol: "RM" },
       { id: "KRW", name: "South Korean Won", symbol: "₩" },
       { id: "CNY", name: "Chinese Yuan", symbol: "¥" },
-    ];
+    ]
 
     interface AllCaseValueProps {
-      text: string;
-      time: string;
-      email: string;
-      number: string;
-      password: string;
-      textarea: string;
-      rating: string;
-      check: boolean;
+      text: string
+      time: string
+      email: string
+      number: string
+      password: string
+      textarea: string
+      rating: string
+      check: boolean
       chips?: {
-        searchText: string;
-        selectedOptions: string[];
-      };
-      color: string;
-      combo: string[];
-      date: string[];
-      file_drop_box?: File[];
-      file: File[] | undefined;
-      image: File | undefined;
-      money: string;
-      phone: string;
-      thumb_field: boolean;
-      toggle: boolean;
-      signature: string;
-      capsule: string;
-      country_code?: PhoneboxCountryCode;
-      currency: string;
-      pin: string;
+        searchText: string
+        selectedOptions: string[]
+      }
+      color: string
+      combo: string[]
+      date: string[]
+      file_drop_box?: File[]
+      file: File[] | undefined
+      image: File | undefined
+      money: string
+      phone: string
+      thumb_field: boolean
+      toggle: boolean
+      signature: string
+      capsule: string
+      country_code?: PhoneboxCountryCode
+      currency: string
+      pin: string
     }
 
     const [value, setValue] = useState<AllCaseValueProps>({
@@ -1018,7 +1031,7 @@ export const Mobile: Story = {
       country_code: DEFAULT_COUNTRY_CODES,
       currency: "USD",
       pin: "",
-    });
+    })
 
     const CAPSULE_TABS: CapsuleTab[] = [
       {
@@ -1029,7 +1042,7 @@ export const Mobile: Story = {
         id: "unpaid",
         title: "Unpaid",
       },
-    ];
+    ]
 
     const PARTS_INPUT: PinboxParts[] = [
       {
@@ -1052,7 +1065,7 @@ export const Mobile: Story = {
       {
         type: "alphabet",
       },
-    ];
+    ]
 
     const schema = z.object({
       text: z.string().min(3, "Text must be at least 3 characters"),
@@ -1076,10 +1089,10 @@ export const Mobile: Story = {
           (arr) =>
             arr.every((val) =>
               FRUIT_OPTIONS.some((opt) => {
-                return opt.value === val;
-              })
+                return opt.value === val
+              }),
             ),
-          "Invalid value in combo"
+          "Invalid value in combo",
         ),
       date: z.array(
         z
@@ -1090,15 +1103,15 @@ export const Mobile: Story = {
               /^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/\d{4}$/.test(val),
             {
               message: "Invalid date",
-            }
-          )
+            },
+          ),
       ),
       file_drop_box: z.any().optional(),
       file: z
         .preprocess((value) => {
-          if (value instanceof FileList) return Array.from(value);
-          if (Array.isArray(value)) return value;
-          return [];
+          if (value instanceof FileList) return Array.from(value)
+          if (Array.isArray(value)) return value
+          return []
         }, z.array(z.any()))
         .refine((files) => files.length > 0, {
           message: "At least one file is required",
@@ -1110,17 +1123,17 @@ export const Mobile: Story = {
           (files) => files.every((file) => file.size <= 5 * 1024 * 1024),
           {
             message: "Each file must be 5MB or less",
-          }
+          },
         ),
       image: z
         .any()
         .refine(
           (file) => {
-            return file?.type === "image/jpeg";
+            return file?.type === "image/jpeg"
           },
           {
             message: "Only JPEG file are allowed",
-          }
+          },
         )
         .refine((file) => file?.size <= 5 * 1024 * 1024, {
           message: "File size must be 5MB or less",
@@ -1141,7 +1154,7 @@ export const Mobile: Story = {
           code: z.string(),
         })
         .optional(),
-    });
+    })
 
     const onFileDropped = async ({
       error,
@@ -1149,27 +1162,27 @@ export const Mobile: Story = {
       setProgressLabel,
       succeed,
     }: OnFileDroppedFunctionArgs) => {
-      const file = files[0];
-      setProgressLabel(`Uploading ${file.name}`);
+      const file = files[0]
+      setProgressLabel(`Uploading ${file.name}`)
 
       return new Promise<void>((resolve) => {
-        let progress = 0;
+        let progress = 0
         const interval = setInterval(() => {
-          progress += 20;
+          progress += 20
 
           if (progress >= 100) {
-            clearInterval(interval);
+            clearInterval(interval)
             if (file === null) {
-              error(file, `file ${files[0].name} is not uploaded`);
+              error(file, `file ${files[0].name} is not uploaded`)
             } else {
-              succeed(file);
+              succeed(file)
             }
-            setProgressLabel(`Uploaded ${files[0].name}`);
-            resolve();
+            setProgressLabel(`Uploaded ${files[0].name}`)
+            resolve()
           }
-        }, 300);
-      });
-    };
+        }, 300)
+      })
+    }
 
     const onComplete = ({
       failedFiles,
@@ -1179,13 +1192,13 @@ export const Mobile: Story = {
       setValue((prev) => ({
         ...prev,
         file_drop_box: succeedFiles,
-      }));
-      console.log(succeedFiles, "This is succeedFiles");
-      console.log(failedFiles, "This is failedFiles");
+      }))
+      console.log(succeedFiles, "This is succeedFiles")
+      console.log(failedFiles, "This is failedFiles")
       setProgressLabel(
-        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`
-      );
-    };
+        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`,
+      )
+    }
 
     const MONTH_NAMES = [
       { text: "JAN", value: "1" },
@@ -1200,7 +1213,7 @@ export const Mobile: Story = {
       { text: "OCT", value: "10" },
       { text: "NOV", value: "11" },
       { text: "DEC", value: "12" },
-    ];
+    ]
 
     const FIELDS: FormFieldGroup[] = [
       [
@@ -1404,7 +1417,7 @@ export const Mobile: Story = {
           },
         },
       ],
-    ];
+    ]
 
     return (
       <StatefulForm
@@ -1420,7 +1433,7 @@ export const Mobile: Story = {
           `,
         }}
         onChange={({ currentState }) => {
-          const [[key, value]] = Object.entries(currentState);
+          const [[key, value]] = Object.entries(currentState)
 
           setValue((prev) => ({
             ...prev,
@@ -1433,7 +1446,7 @@ export const Mobile: Story = {
                   },
                 }
               : currentState),
-          }));
+          }))
         }}
         onValidityChange={setIsFormValid}
         labelSize="14px"
@@ -1443,19 +1456,19 @@ export const Mobile: Story = {
         validationSchema={schema}
         mode="onChange"
       />
-    );
+    )
   },
-};
+}
 
 export const AllCase: Story = {
   render: () => {
-    const [isFormValid, setIsFormValid] = useState(false);
+    const [isFormValid, setIsFormValid] = useState(false)
     const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-      (data) => data.id === "US" || COUNTRY_CODES[206]
-    );
+      (data) => data.id === "US" || COUNTRY_CODES[206],
+    )
 
     if (!DEFAULT_COUNTRY_CODES) {
-      throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
+      throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
     }
 
     const FRUIT_OPTIONS: SelectboxOption[] = [
@@ -1466,7 +1479,7 @@ export const AllCase: Story = {
       { text: "Pineapple", value: "5" },
       { text: "Strawberry", value: "6" },
       { text: "Watermelon", value: "7" },
-    ];
+    ]
 
     const BADGE_OPTIONS: BadgeProps[] = [
       {
@@ -1509,7 +1522,7 @@ export const AllCase: Story = {
         id: "10",
         caption: "Webtoons",
       },
-    ];
+    ]
 
     const CURRENCY_OPTIONS: MoneyboxCurrencyOption[] = [
       { id: "IDR", name: "Indonesian Rupiah", symbol: "Rp" },
@@ -1522,36 +1535,36 @@ export const AllCase: Story = {
       { id: "MYR", name: "Malaysian Ringgit", symbol: "RM" },
       { id: "KRW", name: "South Korean Won", symbol: "₩" },
       { id: "CNY", name: "Chinese Yuan", symbol: "¥" },
-    ];
+    ]
 
     interface AllCaseValueProps {
-      text: string;
-      time: string;
-      email: string;
-      number: string;
-      password: string;
-      textarea: string;
-      rating: string;
-      check: boolean;
+      text: string
+      time: string
+      email: string
+      number: string
+      password: string
+      textarea: string
+      rating: string
+      check: boolean
       chips?: {
-        searchText: string;
-        selectedOptions: string[];
-      };
-      color: string;
-      combo: string[];
-      date: string[];
-      file_drop_box?: File[];
-      file: File[] | undefined;
-      image: File | undefined;
-      money: string;
-      phone: string;
-      thumb_field: boolean;
-      toggle: boolean;
-      signature: string;
-      capsule: string;
-      country_code?: PhoneboxCountryCode;
-      currency: string;
-      pin: string;
+        searchText: string
+        selectedOptions: string[]
+      }
+      color: string
+      combo: string[]
+      date: string[]
+      file_drop_box?: File[]
+      file: File[] | undefined
+      image: File | undefined
+      money: string
+      phone: string
+      thumb_field: boolean
+      toggle: boolean
+      signature: string
+      capsule: string
+      country_code?: PhoneboxCountryCode
+      currency: string
+      pin: string
     }
 
     const [value, setValue] = useState<AllCaseValueProps>({
@@ -1582,7 +1595,7 @@ export const AllCase: Story = {
       country_code: DEFAULT_COUNTRY_CODES,
       currency: "USD",
       pin: "",
-    });
+    })
 
     const CAPSULE_TABS: CapsuleTab[] = [
       {
@@ -1593,7 +1606,7 @@ export const AllCase: Story = {
         id: "unpaid",
         title: "Unpaid",
       },
-    ];
+    ]
 
     const PARTS_INPUT: PinboxParts[] = [
       {
@@ -1616,7 +1629,7 @@ export const AllCase: Story = {
       {
         type: "alphabet",
       },
-    ];
+    ]
 
     const schema = z.object({
       text: z.string().min(3, "Text must be at least 3 characters"),
@@ -1640,10 +1653,10 @@ export const AllCase: Story = {
           (arr) =>
             arr.every((val) =>
               FRUIT_OPTIONS.some((opt) => {
-                return opt.value === val;
-              })
+                return opt.value === val
+              }),
             ),
-          "Invalid value in combo"
+          "Invalid value in combo",
         ),
       date: z.array(
         z
@@ -1654,15 +1667,15 @@ export const AllCase: Story = {
               /^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/\d{4}$/.test(val),
             {
               message: "Invalid date",
-            }
-          )
+            },
+          ),
       ),
       file_drop_box: z.any().optional(),
       file: z
         .preprocess((value) => {
-          if (value instanceof FileList) return Array.from(value);
-          if (Array.isArray(value)) return value;
-          return [];
+          if (value instanceof FileList) return Array.from(value)
+          if (Array.isArray(value)) return value
+          return []
         }, z.array(z.any()))
         .refine((files) => files.length > 0, {
           message: "At least one file is required",
@@ -1674,17 +1687,17 @@ export const AllCase: Story = {
           (files) => files.every((file) => file.size <= 5 * 1024 * 1024),
           {
             message: "Each file must be 5MB or less",
-          }
+          },
         ),
       image: z
         .any()
         .refine(
           (file) => {
-            return file?.type === "image/jpeg";
+            return file?.type === "image/jpeg"
           },
           {
             message: "Only JPEG file are allowed",
-          }
+          },
         )
         .refine((file) => file?.size <= 5 * 1024 * 1024, {
           message: "File size must be 5MB or less",
@@ -1705,7 +1718,7 @@ export const AllCase: Story = {
           code: z.string(),
         })
         .optional(),
-    });
+    })
 
     const onFileDropped = async ({
       error,
@@ -1713,27 +1726,27 @@ export const AllCase: Story = {
       setProgressLabel,
       succeed,
     }: OnFileDroppedFunctionArgs) => {
-      const file = files[0];
-      setProgressLabel(`Uploading ${file.name}`);
+      const file = files[0]
+      setProgressLabel(`Uploading ${file.name}`)
 
       return new Promise<void>((resolve) => {
-        let progress = 0;
+        let progress = 0
         const interval = setInterval(() => {
-          progress += 20;
+          progress += 20
 
           if (progress >= 100) {
-            clearInterval(interval);
+            clearInterval(interval)
             if (file === null) {
-              error(file, `file ${files[0].name} is not uploaded`);
+              error(file, `file ${files[0].name} is not uploaded`)
             } else {
-              succeed(file);
+              succeed(file)
             }
-            setProgressLabel(`Uploaded ${files[0].name}`);
-            resolve();
+            setProgressLabel(`Uploaded ${files[0].name}`)
+            resolve()
           }
-        }, 300);
-      });
-    };
+        }, 300)
+      })
+    }
 
     const onComplete = ({
       failedFiles,
@@ -1743,13 +1756,13 @@ export const AllCase: Story = {
       setValue((prev) => ({
         ...prev,
         file_drop_box: succeedFiles,
-      }));
-      console.log(succeedFiles, "This is succeedFiles");
-      console.log(failedFiles, "This is failedFiles");
+      }))
+      console.log(succeedFiles, "This is succeedFiles")
+      console.log(failedFiles, "This is failedFiles")
       setProgressLabel(
-        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`
-      );
-    };
+        `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`,
+      )
+    }
 
     const MONTH_NAMES = [
       { text: "JAN", value: "1" },
@@ -1764,7 +1777,7 @@ export const AllCase: Story = {
       { text: "OCT", value: "10" },
       { text: "NOV", value: "11" },
       { text: "DEC", value: "12" },
-    ];
+    ]
 
     const FIELDS: FormFieldGroup[] = [
       {
@@ -1978,9 +1991,9 @@ export const AllCase: Story = {
         disabled: !isFormValid,
         rowJustifyPosition: "end",
       },
-    ];
+    ]
 
-    console.log(value.chips.searchText);
+    console.log(value.chips.searchText)
 
     return (
       <StatefulForm
@@ -1995,7 +2008,7 @@ export const AllCase: Story = {
           `,
         }}
         onChange={({ currentState }) => {
-          const [[key, value]] = Object.entries(currentState);
+          const [[key, value]] = Object.entries(currentState)
 
           setValue((prev) => ({
             ...prev,
@@ -2008,7 +2021,7 @@ export const AllCase: Story = {
                   },
                 }
               : currentState),
-          }));
+          }))
         }}
         onValidityChange={setIsFormValid}
         labelSize="14px"
@@ -2018,40 +2031,40 @@ export const AllCase: Story = {
         validationSchema={schema}
         mode="onChange"
       />
-    );
+    )
   },
-};
+}
 
 export const AllCaseDisabled: Story = {
   render: () => {
     interface AllCaseValueProps {
-      text: string;
-      time: string;
-      email: string;
-      number: string;
-      password: string;
-      textarea: string;
-      rating: string;
-      check: boolean;
+      text: string
+      time: string
+      email: string
+      number: string
+      password: string
+      textarea: string
+      rating: string
+      check: boolean
       chips?: {
-        searchText: string;
-        selectedOptions: string[];
-      };
-      color: string;
-      combo: string[];
-      date: string[];
-      file_drop_box?: File[];
-      file: File[] | undefined;
-      image: File | undefined;
-      money: string;
-      phone: string;
-      thumb_field: boolean;
-      togglebox: boolean;
-      signature: string;
-      capsule: string;
-      country_code?: PhoneboxCountryCode;
-      currency: string;
-      pin: string;
+        searchText: string
+        selectedOptions: string[]
+      }
+      color: string
+      combo: string[]
+      date: string[]
+      file_drop_box?: File[]
+      file: File[] | undefined
+      image: File | undefined
+      money: string
+      phone: string
+      thumb_field: boolean
+      togglebox: boolean
+      signature: string
+      capsule: string
+      country_code?: PhoneboxCountryCode
+      currency: string
+      pin: string
     }
 
     const [value, setValue] = useState<AllCaseValueProps>({
@@ -2082,7 +2095,7 @@ export const AllCaseDisabled: Story = {
       country_code: undefined,
       currency: "USD",
       pin: "",
-    });
+    })
 
     const CAPSULE_TABS: CapsuleTab[] = [
       {
@@ -2093,7 +2106,7 @@ export const AllCaseDisabled: Story = {
         id: "unpaid",
         title: "Unpaid",
       },
-    ];
+    ]
 
     const PARTS_INPUT: PinboxParts[] = [
       {
@@ -2116,7 +2129,7 @@ export const AllCaseDisabled: Story = {
       {
         type: "alphabet",
       },
-    ];
+    ]
 
     const FIELDS: FormFieldGroup[] = [
       {
@@ -2331,7 +2344,7 @@ export const AllCaseDisabled: Story = {
         required: true,
         rowJustifyPosition: "end",
       },
-    ];
+    ]
 
     return (
       <StatefulForm
@@ -2347,13 +2360,13 @@ export const AllCaseDisabled: Story = {
         }}
         disabled
         onChange={({ currentState }) => {
-          const { chips, ...rest } = currentState;
-          void chips;
+          const { chips, ...rest } = currentState
+          void chips
 
           setValue((prev) => ({
             ...prev,
             ...rest,
-          }));
+          }))
         }}
         labelSize="14px"
         fieldSize="14px"
@@ -2361,6 +2374,6 @@ export const AllCaseDisabled: Story = {
         formValues={value}
         mode="onChange"
       />
-    );
+    )
   },
-};
+}

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -3291,6 +3291,10 @@ function FieldTooltip({ items, styles }: FieldTooltipProps) {
     return () => observer.disconnect();
   }, [items]);
 
+  if (items.length === 0) {
+    return null;
+  }
+
   return (
     <FieldTooltipWrapper
       aria-label="field-tooltip"

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -3149,7 +3149,6 @@ function StatefulFormLabel({
             arrowStyle: css`
               background-color: ${statefulFormTheme?.fieldTooltip
                 ?.panelBackground};
-              display: none;
 
               ${styles?.helperArrowStyle};
             `,

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -3107,6 +3107,24 @@ function StatefulFormLabel({
   const { currentTheme } = useTheme();
   const statefulFormTheme = currentTheme?.statefulForm;
 
+  const helperValue =
+    typeof helper === "string" ? (
+      <FieldTooltip
+        styles={{
+          itemStyle: css`
+            padding: 4px;
+          `,
+        }}
+        items={[
+          {
+            description: helper,
+          },
+        ]}
+      />
+    ) : (
+      helper
+    );
+
   return (
     <Label
       {...props}
@@ -3131,6 +3149,7 @@ function StatefulFormLabel({
             arrowStyle: css`
               background-color: ${statefulFormTheme?.fieldTooltip
                 ?.panelBackground};
+              display: none;
 
               ${styles?.helperArrowStyle};
             `,
@@ -3139,11 +3158,12 @@ function StatefulFormLabel({
                 ?.panelBackground};
               color: ${statefulFormTheme?.fieldTooltip?.mutedTextColor};
               max-width: 300px;
+              padding: 0px;
               ${styles?.helperDrawerStyle}
             `,
             self: styles?.helperIconStyle,
           }}
-          value={helper}
+          value={helperValue}
         />
       )}
     </Label>

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -1,6 +1,6 @@
-import { useForm, UseFormProps, UseFormSetValue } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import z, { ZodTypeAny, TypeOf, ZodObject } from "zod"
+import { useForm, UseFormProps, UseFormSetValue } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import z, { ZodTypeAny, TypeOf, ZodObject } from "zod";
 import React, {
   ChangeEvent,
   Fragment,
@@ -10,7 +10,7 @@ import React, {
   useLayoutEffect,
   useRef,
   useState,
-} from "react"
+} from "react";
 import {
   Control,
   Controller,
@@ -18,44 +18,44 @@ import {
   FieldValues,
   Path,
   UseFormRegister,
-} from "react-hook-form"
-import { Phonebox, PhoneboxCountryCode, PhoneboxProps } from "./phonebox"
-import { Checkbox, CheckboxProps } from "./checkbox"
-import { Textbox, TextboxProps } from "./textbox"
-import { Colorbox, ColorboxProps } from "./colorbox"
-import { FileDropBox, FileDropBoxProps } from "./file-drop-box"
-import { FileInputBox, FileInputBoxProps } from "./file-input-box"
-import { Imagebox, ImageboxProps } from "./imagebox"
-import { Moneybox, MoneyboxProps } from "./moneybox"
-import { Datebox, DateboxProps } from "./datebox"
-import { Combobox, ComboboxProps } from "./combobox"
-import { Chips, ChipsProps } from "./chips"
-import { Signbox, SignboxProps } from "./signbox"
-import { Textarea, TextareaProps } from "./textarea"
-import styled, { css, CSSProp } from "styled-components"
-import { Rating, RatingProps } from "./rating"
-import { ThumbField, ThumbFieldProps } from "./thumb-field"
-import { Toggle, ToggleProps } from "./toggle"
-import { Capsule, CapsuleProps } from "./capsule"
-import { Timebox, TimeboxProps } from "./timebox"
-import { Button, ButtonProps } from "./button"
-import { Radio, RadioProps } from "./radio"
-import { Helper } from "./helper"
-import { FigureProps } from "./figure"
-import { Pinbox, PinboxProps } from "./pinbox"
-import { FieldLaneProps } from "./field-lane"
-import { Frame, FrameProps } from "./frame"
-import { applyClassName } from "./../constants/classname"
-import { useTheme, StatefulFormThemeConfig } from "./../theme"
+} from "react-hook-form";
+import { Phonebox, PhoneboxCountryCode, PhoneboxProps } from "./phonebox";
+import { Checkbox, CheckboxProps } from "./checkbox";
+import { Textbox, TextboxProps } from "./textbox";
+import { Colorbox, ColorboxProps } from "./colorbox";
+import { FileDropBox, FileDropBoxProps } from "./file-drop-box";
+import { FileInputBox, FileInputBoxProps } from "./file-input-box";
+import { Imagebox, ImageboxProps } from "./imagebox";
+import { Moneybox, MoneyboxProps } from "./moneybox";
+import { Datebox, DateboxProps } from "./datebox";
+import { Combobox, ComboboxProps } from "./combobox";
+import { Chips, ChipsProps } from "./chips";
+import { Signbox, SignboxProps } from "./signbox";
+import { Textarea, TextareaProps } from "./textarea";
+import styled, { css, CSSProp } from "styled-components";
+import { Rating, RatingProps } from "./rating";
+import { ThumbField, ThumbFieldProps } from "./thumb-field";
+import { Toggle, ToggleProps } from "./toggle";
+import { Capsule, CapsuleProps } from "./capsule";
+import { Timebox, TimeboxProps } from "./timebox";
+import { Button, ButtonProps } from "./button";
+import { Radio, RadioProps } from "./radio";
+import { Helper } from "./helper";
+import { FigureProps } from "./figure";
+import { Pinbox, PinboxProps } from "./pinbox";
+import { FieldLaneProps } from "./field-lane";
+import { Frame, FrameProps } from "./frame";
+import { applyClassName } from "./../constants/classname";
+import { useTheme, StatefulFormThemeConfig } from "./../theme";
 
 export type StatefulOnChangeType =
   | ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   | {
       target: {
-        name: string
-        value: FormValueType
-      }
-    }
+        name: string;
+        value: FormValueType;
+      };
+    };
 
 export type FormValueType =
   | string
@@ -68,7 +68,7 @@ export type FormValueType =
   | undefined
   | PhoneboxCountryCode
   | string[]
-  | number[]
+  | number[];
 
 export const FormFieldType = {
   Text: "text",
@@ -98,112 +98,112 @@ export const FormFieldType = {
   Pin: "pin",
   Frame: "frame",
   Custom: "custom",
-} as const
+} as const;
 
-export type FormFieldType = (typeof FormFieldType)[keyof typeof FormFieldType]
+export type FormFieldType = (typeof FormFieldType)[keyof typeof FormFieldType];
 
 export const StatefulFormMode = {
   OnChange: "onChange",
   OnBlur: "onBlur",
   OnSubmit: "onSubmit",
-} as const
+} as const;
 
 export type StatefulFormMode =
-  (typeof StatefulFormMode)[keyof typeof StatefulFormMode]
+  (typeof StatefulFormMode)[keyof typeof StatefulFormMode];
 
 export interface StatefulFormProps<Z extends ZodTypeAny> {
-  fields: FormFieldGroup[]
-  formValues: TypeOf<Z>
-  validationSchema?: Z
-  mode?: StatefulFormMode
-  onValidityChange?: (e: boolean) => void
-  labelSize?: string
-  fieldSize?: string
-  onChange?: (args: { currentState: any }) => void
-  autoFocusField?: string
-  styles?: StatefulFormStyles
-  disabled?: boolean
-  mobile?: boolean
-  className?: string
-  id?: string
+  fields: FormFieldGroup[];
+  formValues: TypeOf<Z>;
+  validationSchema?: Z;
+  mode?: StatefulFormMode;
+  onValidityChange?: (e: boolean) => void;
+  labelSize?: string;
+  fieldSize?: string;
+  onChange?: (args: { currentState: any }) => void;
+  autoFocusField?: string;
+  styles?: StatefulFormStyles;
+  disabled?: boolean;
+  mobile?: boolean;
+  className?: string;
+  id?: string;
 }
 
 export interface StatefulFormStyles extends StatefulFormLabelStyles {
-  containerStyle?: CSSProp
-  frameContainerStyle?: CSSProp
-  frameTitleStyle?: CSSProp
-  mobileFieldGroupStyle?: CSSProp
-  mobileFieldGroupRowDividerStyle?: CSSProp
+  containerStyle?: CSSProp;
+  frameContainerStyle?: CSSProp;
+  frameTitleStyle?: CSSProp;
+  mobileFieldGroupStyle?: CSSProp;
+  mobileFieldGroupRowDividerStyle?: CSSProp;
 }
 
-export type FormFieldGroup = FormFieldProps | FormFieldProps[]
+export type FormFieldGroup = FormFieldProps | FormFieldProps[];
 
 export const FormFieldRowJustifyPosition = {
   Center: "center",
   Start: "start",
   End: "end",
   SpaceBetween: "space-between",
-} as const
+} as const;
 
 export type FormFieldRowJustifyPosition =
-  (typeof FormFieldRowJustifyPosition)[keyof typeof FormFieldRowJustifyPosition]
+  (typeof FormFieldRowJustifyPosition)[keyof typeof FormFieldRowJustifyPosition];
 
 export const FormFieldRowItemsAligment = {
   Center: "center",
   Start: "start",
   End: "end",
   Stretch: "stretch",
-} as const
+} as const;
 
 export type FormFieldRowItemsAligment =
-  (typeof FormFieldRowItemsAligment)[keyof typeof FormFieldRowItemsAligment]
+  (typeof FormFieldRowItemsAligment)[keyof typeof FormFieldRowItemsAligment];
 
 export interface FormFieldProps {
-  name: string
-  id?: string
-  className?: string
-  title?: string
-  helper?: ReactNode
-  required?: boolean
-  type?: FormFieldType
-  placeholder?: string
-  render?: ReactNode
-  hidden?: boolean
-  rows?: number
-  width?: string
-  rowStyle?: CSSProp
-  fields?: FormFieldGroup[]
-  icon?: FigureProps["image"]
-  labelPosition?: FieldLaneProps["labelPosition"]
-  labelGap?: FieldLaneProps["labelGap"]
-  labelWidth?: FieldLaneProps["labelWidth"]
-  disabled?: boolean
-  rowJustifyPosition?: FormFieldRowJustifyPosition
-  rowItemsAlignment?: FormFieldRowItemsAligment
-  onChange?: (e?: StatefulOnChangeType) => void
-  onClick?: (e?: React.MouseEvent) => void
-  textbox?: TextboxProps
-  textarea?: TextareaProps
-  checkbox?: CheckboxProps
-  radio?: RadioProps
-  phonebox?: PhoneboxProps
-  colorbox?: ColorboxProps
-  money?: MoneyboxProps
-  fileDropBox?: FileDropBoxProps
-  fileInputBox?: FileInputBoxProps
-  imagebox?: ImageboxProps
-  signbox?: SignboxProps
-  date?: DateboxProps
-  combobox?: ComboboxProps
-  chips?: ChipsProps
-  rating?: RatingProps
-  thumbField?: ThumbFieldProps
-  toggle?: ToggleProps
-  capsule?: CapsuleProps
-  timebox?: TimeboxProps
-  button?: ButtonProps
-  pinbox?: PinboxProps
-  frame?: FrameProps
+  name: string;
+  id?: string;
+  className?: string;
+  title?: string;
+  helper?: ReactNode;
+  required?: boolean;
+  type?: FormFieldType;
+  placeholder?: string;
+  render?: ReactNode;
+  hidden?: boolean;
+  rows?: number;
+  width?: string;
+  rowStyle?: CSSProp;
+  fields?: FormFieldGroup[];
+  icon?: FigureProps["image"];
+  labelPosition?: FieldLaneProps["labelPosition"];
+  labelGap?: FieldLaneProps["labelGap"];
+  labelWidth?: FieldLaneProps["labelWidth"];
+  disabled?: boolean;
+  rowJustifyPosition?: FormFieldRowJustifyPosition;
+  rowItemsAlignment?: FormFieldRowItemsAligment;
+  onChange?: (e?: StatefulOnChangeType) => void;
+  onClick?: (e?: React.MouseEvent) => void;
+  textbox?: TextboxProps;
+  textarea?: TextareaProps;
+  checkbox?: CheckboxProps;
+  radio?: RadioProps;
+  phonebox?: PhoneboxProps;
+  colorbox?: ColorboxProps;
+  money?: MoneyboxProps;
+  fileDropBox?: FileDropBoxProps;
+  fileInputBox?: FileInputBoxProps;
+  imagebox?: ImageboxProps;
+  signbox?: SignboxProps;
+  date?: DateboxProps;
+  combobox?: ComboboxProps;
+  chips?: ChipsProps;
+  rating?: RatingProps;
+  thumbField?: ThumbFieldProps;
+  toggle?: ToggleProps;
+  capsule?: CapsuleProps;
+  timebox?: TimeboxProps;
+  button?: ButtonProps;
+  pinbox?: PinboxProps;
+  frame?: FrameProps;
 }
 
 function StatefulForm<Z extends ZodTypeAny>({
@@ -227,15 +227,15 @@ function StatefulForm<Z extends ZodTypeAny>({
   // register/Controller — NOT from an external formValues update.
   // RHF's own register/Controller already handles validate+touch for these,
   // so we don't need (and don't want) to force setValue on them again.
-  const internallyChangedFieldsRef = useRef<Set<string>>(new Set())
+  const internallyChangedFieldsRef = useRef<Set<string>>(new Set());
 
   const handleFieldChange = (name: keyof TypeOf<Z>, value: FormValueType) => {
-    if (disabled) return
-    internallyChangedFieldsRef.current.add(name as string)
-    onChange?.({ currentState: { [name]: value } })
-  }
+    if (disabled) return;
+    internallyChangedFieldsRef.current.add(name as string);
+    onChange?.({ currentState: { [name]: value } });
+  };
 
-  const finalSchema = getSchemaForVisibleFields(validationSchema, fields)
+  const finalSchema = getSchemaForVisibleFields(validationSchema, fields);
 
   const formConfig: UseFormProps<TypeOf<Z>> = {
     mode,
@@ -245,10 +245,10 @@ function StatefulForm<Z extends ZodTypeAny>({
       keepErrors: true,
       keepTouched: true,
     },
-  }
+  };
 
   if (validationSchema) {
-    formConfig.resolver = zodResolver(finalSchema)
+    formConfig.resolver = zodResolver(finalSchema);
   }
 
   const {
@@ -256,12 +256,12 @@ function StatefulForm<Z extends ZodTypeAny>({
     control,
     setValue,
     formState: { errors, touchedFields, isValid },
-  } = useForm(formConfig) as ReturnType<typeof useForm<TypeOf<Z>>>
+  } = useForm(formConfig) as ReturnType<typeof useForm<TypeOf<Z>>>;
 
-  const isFile = (val: unknown): val is File => val instanceof File
+  const isFile = (val: unknown): val is File => val instanceof File;
 
   const isFileArray = (val: unknown): val is File[] =>
-    Array.isArray(val) && val.every((v) => v instanceof File)
+    Array.isArray(val) && val.every((v) => v instanceof File);
 
   // Recursively collect ALL field names that hold a real form value —
   // including "custom" fields now, since they need the same touched/validate
@@ -270,35 +270,35 @@ function StatefulForm<Z extends ZodTypeAny>({
   function flattenAllFieldNames(fields: FormFieldGroup[]): string[] {
     return fields.flatMap((f) => {
       if (Array.isArray(f)) {
-        return flattenAllFieldNames(f)
+        return flattenAllFieldNames(f);
       }
 
       if (f.type === "frame" && f.fields) {
-        return flattenAllFieldNames(f.fields as FormFieldGroup[])
+        return flattenAllFieldNames(f.fields as FormFieldGroup[]);
       }
 
       // skip fields that don't hold a real, validatable form value
       if (f.type === "button" || f.type === "custom" || f.hidden) {
-        return []
+        return [];
       }
 
-      return [f.name]
-    })
+      return [f.name];
+    });
   }
 
   // Decide whether a value is "real" enough to be worth touching/validating.
   // Prevents empty/untouched fields from getting falsely marked as touched
   // on initial mount (which would make them show errors immediately).
   const hasMeaningfulValue = (value: unknown): boolean => {
-    if (typeof value === "string") return value.length > 0
-    if (typeof value === "number" || typeof value === "boolean") return true
-    if (isFile(value) || isFileArray(value)) return true
-    return value != null
-  }
+    if (typeof value === "string") return value.length > 0;
+    if (typeof value === "number" || typeof value === "boolean") return true;
+    if (isFile(value) || isFileArray(value)) return true;
+    return value != null;
+  };
 
-  const allFieldNames = flattenAllFieldNames(fields)
+  const allFieldNames = flattenAllFieldNames(fields);
 
-  const prevFormValuesRef = useRef<TypeOf<Z>>(formValues)
+  const prevFormValuesRef = useRef<TypeOf<Z>>(formValues);
 
   // Whenever `formValues` changes — whether from an external source (values
   // prop reactive sync) or a "custom" field's own render logic — RHF's
@@ -308,22 +308,22 @@ function StatefulForm<Z extends ZodTypeAny>({
   // with `shouldValidate` + `shouldTouch` only on fields that actually changed,
   // avoiding unnecessary re-validation on fields that didn't change.
   useEffect(() => {
-    const prevFormValues = prevFormValuesRef.current
+    const prevFormValues = prevFormValuesRef.current;
 
     allFieldNames.forEach((name) => {
-      const key = name as keyof TypeOf<Z>
-      const value = formValues[key]
-      const prevValue = prevFormValues[key]
+      const key = name as keyof TypeOf<Z>;
+      const value = formValues[key];
+      const prevValue = prevFormValues[key];
 
-      const changedInternally = internallyChangedFieldsRef.current.has(name)
+      const changedInternally = internallyChangedFieldsRef.current.has(name);
 
       // consume the flag either way, so it doesn't leak into future renders
-      internallyChangedFieldsRef.current.delete(name)
+      internallyChangedFieldsRef.current.delete(name);
 
       if (changedInternally) {
         // came from real user interaction via register/Controller —
         // RHF already validated + touched it, nothing to do here
-        return
+        return;
       }
 
       // only reaches here for changes NOT triggered by handleFieldChange,
@@ -333,21 +333,21 @@ function StatefulForm<Z extends ZodTypeAny>({
           shouldValidate: true,
           shouldTouch: true,
           shouldDirty: true,
-        })
+        });
       }
-    })
+    });
 
-    prevFormValuesRef.current = formValues
-  }, [formValues, setValue])
+    prevFormValuesRef.current = formValues;
+  }, [formValues, setValue]);
 
   useEffect(() => {
     if (onValidityChange) {
-      onValidityChange(isValid)
+      onValidityChange(isValid);
     }
-  }, [isValid, onValidityChange])
+  }, [isValid, onValidityChange]);
 
   const shouldShowError = (name: keyof TypeOf<Z>): boolean => {
-    const fieldConfig = findField(fields, name as string)
+    const fieldConfig = findField(fields, name as string);
 
     if (
       !fieldConfig ||
@@ -355,62 +355,62 @@ function StatefulForm<Z extends ZodTypeAny>({
       fieldConfig.type === "button" ||
       fieldConfig.hidden
     ) {
-      return false
+      return false;
     }
 
-    const value = formValues[name]
-    const touched = touchedFields[name]
-    const error = errors[name]
+    const value = formValues[name];
+    const touched = touchedFields[name];
+    const error = errors[name];
 
     const hasErrorMessage = (err: unknown): boolean => {
-      if (!err || typeof err !== "object") return false
+      if (!err || typeof err !== "object") return false;
 
-      if (typeof (err as any)?.message === "string") return true
+      if (typeof (err as any)?.message === "string") return true;
 
-      if (typeof (err as any)?.text?.message === "string") return true
+      if (typeof (err as any)?.text?.message === "string") return true;
 
       if (Array.isArray(err)) {
-        return err.some((item) => hasErrorMessage(item))
+        return err.some((item) => hasErrorMessage(item));
       }
 
-      return Object.values(err).some((v) => hasErrorMessage(v))
-    }
+      return Object.values(err).some((v) => hasErrorMessage(v));
+    };
 
     if (typeof value === "string") {
-      return value.length > 0 && !!touched && hasErrorMessage(error)
+      return value.length > 0 && !!touched && hasErrorMessage(error);
     }
 
     if (typeof value === "number" || typeof value === "boolean") {
-      return !!touched && hasErrorMessage(error)
+      return !!touched && hasErrorMessage(error);
     }
 
     if (isFile(value) || isFileArray(value)) {
-      return !!touched && hasErrorMessage(error)
+      return !!touched && hasErrorMessage(error);
     }
 
     if (typeof value === "object" && value !== null) {
-      return !!touched && hasErrorMessage(error)
+      return !!touched && hasErrorMessage(error);
     }
 
-    return !!touched && hasErrorMessage(error)
-  }
+    return !!touched && hasErrorMessage(error);
+  };
 
   function findField(
     fields: FormFieldGroup[],
-    name: string,
+    name: string
   ): FormFieldProps | undefined {
     for (const f of fields) {
       if (Array.isArray(f)) {
-        const found = findField(f, name)
-        if (found) return found
+        const found = findField(f, name);
+        if (found) return found;
       } else if (f.type === "frame" && f.fields) {
-        const found = findField(f.fields, name)
-        if (found) return found
+        const found = findField(f.fields, name);
+        if (found) return found;
       } else if (f.name === name) {
-        return f
+        return f;
       }
     }
-    return undefined
+    return undefined;
   }
 
   return (
@@ -432,80 +432,80 @@ function StatefulForm<Z extends ZodTypeAny>({
       styles={styles}
       shouldShowError={shouldShowError}
     />
-  )
+  );
 }
 
 function unwrapSchema(schema: ZodTypeAny): ZodTypeAny {
   if (schema._def.typeName === "ZodEffects") {
-    return unwrapSchema(schema._def.schema)
+    return unwrapSchema(schema._def.schema);
   }
-  return schema
+  return schema;
 }
 
 function getSchemaForVisibleFields<Z extends ZodTypeAny>(
   validationSchema?: Z,
-  fields?: FormFieldGroup[],
+  fields?: FormFieldGroup[]
 ) {
-  if (!validationSchema) return undefined
+  if (!validationSchema) return undefined;
 
-  const baseSchema = unwrapSchema(validationSchema)
+  const baseSchema = unwrapSchema(validationSchema);
 
   if (baseSchema._def.typeName !== "ZodObject") {
-    throw new Error("StatefulForm only supports Zod object schemas")
+    throw new Error("StatefulForm only supports Zod object schemas");
   }
 
-  const objSchema = baseSchema as ZodObject<any>
+  const objSchema = baseSchema as ZodObject<any>;
 
   function flattenFields(fields: FormFieldGroup[]): FormFieldProps[] {
     return fields.flatMap((f) => {
-      if (Array.isArray(f)) return flattenFields(f)
+      if (Array.isArray(f)) return flattenFields(f);
 
       if (f.type === "frame" && f.fields) {
-        return flattenFields(f.fields as FormFieldGroup[])
+        return flattenFields(f.fields as FormFieldGroup[]);
       }
 
-      return [f]
-    })
+      return [f];
+    });
   }
 
-  const flatFields: FormFieldProps[] = flattenFields(fields)
+  const flatFields: FormFieldProps[] = flattenFields(fields);
 
   const newShape = Object.fromEntries(
     flatFields.map((field) => {
-      const key = field.name
-      const originalFieldSchema = objSchema.shape[key]
+      const key = field.name;
+      const originalFieldSchema = objSchema.shape[key];
 
-      if (!originalFieldSchema) return [key, z.any()]
+      if (!originalFieldSchema) return [key, z.any()];
       return [
         key,
         field.hidden || field.type === "custom"
           ? originalFieldSchema.optional()
           : originalFieldSchema,
-      ]
-    }),
-  )
+      ];
+    })
+  );
 
-  return z.object(newShape)
+  return z.object(newShape);
 }
 
 interface FormFieldsProps<T extends FieldValues> {
-  fields: FormFieldGroup[]
-  formValues: T
-  register: UseFormRegister<T>
-  errors: FieldErrors<T>
-  shouldShowError: (name: string) => boolean
-  control: Control<T>
-  labelSize?: string
-  fieldSize?: string
-  setValue?: UseFormSetValue<T>
-  onChange?: (name: keyof T, value: FormValueType) => void
-  autoFocusField?: string
-  styles?: StatefulFormStyles
-  rowWithFrame?: boolean
-  disabled?: boolean
-  mobile?: boolean
-  className?: string
-  id?: string
+  fields: FormFieldGroup[];
+  formValues: T;
+  register: UseFormRegister<T>;
+  errors: FieldErrors<T>;
+  shouldShowError: (name: string) => boolean;
+  control: Control<T>;
+  labelSize?: string;
+  fieldSize?: string;
+  setValue?: UseFormSetValue<T>;
+  onChange?: (name: keyof T, value: FormValueType) => void;
+  autoFocusField?: string;
+  styles?: StatefulFormStyles;
+  rowWithFrame?: boolean;
+  disabled?: boolean;
+  mobile?: boolean;
+  className?: string;
+  id?: string;
 }
 
 function FormFields<T extends FieldValues>({
@@ -527,20 +527,20 @@ function FormFields<T extends FieldValues>({
   className,
   id,
 }: FormFieldsProps<T>) {
-  const { currentTheme } = useTheme()
-  const statefulFormTheme = currentTheme?.statefulForm
-  const pinboxTheme = currentTheme?.pinbox
+  const { currentTheme } = useTheme();
+  const statefulFormTheme = currentTheme?.statefulForm;
+  const pinboxTheme = currentTheme?.pinbox;
 
-  const refs = useRef<Record<string, HTMLElement | null>>({})
+  const refs = useRef<Record<string, HTMLElement | null>>({});
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      const el = refs.current[autoFocusField]
-      el?.focus?.()
-    }, 50)
+      const el = refs.current[autoFocusField];
+      el?.focus?.();
+    }, 50);
 
-    return () => clearTimeout(timer)
-  }, [])
+    return () => clearTimeout(timer);
+  }, []);
 
   return (
     <ContainerFormField
@@ -550,27 +550,29 @@ function FormFields<T extends FieldValues>({
     >
       {fields.map((group: FormFieldGroup, indexGroup: number) => {
         const visibleFields = (Array.isArray(group) ? group : [group]).filter(
-          (field) => !field.hidden,
-        )
+          (field) => !field.hidden
+        );
 
         if (visibleFields.length === 0) {
-          return
+          return;
         }
 
         const rowJustifiedContent = visibleFields.find(
-          (field) => field.rowJustifyPosition,
-        )?.rowJustifyPosition
+          (field) => field.rowJustifyPosition
+        )?.rowJustifyPosition;
 
         const rowAlignedItem = visibleFields.find(
-          (field) => field.rowItemsAlignment,
-        )?.rowItemsAlignment
+          (field) => field.rowItemsAlignment
+        )?.rowItemsAlignment;
 
         const rowStyleItem = visibleFields.find(
-          (field) => field.rowStyle,
-        )?.rowStyle
+          (field) => field.rowStyle
+        )?.rowStyle;
 
-        const nonButtonFields = visibleFields.filter((f) => f.type !== "button")
-        const hasFieldTitle = nonButtonFields.some((f) => f.title)
+        const nonButtonFields = visibleFields.filter(
+          (f) => f.type !== "button"
+        );
+        const hasFieldTitle = nonButtonFields.some((f) => f.title);
 
         const mobileInputStyle =
           mobile &&
@@ -593,7 +595,7 @@ function FormFields<T extends FieldValues>({
               background-color: transparent !important;
               transition: background-color 9999s ease-in-out 0s;
             }
-          `
+          `;
 
         const mobileBodyStyle =
           mobile &&
@@ -601,23 +603,23 @@ function FormFields<T extends FieldValues>({
             gap: 0px;
             justify-content: space-between;
             align-items: center;
-          `
+          `;
 
         const mobileControlStyle =
           mobile &&
           css`
             width: fit-content;
-          `
+          `;
 
         const mobileLabelStyle =
           mobile &&
           css`
             width: 100%;
-          `
+          `;
 
         const isButtonRow =
           visibleFields.length > 0 &&
-          visibleFields.every((field) => field.type === "button")
+          visibleFields.every((field) => field.type === "button");
 
         const mobileRowFormFieldStyle =
           mobile &&
@@ -637,7 +639,7 @@ function FormFields<T extends FieldValues>({
               gap: 0px;
               overflow: hidden;
             `}
-          `
+          `;
 
         return (
           <RowFormField
@@ -671,15 +673,15 @@ function FormFields<T extends FieldValues>({
             {visibleFields.map((field: FormFieldProps, index: number) => {
               const labelPosition = mobile
                 ? (field?.labelPosition ?? "left")
-                : field?.labelPosition
-              const isLast = index === visibleFields.length - 1
+                : field?.labelPosition;
+              const isLast = index === visibleFields.length - 1;
               const showDivider =
-                mobile && !isLast && Array.isArray(group) && !isButtonRow
-              const label = mobile ? null : field?.title
+                mobile && !isLast && Array.isArray(group) && !isButtonRow;
+              const label = mobile ? null : field?.title;
               const placeholder = mobile
                 ? (field.placeholder ?? field.title)
-                : field.placeholder
-              const required = mobile ? false : field.required
+                : field.placeholder;
+              const required = mobile ? false : field.required;
 
               if (field.type === "frame") {
                 return (
@@ -726,13 +728,13 @@ function FormFields<T extends FieldValues>({
                       />
                     )}
                   </Frame>
-                )
+                );
               }
 
               const fieldNode = (() => {
                 switch (field.type) {
                   case "custom": {
-                    return <Fragment key={index}>{field.render}</Fragment>
+                    return <Fragment key={index}>{field.render}</Fragment>;
                   }
 
                   case "text":
@@ -757,17 +759,17 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e)
+                              field.onChange(e);
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value)
+                              onChange(field.name as keyof T, e.target.value);
                             }
                           },
                         })}
                         ref={(el) => {
-                          if (el) refs.current[field.name] = el
-                          const { ref } = register(field.name as Path<T>)
-                          if (ref) ref(el)
+                          if (el) refs.current[field.name] = el;
+                          const { ref } = register(field.name as Path<T>);
+                          if (ref) ref(el);
                         }}
                         showError={shouldShowError(field.name)}
                         errorMessage={
@@ -830,7 +832,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    )
+                    );
                   }
 
                   case "pin": {
@@ -855,14 +857,14 @@ function FormFields<T extends FieldValues>({
                             helper={field.helper}
                             onBlur={controllerField.onBlur}
                             onChange={(e) => {
-                              controllerField.onChange(e)
+                              controllerField.onChange(e);
 
                               if (field.onChange) {
-                                field.onChange(e)
+                                field.onChange(e);
                               }
 
                               if (onChange) {
-                                onChange(field.name as keyof T, e.target.value)
+                                onChange(field.name as keyof T, e.target.value);
                               }
                             }}
                             showError={shouldShowError(field.name)}
@@ -948,11 +950,11 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    )
+                    );
                   }
 
                   case "button": {
-                    const defaultVariant = field?.button?.variant ?? "default"
+                    const defaultVariant = field?.button?.variant ?? "default";
 
                     const mobileButtonStyle =
                       mobile &&
@@ -968,7 +970,7 @@ function FormFields<T extends FieldValues>({
                         css`
                           background-color: ${statefulFormTheme?.mobileRowFrameBackgroundColor};
                         `}
-                      `
+                      `;
 
                     return (
                       <Button
@@ -1018,9 +1020,9 @@ function FormFields<T extends FieldValues>({
                         }}
                         onClick={(e) => {
                           if (field?.button?.onClick) {
-                            field?.button?.onClick?.(e)
+                            field?.button?.onClick?.(e);
                           } else {
-                            field?.onClick?.(e)
+                            field?.onClick?.(e);
                           }
                         }}
                         disabled={field.disabled || disabled}
@@ -1033,7 +1035,7 @@ function FormFields<T extends FieldValues>({
 
                         {field.title}
                       </Button>
-                    )
+                    );
                   }
 
                   case "time": {
@@ -1051,9 +1053,9 @@ function FormFields<T extends FieldValues>({
                           typeof field.placeholder === "string"
                             ? (() => {
                                 const [hour = "", minute = "", second = ""] =
-                                  field.placeholder.split(/[:/]/)
+                                  field.placeholder.split(/[:/]/);
 
-                                return { hour, minute, second }
+                                return { hour, minute, second };
                               })()
                             : field.placeholder
                         }
@@ -1063,10 +1065,10 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e)
+                              field.onChange(e);
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value)
+                              onChange(field.name as keyof T, e.target.value);
                             }
                           },
                         })}
@@ -1185,12 +1187,12 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                         ref={(el) => {
-                          if (el) refs.current[field.name] = el
-                          const { ref } = register(field.name as Path<T>)
-                          if (ref) ref(el)
+                          if (el) refs.current[field.name] = el;
+                          const { ref } = register(field.name as Path<T>);
+                          if (ref) ref(el);
                         }}
                       />
-                    )
+                    );
                   }
 
                   case "textarea": {
@@ -1211,17 +1213,17 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e)
+                              field.onChange(e);
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value)
+                              onChange(field.name as keyof T, e.target.value);
                             }
                           },
                         })}
                         ref={(el) => {
-                          if (el) refs.current[field.name] = el
-                          const { ref } = register(field.name as Path<T>)
-                          if (ref) ref(el)
+                          if (el) refs.current[field.name] = el;
+                          const { ref } = register(field.name as Path<T>);
+                          if (ref) ref(el);
                         }}
                         showError={shouldShowError(field.name)}
                         errorMessage={
@@ -1282,7 +1284,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    )
+                    );
                   }
 
                   case "checkbox": {
@@ -1294,10 +1296,10 @@ function FormFields<T extends FieldValues>({
                         render={({ field: controllerField }) => {
                           const titleCheckbox = mobile
                             ? (field.title ?? field.placeholder)
-                            : field.title
+                            : field.title;
                           const placeholderCheckbox = mobile
                             ? undefined
-                            : field.placeholder
+                            : field.placeholder;
                           return (
                             <Checkbox
                               id={field.id}
@@ -1313,9 +1315,9 @@ function FormFields<T extends FieldValues>({
                               checked={controllerField.value ?? false}
                               helper={field.helper}
                               ref={(el) => {
-                                if (el) refs.current[field.name] = el
-                                const { ref } = register(field.name as Path<T>)
-                                if (ref) ref(el)
+                                if (el) refs.current[field.name] = el;
+                                const { ref } = register(field.name as Path<T>);
+                                if (ref) ref(el);
                               }}
                               errorMessage={
                                 errors[field.name as keyof T]?.message as
@@ -1325,15 +1327,15 @@ function FormFields<T extends FieldValues>({
                               required={required}
                               showError={shouldShowError(field.name)}
                               onChange={(e) => {
-                                controllerField?.onChange(e)
-                                controllerField?.onBlur()
+                                controllerField?.onChange(e);
+                                controllerField?.onBlur();
                                 if (onChange) {
                                   onChange(
                                     field.name as keyof T,
-                                    e.target.checked,
-                                  )
+                                    e.target.checked
+                                  );
                                 }
-                                field.onChange?.(e)
+                                field.onChange?.(e);
                               }}
                               disabled={field.disabled || disabled}
                               {...field.checkbox}
@@ -1419,10 +1421,10 @@ function FormFields<T extends FieldValues>({
                                 `,
                               }}
                             />
-                          )
+                          );
                         }}
                       />
-                    )
+                    );
                   }
 
                   case "radio": {
@@ -1434,10 +1436,10 @@ function FormFields<T extends FieldValues>({
                         render={({ field: controllerField }) => {
                           const titleRadio = mobile
                             ? (field.title ?? field.placeholder)
-                            : field.title
+                            : field.title;
                           const placeholderRadio = mobile
                             ? undefined
-                            : field.placeholder
+                            : field.placeholder;
                           return (
                             <Radio
                               {...field.radio}
@@ -1460,15 +1462,15 @@ function FormFields<T extends FieldValues>({
                               required={required}
                               showError={shouldShowError(field.name)}
                               onChange={(e) => {
-                                controllerField?.onChange(e)
-                                controllerField?.onBlur()
+                                controllerField?.onChange(e);
+                                controllerField?.onBlur();
                                 if (onChange) {
                                   onChange(
                                     field.name as keyof T,
-                                    e.target.checked,
-                                  )
+                                    e.target.checked
+                                  );
                                 }
-                                field.onChange?.(e)
+                                field.onChange?.(e);
                               }}
                               disabled={field.disabled || disabled}
                               styles={{
@@ -1538,10 +1540,10 @@ function FormFields<T extends FieldValues>({
                                 `,
                               }}
                             />
-                          )
+                          );
                         }}
                       />
-                    )
+                    );
                   }
 
                   case "phone": {
@@ -1562,8 +1564,8 @@ function FormFields<T extends FieldValues>({
                             className={field?.className}
                             required={required}
                             ref={(el) => {
-                              if (el) refs.current[field.name] = el
-                              controllerField.ref(el)
+                              if (el) refs.current[field.name] = el;
+                              controllerField.ref(el);
                             }}
                             onBlur={controllerField.onBlur}
                             value={controllerField.value}
@@ -1574,19 +1576,19 @@ function FormFields<T extends FieldValues>({
                               e:
                                 | {
                                     target: {
-                                      name: string
-                                      value: PhoneboxCountryCode
-                                    }
+                                      name: string;
+                                      value: PhoneboxCountryCode;
+                                    };
                                   }
-                                | ChangeEvent<HTMLInputElement>,
+                                | ChangeEvent<HTMLInputElement>
                             ) => {
                               if (e.target.name === "phone") {
-                                controllerField.onChange(e)
-                                onChange?.("phone", e.target.value)
+                                controllerField.onChange(e);
+                                onChange?.("phone", e.target.value);
                               } else if (e.target.name === "country_code") {
-                                onChange?.("country_code", e.target.value)
+                                onChange?.("country_code", e.target.value);
                               }
-                              field.onChange?.(e)
+                              field.onChange?.(e);
                             }}
                             showError={shouldShowError(field.name)}
                             errorMessage={
@@ -1667,7 +1669,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    )
+                    );
                   }
 
                   case "color": {
@@ -1689,17 +1691,17 @@ function FormFields<T extends FieldValues>({
                             labelWidth={field.labelWidth}
                             labelPosition={labelPosition}
                             ref={(el) => {
-                              if (el) refs.current[field.name] = el
-                              const { ref } = register(field.name as Path<T>)
-                              if (ref) ref(el)
+                              if (el) refs.current[field.name] = el;
+                              const { ref } = register(field.name as Path<T>);
+                              if (ref) ref(el);
                             }}
                             value={controllerField.value}
                             onChange={(e) => {
-                              controllerField?.onChange(e)
-                              controllerField?.onBlur()
-                              field.onChange?.(e)
+                              controllerField?.onChange(e);
+                              controllerField?.onBlur();
+                              field.onChange?.(e);
                               if (onChange) {
-                                onChange(field.name as keyof T, e.target.value)
+                                onChange(field.name as keyof T, e.target.value);
                               }
                             }}
                             showError={shouldShowError(field.name)}
@@ -1799,7 +1801,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    )
+                    );
                   }
 
                   case "file_drop_box": {
@@ -1820,10 +1822,10 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e)
+                              field.onChange(e);
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value)
+                              onChange(field.name as keyof T, e.target.value);
                             }
                           },
                         })}
@@ -1867,7 +1869,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    )
+                    );
                   }
 
                   case "file": {
@@ -1897,24 +1899,24 @@ function FormFields<T extends FieldValues>({
                             setValue(field.name as Path<T>, files as any, {
                               shouldValidate: true,
                               shouldTouch: true,
-                            })
+                            });
 
-                            onChange?.(field.name, files)
+                            onChange?.(field.name, files);
 
                             field.onChange?.({
                               target: { name: field.name, value: files },
-                            })
+                            });
                           } else {
                             setValue(field.name as Path<T>, undefined, {
                               shouldValidate: true,
                               shouldTouch: true,
-                            })
+                            });
 
-                            onChange?.(field.name, undefined)
+                            onChange?.(field.name, undefined);
 
                             field.onChange?.({
                               target: { name: field.name, value: undefined },
-                            })
+                            });
                           }
                         }}
                         styles={{
@@ -1963,7 +1965,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    )
+                    );
                   }
 
                   case "image": {
@@ -1979,26 +1981,26 @@ function FormFields<T extends FieldValues>({
                         helper={field.helper}
                         value={formValues[field.name as keyof T] ?? ""}
                         onFileSelected={(e: File | undefined) => {
-                          const file = e
+                          const file = e;
                           if (file instanceof File) {
                             setValue(field.name as Path<T>, file as any, {
                               shouldValidate: true,
                               shouldTouch: true,
-                            })
+                            });
                           } else {
                             setValue(field.name as Path<T>, undefined, {
                               shouldValidate: true,
                               shouldTouch: true,
-                            })
+                            });
                           }
                           field.onChange?.({
                             target: {
                               name: field.name,
                               value: file ?? undefined,
                             },
-                          })
+                          });
                           if (onChange) {
-                            onChange(field.name as keyof T, file ?? undefined)
+                            onChange(field.name as keyof T, file ?? undefined);
                           }
                         }}
                         label={field.title}
@@ -2007,10 +2009,10 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e)
+                              field.onChange(e);
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value)
+                              onChange(field.name as keyof T, e.target.value);
                             }
                           },
                         })}
@@ -2069,7 +2071,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    )
+                    );
                   }
 
                   case "signbox": {
@@ -2090,10 +2092,10 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e)
+                              field.onChange(e);
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value)
+                              onChange(field.name as keyof T, e.target.value);
                             }
                           },
                         })}
@@ -2147,7 +2149,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    )
+                    );
                   }
 
                   case "money": {
@@ -2166,8 +2168,8 @@ function FormFields<T extends FieldValues>({
                             labelPosition={labelPosition}
                             className={field?.className}
                             ref={(el) => {
-                              if (el) refs.current[field.name] = el
-                              rhf.ref(el)
+                              if (el) refs.current[field.name] = el;
+                              rhf.ref(el);
                             }}
                             name={field.name}
                             label={label}
@@ -2177,21 +2179,21 @@ function FormFields<T extends FieldValues>({
                             required={required}
                             disabled={field.disabled || disabled}
                             onChange={(e) => {
-                              const { name, value } = e.target
+                              const { name, value } = e.target;
 
                               if (field.onChange) {
-                                field.onChange(e)
+                                field.onChange(e);
                               }
 
                               if (onChange && name === "currency") {
-                                onChange("currency", value)
+                                onChange("currency", value);
                               } else {
-                                onChange(field.name as keyof T, value)
+                                onChange(field.name as keyof T, value);
                                 setValue(field.name as Path<T>, value as any, {
                                   shouldValidate: true,
                                   shouldTouch: true,
                                   shouldDirty: true,
-                                })
+                                });
                               }
                             }}
                             onBlur={rhf.onBlur}
@@ -2257,7 +2259,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    )
+                    );
                   }
 
                   case "date": {
@@ -2267,11 +2269,11 @@ function FormFields<T extends FieldValues>({
                         name={field.name as Path<T>}
                         control={control}
                         render={({ field: controllerField }) => {
-                          const value = controllerField.value
+                          const value = controllerField.value;
 
                           const hasValue = Array.isArray(value)
                             ? value.some((v) => v !== "" && v != null)
-                            : value !== "" && value != null
+                            : value !== "" && value != null;
 
                           return (
                             <Datebox
@@ -2289,9 +2291,9 @@ function FormFields<T extends FieldValues>({
                               labelPosition={labelPosition}
                               mobile={mobile}
                               ref={(el) => {
-                                if (el) refs.current[field.name] = el
-                                const { ref } = register(field.name as Path<T>)
-                                if (ref) ref(el)
+                                if (el) refs.current[field.name] = el;
+                                const { ref } = register(field.name as Path<T>);
+                                if (ref) ref(el);
                               }}
                               errorMessage={
                                 errors[field.name as keyof T]?.[0]?.message as
@@ -2301,12 +2303,12 @@ function FormFields<T extends FieldValues>({
                               onChange={(e) => {
                                 const inputValueEvent = {
                                   target: { name: field.name, value: e },
-                                }
-                                controllerField.onChange(inputValueEvent)
-                                controllerField?.onBlur()
-                                field.onChange?.(inputValueEvent)
+                                };
+                                controllerField.onChange(inputValueEvent);
+                                controllerField?.onBlur();
+                                field.onChange?.(inputValueEvent);
                                 if (onChange) {
-                                  onChange(field.name as keyof T, e)
+                                  onChange(field.name as keyof T, e);
                                 }
                               }}
                               selectedDates={controllerField.value}
@@ -2375,10 +2377,10 @@ function FormFields<T extends FieldValues>({
                                 `,
                               }}
                             />
-                          )
+                          );
                         }}
                       />
-                    )
+                    );
                   }
 
                   case "combo": {
@@ -2401,9 +2403,9 @@ function FormFields<T extends FieldValues>({
                             required={required}
                             showError={shouldShowError(field.name)}
                             ref={(el) => {
-                              if (el) refs.current[field.name] = el
-                              const { ref } = register(field.name as Path<T>)
-                              if (ref) ref(el)
+                              if (el) refs.current[field.name] = el;
+                              const { ref } = register(field.name as Path<T>);
+                              if (ref) ref(el);
                             }}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
@@ -2414,12 +2416,12 @@ function FormFields<T extends FieldValues>({
                             onChange={(e) => {
                               const inputValueEvent = {
                                 target: { name: field.name, value: e },
-                              }
-                              controllerField.onChange(inputValueEvent)
-                              controllerField?.onBlur()
-                              field.onChange?.(inputValueEvent)
+                              };
+                              controllerField.onChange(inputValueEvent);
+                              controllerField?.onBlur();
+                              field.onChange?.(inputValueEvent);
                               if (onChange) {
-                                onChange(field.name as keyof T, e)
+                                onChange(field.name as keyof T, e);
                               }
                             }}
                             selectedOptions={controllerField.value}
@@ -2497,7 +2499,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    )
+                    );
                   }
 
                   case "chips": {
@@ -2522,27 +2524,30 @@ function FormFields<T extends FieldValues>({
                             disabled={field.disabled || disabled}
                             inputValue={controllerField.value}
                             setInputValue={(e) => {
-                              controllerField?.onChange(e)
-                              controllerField?.onBlur()
-                              field.onChange?.(e)
+                              controllerField?.onChange(e);
+                              controllerField?.onBlur();
+                              field.onChange?.(e);
 
                               if (onChange) {
                                 onChange(
                                   (field?.name as keyof T) ?? "chips",
-                                  e.target.value,
-                                )
+                                  e.target.value
+                                );
                               }
                             }}
                             onChange={(e) => {
-                              controllerField?.onChange(e)
-                              controllerField?.onBlur()
+                              controllerField?.onChange(e);
+                              controllerField?.onBlur();
                               const inputValueEvent = {
                                 target: { name: field.name, value: e },
-                              }
-                              field.onChange?.(inputValueEvent)
+                              };
+                              field.onChange?.(inputValueEvent);
 
                               if (onChange) {
-                                onChange((field?.name as keyof T) ?? "chips", e)
+                                onChange(
+                                  (field?.name as keyof T) ?? "chips",
+                                  e
+                                );
                               }
                             }}
                             {...field.chips}
@@ -2605,7 +2610,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    )
+                    );
                   }
 
                   case "rating": {
@@ -2617,7 +2622,7 @@ function FormFields<T extends FieldValues>({
                         render={({ field: controllerField, fieldState }) => {
                           const size = mobile
                             ? (field?.rating?.size ?? "lg")
-                            : field?.rating?.size
+                            : field?.rating?.size;
 
                           return (
                             <Rating
@@ -2633,14 +2638,14 @@ function FormFields<T extends FieldValues>({
                               name={field.name}
                               rating={controllerField.value}
                               onChange={(e) => {
-                                controllerField.onChange(e.target.value)
-                                controllerField?.onBlur()
-                                field.onChange?.(e)
+                                controllerField.onChange(e.target.value);
+                                controllerField?.onBlur();
+                                field.onChange?.(e);
                                 if (onChange) {
                                   onChange(
                                     field.name as keyof T,
-                                    e.target.value,
-                                  )
+                                    e.target.value
+                                  );
                                 }
                               }}
                               showError={!!fieldState.error}
@@ -2699,10 +2704,10 @@ function FormFields<T extends FieldValues>({
                                 `,
                               }}
                             />
-                          )
+                          );
                         }}
                       />
-                    )
+                    );
                   }
 
                   case "thumbfield": {
@@ -2725,22 +2730,22 @@ function FormFields<T extends FieldValues>({
                             {...register(field.name as Path<T>, {
                               onChange: (e) => {
                                 if (field.onChange) {
-                                  field.onChange(e)
+                                  field.onChange(e);
                                 }
                                 if (onChange) {
                                   onChange(
                                     field.name as keyof T,
-                                    e.target.checked,
-                                  )
+                                    e.target.checked
+                                  );
                                 }
                               },
                             })}
                             onChange={(e) => {
-                              controllerField?.onChange(e)
-                              controllerField?.onBlur()
-                              field.onChange?.(e)
+                              controllerField?.onChange(e);
+                              controllerField?.onBlur();
+                              field.onChange?.(e);
                               if (onChange) {
-                                onChange(field.name as keyof T, e.target.value)
+                                onChange(field.name as keyof T, e.target.value);
                               }
                             }}
                             showError={shouldShowError(field.name)}
@@ -2823,7 +2828,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    )
+                    );
                   }
 
                   case "toggle": {
@@ -2845,14 +2850,14 @@ function FormFields<T extends FieldValues>({
                             required={required}
                             helper={field.helper}
                             onChange={(e) => {
-                              controllerField?.onChange(e)
-                              controllerField?.onBlur()
-                              field.onChange?.(e)
+                              controllerField?.onChange(e);
+                              controllerField?.onBlur();
+                              field.onChange?.(e);
                               if (onChange) {
                                 onChange(
                                   field.name as keyof T,
-                                  e.target.checked,
-                                )
+                                  e.target.checked
+                                );
                               }
                             }}
                             onBlur={controllerField.onBlur}
@@ -2925,7 +2930,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    )
+                    );
                   }
 
                   case "capsule": {
@@ -2952,12 +2957,12 @@ function FormFields<T extends FieldValues>({
                             onTabChange={(e) => {
                               const inputValueEvent = {
                                 target: { name: field.name, value: e },
-                              }
-                              controllerField?.onChange(e)
-                              controllerField?.onBlur()
-                              field.onChange?.(inputValueEvent)
+                              };
+                              controllerField?.onChange(e);
+                              controllerField?.onBlur();
+                              field.onChange?.(inputValueEvent);
                               if (onChange) {
-                                onChange(field.name as keyof T, e)
+                                onChange(field.name as keyof T, e);
                               }
                             }}
                             showError={shouldShowError(field.name)}
@@ -3029,13 +3034,13 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    )
+                    );
                   }
 
                   default:
-                    return null
+                    return null;
                 }
-              })()
+              })();
 
               return (
                 <Fragment key={index}>
@@ -3048,18 +3053,18 @@ function FormFields<T extends FieldValues>({
                     />
                   )}
                 </Fragment>
-              )
+              );
             })}
           </RowFormField>
-        )
+        );
       })}
     </ContainerFormField>
-  )
+  );
 }
 
 const Divider = styled.div<{
-  $theme?: StatefulFormThemeConfig
-  $style?: CSSProp
+  $theme?: StatefulFormThemeConfig;
+  $style?: CSSProp;
 }>`
   width: 100%;
   height: 1px;
@@ -3067,24 +3072,24 @@ const Divider = styled.div<{
     $theme?.borderColor ?? "rgba(0,0,0,0.08)"};
 
   ${({ $style }) => $style}
-`
+`;
 
 export interface StatefulFormLabelProps
   extends Omit<LabelHTMLAttributes<HTMLLabelElement>, "label" | "style"> {
-  label?: string
-  helper?: ReactNode
-  styles: StatefulFormLabelStyles
-  labelPosition?: FieldLaneProps["labelPosition"]
-  labelWidth?: FieldLaneProps["labelWidth"]
-  required?: boolean
-  disabled?: boolean
+  label?: string;
+  helper?: ReactNode;
+  styles: StatefulFormLabelStyles;
+  labelPosition?: FieldLaneProps["labelPosition"];
+  labelWidth?: FieldLaneProps["labelWidth"];
+  required?: boolean;
+  disabled?: boolean;
 }
 
 export interface StatefulFormLabelStyles {
-  self?: CSSProp
-  helperDrawerStyle?: CSSProp
-  helperIconStyle?: CSSProp
-  helperArrowStyle?: CSSProp
+  self?: CSSProp;
+  helperDrawerStyle?: CSSProp;
+  helperIconStyle?: CSSProp;
+  helperArrowStyle?: CSSProp;
 }
 
 function StatefulFormLabel({
@@ -3099,8 +3104,8 @@ function StatefulFormLabel({
   id,
   ...props
 }: StatefulFormLabelProps) {
-  const { currentTheme } = useTheme()
-  const statefulFormTheme = currentTheme?.statefulForm
+  const { currentTheme } = useTheme();
+  const statefulFormTheme = currentTheme?.statefulForm;
 
   return (
     <Label
@@ -3142,14 +3147,14 @@ function StatefulFormLabel({
         />
       )}
     </Label>
-  )
+  );
 }
 
 const Label = styled.label<{
-  $style?: CSSProp
-  $labelWidth?: FieldLaneProps["labelWidth"]
-  $labelPosition?: FieldLaneProps["labelPosition"]
-  $disabled?: boolean
+  $style?: CSSProp;
+  $labelWidth?: FieldLaneProps["labelWidth"];
+  $labelPosition?: FieldLaneProps["labelPosition"];
+  $disabled?: boolean;
 }>`
   font-size: 0.75rem;
   display: flex;
@@ -3166,24 +3171,24 @@ const Label = styled.label<{
       cursor: not-allowed;
     `}
   ${({ $style }) => $style}
-`
+`;
 
 const Asterisk = styled.span`
   color: red;
   margin-left: 2px;
-`
+`;
 
 const LabelText = styled.span`
   min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-`
+`;
 
 interface StatefulFormSanitizeIdProps {
-  name?: string
-  id?: string
-  prefix?: string
+  name?: string;
+  id?: string;
+  prefix?: string;
 }
 
 function sanitizeId({
@@ -3195,11 +3200,11 @@ function sanitizeId({
     str
       .toLowerCase()
       .replace(/\s+/g, "_") // 1. spaces → underscores
-      .replace(/[^0-9a-z_-]/g, "") // 2. Remove all non-ASCII characters (allow only 0-9, a-z, A-Z, _ and -)
+      .replace(/[^0-9a-z_-]/g, ""); // 2. Remove all non-ASCII characters (allow only 0-9, a-z, A-Z, _ and -)
 
-  if (id) return sanitize(id)
-  if (name) return `${prefix}-${sanitize(name)}`
-  return prefix
+  if (id) return sanitize(id);
+  if (name) return `${prefix}-${sanitize(name)}`;
+  return prefix;
 }
 
 const ContainerFormField = styled.div<{ $style: CSSProp }>`
@@ -3214,7 +3219,7 @@ const ContainerFormField = styled.div<{ $style: CSSProp }>`
   gap: 6px;
 
   ${({ $style }) => $style}
-`
+`;
 
 const RowFormField = styled.div<{ $style: CSSProp }>`
   display: flex;
@@ -3224,44 +3229,44 @@ const RowFormField = styled.div<{ $style: CSSProp }>`
   justify-content: start;
 
   ${({ $style }) => $style}
-`
+`;
 
 export interface FieldTooltipItem {
-  title?: ReactNode
-  description?: ReactNode
+  title?: ReactNode;
+  description?: ReactNode;
 }
 
 export interface FieldTooltipStyles {
-  containerStyle?: CSSProp
-  itemStyle?: CSSProp
-  titleStyle?: CSSProp
-  descriptionStyle?: CSSProp
+  containerStyle?: CSSProp;
+  itemStyle?: CSSProp;
+  titleStyle?: CSSProp;
+  descriptionStyle?: CSSProp;
 }
 
 export interface FieldTooltipProps {
-  items?: FieldTooltipItem[]
-  styles?: FieldTooltipStyles
+  items?: FieldTooltipItem[];
+  styles?: FieldTooltipStyles;
 }
 
 function FieldTooltip({ items, styles }: FieldTooltipProps) {
-  const { currentTheme } = useTheme()
-  const statefulFormTheme = currentTheme?.statefulForm
+  const { currentTheme } = useTheme();
+  const statefulFormTheme = currentTheme?.statefulForm;
 
-  const wrapperRef = useRef<HTMLDivElement>(null)
-  const [isScrollable, setIsScrollable] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [isScrollable, setIsScrollable] = useState(false);
 
   useLayoutEffect(() => {
-    const el = wrapperRef.current
-    if (!el) return
+    const el = wrapperRef.current;
+    if (!el) return;
 
     const updateScrollable = () =>
-      setIsScrollable(el.scrollHeight > el.clientHeight + 2)
+      setIsScrollable(el.scrollHeight > el.clientHeight + 2);
 
-    updateScrollable()
-    const observer = new ResizeObserver(updateScrollable)
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [items])
+    updateScrollable();
+    const observer = new ResizeObserver(updateScrollable);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [items]);
 
   return (
     <FieldTooltipWrapper
@@ -3296,13 +3301,13 @@ function FieldTooltip({ items, styles }: FieldTooltipProps) {
         </FieldTooltipItem>
       ))}
     </FieldTooltipWrapper>
-  )
+  );
 }
 
 const FieldTooltipWrapper = styled.div<{
-  $theme?: StatefulFormThemeConfig
-  $scrollable?: boolean
-  $style?: CSSProp
+  $theme?: StatefulFormThemeConfig;
+  $scrollable?: boolean;
+  $style?: CSSProp;
 }>`
   width: 260px;
   max-height: 30vh;
@@ -3334,12 +3339,12 @@ const FieldTooltipWrapper = styled.div<{
   }
 
   ${({ $style }) => $style}
-`
+`;
 
 const FieldTooltipItem = styled.div<{
-  $theme?: StatefulFormThemeConfig
-  $isLast?: boolean
-  $style?: CSSProp
+  $theme?: StatefulFormThemeConfig;
+  $isLast?: boolean;
+  $style?: CSSProp;
 }>`
   box-sizing: border-box;
   padding: 10px 14px;
@@ -3347,11 +3352,11 @@ const FieldTooltipItem = styled.div<{
     $isLast ? "none" : `1px solid ${$theme?.fieldTooltip?.dividerColor}`};
 
   ${({ $style }) => $style}
-`
+`;
 
 const FieldTooltipTitle = styled.div<{
-  $theme?: StatefulFormThemeConfig
-  $style?: CSSProp
+  $theme?: StatefulFormThemeConfig;
+  $style?: CSSProp;
 }>`
   display: flex;
   align-items: baseline;
@@ -3362,11 +3367,11 @@ const FieldTooltipTitle = styled.div<{
   color: ${({ $theme }) => $theme?.fieldTooltip?.textColor};
 
   ${({ $style }) => $style}
-`
+`;
 
 const FieldTooltipDescription = styled.div<{
-  $theme?: StatefulFormThemeConfig
-  $style?: CSSProp
+  $theme?: StatefulFormThemeConfig;
+  $style?: CSSProp;
 }>`
   margin-top: 3px;
   font-size: 12px;
@@ -3376,10 +3381,10 @@ const FieldTooltipDescription = styled.div<{
   color: ${({ $theme }) => $theme?.fieldTooltip?.mutedTextColor};
 
   ${({ $style }) => $style}
-`
+`;
 
-StatefulForm.Label = StatefulFormLabel
-StatefulForm.sanitizeId = sanitizeId
-StatefulForm.FieldTooltip = FieldTooltip
+StatefulForm.Label = StatefulFormLabel;
+StatefulForm.sanitizeId = sanitizeId;
+StatefulForm.FieldTooltip = FieldTooltip;
 
-export { StatefulForm }
+export { StatefulForm };

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -1,6 +1,6 @@
-import { useForm, UseFormProps, UseFormSetValue } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import z, { ZodTypeAny, TypeOf, ZodObject } from "zod";
+import { useForm, UseFormProps, UseFormSetValue } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import z, { ZodTypeAny, TypeOf, ZodObject } from "zod"
 import React, {
   ChangeEvent,
   Fragment,
@@ -8,7 +8,7 @@ import React, {
   ReactNode,
   useEffect,
   useRef,
-} from "react";
+} from "react"
 import {
   Control,
   Controller,
@@ -16,44 +16,44 @@ import {
   FieldValues,
   Path,
   UseFormRegister,
-} from "react-hook-form";
-import { Phonebox, PhoneboxCountryCode, PhoneboxProps } from "./phonebox";
-import { Checkbox, CheckboxProps } from "./checkbox";
-import { Textbox, TextboxProps } from "./textbox";
-import { Colorbox, ColorboxProps } from "./colorbox";
-import { FileDropBox, FileDropBoxProps } from "./file-drop-box";
-import { FileInputBox, FileInputBoxProps } from "./file-input-box";
-import { Imagebox, ImageboxProps } from "./imagebox";
-import { Moneybox, MoneyboxProps } from "./moneybox";
-import { Datebox, DateboxProps } from "./datebox";
-import { Combobox, ComboboxProps } from "./combobox";
-import { Chips, ChipsProps } from "./chips";
-import { Signbox, SignboxProps } from "./signbox";
-import { Textarea, TextareaProps } from "./textarea";
-import styled, { css, CSSProp } from "styled-components";
-import { Rating, RatingProps } from "./rating";
-import { ThumbField, ThumbFieldProps } from "./thumb-field";
-import { Toggle, ToggleProps } from "./toggle";
-import { Capsule, CapsuleProps } from "./capsule";
-import { Timebox, TimeboxProps } from "./timebox";
-import { Button, ButtonProps } from "./button";
-import { Radio, RadioProps } from "./radio";
-import { Helper } from "./helper";
-import { FigureProps } from "./figure";
-import { Pinbox, PinboxProps } from "./pinbox";
-import { FieldLaneProps } from "./field-lane";
-import { Frame, FrameProps } from "./frame";
-import { applyClassName } from "./../constants/classname";
-import { useTheme, StatefulFormThemeConfig } from "./../theme";
+} from "react-hook-form"
+import { Phonebox, PhoneboxCountryCode, PhoneboxProps } from "./phonebox"
+import { Checkbox, CheckboxProps } from "./checkbox"
+import { Textbox, TextboxProps } from "./textbox"
+import { Colorbox, ColorboxProps } from "./colorbox"
+import { FileDropBox, FileDropBoxProps } from "./file-drop-box"
+import { FileInputBox, FileInputBoxProps } from "./file-input-box"
+import { Imagebox, ImageboxProps } from "./imagebox"
+import { Moneybox, MoneyboxProps } from "./moneybox"
+import { Datebox, DateboxProps } from "./datebox"
+import { Combobox, ComboboxProps } from "./combobox"
+import { Chips, ChipsProps } from "./chips"
+import { Signbox, SignboxProps } from "./signbox"
+import { Textarea, TextareaProps } from "./textarea"
+import styled, { css, CSSProp } from "styled-components"
+import { Rating, RatingProps } from "./rating"
+import { ThumbField, ThumbFieldProps } from "./thumb-field"
+import { Toggle, ToggleProps } from "./toggle"
+import { Capsule, CapsuleProps } from "./capsule"
+import { Timebox, TimeboxProps } from "./timebox"
+import { Button, ButtonProps } from "./button"
+import { Radio, RadioProps } from "./radio"
+import { Helper } from "./helper"
+import { FigureProps } from "./figure"
+import { Pinbox, PinboxProps } from "./pinbox"
+import { FieldLaneProps } from "./field-lane"
+import { Frame, FrameProps } from "./frame"
+import { applyClassName } from "./../constants/classname"
+import { useTheme, StatefulFormThemeConfig } from "./../theme"
 
 export type StatefulOnChangeType =
   | ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   | {
       target: {
-        name: string;
-        value: FormValueType;
-      };
-    };
+        name: string
+        value: FormValueType
+      }
+    }
 
 export type FormValueType =
   | string
@@ -66,7 +66,7 @@ export type FormValueType =
   | undefined
   | PhoneboxCountryCode
   | string[]
-  | number[];
+  | number[]
 
 export const FormFieldType = {
   Text: "text",
@@ -96,112 +96,112 @@ export const FormFieldType = {
   Pin: "pin",
   Frame: "frame",
   Custom: "custom",
-} as const;
+} as const
 
-export type FormFieldType = (typeof FormFieldType)[keyof typeof FormFieldType];
+export type FormFieldType = (typeof FormFieldType)[keyof typeof FormFieldType]
 
 export const StatefulFormMode = {
   OnChange: "onChange",
   OnBlur: "onBlur",
   OnSubmit: "onSubmit",
-} as const;
+} as const
 
 export type StatefulFormMode =
-  (typeof StatefulFormMode)[keyof typeof StatefulFormMode];
+  (typeof StatefulFormMode)[keyof typeof StatefulFormMode]
 
 export interface StatefulFormProps<Z extends ZodTypeAny> {
-  fields: FormFieldGroup[];
-  formValues: TypeOf<Z>;
-  validationSchema?: Z;
-  mode?: StatefulFormMode;
-  onValidityChange?: (e: boolean) => void;
-  labelSize?: string;
-  fieldSize?: string;
-  onChange?: (args: { currentState: any }) => void;
-  autoFocusField?: string;
-  styles?: StatefulFormStyles;
-  disabled?: boolean;
-  mobile?: boolean;
-  className?: string;
-  id?: string;
+  fields: FormFieldGroup[]
+  formValues: TypeOf<Z>
+  validationSchema?: Z
+  mode?: StatefulFormMode
+  onValidityChange?: (e: boolean) => void
+  labelSize?: string
+  fieldSize?: string
+  onChange?: (args: { currentState: any }) => void
+  autoFocusField?: string
+  styles?: StatefulFormStyles
+  disabled?: boolean
+  mobile?: boolean
+  className?: string
+  id?: string
 }
 
 export interface StatefulFormStyles {
-  containerStyle?: CSSProp;
-  frameContainerStyle?: CSSProp;
-  frameTitleStyle?: CSSProp;
-  mobileFieldGroupStyle?: CSSProp;
-  mobileFieldGroupRowDividerStyle?: CSSProp;
+  containerStyle?: CSSProp
+  frameContainerStyle?: CSSProp
+  frameTitleStyle?: CSSProp
+  mobileFieldGroupStyle?: CSSProp
+  mobileFieldGroupRowDividerStyle?: CSSProp
 }
 
-export type FormFieldGroup = FormFieldProps | FormFieldProps[];
+export type FormFieldGroup = FormFieldProps | FormFieldProps[]
 
 export const FormFieldRowJustifyPosition = {
   Center: "center",
   Start: "start",
   End: "end",
   SpaceBetween: "space-between",
-} as const;
+} as const
 
 export type FormFieldRowJustifyPosition =
-  (typeof FormFieldRowJustifyPosition)[keyof typeof FormFieldRowJustifyPosition];
+  (typeof FormFieldRowJustifyPosition)[keyof typeof FormFieldRowJustifyPosition]
 
 export const FormFieldRowItemsAligment = {
   Center: "center",
   Start: "start",
   End: "end",
   Stretch: "stretch",
-} as const;
+} as const
 
 export type FormFieldRowItemsAligment =
-  (typeof FormFieldRowItemsAligment)[keyof typeof FormFieldRowItemsAligment];
+  (typeof FormFieldRowItemsAligment)[keyof typeof FormFieldRowItemsAligment]
 
 export interface FormFieldProps {
-  name: string;
-  id?: string;
-  className?: string;
-  title?: string;
-  helper?: string;
-  required?: boolean;
-  type?: FormFieldType;
-  placeholder?: string;
-  render?: ReactNode;
-  hidden?: boolean;
-  rows?: number;
-  width?: string;
-  rowStyle?: CSSProp;
-  fields?: FormFieldGroup[];
-  icon?: FigureProps["image"];
-  labelPosition?: FieldLaneProps["labelPosition"];
-  labelGap?: FieldLaneProps["labelGap"];
-  labelWidth?: FieldLaneProps["labelWidth"];
-  disabled?: boolean;
-  rowJustifyPosition?: FormFieldRowJustifyPosition;
-  rowItemsAlignment?: FormFieldRowItemsAligment;
-  onChange?: (e?: StatefulOnChangeType) => void;
-  onClick?: (e?: React.MouseEvent) => void;
-  textbox?: TextboxProps;
-  textarea?: TextareaProps;
-  checkbox?: CheckboxProps;
-  radio?: RadioProps;
-  phonebox?: PhoneboxProps;
-  colorbox?: ColorboxProps;
-  money?: MoneyboxProps;
-  fileDropBox?: FileDropBoxProps;
-  fileInputBox?: FileInputBoxProps;
-  imagebox?: ImageboxProps;
-  signbox?: SignboxProps;
-  date?: DateboxProps;
-  combobox?: ComboboxProps;
-  chips?: ChipsProps;
-  rating?: RatingProps;
-  thumbField?: ThumbFieldProps;
-  toggle?: ToggleProps;
-  capsule?: CapsuleProps;
-  timebox?: TimeboxProps;
-  button?: ButtonProps;
-  pinbox?: PinboxProps;
-  frame?: FrameProps;
+  name: string
+  id?: string
+  className?: string
+  title?: string
+  helper?: string
+  required?: boolean
+  type?: FormFieldType
+  placeholder?: string
+  render?: ReactNode
+  hidden?: boolean
+  rows?: number
+  width?: string
+  rowStyle?: CSSProp
+  fields?: FormFieldGroup[]
+  icon?: FigureProps["image"]
+  labelPosition?: FieldLaneProps["labelPosition"]
+  labelGap?: FieldLaneProps["labelGap"]
+  labelWidth?: FieldLaneProps["labelWidth"]
+  disabled?: boolean
+  rowJustifyPosition?: FormFieldRowJustifyPosition
+  rowItemsAlignment?: FormFieldRowItemsAligment
+  onChange?: (e?: StatefulOnChangeType) => void
+  onClick?: (e?: React.MouseEvent) => void
+  textbox?: TextboxProps
+  textarea?: TextareaProps
+  checkbox?: CheckboxProps
+  radio?: RadioProps
+  phonebox?: PhoneboxProps
+  colorbox?: ColorboxProps
+  money?: MoneyboxProps
+  fileDropBox?: FileDropBoxProps
+  fileInputBox?: FileInputBoxProps
+  imagebox?: ImageboxProps
+  signbox?: SignboxProps
+  date?: DateboxProps
+  combobox?: ComboboxProps
+  chips?: ChipsProps
+  rating?: RatingProps
+  thumbField?: ThumbFieldProps
+  toggle?: ToggleProps
+  capsule?: CapsuleProps
+  timebox?: TimeboxProps
+  button?: ButtonProps
+  pinbox?: PinboxProps
+  frame?: FrameProps
 }
 
 function StatefulForm<Z extends ZodTypeAny>({
@@ -225,23 +225,23 @@ function StatefulForm<Z extends ZodTypeAny>({
   // register/Controller — NOT from an external formValues update.
   // RHF's own register/Controller already handles validate+touch for these,
   // so we don't need (and don't want) to force setValue on them again.
-  const internallyChangedFieldsRef = useRef<Set<string>>(new Set());
+  const internallyChangedFieldsRef = useRef<Set<string>>(new Set())
 
   const handleFieldChange = (name: keyof TypeOf<Z>, value: FormValueType) => {
-    if (disabled) return;
-    internallyChangedFieldsRef.current.add(name as string);
-    onChange?.({ currentState: { [name]: value } });
-  };
+    if (disabled) return
+    internallyChangedFieldsRef.current.add(name as string)
+    onChange?.({ currentState: { [name]: value } })
+  }
 
-  const finalSchema = getSchemaForVisibleFields(validationSchema, fields);
+  const finalSchema = getSchemaForVisibleFields(validationSchema, fields)
 
   const formConfig: UseFormProps<TypeOf<Z>> = {
     mode,
     values: formValues,
-  };
+  }
 
   if (validationSchema) {
-    formConfig.resolver = zodResolver(finalSchema);
+    formConfig.resolver = zodResolver(finalSchema)
   }
 
   const {
@@ -249,12 +249,12 @@ function StatefulForm<Z extends ZodTypeAny>({
     control,
     setValue,
     formState: { errors, touchedFields, isValid },
-  } = useForm(formConfig) as ReturnType<typeof useForm<TypeOf<Z>>>;
+  } = useForm(formConfig) as ReturnType<typeof useForm<TypeOf<Z>>>
 
-  const isFile = (val: unknown): val is File => val instanceof File;
+  const isFile = (val: unknown): val is File => val instanceof File
 
   const isFileArray = (val: unknown): val is File[] =>
-    Array.isArray(val) && val.every((v) => v instanceof File);
+    Array.isArray(val) && val.every((v) => v instanceof File)
 
   // Recursively collect ALL field names that hold a real form value —
   // including "custom" fields now, since they need the same touched/validate
@@ -263,35 +263,35 @@ function StatefulForm<Z extends ZodTypeAny>({
   function flattenAllFieldNames(fields: FormFieldGroup[]): string[] {
     return fields.flatMap((f) => {
       if (Array.isArray(f)) {
-        return flattenAllFieldNames(f);
+        return flattenAllFieldNames(f)
       }
 
       if (f.type === "frame" && f.fields) {
-        return flattenAllFieldNames(f.fields as FormFieldGroup[]);
+        return flattenAllFieldNames(f.fields as FormFieldGroup[])
       }
 
       // skip fields that don't hold a real, validatable form value
       if (f.type === "button" || f.type === "custom" || f.hidden) {
-        return [];
+        return []
       }
 
-      return [f.name];
-    });
+      return [f.name]
+    })
   }
 
   // Decide whether a value is "real" enough to be worth touching/validating.
   // Prevents empty/untouched fields from getting falsely marked as touched
   // on initial mount (which would make them show errors immediately).
   const hasMeaningfulValue = (value: unknown): boolean => {
-    if (typeof value === "string") return value.length > 1;
-    if (typeof value === "number" || typeof value === "boolean") return true;
-    if (isFile(value) || isFileArray(value)) return true;
-    return value != null;
-  };
+    if (typeof value === "string") return value.length > 1
+    if (typeof value === "number" || typeof value === "boolean") return true
+    if (isFile(value) || isFileArray(value)) return true
+    return value != null
+  }
 
-  const allFieldNames = flattenAllFieldNames(fields);
+  const allFieldNames = flattenAllFieldNames(fields)
 
-  const prevFormValuesRef = useRef<TypeOf<Z>>(formValues);
+  const prevFormValuesRef = useRef<TypeOf<Z>>(formValues)
 
   // Whenever `formValues` changes — whether from an external source (values
   // prop reactive sync) or a "custom" field's own render logic — RHF's
@@ -301,22 +301,22 @@ function StatefulForm<Z extends ZodTypeAny>({
   // with `shouldValidate` + `shouldTouch` only on fields that actually changed,
   // avoiding unnecessary re-validation on fields that didn't change.
   useEffect(() => {
-    const prevFormValues = prevFormValuesRef.current;
+    const prevFormValues = prevFormValuesRef.current
 
     allFieldNames.forEach((name) => {
-      const key = name as keyof TypeOf<Z>;
-      const value = formValues[key];
-      const prevValue = prevFormValues[key];
+      const key = name as keyof TypeOf<Z>
+      const value = formValues[key]
+      const prevValue = prevFormValues[key]
 
-      const changedInternally = internallyChangedFieldsRef.current.has(name);
+      const changedInternally = internallyChangedFieldsRef.current.has(name)
 
       // consume the flag either way, so it doesn't leak into future renders
-      internallyChangedFieldsRef.current.delete(name);
+      internallyChangedFieldsRef.current.delete(name)
 
       if (changedInternally) {
         // came from real user interaction via register/Controller —
         // RHF already validated + touched it, nothing to do here
-        return;
+        return
       }
 
       // only reaches here for changes NOT triggered by handleFieldChange,
@@ -326,21 +326,21 @@ function StatefulForm<Z extends ZodTypeAny>({
           shouldValidate: true,
           shouldTouch: true,
           shouldDirty: true,
-        });
+        })
       }
-    });
+    })
 
-    prevFormValuesRef.current = formValues;
-  }, [formValues, setValue]);
+    prevFormValuesRef.current = formValues
+  }, [formValues, setValue])
 
   useEffect(() => {
     if (onValidityChange) {
-      onValidityChange(isValid);
+      onValidityChange(isValid)
     }
-  }, [isValid, onValidityChange]);
+  }, [isValid, onValidityChange])
 
   const shouldShowError = (name: keyof TypeOf<Z>): boolean => {
-    const fieldConfig = findField(fields, name as string);
+    const fieldConfig = findField(fields, name as string)
 
     if (
       !fieldConfig ||
@@ -348,62 +348,62 @@ function StatefulForm<Z extends ZodTypeAny>({
       fieldConfig.type === "button" ||
       fieldConfig.hidden
     ) {
-      return false;
+      return false
     }
 
-    const value = formValues[name];
-    const touched = touchedFields[name];
-    const error = errors[name];
+    const value = formValues[name]
+    const touched = touchedFields[name]
+    const error = errors[name]
 
     const hasErrorMessage = (err: unknown): boolean => {
-      if (!err || typeof err !== "object") return false;
+      if (!err || typeof err !== "object") return false
 
-      if (typeof (err as any)?.message === "string") return true;
+      if (typeof (err as any)?.message === "string") return true
 
-      if (typeof (err as any)?.text?.message === "string") return true;
+      if (typeof (err as any)?.text?.message === "string") return true
 
       if (Array.isArray(err)) {
-        return err.some((item) => hasErrorMessage(item));
+        return err.some((item) => hasErrorMessage(item))
       }
 
-      return Object.values(err).some((v) => hasErrorMessage(v));
-    };
+      return Object.values(err).some((v) => hasErrorMessage(v))
+    }
 
     if (typeof value === "string") {
-      return value.length > 0 && !!touched && hasErrorMessage(error);
+      return value.length > 0 && !!touched && hasErrorMessage(error)
     }
 
     if (typeof value === "number" || typeof value === "boolean") {
-      return !!touched && hasErrorMessage(error);
+      return !!touched && hasErrorMessage(error)
     }
 
     if (isFile(value) || isFileArray(value)) {
-      return !!touched && hasErrorMessage(error);
+      return !!touched && hasErrorMessage(error)
     }
 
     if (typeof value === "object" && value !== null) {
-      return !!touched && hasErrorMessage(error);
+      return !!touched && hasErrorMessage(error)
     }
 
-    return !!touched && hasErrorMessage(error);
-  };
+    return !!touched && hasErrorMessage(error)
+  }
 
   function findField(
     fields: FormFieldGroup[],
-    name: string
+    name: string,
   ): FormFieldProps | undefined {
     for (const f of fields) {
       if (Array.isArray(f)) {
-        const found = findField(f, name);
-        if (found) return found;
+        const found = findField(f, name)
+        if (found) return found
       } else if (f.type === "frame" && f.fields) {
-        const found = findField(f.fields, name);
-        if (found) return found;
+        const found = findField(f.fields, name)
+        if (found) return found
       } else if (f.name === name) {
-        return f;
+        return f
       }
     }
-    return undefined;
+    return undefined
   }
 
   return (
@@ -425,80 +425,80 @@ function StatefulForm<Z extends ZodTypeAny>({
       styles={styles}
       shouldShowError={shouldShowError}
     />
-  );
+  )
 }
 
 function unwrapSchema(schema: ZodTypeAny): ZodTypeAny {
   if (schema._def.typeName === "ZodEffects") {
-    return unwrapSchema(schema._def.schema);
+    return unwrapSchema(schema._def.schema)
   }
-  return schema;
+  return schema
 }
 
 function getSchemaForVisibleFields<Z extends ZodTypeAny>(
   validationSchema?: Z,
-  fields?: FormFieldGroup[]
+  fields?: FormFieldGroup[],
 ) {
-  if (!validationSchema) return undefined;
+  if (!validationSchema) return undefined
 
-  const baseSchema = unwrapSchema(validationSchema);
+  const baseSchema = unwrapSchema(validationSchema)
 
   if (baseSchema._def.typeName !== "ZodObject") {
-    throw new Error("StatefulForm only supports Zod object schemas");
+    throw new Error("StatefulForm only supports Zod object schemas")
   }
 
-  const objSchema = baseSchema as ZodObject<any>;
+  const objSchema = baseSchema as ZodObject<any>
 
   function flattenFields(fields: FormFieldGroup[]): FormFieldProps[] {
     return fields.flatMap((f) => {
-      if (Array.isArray(f)) return flattenFields(f);
+      if (Array.isArray(f)) return flattenFields(f)
 
       if (f.type === "frame" && f.fields) {
-        return flattenFields(f.fields as FormFieldGroup[]);
+        return flattenFields(f.fields as FormFieldGroup[])
       }
 
-      return [f];
-    });
+      return [f]
+    })
   }
 
-  const flatFields: FormFieldProps[] = flattenFields(fields);
+  const flatFields: FormFieldProps[] = flattenFields(fields)
 
   const newShape = Object.fromEntries(
     flatFields.map((field) => {
-      const key = field.name;
-      const originalFieldSchema = objSchema.shape[key];
+      const key = field.name
+      const originalFieldSchema = objSchema.shape[key]
 
-      if (!originalFieldSchema) return [key, z.any()];
+      if (!originalFieldSchema) return [key, z.any()]
       return [
         key,
         field.hidden || field.type === "custom"
           ? originalFieldSchema.optional()
           : originalFieldSchema,
-      ];
-    })
-  );
+      ]
+    }),
+  )
 
-  return z.object(newShape);
+  return z.object(newShape)
 }
 
 interface FormFieldsProps<T extends FieldValues> {
-  fields: FormFieldGroup[];
-  formValues: T;
-  register: UseFormRegister<T>;
-  errors: FieldErrors<T>;
-  shouldShowError: (name: string) => boolean;
-  control: Control<T>;
-  labelSize?: string;
-  fieldSize?: string;
-  setValue?: UseFormSetValue<T>;
-  onChange?: (name: keyof T, value: FormValueType) => void;
-  autoFocusField?: string;
-  styles?: StatefulFormStyles;
-  rowWithFrame?: boolean;
-  disabled?: boolean;
-  mobile?: boolean;
-  className?: string;
-  id?: string;
+  fields: FormFieldGroup[]
+  formValues: T
+  register: UseFormRegister<T>
+  errors: FieldErrors<T>
+  shouldShowError: (name: string) => boolean
+  control: Control<T>
+  labelSize?: string
+  fieldSize?: string
+  setValue?: UseFormSetValue<T>
+  onChange?: (name: keyof T, value: FormValueType) => void
+  autoFocusField?: string
+  styles?: StatefulFormStyles
+  rowWithFrame?: boolean
+  disabled?: boolean
+  mobile?: boolean
+  className?: string
+  id?: string
 }
 
 function FormFields<T extends FieldValues>({
@@ -520,21 +520,21 @@ function FormFields<T extends FieldValues>({
   className,
   id,
 }: FormFieldsProps<T>) {
-  const { currentTheme } = useTheme();
-  const statefulFormTheme = currentTheme?.statefulForm;
-  const pinboxTheme = currentTheme?.pinbox;
-  const phoneboxTheme = currentTheme?.phonebox;
+  const { currentTheme } = useTheme()
+  const statefulFormTheme = currentTheme?.statefulForm
+  const pinboxTheme = currentTheme?.pinbox
+  const phoneboxTheme = currentTheme?.phonebox
 
-  const refs = useRef<Record<string, HTMLElement | null>>({});
+  const refs = useRef<Record<string, HTMLElement | null>>({})
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      const el = refs.current[autoFocusField];
-      el?.focus?.();
-    }, 50);
+      const el = refs.current[autoFocusField]
+      el?.focus?.()
+    }, 50)
 
-    return () => clearTimeout(timer);
-  }, []);
+    return () => clearTimeout(timer)
+  }, [])
 
   return (
     <ContainerFormField
@@ -544,29 +544,27 @@ function FormFields<T extends FieldValues>({
     >
       {fields.map((group: FormFieldGroup, indexGroup: number) => {
         const visibleFields = (Array.isArray(group) ? group : [group]).filter(
-          (field) => !field.hidden
-        );
+          (field) => !field.hidden,
+        )
 
         if (visibleFields.length === 0) {
-          return;
+          return
         }
 
         const rowJustifiedContent = visibleFields.find(
-          (field) => field.rowJustifyPosition
-        )?.rowJustifyPosition;
+          (field) => field.rowJustifyPosition,
+        )?.rowJustifyPosition
 
         const rowAlignedItem = visibleFields.find(
-          (field) => field.rowItemsAlignment
-        )?.rowItemsAlignment;
+          (field) => field.rowItemsAlignment,
+        )?.rowItemsAlignment
 
         const rowStyleItem = visibleFields.find(
-          (field) => field.rowStyle
-        )?.rowStyle;
+          (field) => field.rowStyle,
+        )?.rowStyle
 
-        const nonButtonFields = visibleFields.filter(
-          (f) => f.type !== "button"
-        );
-        const hasFieldTitle = nonButtonFields.some((f) => f.title);
+        const nonButtonFields = visibleFields.filter((f) => f.type !== "button")
+        const hasFieldTitle = nonButtonFields.some((f) => f.title)
 
         const mobileInputStyle =
           mobile &&
@@ -589,7 +587,7 @@ function FormFields<T extends FieldValues>({
               background-color: transparent !important;
               transition: background-color 9999s ease-in-out 0s;
             }
-          `;
+          `
 
         const mobileBodyStyle =
           mobile &&
@@ -597,23 +595,23 @@ function FormFields<T extends FieldValues>({
             gap: 0px;
             justify-content: space-between;
             align-items: center;
-          `;
+          `
 
         const mobileControlStyle =
           mobile &&
           css`
             width: fit-content;
-          `;
+          `
 
         const mobileLabelStyle =
           mobile &&
           css`
             width: 100%;
-          `;
+          `
 
         const isButtonRow =
           visibleFields.length > 0 &&
-          visibleFields.every((field) => field.type === "button");
+          visibleFields.every((field) => field.type === "button")
 
         const mobileRowFormFieldStyle =
           mobile &&
@@ -633,7 +631,7 @@ function FormFields<T extends FieldValues>({
               gap: 0px;
               overflow: hidden;
             `}
-          `;
+          `
 
         return (
           <RowFormField
@@ -667,15 +665,15 @@ function FormFields<T extends FieldValues>({
             {visibleFields.map((field: FormFieldProps, index: number) => {
               const labelPosition = mobile
                 ? (field?.labelPosition ?? "left")
-                : field?.labelPosition;
-              const isLast = index === visibleFields.length - 1;
+                : field?.labelPosition
+              const isLast = index === visibleFields.length - 1
               const showDivider =
-                mobile && !isLast && Array.isArray(group) && !isButtonRow;
-              const label = mobile ? null : field?.title;
+                mobile && !isLast && Array.isArray(group) && !isButtonRow
+              const label = mobile ? null : field?.title
               const placeholder = mobile
                 ? (field.placeholder ?? field.title)
-                : field.placeholder;
-              const required = mobile ? false : field.required;
+                : field.placeholder
+              const required = mobile ? false : field.required
 
               if (field.type === "frame") {
                 return (
@@ -722,13 +720,13 @@ function FormFields<T extends FieldValues>({
                       />
                     )}
                   </Frame>
-                );
+                )
               }
 
               const fieldNode = (() => {
                 switch (field.type) {
                   case "custom": {
-                    return <Fragment key={index}>{field.render}</Fragment>;
+                    return <Fragment key={index}>{field.render}</Fragment>
                   }
 
                   case "text":
@@ -753,17 +751,17 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e);
+                              field.onChange(e)
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value);
+                              onChange(field.name as keyof T, e.target.value)
                             }
                           },
                         })}
                         ref={(el) => {
-                          if (el) refs.current[field.name] = el;
-                          const { ref } = register(field.name as Path<T>);
-                          if (ref) ref(el);
+                          if (el) refs.current[field.name] = el
+                          const { ref } = register(field.name as Path<T>)
+                          if (ref) ref(el)
                         }}
                         showError={shouldShowError(field.name)}
                         errorMessage={
@@ -814,7 +812,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "pin": {
@@ -839,14 +837,14 @@ function FormFields<T extends FieldValues>({
                             helper={field.helper}
                             onBlur={controllerField.onBlur}
                             onChange={(e) => {
-                              controllerField.onChange(e);
+                              controllerField.onChange(e)
 
                               if (field.onChange) {
-                                field.onChange(e);
+                                field.onChange(e)
                               }
 
                               if (onChange) {
-                                onChange(field.name as keyof T, e.target.value);
+                                onChange(field.name as keyof T, e.target.value)
                               }
                             }}
                             showError={shouldShowError(field.name)}
@@ -920,11 +918,11 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "button": {
-                    const defaultVariant = field?.button?.variant ?? "default";
+                    const defaultVariant = field?.button?.variant ?? "default"
 
                     const mobileButtonStyle =
                       mobile &&
@@ -940,7 +938,7 @@ function FormFields<T extends FieldValues>({
                         css`
                           background-color: ${statefulFormTheme?.mobileRowFrameBackgroundColor};
                         `}
-                      `;
+                      `
 
                     return (
                       <Button
@@ -990,9 +988,9 @@ function FormFields<T extends FieldValues>({
                         }}
                         onClick={(e) => {
                           if (field?.button?.onClick) {
-                            field?.button?.onClick?.(e);
+                            field?.button?.onClick?.(e)
                           } else {
-                            field?.onClick?.(e);
+                            field?.onClick?.(e)
                           }
                         }}
                         disabled={field.disabled || disabled}
@@ -1005,7 +1003,7 @@ function FormFields<T extends FieldValues>({
 
                         {field.title}
                       </Button>
-                    );
+                    )
                   }
 
                   case "time": {
@@ -1023,9 +1021,9 @@ function FormFields<T extends FieldValues>({
                           typeof field.placeholder === "string"
                             ? (() => {
                                 const [hour = "", minute = "", second = ""] =
-                                  field.placeholder.split(/[:/]/);
+                                  field.placeholder.split(/[:/]/)
 
-                                return { hour, minute, second };
+                                return { hour, minute, second }
                               })()
                             : field.placeholder
                         }
@@ -1035,10 +1033,10 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e);
+                              field.onChange(e)
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value);
+                              onChange(field.name as keyof T, e.target.value)
                             }
                           },
                         })}
@@ -1145,12 +1143,12 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                         ref={(el) => {
-                          if (el) refs.current[field.name] = el;
-                          const { ref } = register(field.name as Path<T>);
-                          if (ref) ref(el);
+                          if (el) refs.current[field.name] = el
+                          const { ref } = register(field.name as Path<T>)
+                          if (ref) ref(el)
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "textarea": {
@@ -1171,17 +1169,17 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e);
+                              field.onChange(e)
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value);
+                              onChange(field.name as keyof T, e.target.value)
                             }
                           },
                         })}
                         ref={(el) => {
-                          if (el) refs.current[field.name] = el;
-                          const { ref } = register(field.name as Path<T>);
-                          if (ref) ref(el);
+                          if (el) refs.current[field.name] = el
+                          const { ref } = register(field.name as Path<T>)
+                          if (ref) ref(el)
                         }}
                         showError={shouldShowError(field.name)}
                         errorMessage={
@@ -1230,7 +1228,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "checkbox": {
@@ -1242,10 +1240,10 @@ function FormFields<T extends FieldValues>({
                         render={({ field: controllerField }) => {
                           const titleCheckbox = mobile
                             ? (field.title ?? field.placeholder)
-                            : field.title;
+                            : field.title
                           const placeholderCheckbox = mobile
                             ? undefined
-                            : field.placeholder;
+                            : field.placeholder
                           return (
                             <Checkbox
                               id={field.id}
@@ -1261,9 +1259,9 @@ function FormFields<T extends FieldValues>({
                               checked={controllerField.value ?? false}
                               helper={field.helper}
                               ref={(el) => {
-                                if (el) refs.current[field.name] = el;
-                                const { ref } = register(field.name as Path<T>);
-                                if (ref) ref(el);
+                                if (el) refs.current[field.name] = el
+                                const { ref } = register(field.name as Path<T>)
+                                if (ref) ref(el)
                               }}
                               errorMessage={
                                 errors[field.name as keyof T]?.message as
@@ -1273,15 +1271,15 @@ function FormFields<T extends FieldValues>({
                               required={required}
                               showError={shouldShowError(field.name)}
                               onChange={(e) => {
-                                controllerField?.onChange(e);
-                                controllerField?.onBlur();
+                                controllerField?.onChange(e)
+                                controllerField?.onBlur()
                                 if (onChange) {
                                   onChange(
                                     field.name as keyof T,
-                                    e.target.checked
-                                  );
+                                    e.target.checked,
+                                  )
                                 }
-                                field.onChange?.(e);
+                                field.onChange?.(e)
                               }}
                               disabled={field.disabled || disabled}
                               {...field.checkbox}
@@ -1355,10 +1353,10 @@ function FormFields<T extends FieldValues>({
                                 `,
                               }}
                             />
-                          );
+                          )
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "radio": {
@@ -1370,10 +1368,10 @@ function FormFields<T extends FieldValues>({
                         render={({ field: controllerField }) => {
                           const titleRadio = mobile
                             ? (field.title ?? field.placeholder)
-                            : field.title;
+                            : field.title
                           const placeholderRadio = mobile
                             ? undefined
-                            : field.placeholder;
+                            : field.placeholder
                           return (
                             <Radio
                               {...field.radio}
@@ -1396,15 +1394,15 @@ function FormFields<T extends FieldValues>({
                               required={required}
                               showError={shouldShowError(field.name)}
                               onChange={(e) => {
-                                controllerField?.onChange(e);
-                                controllerField?.onBlur();
+                                controllerField?.onChange(e)
+                                controllerField?.onBlur()
                                 if (onChange) {
                                   onChange(
                                     field.name as keyof T,
-                                    e.target.checked
-                                  );
+                                    e.target.checked,
+                                  )
                                 }
-                                field.onChange?.(e);
+                                field.onChange?.(e)
                               }}
                               disabled={field.disabled || disabled}
                               styles={{
@@ -1462,10 +1460,10 @@ function FormFields<T extends FieldValues>({
                                 `,
                               }}
                             />
-                          );
+                          )
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "phone": {
@@ -1486,8 +1484,8 @@ function FormFields<T extends FieldValues>({
                             className={field?.className}
                             required={required}
                             ref={(el) => {
-                              if (el) refs.current[field.name] = el;
-                              controllerField.ref(el);
+                              if (el) refs.current[field.name] = el
+                              controllerField.ref(el)
                             }}
                             onBlur={controllerField.onBlur}
                             value={controllerField.value}
@@ -1498,19 +1496,19 @@ function FormFields<T extends FieldValues>({
                               e:
                                 | {
                                     target: {
-                                      name: string;
-                                      value: PhoneboxCountryCode;
-                                    };
+                                      name: string
+                                      value: PhoneboxCountryCode
+                                    }
                                   }
-                                | ChangeEvent<HTMLInputElement>
+                                | ChangeEvent<HTMLInputElement>,
                             ) => {
                               if (e.target.name === "phone") {
-                                controllerField.onChange(e);
-                                onChange?.("phone", e.target.value);
+                                controllerField.onChange(e)
+                                onChange?.("phone", e.target.value)
                               } else if (e.target.name === "country_code") {
-                                onChange?.("country_code", e.target.value);
+                                onChange?.("country_code", e.target.value)
                               }
-                              field.onChange?.(e);
+                              field.onChange?.(e)
                             }}
                             showError={shouldShowError(field.name)}
                             errorMessage={
@@ -1579,7 +1577,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "color": {
@@ -1601,17 +1599,17 @@ function FormFields<T extends FieldValues>({
                             labelWidth={field.labelWidth}
                             labelPosition={labelPosition}
                             ref={(el) => {
-                              if (el) refs.current[field.name] = el;
-                              const { ref } = register(field.name as Path<T>);
-                              if (ref) ref(el);
+                              if (el) refs.current[field.name] = el
+                              const { ref } = register(field.name as Path<T>)
+                              if (ref) ref(el)
                             }}
                             value={controllerField.value}
                             onChange={(e) => {
-                              controllerField?.onChange(e);
-                              controllerField?.onBlur();
-                              field.onChange?.(e);
+                              controllerField?.onChange(e)
+                              controllerField?.onBlur()
+                              field.onChange?.(e)
                               if (onChange) {
-                                onChange(field.name as keyof T, e.target.value);
+                                onChange(field.name as keyof T, e.target.value)
                               }
                             }}
                             showError={shouldShowError(field.name)}
@@ -1699,7 +1697,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "file_drop_box": {
@@ -1720,10 +1718,10 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e);
+                              field.onChange(e)
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value);
+                              onChange(field.name as keyof T, e.target.value)
                             }
                           },
                         })}
@@ -1755,7 +1753,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "file": {
@@ -1785,24 +1783,24 @@ function FormFields<T extends FieldValues>({
                             setValue(field.name as Path<T>, files as any, {
                               shouldValidate: true,
                               shouldTouch: true,
-                            });
+                            })
 
-                            onChange?.(field.name, files);
+                            onChange?.(field.name, files)
 
                             field.onChange?.({
                               target: { name: field.name, value: files },
-                            });
+                            })
                           } else {
                             setValue(field.name as Path<T>, undefined, {
                               shouldValidate: true,
                               shouldTouch: true,
-                            });
+                            })
 
-                            onChange?.(field.name, undefined);
+                            onChange?.(field.name, undefined)
 
                             field.onChange?.({
                               target: { name: field.name, value: undefined },
-                            });
+                            })
                           }
                         }}
                         styles={{
@@ -1839,7 +1837,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "image": {
@@ -1855,26 +1853,26 @@ function FormFields<T extends FieldValues>({
                         helper={field.helper}
                         value={formValues[field.name as keyof T] ?? ""}
                         onFileSelected={(e: File | undefined) => {
-                          const file = e;
+                          const file = e
                           if (file instanceof File) {
                             setValue(field.name as Path<T>, file as any, {
                               shouldValidate: true,
                               shouldTouch: true,
-                            });
+                            })
                           } else {
                             setValue(field.name as Path<T>, undefined, {
                               shouldValidate: true,
                               shouldTouch: true,
-                            });
+                            })
                           }
                           field.onChange?.({
                             target: {
                               name: field.name,
                               value: file ?? undefined,
                             },
-                          });
+                          })
                           if (onChange) {
-                            onChange(field.name as keyof T, file ?? undefined);
+                            onChange(field.name as keyof T, file ?? undefined)
                           }
                         }}
                         label={field.title}
@@ -1883,10 +1881,10 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e);
+                              field.onChange(e)
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value);
+                              onChange(field.name as keyof T, e.target.value)
                             }
                           },
                         })}
@@ -1933,7 +1931,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "signbox": {
@@ -1954,10 +1952,10 @@ function FormFields<T extends FieldValues>({
                         {...register(field.name as Path<T>, {
                           onChange: (e) => {
                             if (field.onChange) {
-                              field.onChange(e);
+                              field.onChange(e)
                             }
                             if (onChange) {
-                              onChange(field.name as keyof T, e.target.value);
+                              onChange(field.name as keyof T, e.target.value)
                             }
                           },
                         })}
@@ -1999,7 +1997,7 @@ function FormFields<T extends FieldValues>({
                           `,
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "money": {
@@ -2018,8 +2016,8 @@ function FormFields<T extends FieldValues>({
                             labelPosition={labelPosition}
                             className={field?.className}
                             ref={(el) => {
-                              if (el) refs.current[field.name] = el;
-                              rhf.ref(el);
+                              if (el) refs.current[field.name] = el
+                              rhf.ref(el)
                             }}
                             name={field.name}
                             label={label}
@@ -2029,21 +2027,21 @@ function FormFields<T extends FieldValues>({
                             required={required}
                             disabled={field.disabled || disabled}
                             onChange={(e) => {
-                              const { name, value } = e.target;
+                              const { name, value } = e.target
 
                               if (field.onChange) {
-                                field.onChange(e);
+                                field.onChange(e)
                               }
 
                               if (onChange && name === "currency") {
-                                onChange("currency", value);
+                                onChange("currency", value)
                               } else {
-                                onChange(field.name as keyof T, value);
+                                onChange(field.name as keyof T, value)
                                 setValue(field.name as Path<T>, value as any, {
                                   shouldValidate: true,
                                   shouldTouch: true,
                                   shouldDirty: true,
-                                });
+                                })
                               }
                             }}
                             onBlur={rhf.onBlur}
@@ -2097,7 +2095,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "date": {
@@ -2107,11 +2105,11 @@ function FormFields<T extends FieldValues>({
                         name={field.name as Path<T>}
                         control={control}
                         render={({ field: controllerField }) => {
-                          const value = controllerField.value;
+                          const value = controllerField.value
 
                           const hasValue = Array.isArray(value)
                             ? value.some((v) => v !== "" && v != null)
-                            : value !== "" && value != null;
+                            : value !== "" && value != null
 
                           return (
                             <Datebox
@@ -2129,9 +2127,9 @@ function FormFields<T extends FieldValues>({
                               labelPosition={labelPosition}
                               mobile={mobile}
                               ref={(el) => {
-                                if (el) refs.current[field.name] = el;
-                                const { ref } = register(field.name as Path<T>);
-                                if (ref) ref(el);
+                                if (el) refs.current[field.name] = el
+                                const { ref } = register(field.name as Path<T>)
+                                if (ref) ref(el)
                               }}
                               errorMessage={
                                 errors[field.name as keyof T]?.[0]?.message as
@@ -2141,12 +2139,12 @@ function FormFields<T extends FieldValues>({
                               onChange={(e) => {
                                 const inputValueEvent = {
                                   target: { name: field.name, value: e },
-                                };
-                                controllerField.onChange(inputValueEvent);
-                                controllerField?.onBlur();
-                                field.onChange?.(inputValueEvent);
+                                }
+                                controllerField.onChange(inputValueEvent)
+                                controllerField?.onBlur()
+                                field.onChange?.(inputValueEvent)
                                 if (onChange) {
-                                  onChange(field.name as keyof T, e);
+                                  onChange(field.name as keyof T, e)
                                 }
                               }}
                               selectedDates={controllerField.value}
@@ -2203,10 +2201,10 @@ function FormFields<T extends FieldValues>({
                                 `,
                               }}
                             />
-                          );
+                          )
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "combo": {
@@ -2229,9 +2227,9 @@ function FormFields<T extends FieldValues>({
                             required={required}
                             showError={shouldShowError(field.name)}
                             ref={(el) => {
-                              if (el) refs.current[field.name] = el;
-                              const { ref } = register(field.name as Path<T>);
-                              if (ref) ref(el);
+                              if (el) refs.current[field.name] = el
+                              const { ref } = register(field.name as Path<T>)
+                              if (ref) ref(el)
                             }}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
@@ -2242,12 +2240,12 @@ function FormFields<T extends FieldValues>({
                             onChange={(e) => {
                               const inputValueEvent = {
                                 target: { name: field.name, value: e },
-                              };
-                              controllerField.onChange(inputValueEvent);
-                              controllerField?.onBlur();
-                              field.onChange?.(inputValueEvent);
+                              }
+                              controllerField.onChange(inputValueEvent)
+                              controllerField?.onBlur()
+                              field.onChange?.(inputValueEvent)
                               if (onChange) {
-                                onChange(field.name as keyof T, e);
+                                onChange(field.name as keyof T, e)
                               }
                             }}
                             selectedOptions={controllerField.value}
@@ -2313,7 +2311,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "chips": {
@@ -2338,30 +2336,27 @@ function FormFields<T extends FieldValues>({
                             disabled={field.disabled || disabled}
                             inputValue={controllerField.value}
                             setInputValue={(e) => {
-                              controllerField?.onChange(e);
-                              controllerField?.onBlur();
-                              field.onChange?.(e);
+                              controllerField?.onChange(e)
+                              controllerField?.onBlur()
+                              field.onChange?.(e)
 
                               if (onChange) {
                                 onChange(
                                   (field?.name as keyof T) ?? "chips",
-                                  e.target.value
-                                );
+                                  e.target.value,
+                                )
                               }
                             }}
                             onChange={(e) => {
-                              controllerField?.onChange(e);
-                              controllerField?.onBlur();
+                              controllerField?.onChange(e)
+                              controllerField?.onBlur()
                               const inputValueEvent = {
                                 target: { name: field.name, value: e },
-                              };
-                              field.onChange?.(inputValueEvent);
+                              }
+                              field.onChange?.(inputValueEvent)
 
                               if (onChange) {
-                                onChange(
-                                  (field?.name as keyof T) ?? "chips",
-                                  e
-                                );
+                                onChange((field?.name as keyof T) ?? "chips", e)
                               }
                             }}
                             {...field.chips}
@@ -2412,7 +2407,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "rating": {
@@ -2424,7 +2419,7 @@ function FormFields<T extends FieldValues>({
                         render={({ field: controllerField, fieldState }) => {
                           const size = mobile
                             ? (field?.rating?.size ?? "lg")
-                            : field?.rating?.size;
+                            : field?.rating?.size
 
                           return (
                             <Rating
@@ -2440,14 +2435,14 @@ function FormFields<T extends FieldValues>({
                               name={field.name}
                               rating={controllerField.value}
                               onChange={(e) => {
-                                controllerField.onChange(e.target.value);
-                                controllerField?.onBlur();
-                                field.onChange?.(e);
+                                controllerField.onChange(e.target.value)
+                                controllerField?.onBlur()
+                                field.onChange?.(e)
                                 if (onChange) {
                                   onChange(
                                     field.name as keyof T,
-                                    e.target.value
-                                  );
+                                    e.target.value,
+                                  )
                                 }
                               }}
                               showError={!!fieldState.error}
@@ -2494,10 +2489,10 @@ function FormFields<T extends FieldValues>({
                                 `,
                               }}
                             />
-                          );
+                          )
                         }}
                       />
-                    );
+                    )
                   }
 
                   case "thumbfield": {
@@ -2520,22 +2515,22 @@ function FormFields<T extends FieldValues>({
                             {...register(field.name as Path<T>, {
                               onChange: (e) => {
                                 if (field.onChange) {
-                                  field.onChange(e);
+                                  field.onChange(e)
                                 }
                                 if (onChange) {
                                   onChange(
                                     field.name as keyof T,
-                                    e.target.checked
-                                  );
+                                    e.target.checked,
+                                  )
                                 }
                               },
                             })}
                             onChange={(e) => {
-                              controllerField?.onChange(e);
-                              controllerField?.onBlur();
-                              field.onChange?.(e);
+                              controllerField?.onChange(e)
+                              controllerField?.onBlur()
+                              field.onChange?.(e)
                               if (onChange) {
-                                onChange(field.name as keyof T, e.target.value);
+                                onChange(field.name as keyof T, e.target.value)
                               }
                             }}
                             showError={shouldShowError(field.name)}
@@ -2606,7 +2601,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "toggle": {
@@ -2628,14 +2623,14 @@ function FormFields<T extends FieldValues>({
                             required={required}
                             helper={field.helper}
                             onChange={(e) => {
-                              controllerField?.onChange(e);
-                              controllerField?.onBlur();
-                              field.onChange?.(e);
+                              controllerField?.onChange(e)
+                              controllerField?.onBlur()
+                              field.onChange?.(e)
                               if (onChange) {
                                 onChange(
                                   field.name as keyof T,
-                                  e.target.checked
-                                );
+                                  e.target.checked,
+                                )
                               }
                             }}
                             onBlur={controllerField.onBlur}
@@ -2696,7 +2691,7 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   case "capsule": {
@@ -2723,12 +2718,12 @@ function FormFields<T extends FieldValues>({
                             onTabChange={(e) => {
                               const inputValueEvent = {
                                 target: { name: field.name, value: e },
-                              };
-                              controllerField?.onChange(e);
-                              controllerField?.onBlur();
-                              field.onChange?.(inputValueEvent);
+                              }
+                              controllerField?.onChange(e)
+                              controllerField?.onBlur()
+                              field.onChange?.(inputValueEvent)
                               if (onChange) {
-                                onChange(field.name as keyof T, e);
+                                onChange(field.name as keyof T, e)
                               }
                             }}
                             showError={shouldShowError(field.name)}
@@ -2788,13 +2783,13 @@ function FormFields<T extends FieldValues>({
                           />
                         )}
                       />
-                    );
+                    )
                   }
 
                   default:
-                    return null;
+                    return null
                 }
-              })();
+              })()
 
               return (
                 <Fragment key={index}>
@@ -2807,18 +2802,18 @@ function FormFields<T extends FieldValues>({
                     />
                   )}
                 </Fragment>
-              );
+              )
             })}
           </RowFormField>
-        );
+        )
       })}
     </ContainerFormField>
-  );
+  )
 }
 
 const Divider = styled.div<{
-  $theme?: StatefulFormThemeConfig;
-  $style?: CSSProp;
+  $theme?: StatefulFormThemeConfig
+  $style?: CSSProp
 }>`
   width: 100%;
   height: 1px;
@@ -2826,17 +2821,17 @@ const Divider = styled.div<{
     $theme?.borderColor ?? "rgba(0,0,0,0.08)"};
 
   ${({ $style }) => $style}
-`;
+`
 
 export interface StatefulFormLabelProps
   extends Omit<LabelHTMLAttributes<HTMLLabelElement>, "label" | "style"> {
-  label?: string;
-  helper?: string;
-  styles: { self?: CSSProp };
-  labelPosition?: FieldLaneProps["labelPosition"];
-  labelWidth?: FieldLaneProps["labelWidth"];
-  required?: boolean;
-  disabled?: boolean;
+  label?: string
+  helper?: string
+  styles: { self?: CSSProp }
+  labelPosition?: FieldLaneProps["labelPosition"]
+  labelWidth?: FieldLaneProps["labelWidth"]
+  required?: boolean
+  disabled?: boolean
 }
 
 function StatefulFormLabel({
@@ -2871,14 +2866,14 @@ function StatefulFormLabel({
 
       {helper && <Helper value={helper} />}
     </Label>
-  );
+  )
 }
 
 const Label = styled.label<{
-  $style?: CSSProp;
-  $labelWidth?: FieldLaneProps["labelWidth"];
-  $labelPosition?: FieldLaneProps["labelPosition"];
-  $disabled?: boolean;
+  $style?: CSSProp
+  $labelWidth?: FieldLaneProps["labelWidth"]
+  $labelPosition?: FieldLaneProps["labelPosition"]
+  $disabled?: boolean
 }>`
   font-size: 0.75rem;
   display: flex;
@@ -2895,24 +2890,24 @@ const Label = styled.label<{
       cursor: not-allowed;
     `}
   ${({ $style }) => $style}
-`;
+`
 
 const Asterisk = styled.span`
   color: red;
   margin-left: 2px;
-`;
+`
 
 const LabelText = styled.span`
   min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-`;
+`
 
 interface StatefulFormSanitizeIdProps {
-  name?: string;
-  id?: string;
-  prefix?: string;
+  name?: string
+  id?: string
+  prefix?: string
 }
 
 function sanitizeId({
@@ -2924,11 +2919,11 @@ function sanitizeId({
     str
       .toLowerCase()
       .replace(/\s+/g, "_") // 1. spaces → underscores
-      .replace(/[^0-9a-z_-]/g, ""); // 2. Remove all non-ASCII characters (allow only 0-9, a-z, A-Z, _ and -)
+      .replace(/[^0-9a-z_-]/g, "") // 2. Remove all non-ASCII characters (allow only 0-9, a-z, A-Z, _ and -)
 
-  if (id) return sanitize(id);
-  if (name) return `${prefix}-${sanitize(name)}`;
-  return prefix;
+  if (id) return sanitize(id)
+  if (name) return `${prefix}-${sanitize(name)}`
+  return prefix
 }
 
 const ContainerFormField = styled.div<{ $style: CSSProp }>`
@@ -2943,7 +2938,7 @@ const ContainerFormField = styled.div<{ $style: CSSProp }>`
   gap: 6px;
 
   ${({ $style }) => $style}
-`;
+`
 
 const RowFormField = styled.div<{ $style: CSSProp }>`
   display: flex;
@@ -2953,9 +2948,9 @@ const RowFormField = styled.div<{ $style: CSSProp }>`
   justify-content: start;
 
   ${({ $style }) => $style}
-`;
+`
 
-StatefulForm.Label = StatefulFormLabel;
-StatefulForm.sanitizeId = sanitizeId;
+StatefulForm.Label = StatefulFormLabel
+StatefulForm.sanitizeId = sanitizeId
 
-export { StatefulForm };
+export { StatefulForm }

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -3265,6 +3265,7 @@ function FieldTooltip({ items, styles }: FieldTooltipProps) {
 
   return (
     <FieldTooltipWrapper
+      aria-label="field-tooltip"
       ref={wrapperRef}
       $theme={statefulFormTheme}
       $scrollable={isScrollable}
@@ -3273,17 +3274,20 @@ function FieldTooltip({ items, styles }: FieldTooltipProps) {
       {items.map(({ title, description }, index) => (
         <FieldTooltipItem
           key={index}
+          aria-label="field-tooltip-item"
           $theme={statefulFormTheme}
           $isLast={index === items.length - 1}
           $style={styles?.itemStyle}
         >
           <FieldTooltipTitle
+            aria-label="field-tooltip-title"
             $style={styles?.titleStyle}
             $theme={statefulFormTheme}
           >
             {title}
           </FieldTooltipTitle>
           <FieldTooltipDescription
+            aria-label="field-tooltip-description"
             $style={styles?.descriptionStyle}
             $theme={statefulFormTheme}
           >

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -238,6 +238,12 @@ function StatefulForm<Z extends ZodTypeAny>({
   const formConfig: UseFormProps<TypeOf<Z>> = {
     mode,
     values: formValues,
+    // Prevent RHF from resetting errors/touched on every formValues change
+    resetOptions: {
+      keepErrors: true,
+      keepTouched: true,
+      keepDirtyValues: true,
+    },
   }
 
   if (validationSchema) {
@@ -370,7 +376,7 @@ function StatefulForm<Z extends ZodTypeAny>({
     }
 
     if (typeof value === "string") {
-      return value.length > 0 && !!touched && hasErrorMessage(error)
+      return value.length > 1 && !!touched && hasErrorMessage(error)
     }
 
     if (typeof value === "number" || typeof value === "boolean") {

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -3112,7 +3112,11 @@ function StatefulFormLabel({
       <FieldTooltip
         styles={{
           itemStyle: css`
-            padding: 4px;
+            padding: 4px 8px;
+            background-color: transparent;
+          `,
+          containerStyle: css`
+            background-color: transparent;
           `,
         }}
         items={[

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -288,7 +288,7 @@ function StatefulForm<Z extends ZodTypeAny>({
   // Prevents empty/untouched fields from getting falsely marked as touched
   // on initial mount (which would make them show errors immediately).
   const hasMeaningfulValue = (value: unknown): boolean => {
-    if (typeof value === "string") return value.length > 1
+    if (typeof value === "string") return value.length > 0
     if (typeof value === "number" || typeof value === "boolean") return true
     if (isFile(value) || isFileArray(value)) return true
     return value != null
@@ -375,7 +375,7 @@ function StatefulForm<Z extends ZodTypeAny>({
     }
 
     if (typeof value === "string") {
-      return value.length > 1 && !!touched && hasErrorMessage(error)
+      return value.length > 0 && !!touched && hasErrorMessage(error)
     }
 
     if (typeof value === "number" || typeof value === "boolean") {

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -7,7 +7,9 @@ import React, {
   LabelHTMLAttributes,
   ReactNode,
   useEffect,
+  useLayoutEffect,
   useRef,
+  useState,
 } from "react"
 import {
   Control,
@@ -126,7 +128,7 @@ export interface StatefulFormProps<Z extends ZodTypeAny> {
   id?: string
 }
 
-export interface StatefulFormStyles {
+export interface StatefulFormStyles extends StatefulFormLabelStyles {
   containerStyle?: CSSProp
   frameContainerStyle?: CSSProp
   frameTitleStyle?: CSSProp
@@ -161,7 +163,7 @@ export interface FormFieldProps {
   id?: string
   className?: string
   title?: string
-  helper?: string
+  helper?: ReactNode
   required?: boolean
   type?: FormFieldType
   placeholder?: string
@@ -528,7 +530,6 @@ function FormFields<T extends FieldValues>({
   const { currentTheme } = useTheme()
   const statefulFormTheme = currentTheme?.statefulForm
   const pinboxTheme = currentTheme?.pinbox
-  const phoneboxTheme = currentTheme?.phonebox
 
   const refs = useRef<Record<string, HTMLElement | null>>({})
 
@@ -778,6 +779,18 @@ function FormFields<T extends FieldValues>({
                         {...field.textbox}
                         styles={{
                           ...field.textbox?.styles,
+                          helperArrowStyle: css`
+                            ${styles?.helperArrowStyle};
+                            ${field.textbox?.styles?.helperArrowStyle};
+                          `,
+                          helperDrawerStyle: css`
+                            ${styles?.helperDrawerStyle};
+                            ${field.textbox?.styles?.helperDrawerStyle};
+                          `,
+                          helperIconStyle: css`
+                            ${styles?.helperIconStyle};
+                            ${field.textbox?.styles?.helperIconStyle};
+                          `,
                           labelStyle: css`
                             ${labelSize &&
                             css`
@@ -862,6 +875,18 @@ function FormFields<T extends FieldValues>({
                             {...field.pinbox}
                             styles={{
                               ...field.pinbox?.styles,
+                              helperArrowStyle: css`
+                                ${styles?.helperArrowStyle};
+                                ${field.pinbox?.styles?.helperArrowStyle};
+                              `,
+                              helperDrawerStyle: css`
+                                ${styles?.helperDrawerStyle};
+                                ${field.pinbox?.styles?.helperDrawerStyle};
+                              `,
+                              helperIconStyle: css`
+                                ${styles?.helperIconStyle};
+                                ${field.pinbox?.styles?.helperIconStyle};
+                              `,
                               containerStyle: css`
                                 ${field.width &&
                                 css`
@@ -1055,6 +1080,18 @@ function FormFields<T extends FieldValues>({
                         {...field.timebox}
                         styles={{
                           ...field.timebox?.styles,
+                          helperArrowStyle: css`
+                            ${styles?.helperArrowStyle};
+                            ${field.timebox?.styles?.helperArrowStyle};
+                          `,
+                          helperDrawerStyle: css`
+                            ${styles?.helperDrawerStyle};
+                            ${field.timebox?.styles?.helperDrawerStyle};
+                          `,
+                          helperIconStyle: css`
+                            ${styles?.helperIconStyle};
+                            ${field.timebox?.styles?.helperIconStyle};
+                          `,
                           self: css`
                             ${fieldSize &&
                             css`
@@ -1196,6 +1233,18 @@ function FormFields<T extends FieldValues>({
                         {...field.textarea}
                         styles={{
                           ...field.textarea?.styles,
+                          helperArrowStyle: css`
+                            ${styles?.helperArrowStyle};
+                            ${field.textarea?.styles?.helperArrowStyle};
+                          `,
+                          helperDrawerStyle: css`
+                            ${styles?.helperDrawerStyle};
+                            ${field.textarea?.styles?.helperDrawerStyle};
+                          `,
+                          helperIconStyle: css`
+                            ${styles?.helperIconStyle};
+                            ${field.textarea?.styles?.helperIconStyle};
+                          `,
                           labelStyle: css`
                             ${labelSize &&
                             css`
@@ -1290,6 +1339,18 @@ function FormFields<T extends FieldValues>({
                               {...field.checkbox}
                               styles={{
                                 ...field.checkbox?.styles,
+                                helperArrowStyle: css`
+                                  ${styles?.helperArrowStyle};
+                                  ${field.checkbox?.styles?.helperArrowStyle};
+                                `,
+                                helperDrawerStyle: css`
+                                  ${styles?.helperDrawerStyle};
+                                  ${field.checkbox?.styles?.helperDrawerStyle};
+                                `,
+                                helperIconStyle: css`
+                                  ${styles?.helperIconStyle};
+                                  ${field.checkbox?.styles?.helperIconStyle};
+                                `,
                                 titleStyle: css`
                                   ${labelSize &&
                                   css`
@@ -1412,6 +1473,18 @@ function FormFields<T extends FieldValues>({
                               disabled={field.disabled || disabled}
                               styles={{
                                 ...field.radio?.styles,
+                                helperArrowStyle: css`
+                                  ${styles?.helperArrowStyle};
+                                  ${field.radio?.styles?.helperArrowStyle};
+                                `,
+                                helperDrawerStyle: css`
+                                  ${styles?.helperDrawerStyle};
+                                  ${field.radio?.styles?.helperDrawerStyle};
+                                `,
+                                helperIconStyle: css`
+                                  ${styles?.helperIconStyle};
+                                  ${field.radio?.styles?.helperIconStyle};
+                                `,
                                 labelStyle: css`
                                   ${labelSize &&
                                   css`
@@ -1525,6 +1598,18 @@ function FormFields<T extends FieldValues>({
                             {...field.phonebox}
                             styles={{
                               ...field.phonebox?.styles,
+                              helperArrowStyle: css`
+                                ${styles?.helperArrowStyle};
+                                ${field.phonebox?.styles?.helperArrowStyle};
+                              `,
+                              helperDrawerStyle: css`
+                                ${styles?.helperDrawerStyle};
+                                ${field.phonebox?.styles?.helperDrawerStyle};
+                              `,
+                              helperIconStyle: css`
+                                ${styles?.helperIconStyle};
+                                ${field.phonebox?.styles?.helperIconStyle};
+                              `,
                               labelStyle: css`
                                 ${labelSize &&
                                 css`
@@ -1623,6 +1708,18 @@ function FormFields<T extends FieldValues>({
                             {...field.colorbox}
                             styles={{
                               ...field.colorbox?.styles,
+                              helperArrowStyle: css`
+                                ${styles?.helperArrowStyle};
+                                ${field.colorbox?.styles?.helperArrowStyle};
+                              `,
+                              helperDrawerStyle: css`
+                                ${styles?.helperDrawerStyle};
+                                ${field.colorbox?.styles?.helperDrawerStyle};
+                              `,
+                              helperIconStyle: css`
+                                ${styles?.helperIconStyle};
+                                ${field.colorbox?.styles?.helperIconStyle};
+                              `,
                               labelStyle: css`
                                 ${labelSize &&
                                 css`
@@ -1733,6 +1830,18 @@ function FormFields<T extends FieldValues>({
                         {...field.fileDropBox}
                         styles={{
                           ...field.fileDropBox?.styles,
+                          helperArrowStyle: css`
+                            ${styles?.helperArrowStyle};
+                            ${field.fileDropBox?.styles?.helperArrowStyle};
+                          `,
+                          helperDrawerStyle: css`
+                            ${styles?.helperDrawerStyle};
+                            ${field.fileDropBox?.styles?.helperDrawerStyle};
+                          `,
+                          helperIconStyle: css`
+                            ${styles?.helperIconStyle};
+                            ${field.fileDropBox?.styles?.helperIconStyle};
+                          `,
                           labelStyle: css`
                             ${labelSize &&
                             css`
@@ -1810,6 +1919,18 @@ function FormFields<T extends FieldValues>({
                         }}
                         styles={{
                           ...field.fileInputBox?.styles,
+                          helperArrowStyle: css`
+                            ${styles?.helperArrowStyle};
+                            ${field.fileInputBox?.styles?.helperArrowStyle};
+                          `,
+                          helperDrawerStyle: css`
+                            ${styles?.helperDrawerStyle};
+                            ${field.fileInputBox?.styles?.helperDrawerStyle};
+                          `,
+                          helperIconStyle: css`
+                            ${styles?.helperIconStyle};
+                            ${field.fileInputBox?.styles?.helperIconStyle};
+                          `,
                           labelStyle: css`
                             ${labelSize &&
                             css`
@@ -1902,6 +2023,18 @@ function FormFields<T extends FieldValues>({
                         {...field.imagebox}
                         styles={{
                           ...field.imagebox?.styles,
+                          helperArrowStyle: css`
+                            ${styles?.helperArrowStyle};
+                            ${field.imagebox?.styles?.helperArrowStyle};
+                          `,
+                          helperDrawerStyle: css`
+                            ${styles?.helperDrawerStyle};
+                            ${field.imagebox?.styles?.helperDrawerStyle};
+                          `,
+                          helperIconStyle: css`
+                            ${styles?.helperIconStyle};
+                            ${field.imagebox?.styles?.helperIconStyle};
+                          `,
                           containerStyle: css`
                             ${field.width &&
                             css`
@@ -1974,6 +2107,18 @@ function FormFields<T extends FieldValues>({
                         {...field.signbox}
                         styles={{
                           ...field.signbox?.styles,
+                          helperArrowStyle: css`
+                            ${styles?.helperArrowStyle};
+                            ${field.signbox?.styles?.helperArrowStyle};
+                          `,
+                          helperDrawerStyle: css`
+                            ${styles?.helperDrawerStyle};
+                            ${field.signbox?.styles?.helperDrawerStyle};
+                          `,
+                          helperIconStyle: css`
+                            ${styles?.helperIconStyle};
+                            ${field.signbox?.styles?.helperIconStyle};
+                          `,
                           labelStyle: css`
                             ${labelSize &&
                             css`
@@ -2055,6 +2200,18 @@ function FormFields<T extends FieldValues>({
                             {...field.money}
                             styles={{
                               ...field.money?.styles,
+                              helperArrowStyle: css`
+                                ${styles?.helperArrowStyle};
+                                ${field.money?.styles?.helperArrowStyle};
+                              `,
+                              helperDrawerStyle: css`
+                                ${styles?.helperDrawerStyle};
+                                ${field.money?.styles?.helperDrawerStyle};
+                              `,
+                              helperIconStyle: css`
+                                ${styles?.helperIconStyle};
+                                ${field.money?.styles?.helperIconStyle};
+                              `,
                               inputWrapperStyle: css`
                                 height: 34px;
                                 ${mobileInputStyle};
@@ -2157,6 +2314,18 @@ function FormFields<T extends FieldValues>({
                               {...field.date}
                               styles={{
                                 ...field?.date?.styles,
+                                helperArrowStyle: css`
+                                  ${styles?.helperArrowStyle};
+                                  ${field.date?.styles?.helperArrowStyle};
+                                `,
+                                helperDrawerStyle: css`
+                                  ${styles?.helperDrawerStyle};
+                                  ${field.date?.styles?.helperDrawerStyle};
+                                `,
+                                helperIconStyle: css`
+                                  ${styles?.helperIconStyle};
+                                  ${field.date?.styles?.helperIconStyle};
+                                `,
                                 selectboxStyle: css`
                                   ${fieldSize &&
                                   css`
@@ -2259,6 +2428,18 @@ function FormFields<T extends FieldValues>({
                             strict={field?.combobox?.strict ?? true}
                             styles={{
                               ...field?.combobox?.styles,
+                              helperArrowStyle: css`
+                                ${styles?.helperArrowStyle};
+                                ${field.combobox?.styles?.helperArrowStyle};
+                              `,
+                              helperDrawerStyle: css`
+                                ${styles?.helperDrawerStyle};
+                                ${field.combobox?.styles?.helperDrawerStyle};
+                              `,
+                              helperIconStyle: css`
+                                ${styles?.helperIconStyle};
+                                ${field.combobox?.styles?.helperIconStyle};
+                              `,
                               bodyStyle: css`
                                 ${!field.title &&
                                 hasFieldTitle &&
@@ -2367,6 +2548,18 @@ function FormFields<T extends FieldValues>({
                             {...field.chips}
                             styles={{
                               ...field.chips?.styles,
+                              helperArrowStyle: css`
+                                ${styles?.helperArrowStyle};
+                                ${field.chips?.styles?.helperArrowStyle};
+                              `,
+                              helperDrawerStyle: css`
+                                ${styles?.helperDrawerStyle};
+                                ${field.chips?.styles?.helperDrawerStyle};
+                              `,
+                              helperIconStyle: css`
+                                ${styles?.helperIconStyle};
+                                ${field.chips?.styles?.helperIconStyle};
+                              `,
                               labelStyle: css`
                                 ${labelSize &&
                                 css`
@@ -2456,6 +2649,18 @@ function FormFields<T extends FieldValues>({
                               {...field.rating}
                               styles={{
                                 ...field.rating?.styles,
+                                helperArrowStyle: css`
+                                  ${styles?.helperArrowStyle};
+                                  ${field.rating?.styles?.helperArrowStyle};
+                                `,
+                                helperDrawerStyle: css`
+                                  ${styles?.helperDrawerStyle};
+                                  ${field.rating?.styles?.helperDrawerStyle};
+                                `,
+                                helperIconStyle: css`
+                                  ${styles?.helperIconStyle};
+                                  ${field.rating?.styles?.helperIconStyle};
+                                `,
                                 labelStyle: css`
                                   ${labelSize &&
                                   css`
@@ -2548,6 +2753,18 @@ function FormFields<T extends FieldValues>({
                             {...field.thumbField}
                             styles={{
                               ...field.thumbField?.styles,
+                              helperArrowStyle: css`
+                                ${styles?.helperArrowStyle};
+                                ${field.thumbField?.styles?.helperArrowStyle};
+                              `,
+                              helperDrawerStyle: css`
+                                ${styles?.helperDrawerStyle};
+                                ${field.thumbField?.styles?.helperDrawerStyle};
+                              `,
+                              helperIconStyle: css`
+                                ${styles?.helperIconStyle};
+                                ${field.thumbField?.styles?.helperIconStyle};
+                              `,
                               labelStyle: css`
                                 ${labelSize &&
                                 css`
@@ -2651,6 +2868,18 @@ function FormFields<T extends FieldValues>({
                             label={field.placeholder}
                             styles={{
                               ...field.toggle?.styles,
+                              helperArrowStyle: css`
+                                ${styles?.helperArrowStyle};
+                                ${field.toggle?.styles?.helperArrowStyle};
+                              `,
+                              helperDrawerStyle: css`
+                                ${styles?.helperDrawerStyle};
+                                ${field.toggle?.styles?.helperDrawerStyle};
+                              `,
+                              helperIconStyle: css`
+                                ${styles?.helperIconStyle};
+                                ${field.toggle?.styles?.helperIconStyle};
+                              `,
                               titleStyle: css`
                                 ${labelSize &&
                                 css`
@@ -2740,6 +2969,18 @@ function FormFields<T extends FieldValues>({
                             {...field.capsule}
                             styles={{
                               ...field.capsule?.styles,
+                              helperArrowStyle: css`
+                                ${styles?.helperArrowStyle};
+                                ${field.capsule?.styles?.helperArrowStyle};
+                              `,
+                              helperDrawerStyle: css`
+                                ${styles?.helperDrawerStyle};
+                                ${field.capsule?.styles?.helperDrawerStyle};
+                              `,
+                              helperIconStyle: css`
+                                ${styles?.helperIconStyle};
+                                ${field.capsule?.styles?.helperIconStyle};
+                              `,
                               labelStyle: css`
                                 ${labelSize &&
                                 css`
@@ -2831,12 +3072,19 @@ const Divider = styled.div<{
 export interface StatefulFormLabelProps
   extends Omit<LabelHTMLAttributes<HTMLLabelElement>, "label" | "style"> {
   label?: string
-  helper?: string
-  styles: { self?: CSSProp }
+  helper?: ReactNode
+  styles: StatefulFormLabelStyles
   labelPosition?: FieldLaneProps["labelPosition"]
   labelWidth?: FieldLaneProps["labelWidth"]
   required?: boolean
   disabled?: boolean
+}
+
+export interface StatefulFormLabelStyles {
+  self?: CSSProp
+  helperDrawerStyle?: CSSProp
+  helperIconStyle?: CSSProp
+  helperArrowStyle?: CSSProp
 }
 
 function StatefulFormLabel({
@@ -2851,6 +3099,9 @@ function StatefulFormLabel({
   id,
   ...props
 }: StatefulFormLabelProps) {
+  const { currentTheme } = useTheme()
+  const statefulFormTheme = currentTheme?.statefulForm
+
   return (
     <Label
       {...props}
@@ -2869,7 +3120,27 @@ function StatefulFormLabel({
         )}
       </LabelText>
 
-      {helper && <Helper value={helper} />}
+      {helper && (
+        <Helper
+          styles={{
+            arrowStyle: css`
+              background-color: ${statefulFormTheme?.fieldTooltip
+                ?.panelBackground};
+
+              ${styles?.helperArrowStyle};
+            `,
+            drawerStyle: css`
+              background-color: ${statefulFormTheme?.fieldTooltip
+                ?.panelBackground};
+              color: ${statefulFormTheme?.fieldTooltip?.mutedTextColor};
+              max-width: 300px;
+              ${styles?.helperDrawerStyle}
+            `,
+            self: styles?.helperIconStyle,
+          }}
+          value={helper}
+        />
+      )}
     </Label>
   )
 }
@@ -2955,7 +3226,156 @@ const RowFormField = styled.div<{ $style: CSSProp }>`
   ${({ $style }) => $style}
 `
 
+export interface FieldTooltipItem {
+  title?: ReactNode
+  description?: ReactNode
+}
+
+export interface FieldTooltipStyles {
+  containerStyle?: CSSProp
+  itemStyle?: CSSProp
+  titleStyle?: CSSProp
+  descriptionStyle?: CSSProp
+}
+
+export interface FieldTooltipProps {
+  items?: FieldTooltipItem[]
+  styles?: FieldTooltipStyles
+}
+
+function FieldTooltip({ items, styles }: FieldTooltipProps) {
+  const { currentTheme } = useTheme()
+  const statefulFormTheme = currentTheme?.statefulForm
+
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const [isScrollable, setIsScrollable] = useState(false)
+
+  useLayoutEffect(() => {
+    const el = wrapperRef.current
+    if (!el) return
+
+    const updateScrollable = () =>
+      setIsScrollable(el.scrollHeight > el.clientHeight + 2)
+
+    updateScrollable()
+    const observer = new ResizeObserver(updateScrollable)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [items])
+
+  return (
+    <FieldTooltipWrapper
+      ref={wrapperRef}
+      $theme={statefulFormTheme}
+      $scrollable={isScrollable}
+      $style={styles?.containerStyle}
+    >
+      {items.map(({ title, description }, index) => (
+        <FieldTooltipItem
+          key={index}
+          $theme={statefulFormTheme}
+          $isLast={index === items.length - 1}
+          $style={styles?.itemStyle}
+        >
+          <FieldTooltipTitle
+            $style={styles?.titleStyle}
+            $theme={statefulFormTheme}
+          >
+            {title}
+          </FieldTooltipTitle>
+          <FieldTooltipDescription
+            $style={styles?.descriptionStyle}
+            $theme={statefulFormTheme}
+          >
+            {description}
+          </FieldTooltipDescription>
+        </FieldTooltipItem>
+      ))}
+    </FieldTooltipWrapper>
+  )
+}
+
+const FieldTooltipWrapper = styled.div<{
+  $theme?: StatefulFormThemeConfig
+  $scrollable?: boolean
+  $style?: CSSProp
+}>`
+  width: 260px;
+  max-height: 30vh;
+  box-sizing: border-box;
+  white-space: normal;
+  overflow-y: ${({ $scrollable }) => ($scrollable ? "auto" : "hidden")};
+  overscroll-behavior: contain;
+  border-radius: 4px;
+  border: 1px solid ${({ $theme }) => $theme?.fieldTooltip?.panelBorder};
+  background: ${({ $theme }) => $theme?.fieldTooltip?.panelBackground};
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.03),
+    0 6px 16px rgba(0, 0, 0, 0.16);
+
+  scrollbar-color: ${({ $theme }) =>
+    `${$theme.fieldTooltip.scrollbarThumbColor} ${$theme.fieldTooltip.scrollbarTrackColor}`};
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: ${({ $theme }) => $theme?.fieldTooltip?.scrollbarTrackColor};
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${({ $theme }) => $theme?.fieldTooltip?.scrollbarThumbColor};
+    border-radius: 8px;
+  }
+
+  ${({ $style }) => $style}
+`
+
+const FieldTooltipItem = styled.div<{
+  $theme?: StatefulFormThemeConfig
+  $isLast?: boolean
+  $style?: CSSProp
+}>`
+  box-sizing: border-box;
+  padding: 10px 14px;
+  border-bottom: ${({ $isLast, $theme }) =>
+    $isLast ? "none" : `1px solid ${$theme?.fieldTooltip?.dividerColor}`};
+
+  ${({ $style }) => $style}
+`
+
+const FieldTooltipTitle = styled.div<{
+  $theme?: StatefulFormThemeConfig
+  $style?: CSSProp
+}>`
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  white-space: normal;
+  font-weight: 600;
+  font-size: 13px;
+  color: ${({ $theme }) => $theme?.fieldTooltip?.textColor};
+
+  ${({ $style }) => $style}
+`
+
+const FieldTooltipDescription = styled.div<{
+  $theme?: StatefulFormThemeConfig
+  $style?: CSSProp
+}>`
+  margin-top: 3px;
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: normal;
+  overflow-wrap: break-word;
+  color: ${({ $theme }) => $theme?.fieldTooltip?.mutedTextColor};
+
+  ${({ $style }) => $style}
+`
+
 StatefulForm.Label = StatefulFormLabel
 StatefulForm.sanitizeId = sanitizeId
+StatefulForm.FieldTooltip = FieldTooltip
 
 export { StatefulForm }

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -242,7 +242,6 @@ function StatefulForm<Z extends ZodTypeAny>({
     resetOptions: {
       keepErrors: true,
       keepTouched: true,
-      keepDirtyValues: true,
     },
   }
 

--- a/components/stateful-form.tsx
+++ b/components/stateful-form.tsx
@@ -49,11 +49,11 @@ import { useTheme, StatefulFormThemeConfig } from "./../theme";
 export type StatefulOnChangeType =
   | ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   | {
-    target: {
-      name: string;
-      value: FormValueType;
+      target: {
+        name: string;
+        value: FormValueType;
+      };
     };
-  };
 
 export type FormValueType =
   | string
@@ -220,8 +220,16 @@ function StatefulForm<Z extends ZodTypeAny>({
   className,
   id,
 }: StatefulFormProps<Z>) {
+  // Tracks field names whose most recent change came from the internal
+  // onChange path (handleFieldChange), i.e. real user interaction through
+  // register/Controller — NOT from an external formValues update.
+  // RHF's own register/Controller already handles validate+touch for these,
+  // so we don't need (and don't want) to force setValue on them again.
+  const internallyChangedFieldsRef = useRef<Set<string>>(new Set());
+
   const handleFieldChange = (name: keyof TypeOf<Z>, value: FormValueType) => {
     if (disabled) return;
+    internallyChangedFieldsRef.current.add(name as string);
     onChange?.({ currentState: { [name]: value } });
   };
 
@@ -229,7 +237,7 @@ function StatefulForm<Z extends ZodTypeAny>({
 
   const formConfig: UseFormProps<TypeOf<Z>> = {
     mode,
-    defaultValues: formValues,
+    values: formValues,
   };
 
   if (validationSchema) {
@@ -243,22 +251,87 @@ function StatefulForm<Z extends ZodTypeAny>({
     formState: { errors, touchedFields, isValid },
   } = useForm(formConfig) as ReturnType<typeof useForm<TypeOf<Z>>>;
 
-  const customFieldNames = fields
-    .flat()
-    .filter((field) => field.type === "custom")
-    .map((field) => field.name);
+  const isFile = (val: unknown): val is File => val instanceof File;
 
-  const customValues = customFieldNames.map((name) => formValues[name]);
+  const isFileArray = (val: unknown): val is File[] =>
+    Array.isArray(val) && val.every((v) => v instanceof File);
 
-  useEffect(() => {
-    customFieldNames.map((name) => {
-      setValue(name as any, formValues[name as any], {
-        shouldValidate: true,
-        shouldTouch: true,
-        shouldDirty: true,
-      });
+  // Recursively collect ALL field names that hold a real form value —
+  // including "custom" fields now, since they need the same touched/validate
+  // sync logic as every other field type. Only skip "button" (no value)
+  // and "hidden" (not meant to be validated/shown).
+  function flattenAllFieldNames(fields: FormFieldGroup[]): string[] {
+    return fields.flatMap((f) => {
+      if (Array.isArray(f)) {
+        return flattenAllFieldNames(f);
+      }
+
+      if (f.type === "frame" && f.fields) {
+        return flattenAllFieldNames(f.fields as FormFieldGroup[]);
+      }
+
+      // skip fields that don't hold a real, validatable form value
+      if (f.type === "button" || f.type === "custom" || f.hidden) {
+        return [];
+      }
+
+      return [f.name];
     });
-  }, [JSON.stringify(customValues), setValue]);
+  }
+
+  // Decide whether a value is "real" enough to be worth touching/validating.
+  // Prevents empty/untouched fields from getting falsely marked as touched
+  // on initial mount (which would make them show errors immediately).
+  const hasMeaningfulValue = (value: unknown): boolean => {
+    if (typeof value === "string") return value.length > 1;
+    if (typeof value === "number" || typeof value === "boolean") return true;
+    if (isFile(value) || isFileArray(value)) return true;
+    return value != null;
+  };
+
+  const allFieldNames = flattenAllFieldNames(fields);
+
+  const prevFormValuesRef = useRef<TypeOf<Z>>(formValues);
+
+  // Whenever `formValues` changes — whether from an external source (values
+  // prop reactive sync) or a "custom" field's own render logic — RHF's
+  // internal reset (triggered by the `values` prop) does NOT automatically
+  // mark fields as touched or re-run validation for display purposes.
+  // So we manually diff against the previous values and force `setValue`
+  // with `shouldValidate` + `shouldTouch` only on fields that actually changed,
+  // avoiding unnecessary re-validation on fields that didn't change.
+  useEffect(() => {
+    const prevFormValues = prevFormValuesRef.current;
+
+    allFieldNames.forEach((name) => {
+      const key = name as keyof TypeOf<Z>;
+      const value = formValues[key];
+      const prevValue = prevFormValues[key];
+
+      const changedInternally = internallyChangedFieldsRef.current.has(name);
+
+      // consume the flag either way, so it doesn't leak into future renders
+      internallyChangedFieldsRef.current.delete(name);
+
+      if (changedInternally) {
+        // came from real user interaction via register/Controller —
+        // RHF already validated + touched it, nothing to do here
+        return;
+      }
+
+      // only reaches here for changes NOT triggered by handleFieldChange,
+      // i.e. genuinely external updates (props, server data, programmatic set, etc.)
+      if (value !== prevValue && hasMeaningfulValue(value)) {
+        setValue(name as any, value as any, {
+          shouldValidate: true,
+          shouldTouch: true,
+          shouldDirty: true,
+        });
+      }
+    });
+
+    prevFormValuesRef.current = formValues;
+  }, [formValues, setValue]);
 
   useEffect(() => {
     if (onValidityChange) {
@@ -281,11 +354,6 @@ function StatefulForm<Z extends ZodTypeAny>({
     const value = formValues[name];
     const touched = touchedFields[name];
     const error = errors[name];
-
-    const isFile = (val: unknown): val is File => val instanceof File;
-
-    const isFileArray = (val: unknown): val is File[] =>
-      Array.isArray(val) && val.every((v) => v instanceof File);
 
     const hasErrorMessage = (err: unknown): boolean => {
       if (!err || typeof err !== "object") return false;
@@ -700,8 +768,8 @@ function FormFields<T extends FieldValues>({
                         showError={shouldShowError(field.name)}
                         errorMessage={
                           errors[field.name as keyof T]?.message as
-                          | string
-                          | undefined
+                            | string
+                            | undefined
                         }
                         disabled={field.disabled || disabled}
                         {...field.textbox}
@@ -784,8 +852,8 @@ function FormFields<T extends FieldValues>({
                             showError={shouldShowError(field.name)}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
-                              | string
-                              | undefined
+                                | string
+                                | undefined
                             }
                             disabled={field.disabled || disabled}
                             {...field.pinbox}
@@ -826,16 +894,16 @@ function FormFields<T extends FieldValues>({
                                   box-shadow: none;
                                   border-bottom: 1px solid
                                     ${shouldShowError(field.name)
-                                    ? pinboxTheme.errorBorderColor ||
-                                    "#f87171"
-                                    : pinboxTheme.borderColor || "#d1d5db"};
+                                      ? pinboxTheme.errorBorderColor ||
+                                        "#f87171"
+                                      : pinboxTheme.borderColor || "#d1d5db"};
 
                                   &:focus {
                                     border: none;
                                     box-shadow: none;
                                     border-bottom: 1px solid
                                       ${pinboxTheme.focusedBorderColor ||
-                                  "#61A9F9"};
+                                      "#61A9F9"};
                                     z-index: 9999;
                                   }
                                 `};
@@ -954,11 +1022,11 @@ function FormFields<T extends FieldValues>({
                         placeholder={
                           typeof field.placeholder === "string"
                             ? (() => {
-                              const [hour = "", minute = "", second = ""] =
-                                field.placeholder.split(/[:/]/);
+                                const [hour = "", minute = "", second = ""] =
+                                  field.placeholder.split(/[:/]/);
 
-                              return { hour, minute, second };
-                            })()
+                                return { hour, minute, second };
+                              })()
                             : field.placeholder
                         }
                         helper={field.helper}
@@ -977,8 +1045,8 @@ function FormFields<T extends FieldValues>({
                         showError={shouldShowError(field.name)}
                         errorMessage={
                           errors[field.name as keyof T]?.message as
-                          | string
-                          | undefined
+                            | string
+                            | undefined
                         }
                         disabled={field.disabled || disabled}
                         {...field.timebox}
@@ -1005,16 +1073,16 @@ function FormFields<T extends FieldValues>({
                               box-shadow: none;
                               border-bottom: 1px solid
                                 ${shouldShowError(field.name)
-                                ? pinboxTheme.errorBorderColor || "#f87171"
-                                : pinboxTheme.borderColor || "#d1d5db"};
+                                  ? pinboxTheme.errorBorderColor || "#f87171"
+                                  : pinboxTheme.borderColor || "#d1d5db"};
 
                               &:focus {
                                 border: none;
                                 box-shadow: none;
                                 border-bottom: 1px solid
                                   ${shouldShowError(field.name)
-                                ? pinboxTheme.errorBorderColor || "#f87171"
-                                : pinboxTheme.borderColor || "#d1d5db"};
+                                    ? pinboxTheme.errorBorderColor || "#f87171"
+                                    : pinboxTheme.borderColor || "#d1d5db"};
                                 z-index: 9999;
                               }
                             `};
@@ -1118,8 +1186,8 @@ function FormFields<T extends FieldValues>({
                         showError={shouldShowError(field.name)}
                         errorMessage={
                           errors[field.name as keyof T]?.message as
-                          | string
-                          | undefined
+                            | string
+                            | undefined
                         }
                         disabled={field.disabled || disabled}
                         {...field.textarea}
@@ -1199,8 +1267,8 @@ function FormFields<T extends FieldValues>({
                               }}
                               errorMessage={
                                 errors[field.name as keyof T]?.message as
-                                | string
-                                | undefined
+                                  | string
+                                  | undefined
                               }
                               required={required}
                               showError={shouldShowError(field.name)}
@@ -1321,8 +1389,8 @@ function FormFields<T extends FieldValues>({
                               checked={controllerField.value ?? false}
                               errorMessage={
                                 errors[field.name as keyof T]?.message as
-                                | string
-                                | undefined
+                                  | string
+                                  | undefined
                               }
                               helper={field.helper}
                               required={required}
@@ -1429,11 +1497,11 @@ function FormFields<T extends FieldValues>({
                             onChange={(
                               e:
                                 | {
-                                  target: {
-                                    name: string;
-                                    value: PhoneboxCountryCode;
-                                  };
-                                }
+                                    target: {
+                                      name: string;
+                                      value: PhoneboxCountryCode;
+                                    };
+                                  }
                                 | ChangeEvent<HTMLInputElement>
                             ) => {
                               if (e.target.name === "phone") {
@@ -1447,8 +1515,8 @@ function FormFields<T extends FieldValues>({
                             showError={shouldShowError(field.name)}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
-                              | string
-                              | undefined
+                                | string
+                                | undefined
                             }
                             disabled={field.disabled || disabled}
                             {...field.phonebox}
@@ -1708,8 +1776,8 @@ function FormFields<T extends FieldValues>({
                         disabled={field.disabled || disabled}
                         errorMessage={
                           errors[field.name as keyof T]?.message as
-                          | string
-                          | undefined
+                            | string
+                            | undefined
                         }
                         {...field.fileInputBox}
                         onFilesSelected={(files: File[]) => {
@@ -1825,8 +1893,8 @@ function FormFields<T extends FieldValues>({
                         showError={shouldShowError(field.name)}
                         errorMessage={
                           errors[field.name as keyof T]?.message as
-                          | string
-                          | undefined
+                            | string
+                            | undefined
                         }
                         {...field.imagebox}
                         styles={{
@@ -1896,8 +1964,8 @@ function FormFields<T extends FieldValues>({
                         showError={shouldShowError(field.name)}
                         errorMessage={
                           errors[field.name as keyof T]?.message as
-                          | string
-                          | undefined
+                            | string
+                            | undefined
                         }
                         disabled={field.disabled || disabled}
                         {...field.signbox}
@@ -2067,8 +2135,8 @@ function FormFields<T extends FieldValues>({
                               }}
                               errorMessage={
                                 errors[field.name as keyof T]?.[0]?.message as
-                                | string
-                                | undefined
+                                  | string
+                                  | undefined
                               }
                               onChange={(e) => {
                                 const inputValueEvent = {
@@ -2167,8 +2235,8 @@ function FormFields<T extends FieldValues>({
                             }}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
-                              | string
-                              | undefined
+                                | string
+                                | undefined
                             }
                             helper={field.helper}
                             onChange={(e) => {
@@ -2473,8 +2541,8 @@ function FormFields<T extends FieldValues>({
                             showError={shouldShowError(field.name)}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
-                              | string
-                              | undefined
+                                | string
+                                | undefined
                             }
                             disabled={field.disabled || disabled}
                             {...field.thumbField}
@@ -2574,8 +2642,8 @@ function FormFields<T extends FieldValues>({
                             showError={shouldShowError(field.name)}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
-                              | string
-                              | undefined
+                                | string
+                                | undefined
                             }
                             disabled={field.disabled || disabled}
                             {...field.toggle}
@@ -2666,8 +2734,8 @@ function FormFields<T extends FieldValues>({
                             showError={shouldShowError(field.name)}
                             errorMessage={
                               errors[field.name as keyof T]?.message as
-                              | string
-                              | undefined
+                                | string
+                                | undefined
                             }
                             {...field.capsule}
                             styles={{

--- a/components/table.stories.tsx
+++ b/components/table.stories.tsx
@@ -36,6 +36,7 @@ import { List } from "./list";
 import { Card } from "./card";
 import { generateSentence } from "./../lib/text";
 import { TableThemeConfig, useTheme } from "./../theme";
+import { StatefulForm } from "./stateful-form";
 
 const meta: Meta<typeof Table> = {
   title: "Content/Table",
@@ -610,24 +611,24 @@ export const Loose: Story = {
 
     const TYPES_DATA = [
       {
-        name: "HTTP",
+        title: "HTTP",
         description: "Standard protocol for transferring web pages.",
       },
       {
-        name: "HTTPS",
+        title: "HTTPS",
         description: "Secure version of HTTP using TLS encryption.",
       },
       {
-        name: "TCP",
+        title: "TCP",
         description: "Reliable, connection-oriented transport protocol.",
       },
       {
-        name: "UDP",
+        title: "UDP",
         description:
           "Fast, connectionless protocol for low-latency communication.",
       },
       {
-        name: "QUIC",
+        title: "QUIC",
         description:
           "Modern transport protocol providing faster and more secure connections.",
       },
@@ -652,7 +653,7 @@ export const Loose: Story = {
     const initialRows = useMemo<LoadBalancerRow[]>(
       () =>
         Array.from({ length: 400 }, (_, i) => {
-          const type = TYPES_DATA[i % TYPES_DATA.length].name;
+          const type = TYPES_DATA[i % TYPES_DATA.length].title;
           const region = REGIONS[i % REGIONS.length];
           const status = STATUS[i % STATUS.length];
 
@@ -830,26 +831,14 @@ export const Loose: Story = {
             image: RiInformationLine,
           },
           subMenu: ({ show }) =>
-            show(
-              TYPES_DATA.map((protocol, index) => (
-                <ProtocolItem $theme={tableTheme} key={index}>
-                  <ProtocolName $theme={tableTheme}>
-                    {protocol.name}
-                  </ProtocolName>
-                  <ProtocolDescription $theme={tableTheme}>
-                    {protocol.description}
-                  </ProtocolDescription>
-                </ProtocolItem>
-              )),
-              {
-                drawerStyle: css`
-                  display: flex;
-                  flex-direction: column;
-                  gap: 6px;
-                  padding: 6px;
-                `,
-              }
-            ),
+            show(<StatefulForm.FieldTooltip items={TYPES_DATA} />, {
+              drawerStyle: css`
+                display: flex;
+                flex-direction: column;
+                gap: 6px;
+                padding: 0px;
+              `,
+            }),
         };
       }
 

--- a/components/textarea.tsx
+++ b/components/textarea.tsx
@@ -5,50 +5,52 @@ import {
   forwardRef,
   useEffect,
   useRef,
-} from "react"
-import styled, { css, CSSProp } from "styled-components"
+} from "react";
+import styled, { css, CSSProp } from "styled-components";
 import {
   FieldLane,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane"
-import { StatefulForm } from "./stateful-form"
-import { useTheme } from "./../theme/provider"
-import { TextareaThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
+} from "./field-lane";
+import { StatefulForm } from "./stateful-form";
+import { useTheme } from "./../theme/provider";
+import { TextareaThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseTextareaProps
   extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "style"> {
-  showError?: boolean
-  styles?: TextareaStyles
-  onChange?: (data: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
-  autogrow?: boolean
-  id?: string
-  width?: string | number
+  showError?: boolean;
+  styles?: TextareaStyles;
+  onChange?: (
+    data: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => void;
+  autogrow?: boolean;
+  id?: string;
+  width?: string | number;
 }
 
 export interface TextareaStyles {
-  self?: CSSProp
+  self?: CSSProp;
 }
 
 const BaseTextarea = forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
   (
     { id, showError, rows, onChange, autogrow, styles, width, ...props },
-    ref,
+    ref
   ) => {
-    const { currentTheme } = useTheme()
-    const textareaTheme = currentTheme?.textarea
+    const { currentTheme } = useTheme();
+    const textareaTheme = currentTheme?.textarea;
 
-    const innerRef = useRef<HTMLTextAreaElement | null>(null)
+    const innerRef = useRef<HTMLTextAreaElement | null>(null);
 
     // runs once on mount
     useEffect(() => {
       if (autogrow && innerRef.current) {
-        innerRef.current.style.height = "auto"
-        innerRef.current.style.height = `${innerRef.current.scrollHeight}px`
+        innerRef.current.style.height = "auto";
+        innerRef.current.style.height = `${innerRef.current.scrollHeight}px`;
       }
-    }, [])
+    }, []);
 
     return (
       <TextareaInput
@@ -58,21 +60,21 @@ const BaseTextarea = forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
         $autogrow={autogrow}
         id={id}
         ref={(el) => {
-          innerRef.current = el
+          innerRef.current = el;
           if (typeof ref === "function") {
-            ref(el)
+            ref(el);
           } else if (ref) {
-            ;(ref as MutableRefObject<HTMLTextAreaElement | null>).current = el
+            (ref as MutableRefObject<HTMLTextAreaElement | null>).current = el;
           }
         }}
         onChange={(e) => {
           if (autogrow) {
-            e.target.style.height = "auto"
-            e.target.style.height = `${e.target.scrollHeight}px`
+            e.target.style.height = "auto";
+            e.target.style.height = `${e.target.scrollHeight}px`;
           }
 
           if (onChange) {
-            onChange(e)
+            onChange(e);
           }
         }}
         rows={rows ?? 3}
@@ -80,17 +82,17 @@ const BaseTextarea = forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
         $style={styles?.self}
         {...(props as TextareaHTMLAttributes<HTMLTextAreaElement>)}
       />
-    )
-  },
-)
+    );
+  }
+);
 
 export interface TextareaProps
   extends Omit<BaseTextareaProps, "styles">,
     Omit<FieldLaneProps, "styles"> {
-  styles?: TextareaStyles & FieldLaneStyles
+  styles?: TextareaStyles & FieldLaneStyles;
 }
 
-export type TextareaDropdownOption = FieldLaneDropdownOption
+export type TextareaDropdownOption = FieldLaneDropdownOption;
 
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ ...props }, ref) => {
@@ -109,12 +111,12 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       labelPosition,
       className,
       ...rest
-    } = props
+    } = props;
     const inputId = StatefulForm.sanitizeId({
       prefix: "textarea",
       name: props.name,
       id: props.id,
-    })
+    });
 
     const {
       bodyStyle,
@@ -125,7 +127,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       helperIconStyle,
       helperArrowStyle,
       self,
-    } = styles ?? {}
+    } = styles ?? {};
 
     return (
       <FieldLane
@@ -172,17 +174,17 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           ref={ref}
         />
       </FieldLane>
-    )
-  },
-)
+    );
+  }
+);
 
 const TextareaInput = styled.textarea<{
-  $error?: boolean
-  $style?: CSSProp
-  $autogrow?: boolean
-  $disabled?: boolean
-  $theme?: TextareaThemeConfig
-  $width?: string | number
+  $error?: boolean;
+  $style?: CSSProp;
+  $autogrow?: boolean;
+  $disabled?: boolean;
+  $theme?: TextareaThemeConfig;
+  $width?: string | number;
 }>`
   border-radius: 2px;
   font-size: 0.75rem;
@@ -262,6 +264,6 @@ const TextareaInput = styled.textarea<{
     `}
 
   ${({ $style }) => $style}
-`
+`;
 
-export { Textarea }
+export { Textarea };

--- a/components/textarea.tsx
+++ b/components/textarea.tsx
@@ -5,52 +5,50 @@ import {
   forwardRef,
   useEffect,
   useRef,
-} from "react";
-import styled, { css, CSSProp } from "styled-components";
+} from "react"
+import styled, { css, CSSProp } from "styled-components"
 import {
   FieldLane,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane";
-import { StatefulForm } from "./stateful-form";
-import { useTheme } from "./../theme/provider";
-import { TextareaThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
+} from "./field-lane"
+import { StatefulForm } from "./stateful-form"
+import { useTheme } from "./../theme/provider"
+import { TextareaThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
 
 interface BaseTextareaProps
   extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "style"> {
-  showError?: boolean;
-  styles?: TextareaStyles;
-  onChange?: (
-    data: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => void;
-  autogrow?: boolean;
-  id?: string;
-  width?: string | number;
+  showError?: boolean
+  styles?: TextareaStyles
+  onChange?: (data: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
+  autogrow?: boolean
+  id?: string
+  width?: string | number
 }
 
 export interface TextareaStyles {
-  self?: CSSProp;
+  self?: CSSProp
 }
 
 const BaseTextarea = forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
   (
     { id, showError, rows, onChange, autogrow, styles, width, ...props },
-    ref
+    ref,
   ) => {
-    const { currentTheme } = useTheme();
-    const textareaTheme = currentTheme?.textarea;
+    const { currentTheme } = useTheme()
+    const textareaTheme = currentTheme?.textarea
 
-    const innerRef = useRef<HTMLTextAreaElement | null>(null);
+    const innerRef = useRef<HTMLTextAreaElement | null>(null)
 
     // runs once on mount
     useEffect(() => {
       if (autogrow && innerRef.current) {
-        innerRef.current.style.height = "auto";
-        innerRef.current.style.height = `${innerRef.current.scrollHeight}px`;
+        innerRef.current.style.height = "auto"
+        innerRef.current.style.height = `${innerRef.current.scrollHeight}px`
       }
-    }, []);
+    }, [])
 
     return (
       <TextareaInput
@@ -60,21 +58,21 @@ const BaseTextarea = forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
         $autogrow={autogrow}
         id={id}
         ref={(el) => {
-          innerRef.current = el;
+          innerRef.current = el
           if (typeof ref === "function") {
-            ref(el);
+            ref(el)
           } else if (ref) {
-            (ref as MutableRefObject<HTMLTextAreaElement | null>).current = el;
+            ;(ref as MutableRefObject<HTMLTextAreaElement | null>).current = el
           }
         }}
         onChange={(e) => {
           if (autogrow) {
-            e.target.style.height = "auto";
-            e.target.style.height = `${e.target.scrollHeight}px`;
+            e.target.style.height = "auto"
+            e.target.style.height = `${e.target.scrollHeight}px`
           }
 
           if (onChange) {
-            onChange(e);
+            onChange(e)
           }
         }}
         rows={rows ?? 3}
@@ -82,17 +80,17 @@ const BaseTextarea = forwardRef<HTMLTextAreaElement, BaseTextareaProps>(
         $style={styles?.self}
         {...(props as TextareaHTMLAttributes<HTMLTextAreaElement>)}
       />
-    );
-  }
-);
+    )
+  },
+)
 
 export interface TextareaProps
   extends Omit<BaseTextareaProps, "styles">,
     Omit<FieldLaneProps, "styles"> {
-  styles?: TextareaStyles & FieldLaneStyles;
+  styles?: TextareaStyles & FieldLaneStyles
 }
 
-export type TextareaDropdownOption = FieldLaneDropdownOption;
+export type TextareaDropdownOption = FieldLaneDropdownOption
 
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ ...props }, ref) => {
@@ -111,20 +109,23 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       labelPosition,
       className,
       ...rest
-    } = props;
+    } = props
     const inputId = StatefulForm.sanitizeId({
       prefix: "textarea",
       name: props.name,
       id: props.id,
-    });
+    })
 
     const {
       bodyStyle,
       containerStyle,
       controlStyle,
       labelStyle,
-      self: textareaStyles,
-    } = styles ?? {};
+      helperDrawerStyle,
+      helperIconStyle,
+      helperArrowStyle,
+      self,
+    } = styles ?? {}
 
     return (
       <FieldLane
@@ -147,6 +148,9 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           controlStyle,
           containerStyle,
           labelStyle,
+          helperDrawerStyle,
+          helperIconStyle,
+          helperArrowStyle,
         }}
       >
         <BaseTextarea
@@ -162,23 +166,23 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                 border-bottom-left-radius: 0px;
               `}
 
-              ${textareaStyles}
+              ${self};
             `,
           }}
           ref={ref}
         />
       </FieldLane>
-    );
-  }
-);
+    )
+  },
+)
 
 const TextareaInput = styled.textarea<{
-  $error?: boolean;
-  $style?: CSSProp;
-  $autogrow?: boolean;
-  $disabled?: boolean;
-  $theme?: TextareaThemeConfig;
-  $width?: string | number;
+  $error?: boolean
+  $style?: CSSProp
+  $autogrow?: boolean
+  $disabled?: boolean
+  $theme?: TextareaThemeConfig
+  $width?: string | number
 }>`
   border-radius: 2px;
   font-size: 0.75rem;
@@ -258,6 +262,6 @@ const TextareaInput = styled.textarea<{
     `}
 
   ${({ $style }) => $style}
-`;
+`
 
-export { Textarea };
+export { Textarea }

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -1,51 +1,51 @@
-import { RiEyeLine, RiEyeOffLine } from "@remixicon/react";
+import { RiEyeLine, RiEyeOffLine } from "@remixicon/react"
 import {
   ChangeEvent,
   InputHTMLAttributes,
   forwardRef,
   useEffect,
   useState,
-} from "react";
-import styled, { css, CSSProp } from "styled-components";
-import { Button } from "./button";
+} from "react"
+import styled, { css, CSSProp } from "styled-components"
+import { Button } from "./button"
 import {
   FieldLane,
   FieldLaneAction,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane";
-import { StatefulForm } from "./stateful-form";
-import { useTheme } from "./../theme/provider";
-import { TextboxThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
+} from "./field-lane"
+import { StatefulForm } from "./stateful-form"
+import { useTheme } from "./../theme/provider"
+import { TextboxThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
 
 interface BaseTextboxProps
   extends Omit<
     InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement>,
     "style"
   > {
-  showError?: boolean;
-  onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
-  styles?: TextboxStyles;
+  showError?: boolean
+  onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
+  styles?: TextboxStyles
 }
 
 export interface TextboxStyles {
-  self?: CSSProp;
+  self?: CSSProp
 }
 
 const BaseTextbox = forwardRef<HTMLInputElement, BaseTextboxProps>(
   ({ showError, onChange, styles, type = "text", id, ...props }, ref) => {
-    const { currentTheme } = useTheme();
-    const textboxTheme = currentTheme?.textbox;
+    const { currentTheme } = useTheme()
+    const textboxTheme = currentTheme?.textbox
 
-    const [showPassword, setShowPassword] = useState<boolean>(false);
+    const [showPassword, setShowPassword] = useState<boolean>(false)
 
     useEffect(() => {
       if (showError) {
-        setShowPassword(false);
+        setShowPassword(false)
       }
-    }, [showError]);
+    }, [showError])
 
     return (
       <>
@@ -105,19 +105,19 @@ const BaseTextbox = forwardRef<HTMLInputElement, BaseTextboxProps>(
           </Button>
         )}
       </>
-    );
-  }
-);
+    )
+  },
+)
 
-export type TextboxDropdownOption = FieldLaneDropdownOption;
+export type TextboxDropdownOption = FieldLaneDropdownOption
 
 export interface TextboxProps
   extends Omit<BaseTextboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "id" | "type"> {
-  styles?: TextboxStyles & FieldLaneStyles;
+  styles?: TextboxStyles & FieldLaneStyles
 }
 
-export type TextboxAction = FieldLaneAction;
+export type TextboxAction = FieldLaneAction
 
 const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
   ({ ...props }, ref) => {
@@ -136,13 +136,24 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
       labelWidth,
       className,
       ...rest
-    } = props;
+    } = props
 
     const inputId = StatefulForm.sanitizeId({
       prefix: "textbox",
       name: props.name,
       id: props.id,
-    });
+    })
+
+    const {
+      bodyStyle,
+      containerStyle,
+      controlStyle,
+      labelStyle,
+      helperDrawerStyle,
+      helperIconStyle,
+      helperArrowStyle,
+      self,
+    } = styles ?? {}
 
     return (
       <FieldLane
@@ -161,10 +172,13 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
         required={rest.required}
         className={applyClassName("textbox", className)}
         styles={{
-          bodyStyle: styles?.bodyStyle,
-          controlStyle: styles?.controlStyle,
-          containerStyle: styles?.containerStyle,
-          labelStyle: styles?.labelStyle,
+          bodyStyle,
+          controlStyle,
+          containerStyle,
+          labelStyle,
+          helperDrawerStyle,
+          helperIconStyle,
+          helperArrowStyle,
         }}
       >
         <BaseTextbox
@@ -179,22 +193,22 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
                 border-top-left-radius: 0px;
                 border-bottom-left-radius: 0px;
               `}
-              ${styles?.self}
+              ${self}
             `,
           }}
           type={type}
           ref={ref}
         />
       </FieldLane>
-    );
-  }
-);
+    )
+  },
+)
 
 const Input = styled.input<{
-  $error?: boolean;
-  $style?: CSSProp;
-  $disabled?: boolean;
-  $theme: TextboxThemeConfig;
+  $error?: boolean
+  $style?: CSSProp
+  $disabled?: boolean
+  $theme: TextboxThemeConfig
 }>`
   border-radius: 2px;
   font-size: 0.75rem;
@@ -256,6 +270,6 @@ const Input = styled.input<{
   }
 
   ${({ $style }) => $style}
-`;
+`
 
-export { Textbox };
+export { Textbox }

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -1,51 +1,51 @@
-import { RiEyeLine, RiEyeOffLine } from "@remixicon/react"
+import { RiEyeLine, RiEyeOffLine } from "@remixicon/react";
 import {
   ChangeEvent,
   InputHTMLAttributes,
   forwardRef,
   useEffect,
   useState,
-} from "react"
-import styled, { css, CSSProp } from "styled-components"
-import { Button } from "./button"
+} from "react";
+import styled, { css, CSSProp } from "styled-components";
+import { Button } from "./button";
 import {
   FieldLane,
   FieldLaneAction,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane"
-import { StatefulForm } from "./stateful-form"
-import { useTheme } from "./../theme/provider"
-import { TextboxThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
+} from "./field-lane";
+import { StatefulForm } from "./stateful-form";
+import { useTheme } from "./../theme/provider";
+import { TextboxThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseTextboxProps
   extends Omit<
     InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement>,
     "style"
   > {
-  showError?: boolean
-  onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
-  styles?: TextboxStyles
+  showError?: boolean;
+  onChange?: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  styles?: TextboxStyles;
 }
 
 export interface TextboxStyles {
-  self?: CSSProp
+  self?: CSSProp;
 }
 
 const BaseTextbox = forwardRef<HTMLInputElement, BaseTextboxProps>(
   ({ showError, onChange, styles, type = "text", id, ...props }, ref) => {
-    const { currentTheme } = useTheme()
-    const textboxTheme = currentTheme?.textbox
+    const { currentTheme } = useTheme();
+    const textboxTheme = currentTheme?.textbox;
 
-    const [showPassword, setShowPassword] = useState<boolean>(false)
+    const [showPassword, setShowPassword] = useState<boolean>(false);
 
     useEffect(() => {
       if (showError) {
-        setShowPassword(false)
+        setShowPassword(false);
       }
-    }, [showError])
+    }, [showError]);
 
     return (
       <>
@@ -105,19 +105,19 @@ const BaseTextbox = forwardRef<HTMLInputElement, BaseTextboxProps>(
           </Button>
         )}
       </>
-    )
-  },
-)
+    );
+  }
+);
 
-export type TextboxDropdownOption = FieldLaneDropdownOption
+export type TextboxDropdownOption = FieldLaneDropdownOption;
 
 export interface TextboxProps
   extends Omit<BaseTextboxProps, "styles">,
     Omit<FieldLaneProps, "styles" | "id" | "type"> {
-  styles?: TextboxStyles & FieldLaneStyles
+  styles?: TextboxStyles & FieldLaneStyles;
 }
 
-export type TextboxAction = FieldLaneAction
+export type TextboxAction = FieldLaneAction;
 
 const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
   ({ ...props }, ref) => {
@@ -136,13 +136,13 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
       labelWidth,
       className,
       ...rest
-    } = props
+    } = props;
 
     const inputId = StatefulForm.sanitizeId({
       prefix: "textbox",
       name: props.name,
       id: props.id,
-    })
+    });
 
     const {
       bodyStyle,
@@ -153,7 +153,7 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
       helperIconStyle,
       helperArrowStyle,
       self,
-    } = styles ?? {}
+    } = styles ?? {};
 
     return (
       <FieldLane
@@ -200,15 +200,15 @@ const Textbox = forwardRef<HTMLInputElement, TextboxProps>(
           ref={ref}
         />
       </FieldLane>
-    )
-  },
-)
+    );
+  }
+);
 
 const Input = styled.input<{
-  $error?: boolean
-  $style?: CSSProp
-  $disabled?: boolean
-  $theme: TextboxThemeConfig
+  $error?: boolean;
+  $style?: CSSProp;
+  $disabled?: boolean;
+  $theme: TextboxThemeConfig;
 }>`
   border-radius: 2px;
   font-size: 0.75rem;
@@ -270,6 +270,6 @@ const Input = styled.input<{
   }
 
   ${({ $style }) => $style}
-`
+`;
 
-export { Textbox }
+export { Textbox };

--- a/components/thumb-field.tsx
+++ b/components/thumb-field.tsx
@@ -4,48 +4,48 @@ import {
   RiThumbDownLine,
   RiThumbUpFill,
   RiThumbUpLine,
-} from "@remixicon/react";
-import { ChangeEvent, ReactNode, useRef, useState } from "react";
-import styled, { css, CSSProp } from "styled-components";
-import { StatefulForm } from "./stateful-form";
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { useTheme } from "./../theme/provider";
-import { ThumbFieldThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
+} from "@remixicon/react"
+import { ChangeEvent, ReactNode, useRef, useState } from "react"
+import styled, { css, CSSProp } from "styled-components"
+import { StatefulForm } from "./stateful-form"
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
+import { useTheme } from "./../theme/provider"
+import { ThumbFieldThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
 
 interface BaseThumbFieldProps {
-  value?: boolean | null;
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-  thumbsUpBackgroundColor?: string;
-  thumbsDownBackgroundColor?: string;
-  disabled?: boolean;
-  name?: string;
-  styles?: BaseThumbFieldStyles;
-  id?: string;
-  showError?: boolean;
-  thumbText?: ThumbFieldThumbText;
+  value?: boolean | null
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
+  thumbsUpBackgroundColor?: string
+  thumbsDownBackgroundColor?: string
+  disabled?: boolean
+  name?: string
+  styles?: BaseThumbFieldStyles
+  id?: string
+  showError?: boolean
+  thumbText?: ThumbFieldThumbText
 }
 
 export interface ThumbFieldThumbText {
-  up?: ReactNode;
-  down?: ReactNode;
+  up?: ReactNode
+  down?: ReactNode
 }
 
 interface BaseThumbFieldStyles {
-  triggerWrapperStyle?: CSSProp;
-  triggerUpStyle?: CSSProp;
-  triggerDownStyle?: CSSProp;
-  thumbUpTextStyle?: CSSProp;
-  thumbDownTextStyle?: CSSProp;
+  triggerWrapperStyle?: CSSProp
+  triggerUpStyle?: CSSProp
+  triggerDownStyle?: CSSProp
+  thumbUpTextStyle?: CSSProp
+  thumbDownTextStyle?: CSSProp
 }
 
 const ThumbFieldValue = {
   Up: "up",
   Down: "down",
   Blank: "blank",
-} as const;
+} as const
 
-type ThumbFieldValue = (typeof ThumbFieldValue)[keyof typeof ThumbFieldValue];
+type ThumbFieldValue = (typeof ThumbFieldValue)[keyof typeof ThumbFieldValue]
 
 function BaseThumbField({
   onChange,
@@ -59,26 +59,26 @@ function BaseThumbField({
   styles,
   id,
 }: BaseThumbFieldProps) {
-  const { currentTheme } = useTheme();
-  const thumbFieldTheme = currentTheme.thumbField;
+  const { currentTheme } = useTheme()
+  const thumbFieldTheme = currentTheme.thumbField
 
   const inputId = StatefulForm.sanitizeId({
     prefix: "thumbfield",
     name,
     id,
-  });
+  })
 
   const thumbValue =
     value === true
       ? ThumbFieldValue.Up
       : value === false
         ? ThumbFieldValue.Down
-        : ThumbFieldValue.Blank;
+        : ThumbFieldValue.Blank
 
-  const thumbInputRef = useRef<HTMLInputElement>(null);
+  const thumbInputRef = useRef<HTMLInputElement>(null)
 
   const handleChangeValue = (value: ThumbFieldValue) => {
-    if (disabled) return;
+    if (disabled) return
 
     if (onChange) {
       const syntheticEvent = {
@@ -91,11 +91,11 @@ function BaseThumbField({
                 ? false
                 : "",
         },
-      } as ChangeEvent<HTMLInputElement>;
+      } as ChangeEvent<HTMLInputElement>
 
-      onChange(syntheticEvent);
+      onChange(syntheticEvent)
     }
-  };
+  }
 
   return (
     <InputGroup aria-label="thumb-field" $style={styles?.triggerWrapperStyle}>
@@ -173,16 +173,15 @@ function BaseThumbField({
         </ErrorIconWrapper>
       )}
     </InputGroup>
-  );
+  )
 }
 
-export type ThumbFieldStyles = BaseThumbFieldStyles & FieldLaneStyles;
+export type ThumbFieldStyles = BaseThumbFieldStyles & FieldLaneStyles
 
 export interface ThumbFieldProps
-  extends
-    Omit<BaseThumbFieldProps, "styles">,
+  extends Omit<BaseThumbFieldProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: ThumbFieldStyles;
+  styles?: ThumbFieldStyles
 }
 
 function ThumbField({
@@ -204,15 +203,18 @@ function ThumbField({
     prefix: "ThumbField",
     name,
     id,
-  });
+  })
 
   const {
     bodyStyle,
     controlStyle,
     containerStyle,
     labelStyle,
+    helperDrawerStyle,
+    helperIconStyle,
+    helperArrowStyle,
     ...thumbFieldStyles
-  } = styles ?? {};
+  } = styles ?? {}
 
   return (
     <FieldLane
@@ -233,6 +235,9 @@ function ThumbField({
         controlStyle,
         containerStyle,
         labelStyle,
+        helperDrawerStyle,
+        helperIconStyle,
+        helperArrowStyle,
       }}
     >
       <BaseThumbField
@@ -244,14 +249,14 @@ function ThumbField({
         showError={showError}
       />
     </FieldLane>
-  );
+  )
 }
 
 const ThumbText = styled.span<{ $style?: CSSProp }>`
   font-size: 14px;
 
   ${({ $style }) => $style}
-`;
+`
 
 const InputGroup = styled.div<{ $style?: CSSProp }>`
   display: flex;
@@ -259,15 +264,15 @@ const InputGroup = styled.div<{ $style?: CSSProp }>`
   gap: 8px;
   align-items: center;
   ${({ $style }) => $style};
-`;
+`
 
 const TriggerWrapper = styled.div<{
-  $triggerStyle?: CSSProp;
-  $active?: boolean;
-  $activeColor?: string;
-  $showError?: boolean;
-  $disabled?: boolean;
-  $theme?: ThumbFieldThemeConfig;
+  $triggerStyle?: CSSProp
+  $active?: boolean
+  $activeColor?: string
+  $showError?: boolean
+  $disabled?: boolean
+  $theme?: ThumbFieldThemeConfig
 }>`
   display: flex;
   align-items: center;
@@ -299,7 +304,7 @@ const TriggerWrapper = styled.div<{
   }
 
   ${({ $triggerStyle }) => $triggerStyle}
-`;
+`
 
 const ErrorIconWrapper = styled.div`
   background-color: #dc2626;
@@ -309,6 +314,6 @@ const ErrorIconWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-`;
+`
 
-export { ThumbField };
+export { ThumbField }

--- a/components/thumb-field.tsx
+++ b/components/thumb-field.tsx
@@ -4,48 +4,48 @@ import {
   RiThumbDownLine,
   RiThumbUpFill,
   RiThumbUpLine,
-} from "@remixicon/react"
-import { ChangeEvent, ReactNode, useRef, useState } from "react"
-import styled, { css, CSSProp } from "styled-components"
-import { StatefulForm } from "./stateful-form"
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
-import { useTheme } from "./../theme/provider"
-import { ThumbFieldThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
+} from "@remixicon/react";
+import { ChangeEvent, ReactNode, useRef, useState } from "react";
+import styled, { css, CSSProp } from "styled-components";
+import { StatefulForm } from "./stateful-form";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
+import { useTheme } from "./../theme/provider";
+import { ThumbFieldThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseThumbFieldProps {
-  value?: boolean | null
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
-  thumbsUpBackgroundColor?: string
-  thumbsDownBackgroundColor?: string
-  disabled?: boolean
-  name?: string
-  styles?: BaseThumbFieldStyles
-  id?: string
-  showError?: boolean
-  thumbText?: ThumbFieldThumbText
+  value?: boolean | null;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  thumbsUpBackgroundColor?: string;
+  thumbsDownBackgroundColor?: string;
+  disabled?: boolean;
+  name?: string;
+  styles?: BaseThumbFieldStyles;
+  id?: string;
+  showError?: boolean;
+  thumbText?: ThumbFieldThumbText;
 }
 
 export interface ThumbFieldThumbText {
-  up?: ReactNode
-  down?: ReactNode
+  up?: ReactNode;
+  down?: ReactNode;
 }
 
 interface BaseThumbFieldStyles {
-  triggerWrapperStyle?: CSSProp
-  triggerUpStyle?: CSSProp
-  triggerDownStyle?: CSSProp
-  thumbUpTextStyle?: CSSProp
-  thumbDownTextStyle?: CSSProp
+  triggerWrapperStyle?: CSSProp;
+  triggerUpStyle?: CSSProp;
+  triggerDownStyle?: CSSProp;
+  thumbUpTextStyle?: CSSProp;
+  thumbDownTextStyle?: CSSProp;
 }
 
 const ThumbFieldValue = {
   Up: "up",
   Down: "down",
   Blank: "blank",
-} as const
+} as const;
 
-type ThumbFieldValue = (typeof ThumbFieldValue)[keyof typeof ThumbFieldValue]
+type ThumbFieldValue = (typeof ThumbFieldValue)[keyof typeof ThumbFieldValue];
 
 function BaseThumbField({
   onChange,
@@ -59,26 +59,26 @@ function BaseThumbField({
   styles,
   id,
 }: BaseThumbFieldProps) {
-  const { currentTheme } = useTheme()
-  const thumbFieldTheme = currentTheme.thumbField
+  const { currentTheme } = useTheme();
+  const thumbFieldTheme = currentTheme.thumbField;
 
   const inputId = StatefulForm.sanitizeId({
     prefix: "thumbfield",
     name,
     id,
-  })
+  });
 
   const thumbValue =
     value === true
       ? ThumbFieldValue.Up
       : value === false
         ? ThumbFieldValue.Down
-        : ThumbFieldValue.Blank
+        : ThumbFieldValue.Blank;
 
-  const thumbInputRef = useRef<HTMLInputElement>(null)
+  const thumbInputRef = useRef<HTMLInputElement>(null);
 
   const handleChangeValue = (value: ThumbFieldValue) => {
-    if (disabled) return
+    if (disabled) return;
 
     if (onChange) {
       const syntheticEvent = {
@@ -91,11 +91,11 @@ function BaseThumbField({
                 ? false
                 : "",
         },
-      } as ChangeEvent<HTMLInputElement>
+      } as ChangeEvent<HTMLInputElement>;
 
-      onChange(syntheticEvent)
+      onChange(syntheticEvent);
     }
-  }
+  };
 
   return (
     <InputGroup aria-label="thumb-field" $style={styles?.triggerWrapperStyle}>
@@ -173,15 +173,15 @@ function BaseThumbField({
         </ErrorIconWrapper>
       )}
     </InputGroup>
-  )
+  );
 }
 
-export type ThumbFieldStyles = BaseThumbFieldStyles & FieldLaneStyles
+export type ThumbFieldStyles = BaseThumbFieldStyles & FieldLaneStyles;
 
 export interface ThumbFieldProps
   extends Omit<BaseThumbFieldProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: ThumbFieldStyles
+  styles?: ThumbFieldStyles;
 }
 
 function ThumbField({
@@ -203,7 +203,7 @@ function ThumbField({
     prefix: "ThumbField",
     name,
     id,
-  })
+  });
 
   const {
     bodyStyle,
@@ -214,7 +214,7 @@ function ThumbField({
     helperIconStyle,
     helperArrowStyle,
     ...thumbFieldStyles
-  } = styles ?? {}
+  } = styles ?? {};
 
   return (
     <FieldLane
@@ -249,14 +249,14 @@ function ThumbField({
         showError={showError}
       />
     </FieldLane>
-  )
+  );
 }
 
 const ThumbText = styled.span<{ $style?: CSSProp }>`
   font-size: 14px;
 
   ${({ $style }) => $style}
-`
+`;
 
 const InputGroup = styled.div<{ $style?: CSSProp }>`
   display: flex;
@@ -264,15 +264,15 @@ const InputGroup = styled.div<{ $style?: CSSProp }>`
   gap: 8px;
   align-items: center;
   ${({ $style }) => $style};
-`
+`;
 
 const TriggerWrapper = styled.div<{
-  $triggerStyle?: CSSProp
-  $active?: boolean
-  $activeColor?: string
-  $showError?: boolean
-  $disabled?: boolean
-  $theme?: ThumbFieldThemeConfig
+  $triggerStyle?: CSSProp;
+  $active?: boolean;
+  $activeColor?: string;
+  $showError?: boolean;
+  $disabled?: boolean;
+  $theme?: ThumbFieldThemeConfig;
 }>`
   display: flex;
   align-items: center;
@@ -304,7 +304,7 @@ const TriggerWrapper = styled.div<{
   }
 
   ${({ $triggerStyle }) => $triggerStyle}
-`
+`;
 
 const ErrorIconWrapper = styled.div`
   background-color: #dc2626;
@@ -314,6 +314,6 @@ const ErrorIconWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-`
+`;
 
-export { ThumbField }
+export { ThumbField };

--- a/components/timebox.tsx
+++ b/components/timebox.tsx
@@ -7,49 +7,49 @@ import {
   useImperativeHandle,
   useRef,
   useState,
-} from "react";
-import styled, { css, CSSProp } from "styled-components";
+} from "react"
+import styled, { css, CSSProp } from "styled-components"
 import {
   FieldLane,
   FieldLaneAction,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane";
-import { StatefulForm } from "./stateful-form";
-import { useTheme } from "./../theme/provider";
-import { TimeboxThemeConfig } from "./../theme";
-import { applyClassName } from "./../constants/classname";
-import { Wheel } from "./wheel";
+} from "./field-lane"
+import { StatefulForm } from "./stateful-form"
+import { useTheme } from "./../theme/provider"
+import { TimeboxThemeConfig } from "./../theme"
+import { applyClassName } from "./../constants/classname"
+import { Wheel } from "./wheel"
 
 interface BaseTimeboxProps
   extends Omit<
     InputHTMLAttributes<HTMLInputElement>,
     "style" | "placeholder" | "value" | "name"
   > {
-  withSeconds?: boolean;
-  editable?: boolean;
-  styles?: TimeboxStyles;
-  showError?: boolean;
-  value?: string;
-  name?: string;
-  onKeyDown?: (e: KeyboardEvent<HTMLInputElement | HTMLDivElement>) => void;
-  placeholder?: TimeboxPlaceholder;
-  mobile?: boolean;
+  withSeconds?: boolean
+  editable?: boolean
+  styles?: TimeboxStyles
+  showError?: boolean
+  value?: string
+  name?: string
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement | HTMLDivElement>) => void
+  placeholder?: TimeboxPlaceholder
+  mobile?: boolean
 }
 
 export interface TimeboxStyles {
-  self?: CSSProp;
-  inputWrapperStyle?: CSSProp;
+  self?: CSSProp
+  inputWrapperStyle?: CSSProp
 }
 
 export interface TimeboxPlaceholder {
-  hour?: string;
-  minute?: string;
-  second?: string;
+  hour?: string
+  minute?: string
+  second?: string
 }
 
-export type TimeboxDropdownOption = FieldLaneDropdownOption;
+export type TimeboxDropdownOption = FieldLaneDropdownOption
 
 const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
   (
@@ -67,183 +67,183 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
       id,
       mobile,
     },
-    ref
+    ref,
   ) => {
-    const { currentTheme } = useTheme();
-    const timeboxTheme = currentTheme?.timebox;
+    const { currentTheme } = useTheme()
+    const timeboxTheme = currentTheme?.timebox
 
     const {
       hour: placeholderHour = "HH",
       minute: placeholderMinute = "MM",
       second: placeholderSecond = "SS",
-    } = placeholder ?? {};
+    } = placeholder ?? {}
 
-    const stateValue = value ? value : "";
+    const stateValue = value ? value : ""
 
-    const [valueLocal, setValueLocal] = useState<string>(stateValue);
-    const [hour, setHour] = useState<string>("");
-    const [minute, setMinute] = useState<string>("");
-    const [second, setSecond] = useState<string>("");
-    const [isFocused, setIsFocused] = useState(false);
+    const [valueLocal, setValueLocal] = useState<string>(stateValue)
+    const [hour, setHour] = useState<string>("")
+    const [minute, setMinute] = useState<string>("")
+    const [second, setSecond] = useState<string>("")
+    const [isFocused, setIsFocused] = useState(false)
 
-    const hourRef = useRef<HTMLInputElement>(null);
-    const minuteRef = useRef<HTMLInputElement>(null);
-    const secondRef = useRef<HTMLInputElement>(null);
+    const hourRef = useRef<HTMLInputElement>(null)
+    const minuteRef = useRef<HTMLInputElement>(null)
+    const secondRef = useRef<HTMLInputElement>(null)
 
-    const hasBeenFocused = useRef(false);
-    const blurTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const hasBeenFocused = useRef(false)
+    const blurTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-    const hourVal = useRef(hour);
-    const minuteVal = useRef(minute);
-    const secondVal = useRef(second);
+    const hourVal = useRef(hour)
+    const minuteVal = useRef(minute)
+    const secondVal = useRef(second)
 
-    useImperativeHandle(ref, () => hourRef.current!);
+    useImperativeHandle(ref, () => hourRef.current!)
 
-    const dataType = withSeconds ? `timebox-with-second` : `timebox`;
+    const dataType = withSeconds ? `timebox-with-second` : `timebox`
 
     useEffect(() => {
       if (valueLocal) {
-        const parts = valueLocal.split(":");
-        const [hh, mm, ss] = parts;
-        setHour(hh ?? "00");
-        setMinute(mm ?? "00");
-        setSecond(ss ?? "00");
+        const parts = valueLocal.split(":")
+        const [hh, mm, ss] = parts
+        setHour(hh ?? "00")
+        setMinute(mm ?? "00")
+        setSecond(ss ?? "00")
       }
-    }, []);
+    }, [])
 
     const handleChange = (
       type: "hour" | "minute" | "second",
-      value: string
+      value: string,
     ) => {
-      minuteVal.current = minute;
-      hourVal.current = hour;
-      secondVal.current = second;
+      minuteVal.current = minute
+      hourVal.current = hour
+      secondVal.current = second
 
-      const newDigit = value.slice(-1);
-      const numeric = /^\d$/.test(newDigit);
+      const newDigit = value.slice(-1)
+      const numeric = /^\d$/.test(newDigit)
 
-      if (!numeric && value !== "") return;
+      if (!numeric && value !== "") return
 
-      const maxValues = { hour: 24, minute: 59, second: 59 };
+      const maxValues = { hour: 24, minute: 59, second: 59 }
 
       const refMap = {
         hour: hourRef,
         minute: minuteRef,
         second: secondRef,
-      };
+      }
 
       const setters = {
         hour: setHour,
         minute: setMinute,
         second: setSecond,
-      };
+      }
 
       let nextType: "minute" | "second" | null =
         type === "hour"
           ? "minute"
           : type === "minute" && withSeconds
             ? "second"
-            : null;
+            : null
 
-      let nextHour = hour;
-      let nextMinute = minute;
-      let nextSecond = second;
+      let nextHour = hour
+      let nextMinute = minute
+      let nextSecond = second
 
       const setNext = (t: "hour" | "minute" | "second", val: string) => {
         if (t === "hour") {
-          nextHour = val;
-          hourVal.current = val;
+          nextHour = val
+          hourVal.current = val
         }
         if (t === "minute") {
-          nextMinute = val;
-          minuteVal.current = val;
+          nextMinute = val
+          minuteVal.current = val
         }
         if (t === "second") {
-          nextSecond = val;
-          secondVal.current = val;
+          nextSecond = val
+          secondVal.current = val
         }
-        setters[t](val);
-      };
+        setters[t](val)
+      }
 
       const callOnChange = () => {
         const formatted = [
           (nextHour || "0").padStart(2, "0"),
           (nextMinute || "0").padStart(2, "0"),
           (nextSecond || "0").padStart(2, "0"),
-        ].join(":");
+        ].join(":")
 
-        setValueLocal(formatted);
+        setValueLocal(formatted)
         if (onChange) {
           onChange({
             target: { name, value: formatted },
-          } as ChangeEvent<HTMLInputElement>);
+          } as ChangeEvent<HTMLInputElement>)
         }
-      };
+      }
 
       if (value.length <= 2) {
-        let num = Number(value);
+        let num = Number(value)
 
         if (value.length === 2 && num > maxValues[type]) {
-          const firstDigit = value[0];
-          const secondDigit = value[1];
+          const firstDigit = value[0]
+          const secondDigit = value[1]
 
-          setNext(type, firstDigit);
+          setNext(type, firstDigit)
 
           if (nextType && !mobile) {
-            refMap[nextType].current?.focus();
-            setNext(nextType, secondDigit);
+            refMap[nextType].current?.focus()
+            setNext(nextType, secondDigit)
           }
 
-          callOnChange();
-          return;
+          callOnChange()
+          return
         } else if (value.length === 2) {
-          setNext(type, value);
+          setNext(type, value)
           if (nextType && !mobile) {
-            refMap[nextType].current?.focus();
+            refMap[nextType].current?.focus()
           }
-          callOnChange();
-          return;
+          callOnChange()
+          return
         }
 
-        setNext(type, value);
+        setNext(type, value)
       }
 
       if (value.length > 2) {
-        const overflowDigit = value[value.length - 1];
-        const trimmedCurrent = value.slice(0, 2);
+        const overflowDigit = value[value.length - 1]
+        const trimmedCurrent = value.slice(0, 2)
 
-        setNext(type, trimmedCurrent);
+        setNext(type, trimmedCurrent)
 
         if (nextType && !mobile) {
-          refMap[nextType].current?.focus();
+          refMap[nextType].current?.focus()
 
-          const base = nextType === "minute" ? nextMinute : nextSecond;
-          const nextValue = (base + overflowDigit).slice(-2);
-          setNext(nextType, nextValue);
+          const base = nextType === "minute" ? nextMinute : nextSecond
+          const nextValue = (base + overflowDigit).slice(-2)
+          setNext(nextType, nextValue)
         }
       }
 
-      callOnChange();
-    };
+      callOnChange()
+    }
 
     const focusSmartField = () => {
       if (!hourVal.current || hourVal.current.length < 2) {
-        hourRef.current?.focus();
+        hourRef.current?.focus()
       } else if (!minuteVal.current || minuteVal.current.length < 2) {
-        minuteRef.current?.focus();
+        minuteRef.current?.focus()
       } else if (
         withSeconds &&
         (!secondVal.current || secondVal.current.length < 2)
       ) {
-        secondRef.current?.focus();
+        secondRef.current?.focus()
       } else {
         if (withSeconds) {
-          secondRef.current?.focus();
+          secondRef.current?.focus()
         } else {
-          minuteRef.current?.focus();
+          minuteRef.current?.focus()
         }
       }
-    };
+    }
 
     const wheelParts = {
       hour: {
@@ -258,7 +258,7 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
         id: "second",
         values: seconds,
       },
-    };
+    }
 
     return (
       <>
@@ -270,21 +270,21 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
           $theme={timeboxTheme}
           onKeyDown={(e) => {
             if (onKeyDown && !mobile) {
-              onKeyDown(e);
+              onKeyDown(e)
             }
           }}
           onBlur={() => {
-            setIsFocused(false);
+            setIsFocused(false)
 
-            if (blurTimeout.current) clearTimeout(blurTimeout.current);
+            if (blurTimeout.current) clearTimeout(blurTimeout.current)
             blurTimeout.current = setTimeout(() => {
               const anyFocused = [hourRef, minuteRef, secondRef].some(
-                (r) => r.current === document.activeElement
-              );
+                (r) => r.current === document.activeElement,
+              )
               if (!anyFocused) {
-                hasBeenFocused.current = false;
+                hasBeenFocused.current = false
               }
-            }, 0);
+            }, 0)
           }}
         >
           <Input
@@ -304,29 +304,29 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
             onChange={(e) => handleChange("hour", e.target.value)}
             $theme={timeboxTheme}
             onFocus={() => {
-              setIsFocused(true);
+              setIsFocused(true)
 
               if (!hasBeenFocused.current) {
-                hasBeenFocused.current = true;
-                focusSmartField();
+                hasBeenFocused.current = true
+                focusSmartField()
               }
             }}
             min={0}
             max={24}
             $inputStyle={styles?.self}
             onKeyDown={(e) => {
-              if (mobile) return;
+              if (mobile) return
 
-              const { selectionEnd, value } = e.currentTarget;
+              const { selectionEnd, value } = e.currentTarget
 
               if (e.key === "ArrowRight" && selectionEnd === value.length) {
-                e.preventDefault();
-                minuteRef.current?.focus();
+                e.preventDefault()
+                minuteRef.current?.focus()
               }
 
               if (e.key === ":") {
-                e.preventDefault();
-                minuteRef.current?.focus();
+                e.preventDefault()
+                minuteRef.current?.focus()
               }
             }}
           />
@@ -346,37 +346,37 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
             value={minute}
             onChange={(e) => handleChange("minute", e.target.value)}
             onFocus={() => {
-              setIsFocused(true);
+              setIsFocused(true)
             }}
             onBlur={() => {
-              setIsFocused(false);
+              setIsFocused(false)
             }}
             min={0}
             max={59}
             $inputStyle={styles?.self}
             onKeyDown={(e) => {
-              if (mobile) return;
+              if (mobile) return
 
-              const { selectionStart, selectionEnd, value } = e.currentTarget;
+              const { selectionStart, selectionEnd, value } = e.currentTarget
 
               if (e.key === "Backspace" && selectionStart === 0) {
-                e.preventDefault();
-                hourRef.current?.focus();
+                e.preventDefault()
+                hourRef.current?.focus()
               }
 
               if (e.key === "ArrowRight" && selectionEnd === value.length) {
-                e.preventDefault();
-                if (withSeconds) secondRef.current?.focus();
+                e.preventDefault()
+                if (withSeconds) secondRef.current?.focus()
               }
 
               if (e.key === "ArrowLeft" && selectionStart === 0) {
-                e.preventDefault();
-                hourRef.current?.focus();
+                e.preventDefault()
+                hourRef.current?.focus()
               }
 
               if (e.key === ":") {
-                e.preventDefault();
-                secondRef.current?.focus();
+                e.preventDefault()
+                secondRef.current?.focus()
               }
             }}
           />
@@ -398,29 +398,29 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
                 value={second}
                 onChange={(e) => handleChange("second", e.target.value)}
                 onFocus={() => {
-                  setIsFocused(true);
+                  setIsFocused(true)
                 }}
                 onBlur={() => {
-                  setIsFocused(false);
+                  setIsFocused(false)
                 }}
                 min={0}
                 max={59}
                 $inputStyle={styles?.self}
                 onKeyDown={(e) => {
-                  if (mobile) return;
+                  if (mobile) return
 
-                  const { selectionStart } = e.currentTarget;
+                  const { selectionStart } = e.currentTarget
                   if (e.key === "Backspace" && selectionStart === 0) {
-                    e.preventDefault();
-                    minuteRef.current?.focus();
+                    e.preventDefault()
+                    minuteRef.current?.focus()
                   }
 
                   if (
                     e.key === "ArrowLeft" &&
                     e.currentTarget.selectionStart === 0
                   ) {
-                    e.preventDefault();
-                    minuteRef.current?.focus();
+                    e.preventDefault()
+                    minuteRef.current?.focus()
                   }
                 }}
               />
@@ -450,13 +450,13 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
             }}
             onChange={(value, changedId) => {
               if (changedId === "hour") {
-                handleChange("hour", value.hour);
+                handleChange("hour", value.hour)
               }
               if (changedId === "minute") {
-                handleChange("minute", value.minute);
+                handleChange("minute", value.minute)
               }
               if (withSeconds && changedId === "second") {
-                handleChange("second", value.second);
+                handleChange("second", value.second)
               }
             }}
             parts={[
@@ -472,17 +472,17 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
           />
         )}
       </>
-    );
-  }
-);
+    )
+  },
+)
 
 export interface TimeboxProps
   extends Omit<BaseTimeboxProps, "styles" | "inputId">,
     Omit<FieldLaneProps, "styles" | "inputId" | "type"> {
-  styles?: TimeboxStyles & FieldLaneStyles;
+  styles?: TimeboxStyles & FieldLaneStyles
 }
 
-export type TimeboxAction = FieldLaneAction;
+export type TimeboxAction = FieldLaneAction
 
 const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
   ({ ...props }, ref) => {
@@ -500,16 +500,25 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
       labelPosition,
       className,
       ...rest
-    } = props;
+    } = props
 
     const inputId = StatefulForm.sanitizeId({
       prefix: "timebox",
       name: props.name,
       id: props.id,
-    });
+    })
 
-    const { bodyStyle, containerStyle, controlStyle, labelStyle } =
-      styles ?? {};
+    const {
+      bodyStyle,
+      containerStyle,
+      controlStyle,
+      labelStyle,
+      helperDrawerStyle,
+      helperIconStyle,
+      helperArrowStyle,
+      inputWrapperStyle,
+      self,
+    } = styles ?? {}
 
     return (
       <FieldLane
@@ -532,6 +541,9 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
           controlStyle,
           containerStyle,
           labelStyle,
+          helperDrawerStyle,
+          helperIconStyle,
+          helperArrowStyle,
         }}
       >
         <BaseTimebox
@@ -546,23 +558,23 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
               css`
                 border-top-left-radius: 0px;
                 border-bottom-left-radius: 0px;
-              `}
-              ${styles?.inputWrapperStyle}
+              `};
+              ${inputWrapperStyle};
             `,
-            self: styles?.self,
+            self,
           }}
         />
       </FieldLane>
-    );
-  }
-);
+    )
+  },
+)
 
 const InputGroup = styled.div<{
-  $focused: boolean;
-  $error: boolean;
-  $style?: CSSProp;
-  $disabled?: boolean;
-  $theme?: TimeboxThemeConfig;
+  $focused: boolean
+  $error: boolean
+  $style?: CSSProp
+  $disabled?: boolean
+  $theme?: TimeboxThemeConfig
 }>`
   display: flex;
   flex-direction: row;
@@ -591,11 +603,11 @@ const InputGroup = styled.div<{
         `};
 
   ${({ $style }) => $style}
-`;
+`
 
 const Input = styled.input<{
-  $inputStyle?: CSSProp;
-  $theme?: TimeboxThemeConfig;
+  $inputStyle?: CSSProp
+  $theme?: TimeboxThemeConfig
 }>`
   min-width: 50px;
   max-width: 50px;
@@ -628,22 +640,22 @@ const Input = styled.input<{
   }
 
   ${({ $inputStyle }) => $inputStyle}
-`;
+`
 
 const Colon = styled.span<{ $theme?: TimeboxThemeConfig }>`
   transform: translateY(-1px);
-`;
+`
 
 const hours = Array.from({ length: 24 }, (_, i) => {
-  const h = i;
-  return { value: h.toString(), text: h.toString() };
-});
+  const h = i
+  return { value: h.toString(), text: h.toString() }
+})
 
 const minutes = Array.from({ length: 60 }, (_, i) => ({
   value: i.toString(),
   text: i.toString().padStart(2, "0"),
-}));
+}))
 
-const seconds = minutes;
+const seconds = minutes
 
-export { Timebox };
+export { Timebox }

--- a/components/timebox.tsx
+++ b/components/timebox.tsx
@@ -7,49 +7,49 @@ import {
   useImperativeHandle,
   useRef,
   useState,
-} from "react"
-import styled, { css, CSSProp } from "styled-components"
+} from "react";
+import styled, { css, CSSProp } from "styled-components";
 import {
   FieldLane,
   FieldLaneAction,
   FieldLaneDropdownOption,
   FieldLaneProps,
   FieldLaneStyles,
-} from "./field-lane"
-import { StatefulForm } from "./stateful-form"
-import { useTheme } from "./../theme/provider"
-import { TimeboxThemeConfig } from "./../theme"
-import { applyClassName } from "./../constants/classname"
-import { Wheel } from "./wheel"
+} from "./field-lane";
+import { StatefulForm } from "./stateful-form";
+import { useTheme } from "./../theme/provider";
+import { TimeboxThemeConfig } from "./../theme";
+import { applyClassName } from "./../constants/classname";
+import { Wheel } from "./wheel";
 
 interface BaseTimeboxProps
   extends Omit<
     InputHTMLAttributes<HTMLInputElement>,
     "style" | "placeholder" | "value" | "name"
   > {
-  withSeconds?: boolean
-  editable?: boolean
-  styles?: TimeboxStyles
-  showError?: boolean
-  value?: string
-  name?: string
-  onKeyDown?: (e: KeyboardEvent<HTMLInputElement | HTMLDivElement>) => void
-  placeholder?: TimeboxPlaceholder
-  mobile?: boolean
+  withSeconds?: boolean;
+  editable?: boolean;
+  styles?: TimeboxStyles;
+  showError?: boolean;
+  value?: string;
+  name?: string;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement | HTMLDivElement>) => void;
+  placeholder?: TimeboxPlaceholder;
+  mobile?: boolean;
 }
 
 export interface TimeboxStyles {
-  self?: CSSProp
-  inputWrapperStyle?: CSSProp
+  self?: CSSProp;
+  inputWrapperStyle?: CSSProp;
 }
 
 export interface TimeboxPlaceholder {
-  hour?: string
-  minute?: string
-  second?: string
+  hour?: string;
+  minute?: string;
+  second?: string;
 }
 
-export type TimeboxDropdownOption = FieldLaneDropdownOption
+export type TimeboxDropdownOption = FieldLaneDropdownOption;
 
 const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
   (
@@ -67,183 +67,183 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
       id,
       mobile,
     },
-    ref,
+    ref
   ) => {
-    const { currentTheme } = useTheme()
-    const timeboxTheme = currentTheme?.timebox
+    const { currentTheme } = useTheme();
+    const timeboxTheme = currentTheme?.timebox;
 
     const {
       hour: placeholderHour = "HH",
       minute: placeholderMinute = "MM",
       second: placeholderSecond = "SS",
-    } = placeholder ?? {}
+    } = placeholder ?? {};
 
-    const stateValue = value ? value : ""
+    const stateValue = value ? value : "";
 
-    const [valueLocal, setValueLocal] = useState<string>(stateValue)
-    const [hour, setHour] = useState<string>("")
-    const [minute, setMinute] = useState<string>("")
-    const [second, setSecond] = useState<string>("")
-    const [isFocused, setIsFocused] = useState(false)
+    const [valueLocal, setValueLocal] = useState<string>(stateValue);
+    const [hour, setHour] = useState<string>("");
+    const [minute, setMinute] = useState<string>("");
+    const [second, setSecond] = useState<string>("");
+    const [isFocused, setIsFocused] = useState(false);
 
-    const hourRef = useRef<HTMLInputElement>(null)
-    const minuteRef = useRef<HTMLInputElement>(null)
-    const secondRef = useRef<HTMLInputElement>(null)
+    const hourRef = useRef<HTMLInputElement>(null);
+    const minuteRef = useRef<HTMLInputElement>(null);
+    const secondRef = useRef<HTMLInputElement>(null);
 
-    const hasBeenFocused = useRef(false)
-    const blurTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const hasBeenFocused = useRef(false);
+    const blurTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    const hourVal = useRef(hour)
-    const minuteVal = useRef(minute)
-    const secondVal = useRef(second)
+    const hourVal = useRef(hour);
+    const minuteVal = useRef(minute);
+    const secondVal = useRef(second);
 
-    useImperativeHandle(ref, () => hourRef.current!)
+    useImperativeHandle(ref, () => hourRef.current!);
 
-    const dataType = withSeconds ? `timebox-with-second` : `timebox`
+    const dataType = withSeconds ? `timebox-with-second` : `timebox`;
 
     useEffect(() => {
       if (valueLocal) {
-        const parts = valueLocal.split(":")
-        const [hh, mm, ss] = parts
-        setHour(hh ?? "00")
-        setMinute(mm ?? "00")
-        setSecond(ss ?? "00")
+        const parts = valueLocal.split(":");
+        const [hh, mm, ss] = parts;
+        setHour(hh ?? "00");
+        setMinute(mm ?? "00");
+        setSecond(ss ?? "00");
       }
-    }, [])
+    }, []);
 
     const handleChange = (
       type: "hour" | "minute" | "second",
-      value: string,
+      value: string
     ) => {
-      minuteVal.current = minute
-      hourVal.current = hour
-      secondVal.current = second
+      minuteVal.current = minute;
+      hourVal.current = hour;
+      secondVal.current = second;
 
-      const newDigit = value.slice(-1)
-      const numeric = /^\d$/.test(newDigit)
+      const newDigit = value.slice(-1);
+      const numeric = /^\d$/.test(newDigit);
 
-      if (!numeric && value !== "") return
+      if (!numeric && value !== "") return;
 
-      const maxValues = { hour: 24, minute: 59, second: 59 }
+      const maxValues = { hour: 24, minute: 59, second: 59 };
 
       const refMap = {
         hour: hourRef,
         minute: minuteRef,
         second: secondRef,
-      }
+      };
 
       const setters = {
         hour: setHour,
         minute: setMinute,
         second: setSecond,
-      }
+      };
 
       let nextType: "minute" | "second" | null =
         type === "hour"
           ? "minute"
           : type === "minute" && withSeconds
             ? "second"
-            : null
+            : null;
 
-      let nextHour = hour
-      let nextMinute = minute
-      let nextSecond = second
+      let nextHour = hour;
+      let nextMinute = minute;
+      let nextSecond = second;
 
       const setNext = (t: "hour" | "minute" | "second", val: string) => {
         if (t === "hour") {
-          nextHour = val
-          hourVal.current = val
+          nextHour = val;
+          hourVal.current = val;
         }
         if (t === "minute") {
-          nextMinute = val
-          minuteVal.current = val
+          nextMinute = val;
+          minuteVal.current = val;
         }
         if (t === "second") {
-          nextSecond = val
-          secondVal.current = val
+          nextSecond = val;
+          secondVal.current = val;
         }
-        setters[t](val)
-      }
+        setters[t](val);
+      };
 
       const callOnChange = () => {
         const formatted = [
           (nextHour || "0").padStart(2, "0"),
           (nextMinute || "0").padStart(2, "0"),
           (nextSecond || "0").padStart(2, "0"),
-        ].join(":")
+        ].join(":");
 
-        setValueLocal(formatted)
+        setValueLocal(formatted);
         if (onChange) {
           onChange({
             target: { name, value: formatted },
-          } as ChangeEvent<HTMLInputElement>)
+          } as ChangeEvent<HTMLInputElement>);
         }
-      }
+      };
 
       if (value.length <= 2) {
-        let num = Number(value)
+        let num = Number(value);
 
         if (value.length === 2 && num > maxValues[type]) {
-          const firstDigit = value[0]
-          const secondDigit = value[1]
+          const firstDigit = value[0];
+          const secondDigit = value[1];
 
-          setNext(type, firstDigit)
+          setNext(type, firstDigit);
 
           if (nextType && !mobile) {
-            refMap[nextType].current?.focus()
-            setNext(nextType, secondDigit)
+            refMap[nextType].current?.focus();
+            setNext(nextType, secondDigit);
           }
 
-          callOnChange()
-          return
+          callOnChange();
+          return;
         } else if (value.length === 2) {
-          setNext(type, value)
+          setNext(type, value);
           if (nextType && !mobile) {
-            refMap[nextType].current?.focus()
+            refMap[nextType].current?.focus();
           }
-          callOnChange()
-          return
+          callOnChange();
+          return;
         }
 
-        setNext(type, value)
+        setNext(type, value);
       }
 
       if (value.length > 2) {
-        const overflowDigit = value[value.length - 1]
-        const trimmedCurrent = value.slice(0, 2)
+        const overflowDigit = value[value.length - 1];
+        const trimmedCurrent = value.slice(0, 2);
 
-        setNext(type, trimmedCurrent)
+        setNext(type, trimmedCurrent);
 
         if (nextType && !mobile) {
-          refMap[nextType].current?.focus()
+          refMap[nextType].current?.focus();
 
-          const base = nextType === "minute" ? nextMinute : nextSecond
-          const nextValue = (base + overflowDigit).slice(-2)
-          setNext(nextType, nextValue)
+          const base = nextType === "minute" ? nextMinute : nextSecond;
+          const nextValue = (base + overflowDigit).slice(-2);
+          setNext(nextType, nextValue);
         }
       }
 
-      callOnChange()
-    }
+      callOnChange();
+    };
 
     const focusSmartField = () => {
       if (!hourVal.current || hourVal.current.length < 2) {
-        hourRef.current?.focus()
+        hourRef.current?.focus();
       } else if (!minuteVal.current || minuteVal.current.length < 2) {
-        minuteRef.current?.focus()
+        minuteRef.current?.focus();
       } else if (
         withSeconds &&
         (!secondVal.current || secondVal.current.length < 2)
       ) {
-        secondRef.current?.focus()
+        secondRef.current?.focus();
       } else {
         if (withSeconds) {
-          secondRef.current?.focus()
+          secondRef.current?.focus();
         } else {
-          minuteRef.current?.focus()
+          minuteRef.current?.focus();
         }
       }
-    }
+    };
 
     const wheelParts = {
       hour: {
@@ -258,7 +258,7 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
         id: "second",
         values: seconds,
       },
-    }
+    };
 
     return (
       <>
@@ -270,21 +270,21 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
           $theme={timeboxTheme}
           onKeyDown={(e) => {
             if (onKeyDown && !mobile) {
-              onKeyDown(e)
+              onKeyDown(e);
             }
           }}
           onBlur={() => {
-            setIsFocused(false)
+            setIsFocused(false);
 
-            if (blurTimeout.current) clearTimeout(blurTimeout.current)
+            if (blurTimeout.current) clearTimeout(blurTimeout.current);
             blurTimeout.current = setTimeout(() => {
               const anyFocused = [hourRef, minuteRef, secondRef].some(
-                (r) => r.current === document.activeElement,
-              )
+                (r) => r.current === document.activeElement
+              );
               if (!anyFocused) {
-                hasBeenFocused.current = false
+                hasBeenFocused.current = false;
               }
-            }, 0)
+            }, 0);
           }}
         >
           <Input
@@ -304,29 +304,29 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
             onChange={(e) => handleChange("hour", e.target.value)}
             $theme={timeboxTheme}
             onFocus={() => {
-              setIsFocused(true)
+              setIsFocused(true);
 
               if (!hasBeenFocused.current) {
-                hasBeenFocused.current = true
-                focusSmartField()
+                hasBeenFocused.current = true;
+                focusSmartField();
               }
             }}
             min={0}
             max={24}
             $inputStyle={styles?.self}
             onKeyDown={(e) => {
-              if (mobile) return
+              if (mobile) return;
 
-              const { selectionEnd, value } = e.currentTarget
+              const { selectionEnd, value } = e.currentTarget;
 
               if (e.key === "ArrowRight" && selectionEnd === value.length) {
-                e.preventDefault()
-                minuteRef.current?.focus()
+                e.preventDefault();
+                minuteRef.current?.focus();
               }
 
               if (e.key === ":") {
-                e.preventDefault()
-                minuteRef.current?.focus()
+                e.preventDefault();
+                minuteRef.current?.focus();
               }
             }}
           />
@@ -346,37 +346,37 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
             value={minute}
             onChange={(e) => handleChange("minute", e.target.value)}
             onFocus={() => {
-              setIsFocused(true)
+              setIsFocused(true);
             }}
             onBlur={() => {
-              setIsFocused(false)
+              setIsFocused(false);
             }}
             min={0}
             max={59}
             $inputStyle={styles?.self}
             onKeyDown={(e) => {
-              if (mobile) return
+              if (mobile) return;
 
-              const { selectionStart, selectionEnd, value } = e.currentTarget
+              const { selectionStart, selectionEnd, value } = e.currentTarget;
 
               if (e.key === "Backspace" && selectionStart === 0) {
-                e.preventDefault()
-                hourRef.current?.focus()
+                e.preventDefault();
+                hourRef.current?.focus();
               }
 
               if (e.key === "ArrowRight" && selectionEnd === value.length) {
-                e.preventDefault()
-                if (withSeconds) secondRef.current?.focus()
+                e.preventDefault();
+                if (withSeconds) secondRef.current?.focus();
               }
 
               if (e.key === "ArrowLeft" && selectionStart === 0) {
-                e.preventDefault()
-                hourRef.current?.focus()
+                e.preventDefault();
+                hourRef.current?.focus();
               }
 
               if (e.key === ":") {
-                e.preventDefault()
-                secondRef.current?.focus()
+                e.preventDefault();
+                secondRef.current?.focus();
               }
             }}
           />
@@ -398,29 +398,29 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
                 value={second}
                 onChange={(e) => handleChange("second", e.target.value)}
                 onFocus={() => {
-                  setIsFocused(true)
+                  setIsFocused(true);
                 }}
                 onBlur={() => {
-                  setIsFocused(false)
+                  setIsFocused(false);
                 }}
                 min={0}
                 max={59}
                 $inputStyle={styles?.self}
                 onKeyDown={(e) => {
-                  if (mobile) return
+                  if (mobile) return;
 
-                  const { selectionStart } = e.currentTarget
+                  const { selectionStart } = e.currentTarget;
                   if (e.key === "Backspace" && selectionStart === 0) {
-                    e.preventDefault()
-                    minuteRef.current?.focus()
+                    e.preventDefault();
+                    minuteRef.current?.focus();
                   }
 
                   if (
                     e.key === "ArrowLeft" &&
                     e.currentTarget.selectionStart === 0
                   ) {
-                    e.preventDefault()
-                    minuteRef.current?.focus()
+                    e.preventDefault();
+                    minuteRef.current?.focus();
                   }
                 }}
               />
@@ -450,13 +450,13 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
             }}
             onChange={(value, changedId) => {
               if (changedId === "hour") {
-                handleChange("hour", value.hour)
+                handleChange("hour", value.hour);
               }
               if (changedId === "minute") {
-                handleChange("minute", value.minute)
+                handleChange("minute", value.minute);
               }
               if (withSeconds && changedId === "second") {
-                handleChange("second", value.second)
+                handleChange("second", value.second);
               }
             }}
             parts={[
@@ -472,17 +472,17 @@ const BaseTimebox = forwardRef<HTMLInputElement, BaseTimeboxProps>(
           />
         )}
       </>
-    )
-  },
-)
+    );
+  }
+);
 
 export interface TimeboxProps
   extends Omit<BaseTimeboxProps, "styles" | "inputId">,
     Omit<FieldLaneProps, "styles" | "inputId" | "type"> {
-  styles?: TimeboxStyles & FieldLaneStyles
+  styles?: TimeboxStyles & FieldLaneStyles;
 }
 
-export type TimeboxAction = FieldLaneAction
+export type TimeboxAction = FieldLaneAction;
 
 const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
   ({ ...props }, ref) => {
@@ -500,13 +500,13 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
       labelPosition,
       className,
       ...rest
-    } = props
+    } = props;
 
     const inputId = StatefulForm.sanitizeId({
       prefix: "timebox",
       name: props.name,
       id: props.id,
-    })
+    });
 
     const {
       bodyStyle,
@@ -518,7 +518,7 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
       helperArrowStyle,
       inputWrapperStyle,
       self,
-    } = styles ?? {}
+    } = styles ?? {};
 
     return (
       <FieldLane
@@ -565,16 +565,16 @@ const Timebox = forwardRef<HTMLInputElement, TimeboxProps>(
           }}
         />
       </FieldLane>
-    )
-  },
-)
+    );
+  }
+);
 
 const InputGroup = styled.div<{
-  $focused: boolean
-  $error: boolean
-  $style?: CSSProp
-  $disabled?: boolean
-  $theme?: TimeboxThemeConfig
+  $focused: boolean;
+  $error: boolean;
+  $style?: CSSProp;
+  $disabled?: boolean;
+  $theme?: TimeboxThemeConfig;
 }>`
   display: flex;
   flex-direction: row;
@@ -603,11 +603,11 @@ const InputGroup = styled.div<{
         `};
 
   ${({ $style }) => $style}
-`
+`;
 
 const Input = styled.input<{
-  $inputStyle?: CSSProp
-  $theme?: TimeboxThemeConfig
+  $inputStyle?: CSSProp;
+  $theme?: TimeboxThemeConfig;
 }>`
   min-width: 50px;
   max-width: 50px;
@@ -640,22 +640,22 @@ const Input = styled.input<{
   }
 
   ${({ $inputStyle }) => $inputStyle}
-`
+`;
 
 const Colon = styled.span<{ $theme?: TimeboxThemeConfig }>`
   transform: translateY(-1px);
-`
+`;
 
 const hours = Array.from({ length: 24 }, (_, i) => {
-  const h = i
-  return { value: h.toString(), text: h.toString() }
-})
+  const h = i;
+  return { value: h.toString(), text: h.toString() };
+});
 
 const minutes = Array.from({ length: 60 }, (_, i) => ({
   value: i.toString(),
   text: i.toString().padStart(2, "0"),
-}))
+}));
 
-const seconds = minutes
+const seconds = minutes;
 
-export { Timebox }
+export { Timebox };

--- a/components/toggle.tsx
+++ b/components/toggle.tsx
@@ -1,34 +1,34 @@
-import { ChangeEvent, InputHTMLAttributes } from "react"
-import { motion } from "framer-motion"
-import { LoadingSpinner } from "./loading-spinner"
-import styled, { css, CSSProp } from "styled-components"
-import { StatefulForm } from "./stateful-form"
-import { Figure, FigureProps } from "./figure"
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
-import { useTheme } from "../theme/provider"
-import { ToggleThemeConfig } from "../theme"
-import { applyClassName } from "./../constants/classname"
+import { ChangeEvent, InputHTMLAttributes } from "react";
+import { motion } from "framer-motion";
+import { LoadingSpinner } from "./loading-spinner";
+import styled, { css, CSSProp } from "styled-components";
+import { StatefulForm } from "./stateful-form";
+import { Figure, FigureProps } from "./figure";
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
+import { useTheme } from "../theme/provider";
+import { ToggleThemeConfig } from "../theme";
+import { applyClassName } from "./../constants/classname";
 
 interface BaseToggleProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "style"> {
-  checked?: boolean
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
-  icon?: FigureProps
-  isLoading?: boolean
-  name?: string
-  label?: string
-  description?: string
-  size?: number
-  styles?: BaseToggleStyles
+  checked?: boolean;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  icon?: FigureProps;
+  isLoading?: boolean;
+  name?: string;
+  label?: string;
+  description?: string;
+  size?: number;
+  styles?: BaseToggleStyles;
 }
 
 interface BaseToggleStyles {
-  descriptionStyle?: CSSProp
-  rowStyle?: CSSProp
-  textWrapperStyle?: CSSProp
-  errorStyle?: CSSProp
-  labelStyle?: CSSProp
-  titleStyle?: CSSProp
+  descriptionStyle?: CSSProp;
+  rowStyle?: CSSProp;
+  textWrapperStyle?: CSSProp;
+  errorStyle?: CSSProp;
+  labelStyle?: CSSProp;
+  titleStyle?: CSSProp;
 }
 
 function BaseToggle({
@@ -45,11 +45,11 @@ function BaseToggle({
   disabled,
   ...props
 }: BaseToggleProps) {
-  const { currentTheme } = useTheme()
-  const toggleTheme = currentTheme.toggle
+  const { currentTheme } = useTheme();
+  const toggleTheme = currentTheme.toggle;
 
   const { heightWrapper, widthWrapper, thumbShift, iconSize } =
-    getToggleSize(size)
+    getToggleSize(size);
 
   return (
     <ToggleWrapper
@@ -80,9 +80,9 @@ function BaseToggle({
           checked={checked}
           disabled={disabled}
           onChange={(e) => {
-            if (disabled) return
+            if (disabled) return;
             if (onChange) {
-              onChange(e)
+              onChange(e);
             }
           }}
         />
@@ -134,15 +134,15 @@ function BaseToggle({
         </ToggleTextWrapper>
       )}
     </ToggleWrapper>
-  )
+  );
 }
 
-export type ToggleStyles = BaseToggleStyles & FieldLaneStyles
+export type ToggleStyles = BaseToggleStyles & FieldLaneStyles;
 
 export interface ToggleProps
   extends Omit<BaseToggleProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: ToggleStyles
+  styles?: ToggleStyles;
 }
 
 function Toggle({
@@ -166,7 +166,7 @@ function Toggle({
     prefix: "toggle",
     name,
     id,
-  })
+  });
 
   const {
     bodyStyle,
@@ -177,7 +177,7 @@ function Toggle({
     helperIconStyle,
     helperArrowStyle,
     ...toggleStyles
-  } = styles ?? {}
+  } = styles ?? {};
 
   return (
     <FieldLane
@@ -216,27 +216,27 @@ function Toggle({
         description={description}
       />
     </FieldLane>
-  )
+  );
 }
 
 const getToggleSize = (size: number) => {
-  const widthWrapper = size * 2
-  const heightWrapper = size * 1
-  const thumbShift = size * 1.02
-  const iconSize = size * 0.6
+  const widthWrapper = size * 2;
+  const heightWrapper = size * 1;
+  const thumbShift = size * 1.02;
+  const iconSize = size * 0.6;
 
   return {
     widthWrapper,
     heightWrapper,
     thumbShift,
     iconSize,
-  }
-}
+  };
+};
 
 const ToggleWrapper = styled.div<{
-  $style?: CSSProp
-  $disabled?: boolean
-  $theme?: ToggleThemeConfig
+  $style?: CSSProp;
+  $disabled?: boolean;
+  $theme?: ToggleThemeConfig;
 }>`
   display: flex;
   flex-direction: row;
@@ -255,7 +255,7 @@ const ToggleWrapper = styled.div<{
     `};
 
   ${({ $style }) => $style}
-`
+`;
 
 const ToggleTextWrapper = styled.div<{ $style?: CSSProp }>`
   display: flex;
@@ -263,7 +263,7 @@ const ToggleTextWrapper = styled.div<{ $style?: CSSProp }>`
   width: 100%;
 
   ${({ $style }) => $style}
-`
+`;
 
 const StyledLabel = styled(motion.label)<{ $disabled?: boolean }>`
   position: relative;
@@ -278,18 +278,18 @@ const StyledLabel = styled(motion.label)<{ $disabled?: boolean }>`
       cursor: not-allowed;
       pointer-events: none;
     `}
-`
+`;
 
 const StyledInput = styled.input`
   position: absolute;
   width: 0;
   height: 0;
   opacity: 0;
-`
+`;
 
 const ToggleBackground = styled.div<{
-  $checked: boolean
-  $theme?: ToggleThemeConfig
+  $checked: boolean;
+  $theme?: ToggleThemeConfig;
 }>`
   width: 100%;
   height: 100%;
@@ -299,10 +299,10 @@ const ToggleBackground = styled.div<{
   background-color: ${({ $checked, $theme }) =>
     $checked ? $theme?.checkedBackgroundColor : $theme?.backgroundColor};
   border: 1px solid ${({ $theme }) => $theme?.borderColor};
-`
+`;
 
 const ToggleButton = styled(motion.div)<{
-  $theme?: ToggleThemeConfig
+  $theme?: ToggleThemeConfig;
 }>`
   position: absolute;
   top: 0;
@@ -313,16 +313,16 @@ const ToggleButton = styled(motion.div)<{
   border-radius: 9999px;
   background-color: ${({ $theme }) => $theme?.thumbColor};
   box-shadow: ${({ $theme }) => $theme?.boxShadow};
-`
+`;
 
 const Description = styled.span<{
-  $style?: CSSProp
-  $theme?: ToggleThemeConfig
+  $style?: CSSProp;
+  $theme?: ToggleThemeConfig;
 }>`
   font-size: 12px;
   width: 100%;
   color: ${({ $theme }) => $theme?.descriptionColor};
   ${({ $style }) => $style}
-`
+`;
 
-export { Toggle }
+export { Toggle };

--- a/components/toggle.tsx
+++ b/components/toggle.tsx
@@ -1,34 +1,34 @@
-import { ChangeEvent, InputHTMLAttributes } from "react";
-import { motion } from "framer-motion";
-import { LoadingSpinner } from "./loading-spinner";
-import styled, { css, CSSProp } from "styled-components";
-import { StatefulForm } from "./stateful-form";
-import { Figure, FigureProps } from "./figure";
-import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane";
-import { useTheme } from "../theme/provider";
-import { ToggleThemeConfig } from "../theme";
-import { applyClassName } from "./../constants/classname";
+import { ChangeEvent, InputHTMLAttributes } from "react"
+import { motion } from "framer-motion"
+import { LoadingSpinner } from "./loading-spinner"
+import styled, { css, CSSProp } from "styled-components"
+import { StatefulForm } from "./stateful-form"
+import { Figure, FigureProps } from "./figure"
+import { FieldLane, FieldLaneProps, FieldLaneStyles } from "./field-lane"
+import { useTheme } from "../theme/provider"
+import { ToggleThemeConfig } from "../theme"
+import { applyClassName } from "./../constants/classname"
 
 interface BaseToggleProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "style"> {
-  checked?: boolean;
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-  icon?: FigureProps;
-  isLoading?: boolean;
-  name?: string;
-  label?: string;
-  description?: string;
-  size?: number;
-  styles?: BaseToggleStyles;
+  checked?: boolean
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
+  icon?: FigureProps
+  isLoading?: boolean
+  name?: string
+  label?: string
+  description?: string
+  size?: number
+  styles?: BaseToggleStyles
 }
 
 interface BaseToggleStyles {
-  descriptionStyle?: CSSProp;
-  rowStyle?: CSSProp;
-  textWrapperStyle?: CSSProp;
-  errorStyle?: CSSProp;
-  labelStyle?: CSSProp;
-  titleStyle?: CSSProp;
+  descriptionStyle?: CSSProp
+  rowStyle?: CSSProp
+  textWrapperStyle?: CSSProp
+  errorStyle?: CSSProp
+  labelStyle?: CSSProp
+  titleStyle?: CSSProp
 }
 
 function BaseToggle({
@@ -45,11 +45,11 @@ function BaseToggle({
   disabled,
   ...props
 }: BaseToggleProps) {
-  const { currentTheme } = useTheme();
-  const toggleTheme = currentTheme.toggle;
+  const { currentTheme } = useTheme()
+  const toggleTheme = currentTheme.toggle
 
   const { heightWrapper, widthWrapper, thumbShift, iconSize } =
-    getToggleSize(size);
+    getToggleSize(size)
 
   return (
     <ToggleWrapper
@@ -80,9 +80,9 @@ function BaseToggle({
           checked={checked}
           disabled={disabled}
           onChange={(e) => {
-            if (disabled) return;
+            if (disabled) return
             if (onChange) {
-              onChange(e);
+              onChange(e)
             }
           }}
         />
@@ -134,15 +134,15 @@ function BaseToggle({
         </ToggleTextWrapper>
       )}
     </ToggleWrapper>
-  );
+  )
 }
 
-export type ToggleStyles = BaseToggleStyles & FieldLaneStyles;
+export type ToggleStyles = BaseToggleStyles & FieldLaneStyles
 
 export interface ToggleProps
   extends Omit<BaseToggleProps, "styles">,
     Omit<FieldLaneProps, "styles" | "type" | "dropdowns" | "actions"> {
-  styles?: ToggleStyles;
+  styles?: ToggleStyles
 }
 
 function Toggle({
@@ -166,15 +166,18 @@ function Toggle({
     prefix: "toggle",
     name,
     id,
-  });
+  })
 
   const {
     bodyStyle,
     controlStyle,
     containerStyle,
     titleStyle,
+    helperDrawerStyle,
+    helperIconStyle,
+    helperArrowStyle,
     ...toggleStyles
-  } = styles ?? {};
+  } = styles ?? {}
 
   return (
     <FieldLane
@@ -199,6 +202,9 @@ function Toggle({
         controlStyle,
         containerStyle,
         labelStyle: titleStyle,
+        helperDrawerStyle,
+        helperIconStyle,
+        helperArrowStyle,
       }}
     >
       <BaseToggle
@@ -210,27 +216,27 @@ function Toggle({
         description={description}
       />
     </FieldLane>
-  );
+  )
 }
 
 const getToggleSize = (size: number) => {
-  const widthWrapper = size * 2;
-  const heightWrapper = size * 1;
-  const thumbShift = size * 1.02;
-  const iconSize = size * 0.6;
+  const widthWrapper = size * 2
+  const heightWrapper = size * 1
+  const thumbShift = size * 1.02
+  const iconSize = size * 0.6
 
   return {
     widthWrapper,
     heightWrapper,
     thumbShift,
     iconSize,
-  };
-};
+  }
+}
 
 const ToggleWrapper = styled.div<{
-  $style?: CSSProp;
-  $disabled?: boolean;
-  $theme?: ToggleThemeConfig;
+  $style?: CSSProp
+  $disabled?: boolean
+  $theme?: ToggleThemeConfig
 }>`
   display: flex;
   flex-direction: row;
@@ -249,7 +255,7 @@ const ToggleWrapper = styled.div<{
     `};
 
   ${({ $style }) => $style}
-`;
+`
 
 const ToggleTextWrapper = styled.div<{ $style?: CSSProp }>`
   display: flex;
@@ -257,7 +263,7 @@ const ToggleTextWrapper = styled.div<{ $style?: CSSProp }>`
   width: 100%;
 
   ${({ $style }) => $style}
-`;
+`
 
 const StyledLabel = styled(motion.label)<{ $disabled?: boolean }>`
   position: relative;
@@ -272,18 +278,18 @@ const StyledLabel = styled(motion.label)<{ $disabled?: boolean }>`
       cursor: not-allowed;
       pointer-events: none;
     `}
-`;
+`
 
 const StyledInput = styled.input`
   position: absolute;
   width: 0;
   height: 0;
   opacity: 0;
-`;
+`
 
 const ToggleBackground = styled.div<{
-  $checked: boolean;
-  $theme?: ToggleThemeConfig;
+  $checked: boolean
+  $theme?: ToggleThemeConfig
 }>`
   width: 100%;
   height: 100%;
@@ -293,10 +299,10 @@ const ToggleBackground = styled.div<{
   background-color: ${({ $checked, $theme }) =>
     $checked ? $theme?.checkedBackgroundColor : $theme?.backgroundColor};
   border: 1px solid ${({ $theme }) => $theme?.borderColor};
-`;
+`
 
 const ToggleButton = styled(motion.div)<{
-  $theme?: ToggleThemeConfig;
+  $theme?: ToggleThemeConfig
 }>`
   position: absolute;
   top: 0;
@@ -307,16 +313,16 @@ const ToggleButton = styled(motion.div)<{
   border-radius: 9999px;
   background-color: ${({ $theme }) => $theme?.thumbColor};
   box-shadow: ${({ $theme }) => $theme?.boxShadow};
-`;
+`
 
 const Description = styled.span<{
-  $style?: CSSProp;
-  $theme?: ToggleThemeConfig;
+  $style?: CSSProp
+  $theme?: ToggleThemeConfig
 }>`
   font-size: 12px;
   width: 100%;
   color: ${({ $theme }) => $theme?.descriptionColor};
   ${({ $style }) => $style}
-`;
+`
 
-export { Toggle };
+export { Toggle }

--- a/package.json
+++ b/package.json
@@ -438,6 +438,7 @@
     "fast-glob": "^3.3.3",
     "fs-extra": "^11.3.4",
     "globals": "^15.15.0",
+    "oxfmt": "^0.62.0",
     "prettier": "^3.5.3",
     "storybook": "^8.6.14",
     "typescript": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -438,7 +438,6 @@
     "fast-glob": "^3.3.3",
     "fs-extra": "^11.3.4",
     "globals": "^15.15.0",
-    "oxfmt": "^0.62.0",
     "prettier": "^3.5.3",
     "storybook": "^8.6.14",
     "typescript": "^5.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       globals:
         specifier: ^15.15.0
         version: 15.15.0
+      oxfmt:
+        specifier: ^0.62.0
+        version: 0.62.0
       prettier:
         specifier: ^3.5.3
         version: 3.6.2
@@ -633,6 +636,120 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxfmt/binding-android-arm-eabi@0.62.0':
+    resolution: {integrity: sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.62.0':
+    resolution: {integrity: sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.62.0':
+    resolution: {integrity: sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.62.0':
+    resolution: {integrity: sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.62.0':
+    resolution: {integrity: sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.62.0':
+    resolution: {integrity: sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.62.0':
+    resolution: {integrity: sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.62.0':
+    resolution: {integrity: sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-musl@0.62.0':
+    resolution: {integrity: sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
+    resolution: {integrity: sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
+    resolution: {integrity: sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.62.0':
+    resolution: {integrity: sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.62.0':
+    resolution: {integrity: sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-gnu@0.62.0':
+    resolution: {integrity: sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-musl@0.62.0':
+    resolution: {integrity: sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-openharmony-arm64@0.62.0':
+    resolution: {integrity: sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.62.0':
+    resolution: {integrity: sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.62.0':
+    resolution: {integrity: sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.62.0':
+    resolution: {integrity: sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2444,6 +2561,19 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  oxfmt@0.62.0:
+    resolution: {integrity: sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-limit@1.3.0:
     resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
     engines: {node: '>=4'}
@@ -2910,6 +3040,10 @@ packages:
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
@@ -3619,6 +3753,63 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@oxfmt/binding-android-arm-eabi@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.62.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.62.0':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -5681,6 +5872,30 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  oxfmt@0.62.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.62.0
+      '@oxfmt/binding-android-arm64': 0.62.0
+      '@oxfmt/binding-darwin-arm64': 0.62.0
+      '@oxfmt/binding-darwin-x64': 0.62.0
+      '@oxfmt/binding-freebsd-x64': 0.62.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.62.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.62.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.62.0
+      '@oxfmt/binding-linux-arm64-musl': 0.62.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.62.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.62.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.62.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.62.0
+      '@oxfmt/binding-linux-x64-gnu': 0.62.0
+      '@oxfmt/binding-linux-x64-musl': 0.62.0
+      '@oxfmt/binding-openharmony-arm64': 0.62.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.62.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.62.0
+      '@oxfmt/binding-win32-x64-msvc': 0.62.0
+
   p-limit@1.3.0:
     dependencies:
       p-try: 1.0.0
@@ -6220,6 +6435,8 @@ snapshots:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@1.2.0:
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,22 +1,23 @@
-lockfileVersion: "9.0"
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
+
   .:
     dependencies:
-      "@floating-ui/react":
+      '@floating-ui/react':
         specifier: ^0.27.8
         version: 0.27.15(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      "@hookform/resolvers":
+      '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.2.1(react-hook-form@7.61.1(react@19.1.1))
-      "@remixicon/react":
+      '@remixicon/react':
         specifier: ^4.6.0
         version: 4.6.0(react@19.1.1)
-      "@tanstack/react-virtual":
+      '@tanstack/react-virtual':
         specifier: ^3.14.5
         version: 3.14.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       framer-motion:
@@ -47,58 +48,58 @@ importers:
         specifier: ^3.24.4
         version: 3.25.76
     devDependencies:
-      "@babel/parser":
+      '@babel/parser':
         specifier: ^7.29.2
         version: 7.29.2
-      "@babel/traverse":
+      '@babel/traverse':
         specifier: ^7.29.0
         version: 7.29.0
-      "@eslint/js":
+      '@eslint/js':
         specifier: ^9.26.0
         version: 9.32.0
-      "@storybook/addon-essentials":
+      '@storybook/addon-essentials':
         specifier: ^8.6.14
         version: 8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/addon-storysource":
+      '@storybook/addon-storysource':
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/blocks":
+      '@storybook/blocks':
         specifier: ^8.6.14
         version: 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/core-events":
+      '@storybook/core-events':
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/manager-api":
+      '@storybook/manager-api':
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/preview-api":
+      '@storybook/preview-api':
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/react":
+      '@storybook/react':
         specifier: ^8.6.14
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)
-      "@storybook/react-vite":
+      '@storybook/react-vite':
         specifier: ^8.6.14
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
-      "@storybook/theming":
+      '@storybook/theming':
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@testing-library/cypress":
+      '@testing-library/cypress':
         specifier: ^10.0.3
         version: 10.0.3(cypress@14.5.3)
-      "@types/react":
+      '@types/react':
         specifier: ^19.1.9
         version: 19.1.9
-      "@types/react-dom":
+      '@types/react-dom':
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
-      "@typescript-eslint/eslint-plugin":
+      '@typescript-eslint/eslint-plugin':
         specifier: ^8.32.1
         version: 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      "@typescript-eslint/parser":
+      '@typescript-eslint/parser':
         specifier: ^8.32.1
         version: 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      "@vitejs/plugin-react":
+      '@vitejs/plugin-react':
         specifier: ^4.4.1
         version: 4.7.0(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       barrelsby:
@@ -131,9 +132,6 @@ importers:
       globals:
         specifier: ^15.15.0
         version: 15.15.0
-      oxfmt:
-        specifier: ^0.62.0
-        version: 0.62.0
       prettier:
         specifier: ^3.5.3
         version: 3.6.2
@@ -148,1259 +146,675 @@ importers:
         version: 6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)
 
 packages:
-  "@adobe/css-tools@4.4.3":
-    resolution:
-      {
-        integrity: sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==,
-      }
 
-  "@ampproject/remapping@2.3.0":
-    resolution:
-      {
-        integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==,
-      }
-    engines: { node: ">=6.0.0" }
+  '@adobe/css-tools@4.4.3':
+    resolution: {integrity: sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==}
 
-  "@babel/code-frame@7.27.1":
-    resolution:
-      {
-        integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
-  "@babel/code-frame@7.29.0":
-    resolution:
-      {
-        integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/compat-data@7.28.0":
-    resolution:
-      {
-        integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/core@7.28.0":
-    resolution:
-      {
-        integrity: sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/compat-data@7.28.0':
+    resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/generator@7.28.0":
-    resolution:
-      {
-        integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/core@7.28.0':
+    resolution: {integrity: sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/generator@7.29.1":
-    resolution:
-      {
-        integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/generator@7.28.0':
+    resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-compilation-targets@7.27.2":
-    resolution:
-      {
-        integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-globals@7.28.0":
-    resolution:
-      {
-        integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-compilation-targets@7.27.2':
+    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-module-imports@7.27.1":
-    resolution:
-      {
-        integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-module-transforms@7.27.3":
-    resolution:
-      {
-        integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-module-imports@7.27.1':
+    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.27.3':
+    resolution: {integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
-      "@babel/core": ^7.0.0
+      '@babel/core': ^7.0.0
 
-  "@babel/helper-plugin-utils@7.27.1":
-    resolution:
-      {
-        integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-plugin-utils@7.27.1':
+    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-string-parser@7.27.1":
-    resolution:
-      {
-        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-validator-identifier@7.27.1":
-    resolution:
-      {
-        integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-validator-identifier@7.28.5":
-    resolution:
-      {
-        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helper-validator-option@7.27.1":
-    resolution:
-      {
-        integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/helpers@7.28.2":
-    resolution:
-      {
-        integrity: sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/helpers@7.28.2':
+    resolution: {integrity: sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/parser@7.29.2":
-    resolution:
-      {
-        integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==,
-      }
-    engines: { node: ">=6.0.0" }
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
-  "@babel/plugin-transform-react-jsx-self@7.27.1":
-    resolution:
-      {
-        integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      '@babel/core': ^7.0.0-0
 
-  "@babel/plugin-transform-react-jsx-source@7.27.1":
-    resolution:
-      {
-        integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      '@babel/core': ^7.0.0-0
 
-  "@babel/runtime@7.28.2":
-    resolution:
-      {
-        integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/runtime@7.28.2':
+    resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/template@7.27.2":
-    resolution:
-      {
-        integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/template@7.27.2':
+    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/template@7.28.6":
-    resolution:
-      {
-        integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/traverse@7.29.0":
-    resolution:
-      {
-        integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/types@7.28.2":
-    resolution:
-      {
-        integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
+    engines: {node: '>=6.9.0'}
 
-  "@babel/types@7.29.0":
-    resolution:
-      {
-        integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
-      }
-    engines: { node: ">=6.9.0" }
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
 
-  "@cypress/request@3.0.9":
-    resolution:
-      {
-        integrity: sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==,
-      }
-    engines: { node: ">= 6" }
+  '@cypress/request@3.0.9':
+    resolution: {integrity: sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==}
+    engines: {node: '>= 6'}
 
-  "@cypress/xvfb@1.2.4":
-    resolution:
-      {
-        integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==,
-      }
+  '@cypress/xvfb@1.2.4':
+    resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
 
-  "@emotion/is-prop-valid@1.2.2":
-    resolution:
-      {
-        integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==,
-      }
+  '@emotion/is-prop-valid@1.2.2':
+    resolution: {integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==}
 
-  "@emotion/memoize@0.8.1":
-    resolution:
-      {
-        integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==,
-      }
+  '@emotion/memoize@0.8.1':
+    resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
 
-  "@emotion/unitless@0.8.1":
-    resolution:
-      {
-        integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==,
-      }
+  '@emotion/unitless@0.8.1':
+    resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
 
-  "@esbuild/aix-ppc64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/aix-ppc64@0.25.8':
+    resolution: {integrity: sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-arm64@0.25.8':
+    resolution: {integrity: sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  "@esbuild/android-arm@0.25.8":
-    resolution:
-      {
-        integrity: sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-arm@0.25.8':
+    resolution: {integrity: sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-x64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-x64@0.25.8':
+    resolution: {integrity: sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  "@esbuild/darwin-arm64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/darwin-arm64@0.25.8':
+    resolution: {integrity: sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  "@esbuild/darwin-x64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/darwin-x64@0.25.8':
+    resolution: {integrity: sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/freebsd-arm64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/freebsd-arm64@0.25.8':
+    resolution: {integrity: sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  "@esbuild/freebsd-x64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/freebsd-x64@0.25.8':
+    resolution: {integrity: sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/linux-arm64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-arm64@0.25.8':
+    resolution: {integrity: sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  "@esbuild/linux-arm@0.25.8":
-    resolution:
-      {
-        integrity: sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-arm@0.25.8':
+    resolution: {integrity: sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.25.8":
-    resolution:
-      {
-        integrity: sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-ia32@0.25.8':
+    resolution: {integrity: sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  "@esbuild/linux-loong64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-loong64@0.25.8':
+    resolution: {integrity: sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.25.8":
-    resolution:
-      {
-        integrity: sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-mips64el@0.25.8':
+    resolution: {integrity: sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  "@esbuild/linux-ppc64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-ppc64@0.25.8':
+    resolution: {integrity: sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-riscv64@0.25.8':
+    resolution: {integrity: sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-s390x@0.25.8":
-    resolution:
-      {
-        integrity: sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-s390x@0.25.8':
+    resolution: {integrity: sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-x64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-x64@0.25.8':
+    resolution: {integrity: sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/netbsd-arm64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/netbsd-arm64@0.25.8':
+    resolution: {integrity: sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/netbsd-x64@0.25.8':
+    resolution: {integrity: sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/openbsd-arm64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openbsd-arm64@0.25.8':
+    resolution: {integrity: sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  "@esbuild/openbsd-x64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openbsd-x64@0.25.8':
+    resolution: {integrity: sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openharmony-arm64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openharmony-arm64@0.25.8':
+    resolution: {integrity: sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  "@esbuild/sunos-x64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/sunos-x64@0.25.8':
+    resolution: {integrity: sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/win32-arm64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-arm64@0.25.8':
+    resolution: {integrity: sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.25.8":
-    resolution:
-      {
-        integrity: sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-ia32@0.25.8':
+    resolution: {integrity: sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-x64@0.25.8":
-    resolution:
-      {
-        integrity: sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-x64@0.25.8':
+    resolution: {integrity: sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  "@eslint-community/eslint-utils@4.7.0":
-    resolution:
-      {
-        integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==,
-      }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+  '@eslint-community/eslint-utils@4.7.0':
+    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  "@eslint-community/regexpp@4.12.1":
-    resolution:
-      {
-        integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==,
-      }
-    engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
+  '@eslint-community/regexpp@4.12.1':
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  "@eslint/config-array@0.21.0":
-    resolution:
-      {
-        integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/config-array@0.21.0':
+    resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@eslint/config-helpers@0.3.0":
-    resolution:
-      {
-        integrity: sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/config-helpers@0.3.0':
+    resolution: {integrity: sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@eslint/core@0.15.1":
-    resolution:
-      {
-        integrity: sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/core@0.15.1':
+    resolution: {integrity: sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@eslint/eslintrc@3.3.1":
-    resolution:
-      {
-        integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@eslint/js@9.32.0":
-    resolution:
-      {
-        integrity: sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/js@9.32.0':
+    resolution: {integrity: sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@eslint/object-schema@2.1.6":
-    resolution:
-      {
-        integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/object-schema@2.1.6':
+    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@eslint/plugin-kit@0.3.4":
-    resolution:
-      {
-        integrity: sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@eslint/plugin-kit@0.3.4':
+    resolution: {integrity: sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@floating-ui/core@1.7.3":
-    resolution:
-      {
-        integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==,
-      }
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
-  "@floating-ui/dom@1.7.3":
-    resolution:
-      {
-        integrity: sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==,
-      }
+  '@floating-ui/dom@1.7.3':
+    resolution: {integrity: sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==}
 
-  "@floating-ui/react-dom@2.1.5":
-    resolution:
-      {
-        integrity: sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==,
-      }
+  '@floating-ui/react-dom@2.1.5':
+    resolution: {integrity: sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==}
     peerDependencies:
-      react: ">=16.8.0"
-      react-dom: ">=16.8.0"
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
-  "@floating-ui/react@0.27.15":
-    resolution:
-      {
-        integrity: sha512-0LGxhBi3BB1DwuSNQAmuaSuertFzNAerlMdPbotjTVnvPtdOs7CkrHLaev5NIXemhzDXNC0tFzuseut7cWA5mw==,
-      }
+  '@floating-ui/react@0.27.15':
+    resolution: {integrity: sha512-0LGxhBi3BB1DwuSNQAmuaSuertFzNAerlMdPbotjTVnvPtdOs7CkrHLaev5NIXemhzDXNC0tFzuseut7cWA5mw==}
     peerDependencies:
-      react: ">=17.0.0"
-      react-dom: ">=17.0.0"
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
 
-  "@floating-ui/utils@0.2.10":
-    resolution:
-      {
-        integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==,
-      }
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  "@hookform/resolvers@5.2.1":
-    resolution:
-      {
-        integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==,
-      }
+  '@hookform/resolvers@5.2.1':
+    resolution: {integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==}
     peerDependencies:
       react-hook-form: ^7.55.0
 
-  "@humanfs/core@0.19.1":
-    resolution:
-      {
-        integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
-      }
-    engines: { node: ">=18.18.0" }
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
 
-  "@humanfs/node@0.16.6":
-    resolution:
-      {
-        integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==,
-      }
-    engines: { node: ">=18.18.0" }
+  '@humanfs/node@0.16.6':
+    resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
+    engines: {node: '>=18.18.0'}
 
-  "@humanwhocodes/module-importer@1.0.1":
-    resolution:
-      {
-        integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==,
-      }
-    engines: { node: ">=12.22" }
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
 
-  "@humanwhocodes/retry@0.3.1":
-    resolution:
-      {
-        integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==,
-      }
-    engines: { node: ">=18.18" }
+  '@humanwhocodes/retry@0.3.1':
+    resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
+    engines: {node: '>=18.18'}
 
-  "@humanwhocodes/retry@0.4.3":
-    resolution:
-      {
-        integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
-      }
-    engines: { node: ">=18.18" }
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
-  "@isaacs/cliui@8.0.2":
-    resolution:
-      {
-        integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==,
-      }
-    engines: { node: ">=12" }
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
 
-  "@joshwooding/vite-plugin-react-docgen-typescript@0.5.0":
-    resolution:
-      {
-        integrity: sha512-qYDdL7fPwLRI+bJNurVcis+tNgJmvWjH4YTBGXTA8xMuxFrnAz6E5o35iyzyKbq5J5Lr8mJGfrR5GXl+WGwhgQ==,
-      }
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0':
+    resolution: {integrity: sha512-qYDdL7fPwLRI+bJNurVcis+tNgJmvWjH4YTBGXTA8xMuxFrnAz6E5o35iyzyKbq5J5Lr8mJGfrR5GXl+WGwhgQ==}
     peerDependencies:
-      typescript: ">= 4.3.x"
+      typescript: '>= 4.3.x'
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  "@jridgewell/gen-mapping@0.3.12":
-    resolution:
-      {
-        integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==,
-      }
+  '@jridgewell/gen-mapping@0.3.12':
+    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
 
-  "@jridgewell/resolve-uri@3.1.2":
-    resolution:
-      {
-        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
-      }
-    engines: { node: ">=6.0.0" }
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
 
-  "@jridgewell/source-map@0.3.11":
-    resolution:
-      {
-        integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==,
-      }
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
 
-  "@jridgewell/sourcemap-codec@1.5.4":
-    resolution:
-      {
-        integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==,
-      }
+  '@jridgewell/sourcemap-codec@1.5.4':
+    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
 
-  "@jridgewell/trace-mapping@0.3.29":
-    resolution:
-      {
-        integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==,
-      }
+  '@jridgewell/trace-mapping@0.3.29':
+    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
-  "@mdx-js/react@3.1.0":
-    resolution:
-      {
-        integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==,
-      }
+  '@mdx-js/react@3.1.0':
+    resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
     peerDependencies:
-      "@types/react": ">=16"
-      react: ">=16"
+      '@types/react': '>=16'
+      react: '>=16'
 
-  "@napi-rs/canvas-android-arm64@0.1.99":
-    resolution:
-      {
-        integrity: sha512-9OCRt8VVxA17m32NWZKyNC2qamdaS/SC5CEOIQwFngRq0DIeVm4PDal+6Ljnhqm2whZiC63DNuKZ4xSp2nbj9w==,
-      }
-    engines: { node: ">= 10" }
+  '@napi-rs/canvas-android-arm64@0.1.99':
+    resolution: {integrity: sha512-9OCRt8VVxA17m32NWZKyNC2qamdaS/SC5CEOIQwFngRq0DIeVm4PDal+6Ljnhqm2whZiC63DNuKZ4xSp2nbj9w==}
+    engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
 
-  "@napi-rs/canvas-darwin-arm64@0.1.99":
-    resolution:
-      {
-        integrity: sha512-lupMDMy1+H38dhyCcLirOKKVUyzzlxi7j7rGPLI3vViMHOoPjcXO1b10ivy+ad+q6MiwHfoLjKTCoLke5ySOBg==,
-      }
-    engines: { node: ">= 10" }
+  '@napi-rs/canvas-darwin-arm64@0.1.99':
+    resolution: {integrity: sha512-lupMDMy1+H38dhyCcLirOKKVUyzzlxi7j7rGPLI3vViMHOoPjcXO1b10ivy+ad+q6MiwHfoLjKTCoLke5ySOBg==}
+    engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  "@napi-rs/canvas-darwin-x64@0.1.99":
-    resolution:
-      {
-        integrity: sha512-fdz02t4w8n6Ii/rYhWig6STb/zcTmCC/6YZTGmjoDeidDwn9Wf0ukQVynhCPEs29vqUc66wHZKsuIgMs9tycCg==,
-      }
-    engines: { node: ">= 10" }
+  '@napi-rs/canvas-darwin-x64@0.1.99':
+    resolution: {integrity: sha512-fdz02t4w8n6Ii/rYhWig6STb/zcTmCC/6YZTGmjoDeidDwn9Wf0ukQVynhCPEs29vqUc66wHZKsuIgMs9tycCg==}
+    engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  "@napi-rs/canvas-linux-arm-gnueabihf@0.1.99":
-    resolution:
-      {
-        integrity: sha512-w4FwVwlNo00ezeRhfY62IVIyt6G3u8wodkPtiqWc52BUHx+VDBUM2vkS3ogfANaLI7hnf3s6WK4LyZVUjBg1lA==,
-      }
-    engines: { node: ">= 10" }
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.99':
+    resolution: {integrity: sha512-w4FwVwlNo00ezeRhfY62IVIyt6G3u8wodkPtiqWc52BUHx+VDBUM2vkS3ogfANaLI7hnf3s6WK4LyZVUjBg1lA==}
+    engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  "@napi-rs/canvas-linux-arm64-gnu@0.1.99":
-    resolution:
-      {
-        integrity: sha512-8JvHeexKQ8c7g0q7YJ29NVQwnf1ePghP9ys9ZN0R0qzyqJQ9Uw6N9qnDINArlm3IYHexB7LjzArIfhQiqSDGvQ==,
-      }
-    engines: { node: ">= 10" }
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.99':
+    resolution: {integrity: sha512-8JvHeexKQ8c7g0q7YJ29NVQwnf1ePghP9ys9ZN0R0qzyqJQ9Uw6N9qnDINArlm3IYHexB7LjzArIfhQiqSDGvQ==}
+    engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  "@napi-rs/canvas-linux-arm64-musl@0.1.99":
-    resolution:
-      {
-        integrity: sha512-Z+6nyLdJXWzLPVxi4H6g9TJop4DwN3KSgHWto5JCbZV5/uKoVqcSynPs0tGlUHOoWI8S8tEvJspz51GQkvr07w==,
-      }
-    engines: { node: ">= 10" }
+  '@napi-rs/canvas-linux-arm64-musl@0.1.99':
+    resolution: {integrity: sha512-Z+6nyLdJXWzLPVxi4H6g9TJop4DwN3KSgHWto5JCbZV5/uKoVqcSynPs0tGlUHOoWI8S8tEvJspz51GQkvr07w==}
+    engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  "@napi-rs/canvas-linux-riscv64-gnu@0.1.99":
-    resolution:
-      {
-        integrity: sha512-jAnfOUv4IO1l8Levk5t85oVtEBOXLa07KnIUgWo1CDlPxiqpxS3uBfiE38Lvj/CQgHaNF6Nxk/SaemwLgsVJgw==,
-      }
-    engines: { node: ">= 10" }
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.99':
+    resolution: {integrity: sha512-jAnfOUv4IO1l8Levk5t85oVtEBOXLa07KnIUgWo1CDlPxiqpxS3uBfiE38Lvj/CQgHaNF6Nxk/SaemwLgsVJgw==}
+    engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
 
-  "@napi-rs/canvas-linux-x64-gnu@0.1.99":
-    resolution:
-      {
-        integrity: sha512-mIkXw3fGmbYyFjSmfWEvty4jN+rwEOmv0+Dy9bRvvTzLYWCgm3RMgUEQVfAKFw96nIRFnyNZiK83KNQaVVFjng==,
-      }
-    engines: { node: ">= 10" }
+  '@napi-rs/canvas-linux-x64-gnu@0.1.99':
+    resolution: {integrity: sha512-mIkXw3fGmbYyFjSmfWEvty4jN+rwEOmv0+Dy9bRvvTzLYWCgm3RMgUEQVfAKFw96nIRFnyNZiK83KNQaVVFjng==}
+    engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  "@napi-rs/canvas-linux-x64-musl@0.1.99":
-    resolution:
-      {
-        integrity: sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==,
-      }
-    engines: { node: ">= 10" }
+  '@napi-rs/canvas-linux-x64-musl@0.1.99':
+    resolution: {integrity: sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==}
+    engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  "@napi-rs/canvas-win32-arm64-msvc@0.1.99":
-    resolution:
-      {
-        integrity: sha512-XE6KUkfqRsCNejcoRMiMr3RaUeObxNf6y7dut3hrq2rn7PzfRTZgrjF1F/B2C7FcdgqY/vSHWpQeMuNz1vTNHg==,
-      }
-    engines: { node: ">= 10" }
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.99':
+    resolution: {integrity: sha512-XE6KUkfqRsCNejcoRMiMr3RaUeObxNf6y7dut3hrq2rn7PzfRTZgrjF1F/B2C7FcdgqY/vSHWpQeMuNz1vTNHg==}
+    engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  "@napi-rs/canvas-win32-x64-msvc@0.1.99":
-    resolution:
-      {
-        integrity: sha512-plMYGVbc/vmmPF9MtmHbwNk1rL1Aj53vQZt+Gnv1oZn6gmd9jEHHJ0n9Nd2nxa5sKH7TS5IjkCDM6289O0d6PQ==,
-      }
-    engines: { node: ">= 10" }
+  '@napi-rs/canvas-win32-x64-msvc@0.1.99':
+    resolution: {integrity: sha512-plMYGVbc/vmmPF9MtmHbwNk1rL1Aj53vQZt+Gnv1oZn6gmd9jEHHJ0n9Nd2nxa5sKH7TS5IjkCDM6289O0d6PQ==}
+    engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  "@napi-rs/canvas@0.1.99":
-    resolution:
-      {
-        integrity: sha512-zN4eQlK3eBf7aJBcTHZilpBH3tDekBzPMIWC8r0s94Ecl73XfOyFi4w7yKFMRVUT0lvNQjtOL8YSrwqQj6mZFg==,
-      }
-    engines: { node: ">= 10" }
+  '@napi-rs/canvas@0.1.99':
+    resolution: {integrity: sha512-zN4eQlK3eBf7aJBcTHZilpBH3tDekBzPMIWC8r0s94Ecl73XfOyFi4w7yKFMRVUT0lvNQjtOL8YSrwqQj6mZFg==}
+    engines: {node: '>= 10'}
 
-  "@nodelib/fs.scandir@2.1.5":
-    resolution:
-      {
-        integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
-      }
-    engines: { node: ">= 8" }
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
 
-  "@nodelib/fs.stat@2.0.5":
-    resolution:
-      {
-        integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
-      }
-    engines: { node: ">= 8" }
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
 
-  "@nodelib/fs.walk@1.2.8":
-    resolution:
-      {
-        integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
-      }
-    engines: { node: ">= 8" }
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
-  "@oxfmt/binding-android-arm-eabi@0.62.0":
-    resolution:
-      {
-        integrity: sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm]
-    os: [android]
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
-  "@oxfmt/binding-android-arm64@0.62.0":
-    resolution:
-      {
-        integrity: sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm64]
-    os: [android]
-
-  "@oxfmt/binding-darwin-arm64@0.62.0":
-    resolution:
-      {
-        integrity: sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm64]
-    os: [darwin]
-
-  "@oxfmt/binding-darwin-x64@0.62.0":
-    resolution:
-      {
-        integrity: sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [x64]
-    os: [darwin]
-
-  "@oxfmt/binding-freebsd-x64@0.62.0":
-    resolution:
-      {
-        integrity: sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [x64]
-    os: [freebsd]
-
-  "@oxfmt/binding-linux-arm-gnueabihf@0.62.0":
-    resolution:
-      {
-        integrity: sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm]
-    os: [linux]
-
-  "@oxfmt/binding-linux-arm-musleabihf@0.62.0":
-    resolution:
-      {
-        integrity: sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm]
-    os: [linux]
-
-  "@oxfmt/binding-linux-arm64-gnu@0.62.0":
-    resolution:
-      {
-        integrity: sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm64]
-    os: [linux]
-
-  "@oxfmt/binding-linux-arm64-musl@0.62.0":
-    resolution:
-      {
-        integrity: sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm64]
-    os: [linux]
-
-  "@oxfmt/binding-linux-ppc64-gnu@0.62.0":
-    resolution:
-      {
-        integrity: sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [ppc64]
-    os: [linux]
-
-  "@oxfmt/binding-linux-riscv64-gnu@0.62.0":
-    resolution:
-      {
-        integrity: sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [riscv64]
-    os: [linux]
-
-  "@oxfmt/binding-linux-riscv64-musl@0.62.0":
-    resolution:
-      {
-        integrity: sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [riscv64]
-    os: [linux]
-
-  "@oxfmt/binding-linux-s390x-gnu@0.62.0":
-    resolution:
-      {
-        integrity: sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [s390x]
-    os: [linux]
-
-  "@oxfmt/binding-linux-x64-gnu@0.62.0":
-    resolution:
-      {
-        integrity: sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [x64]
-    os: [linux]
-
-  "@oxfmt/binding-linux-x64-musl@0.62.0":
-    resolution:
-      {
-        integrity: sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [x64]
-    os: [linux]
-
-  "@oxfmt/binding-openharmony-arm64@0.62.0":
-    resolution:
-      {
-        integrity: sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm64]
-    os: [openharmony]
-
-  "@oxfmt/binding-win32-arm64-msvc@0.62.0":
-    resolution:
-      {
-        integrity: sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [arm64]
-    os: [win32]
-
-  "@oxfmt/binding-win32-ia32-msvc@0.62.0":
-    resolution:
-      {
-        integrity: sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [ia32]
-    os: [win32]
-
-  "@oxfmt/binding-win32-x64-msvc@0.62.0":
-    resolution:
-      {
-        integrity: sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [x64]
-    os: [win32]
-
-  "@pkgjs/parseargs@0.11.0":
-    resolution:
-      {
-        integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==,
-      }
-    engines: { node: ">=14" }
-
-  "@remixicon/react@4.6.0":
-    resolution:
-      {
-        integrity: sha512-bY56maEgT5IYUSRotqy9h03IAKJC85vlKtWFg2FKzfs8JPrkdBAYSa9dxoUSKFwGzup8Ux6vjShs9Aec3jvr2w==,
-      }
+  '@remixicon/react@4.6.0':
+    resolution: {integrity: sha512-bY56maEgT5IYUSRotqy9h03IAKJC85vlKtWFg2FKzfs8JPrkdBAYSa9dxoUSKFwGzup8Ux6vjShs9Aec3jvr2w==}
     peerDependencies:
-      react: ">=18.2.0"
+      react: '>=18.2.0'
 
-  "@rolldown/pluginutils@1.0.0-beta.27":
-    resolution:
-      {
-        integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==,
-      }
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
-  "@rollup/pluginutils@5.2.0":
-    resolution:
-      {
-        integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==,
-      }
-    engines: { node: ">=14.0.0" }
+  '@rollup/pluginutils@5.2.0':
+    resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  "@rollup/rollup-android-arm-eabi@4.46.2":
-    resolution:
-      {
-        integrity: sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==,
-      }
+  '@rollup/rollup-android-arm-eabi@4.46.2':
+    resolution: {integrity: sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==}
     cpu: [arm]
     os: [android]
 
-  "@rollup/rollup-android-arm64@4.46.2":
-    resolution:
-      {
-        integrity: sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==,
-      }
+  '@rollup/rollup-android-arm64@4.46.2':
+    resolution: {integrity: sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==}
     cpu: [arm64]
     os: [android]
 
-  "@rollup/rollup-darwin-arm64@4.46.2":
-    resolution:
-      {
-        integrity: sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==,
-      }
+  '@rollup/rollup-darwin-arm64@4.46.2':
+    resolution: {integrity: sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==}
     cpu: [arm64]
     os: [darwin]
 
-  "@rollup/rollup-darwin-x64@4.46.2":
-    resolution:
-      {
-        integrity: sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==,
-      }
+  '@rollup/rollup-darwin-x64@4.46.2':
+    resolution: {integrity: sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==}
     cpu: [x64]
     os: [darwin]
 
-  "@rollup/rollup-freebsd-arm64@4.46.2":
-    resolution:
-      {
-        integrity: sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==,
-      }
+  '@rollup/rollup-freebsd-arm64@4.46.2':
+    resolution: {integrity: sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==}
     cpu: [arm64]
     os: [freebsd]
 
-  "@rollup/rollup-freebsd-x64@4.46.2":
-    resolution:
-      {
-        integrity: sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==,
-      }
+  '@rollup/rollup-freebsd-x64@4.46.2':
+    resolution: {integrity: sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==}
     cpu: [x64]
     os: [freebsd]
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.46.2":
-    resolution:
-      {
-        integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==,
-      }
+  '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
+    resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
     cpu: [arm]
     os: [linux]
 
-  "@rollup/rollup-linux-arm-musleabihf@4.46.2":
-    resolution:
-      {
-        integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==,
-      }
+  '@rollup/rollup-linux-arm-musleabihf@4.46.2':
+    resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
     cpu: [arm]
     os: [linux]
 
-  "@rollup/rollup-linux-arm64-gnu@4.46.2":
-    resolution:
-      {
-        integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==,
-      }
+  '@rollup/rollup-linux-arm64-gnu@4.46.2':
+    resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
     cpu: [arm64]
     os: [linux]
 
-  "@rollup/rollup-linux-arm64-musl@4.46.2":
-    resolution:
-      {
-        integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==,
-      }
+  '@rollup/rollup-linux-arm64-musl@4.46.2':
+    resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
     cpu: [arm64]
     os: [linux]
 
-  "@rollup/rollup-linux-loongarch64-gnu@4.46.2":
-    resolution:
-      {
-        integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==,
-      }
+  '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
+    resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
     cpu: [loong64]
     os: [linux]
 
-  "@rollup/rollup-linux-ppc64-gnu@4.46.2":
-    resolution:
-      {
-        integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==,
-      }
+  '@rollup/rollup-linux-ppc64-gnu@4.46.2':
+    resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
     cpu: [ppc64]
     os: [linux]
 
-  "@rollup/rollup-linux-riscv64-gnu@4.46.2":
-    resolution:
-      {
-        integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==,
-      }
+  '@rollup/rollup-linux-riscv64-gnu@4.46.2':
+    resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
     cpu: [riscv64]
     os: [linux]
 
-  "@rollup/rollup-linux-riscv64-musl@4.46.2":
-    resolution:
-      {
-        integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==,
-      }
+  '@rollup/rollup-linux-riscv64-musl@4.46.2':
+    resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
     cpu: [riscv64]
     os: [linux]
 
-  "@rollup/rollup-linux-s390x-gnu@4.46.2":
-    resolution:
-      {
-        integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==,
-      }
+  '@rollup/rollup-linux-s390x-gnu@4.46.2':
+    resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
     cpu: [s390x]
     os: [linux]
 
-  "@rollup/rollup-linux-x64-gnu@4.46.2":
-    resolution:
-      {
-        integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==,
-      }
+  '@rollup/rollup-linux-x64-gnu@4.46.2':
+    resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
     cpu: [x64]
     os: [linux]
 
-  "@rollup/rollup-linux-x64-musl@4.46.2":
-    resolution:
-      {
-        integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==,
-      }
+  '@rollup/rollup-linux-x64-musl@4.46.2':
+    resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
     cpu: [x64]
     os: [linux]
 
-  "@rollup/rollup-win32-arm64-msvc@4.46.2":
-    resolution:
-      {
-        integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==,
-      }
+  '@rollup/rollup-win32-arm64-msvc@4.46.2':
+    resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
     cpu: [arm64]
     os: [win32]
 
-  "@rollup/rollup-win32-ia32-msvc@4.46.2":
-    resolution:
-      {
-        integrity: sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==,
-      }
+  '@rollup/rollup-win32-ia32-msvc@4.46.2':
+    resolution: {integrity: sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==}
     cpu: [ia32]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-msvc@4.46.2":
-    resolution:
-      {
-        integrity: sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==,
-      }
+  '@rollup/rollup-win32-x64-msvc@4.46.2':
+    resolution: {integrity: sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==}
     cpu: [x64]
     os: [win32]
 
-  "@standard-schema/utils@0.3.0":
-    resolution:
-      {
-        integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==,
-      }
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
-  "@storybook/addon-actions@8.6.14":
-    resolution:
-      {
-        integrity: sha512-mDQxylxGGCQSK7tJPkD144J8jWh9IU9ziJMHfB84PKpI/V5ZgqMDnpr2bssTrUaGDqU5e1/z8KcRF+Melhs9pQ==,
-      }
+  '@storybook/addon-actions@8.6.14':
+    resolution: {integrity: sha512-mDQxylxGGCQSK7tJPkD144J8jWh9IU9ziJMHfB84PKpI/V5ZgqMDnpr2bssTrUaGDqU5e1/z8KcRF+Melhs9pQ==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/addon-backgrounds@8.6.14":
-    resolution:
-      {
-        integrity: sha512-l9xS8qWe5n4tvMwth09QxH2PmJbCctEvBAc1tjjRasAfrd69f7/uFK4WhwJAstzBTNgTc8VXI4w8ZR97i1sFbg==,
-      }
+  '@storybook/addon-backgrounds@8.6.14':
+    resolution: {integrity: sha512-l9xS8qWe5n4tvMwth09QxH2PmJbCctEvBAc1tjjRasAfrd69f7/uFK4WhwJAstzBTNgTc8VXI4w8ZR97i1sFbg==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/addon-controls@8.6.14":
-    resolution:
-      {
-        integrity: sha512-IiQpkNJdiRyA4Mq9mzjZlvQugL/aE7hNgVxBBGPiIZG6wb6Ht9hNnBYpap5ZXXFKV9p2qVI0FZK445ONmAa+Cw==,
-      }
+  '@storybook/addon-controls@8.6.14':
+    resolution: {integrity: sha512-IiQpkNJdiRyA4Mq9mzjZlvQugL/aE7hNgVxBBGPiIZG6wb6Ht9hNnBYpap5ZXXFKV9p2qVI0FZK445ONmAa+Cw==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/addon-docs@8.6.14":
-    resolution:
-      {
-        integrity: sha512-Obpd0OhAF99JyU5pp5ci17YmpcQtMNgqW2pTXV8jAiiipWpwO++hNDeQmLmlSXB399XjtRDOcDVkoc7rc6JzdQ==,
-      }
+  '@storybook/addon-docs@8.6.14':
+    resolution: {integrity: sha512-Obpd0OhAF99JyU5pp5ci17YmpcQtMNgqW2pTXV8jAiiipWpwO++hNDeQmLmlSXB399XjtRDOcDVkoc7rc6JzdQ==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/addon-essentials@8.6.14":
-    resolution:
-      {
-        integrity: sha512-5ZZSHNaW9mXMOFkoPyc3QkoNGdJHETZydI62/OASR0lmPlJ1065TNigEo5dJddmZNn0/3bkE8eKMAzLnO5eIdA==,
-      }
+  '@storybook/addon-essentials@8.6.14':
+    resolution: {integrity: sha512-5ZZSHNaW9mXMOFkoPyc3QkoNGdJHETZydI62/OASR0lmPlJ1065TNigEo5dJddmZNn0/3bkE8eKMAzLnO5eIdA==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/addon-highlight@8.6.14":
-    resolution:
-      {
-        integrity: sha512-4H19OJlapkofiE9tM6K/vsepf4ir9jMm9T+zw5L85blJZxhKZIbJ6FO0TCG9PDc4iPt3L6+aq5B0X29s9zicNQ==,
-      }
+  '@storybook/addon-highlight@8.6.14':
+    resolution: {integrity: sha512-4H19OJlapkofiE9tM6K/vsepf4ir9jMm9T+zw5L85blJZxhKZIbJ6FO0TCG9PDc4iPt3L6+aq5B0X29s9zicNQ==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/addon-measure@8.6.14":
-    resolution:
-      {
-        integrity: sha512-1Tlyb72NX8aAqm6I6OICsUuGOP6hgnXcuFlXucyhKomPa6j3Eu2vKu561t/f0oGtAK2nO93Z70kVaEh5X+vaGw==,
-      }
+  '@storybook/addon-measure@8.6.14':
+    resolution: {integrity: sha512-1Tlyb72NX8aAqm6I6OICsUuGOP6hgnXcuFlXucyhKomPa6j3Eu2vKu561t/f0oGtAK2nO93Z70kVaEh5X+vaGw==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/addon-outline@8.6.14":
-    resolution:
-      {
-        integrity: sha512-CW857JvN6OxGWElqjlzJO2S69DHf+xO3WsEfT5mT3ZtIjmsvRDukdWfDU9bIYUFyA2lFvYjncBGjbK+I91XR7w==,
-      }
+  '@storybook/addon-outline@8.6.14':
+    resolution: {integrity: sha512-CW857JvN6OxGWElqjlzJO2S69DHf+xO3WsEfT5mT3ZtIjmsvRDukdWfDU9bIYUFyA2lFvYjncBGjbK+I91XR7w==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/addon-storysource@8.6.14":
-    resolution:
-      {
-        integrity: sha512-/eDCNUHPdsVDF53B+Ebi9gHSNcRrA3puo1UCDio8wMN+jBMoWh6E5wSjXDsxWaOyp0Zwuq8XUx8AdgTlg/rcrw==,
-      }
+  '@storybook/addon-storysource@8.6.14':
+    resolution: {integrity: sha512-/eDCNUHPdsVDF53B+Ebi9gHSNcRrA3puo1UCDio8wMN+jBMoWh6E5wSjXDsxWaOyp0Zwuq8XUx8AdgTlg/rcrw==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/addon-toolbars@8.6.14":
-    resolution:
-      {
-        integrity: sha512-W/wEXT8h3VyZTVfWK/84BAcjAxTdtRiAkT2KAN0nbSHxxB5KEM1MjKpKu2upyzzMa3EywITqbfy4dP6lpkVTwQ==,
-      }
+  '@storybook/addon-toolbars@8.6.14':
+    resolution: {integrity: sha512-W/wEXT8h3VyZTVfWK/84BAcjAxTdtRiAkT2KAN0nbSHxxB5KEM1MjKpKu2upyzzMa3EywITqbfy4dP6lpkVTwQ==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/addon-viewport@8.6.14":
-    resolution:
-      {
-        integrity: sha512-gNzVQbMqRC+/4uQTPI2ZrWuRHGquTMZpdgB9DrD88VTEjNudP+J6r8myLfr2VvGksBbUMHkGHMXHuIhrBEnXYA==,
-      }
+  '@storybook/addon-viewport@8.6.14':
+    resolution: {integrity: sha512-gNzVQbMqRC+/4uQTPI2ZrWuRHGquTMZpdgB9DrD88VTEjNudP+J6r8myLfr2VvGksBbUMHkGHMXHuIhrBEnXYA==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/blocks@8.6.14":
-    resolution:
-      {
-        integrity: sha512-rBMHAfA39AGHgkrDze4RmsnQTMw1ND5fGWobr9pDcJdnDKWQWNRD7Nrlxj0gFlN3n4D9lEZhWGdFrCbku7FVAQ==,
-      }
+  '@storybook/blocks@8.6.14':
+    resolution: {integrity: sha512-rBMHAfA39AGHgkrDze4RmsnQTMw1ND5fGWobr9pDcJdnDKWQWNRD7Nrlxj0gFlN3n4D9lEZhWGdFrCbku7FVAQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1411,1571 +825,905 @@ packages:
       react-dom:
         optional: true
 
-  "@storybook/builder-vite@8.6.14":
-    resolution:
-      {
-        integrity: sha512-ajWYhy32ksBWxwWHrjwZzyC0Ii5ZTeu5lsqA95Q/EQBB0P5qWlHWGM3AVyv82Mz/ND03ebGy123uVwgf6olnYQ==,
-      }
+  '@storybook/builder-vite@8.6.14':
+    resolution: {integrity: sha512-ajWYhy32ksBWxwWHrjwZzyC0Ii5ZTeu5lsqA95Q/EQBB0P5qWlHWGM3AVyv82Mz/ND03ebGy123uVwgf6olnYQ==}
     peerDependencies:
       storybook: ^8.6.14
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
 
-  "@storybook/components@8.6.14":
-    resolution:
-      {
-        integrity: sha512-HNR2mC5I4Z5ek8kTrVZlIY/B8gJGs5b3XdZPBPBopTIN6U/YHXiDyOjY3JlaS4fSG1fVhp/Qp1TpMn1w/9m1pw==,
-      }
+  '@storybook/components@8.6.14':
+    resolution: {integrity: sha512-HNR2mC5I4Z5ek8kTrVZlIY/B8gJGs5b3XdZPBPBopTIN6U/YHXiDyOjY3JlaS4fSG1fVhp/Qp1TpMn1w/9m1pw==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  "@storybook/core-events@8.6.14":
-    resolution:
-      {
-        integrity: sha512-RrJ95u3HuIE4Nk8VmZP0tc/u0vYoE2v9fYlMw6K2GUSExzKDITs3voy6WMIY7Q3qbQun8XUXVlmqkuFzTEy/pA==,
-      }
+  '@storybook/core-events@8.6.14':
+    resolution: {integrity: sha512-RrJ95u3HuIE4Nk8VmZP0tc/u0vYoE2v9fYlMw6K2GUSExzKDITs3voy6WMIY7Q3qbQun8XUXVlmqkuFzTEy/pA==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  "@storybook/core@8.6.14":
-    resolution:
-      {
-        integrity: sha512-1P/w4FSNRqP8j3JQBOi3yGt8PVOgSRbP66Ok520T78eJBeqx9ukCfl912PQZ7SPbW3TIunBwLXMZOjZwBB/JmA==,
-      }
+  '@storybook/core@8.6.14':
+    resolution: {integrity: sha512-1P/w4FSNRqP8j3JQBOi3yGt8PVOgSRbP66Ok520T78eJBeqx9ukCfl912PQZ7SPbW3TIunBwLXMZOjZwBB/JmA==}
     peerDependencies:
       prettier: ^2 || ^3
     peerDependenciesMeta:
       prettier:
         optional: true
 
-  "@storybook/csf-plugin@8.6.14":
-    resolution:
-      {
-        integrity: sha512-dErtc9teAuN+eelN8FojzFE635xlq9cNGGGEu0WEmMUQ4iJ8pingvBO1N8X3scz4Ry7KnxX++NNf3J3gpxS8qQ==,
-      }
+  '@storybook/csf-plugin@8.6.14':
+    resolution: {integrity: sha512-dErtc9teAuN+eelN8FojzFE635xlq9cNGGGEu0WEmMUQ4iJ8pingvBO1N8X3scz4Ry7KnxX++NNf3J3gpxS8qQ==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/global@5.0.0":
-    resolution:
-      {
-        integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==,
-      }
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
 
-  "@storybook/icons@1.4.0":
-    resolution:
-      {
-        integrity: sha512-Td73IeJxOyalzvjQL+JXx72jlIYHgs+REaHiREOqfpo3A2AYYG71AUbcv+lg7mEDIweKVCxsMQ0UKo634c8XeA==,
-      }
-    engines: { node: ">=14.0.0" }
+  '@storybook/icons@1.4.0':
+    resolution: {integrity: sha512-Td73IeJxOyalzvjQL+JXx72jlIYHgs+REaHiREOqfpo3A2AYYG71AUbcv+lg7mEDIweKVCxsMQ0UKo634c8XeA==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
 
-  "@storybook/instrumenter@8.6.14":
-    resolution:
-      {
-        integrity: sha512-iG4MlWCcz1L7Yu8AwgsnfVAmMbvyRSk700Mfy2g4c8y5O+Cv1ejshE1LBBsCwHgkuqU0H4R0qu4g23+6UnUemQ==,
-      }
+  '@storybook/instrumenter@8.6.14':
+    resolution: {integrity: sha512-iG4MlWCcz1L7Yu8AwgsnfVAmMbvyRSk700Mfy2g4c8y5O+Cv1ejshE1LBBsCwHgkuqU0H4R0qu4g23+6UnUemQ==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/manager-api@8.6.14":
-    resolution:
-      {
-        integrity: sha512-ez0Zihuy17udLbfHZQXkGqwtep0mSGgHcNzGN7iZrMP1m+VmNo+7aGCJJdvXi7+iU3yq8weXSQFWg5DqWgLS7g==,
-      }
+  '@storybook/manager-api@8.6.14':
+    resolution: {integrity: sha512-ez0Zihuy17udLbfHZQXkGqwtep0mSGgHcNzGN7iZrMP1m+VmNo+7aGCJJdvXi7+iU3yq8weXSQFWg5DqWgLS7g==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  "@storybook/preview-api@8.6.14":
-    resolution:
-      {
-        integrity: sha512-2GhcCd4dNMrnD7eooEfvbfL4I83qAqEyO0CO7JQAmIO6Rxb9BsOLLI/GD5HkvQB73ArTJ+PT50rfaO820IExOQ==,
-      }
+  '@storybook/preview-api@8.6.14':
+    resolution: {integrity: sha512-2GhcCd4dNMrnD7eooEfvbfL4I83qAqEyO0CO7JQAmIO6Rxb9BsOLLI/GD5HkvQB73ArTJ+PT50rfaO820IExOQ==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  "@storybook/react-dom-shim@8.6.14":
-    resolution:
-      {
-        integrity: sha512-0hixr3dOy3f3M+HBofp3jtMQMS+sqzjKNgl7Arfuj3fvjmyXOks/yGjDImySR4imPtEllvPZfhiQNlejheaInw==,
-      }
+  '@storybook/react-dom-shim@8.6.14':
+    resolution: {integrity: sha512-0hixr3dOy3f3M+HBofp3jtMQMS+sqzjKNgl7Arfuj3fvjmyXOks/yGjDImySR4imPtEllvPZfhiQNlejheaInw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^8.6.14
 
-  "@storybook/react-vite@8.6.14":
-    resolution:
-      {
-        integrity: sha512-FZU0xMPxa4/TO87FgcWwappOxLBHZV5HSRK5K+2bJD7rFJAoNorbHvB4Q1zvIAk7eCMjkr2GPCPHx9PRB9vJFg==,
-      }
-    engines: { node: ">=18.0.0" }
+  '@storybook/react-vite@8.6.14':
+    resolution: {integrity: sha512-FZU0xMPxa4/TO87FgcWwappOxLBHZV5HSRK5K+2bJD7rFJAoNorbHvB4Q1zvIAk7eCMjkr2GPCPHx9PRB9vJFg==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
-      "@storybook/test": 8.6.14
+      '@storybook/test': 8.6.14
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^8.6.14
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
-      "@storybook/test":
+      '@storybook/test':
         optional: true
 
-  "@storybook/react@8.6.14":
-    resolution:
-      {
-        integrity: sha512-BOepx5bBFwl/CPI+F+LnmMmsG1wQYmrX/UQXgUbHQUU9Tj7E2ndTnNbpIuSLc8IrM03ru+DfwSg1Co3cxWtT+g==,
-      }
-    engines: { node: ">=18.0.0" }
+  '@storybook/react@8.6.14':
+    resolution: {integrity: sha512-BOepx5bBFwl/CPI+F+LnmMmsG1wQYmrX/UQXgUbHQUU9Tj7E2ndTnNbpIuSLc8IrM03ru+DfwSg1Co3cxWtT+g==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
-      "@storybook/test": 8.6.14
+      '@storybook/test': 8.6.14
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^8.6.14
-      typescript: ">= 4.2.x"
+      typescript: '>= 4.2.x'
     peerDependenciesMeta:
-      "@storybook/test":
+      '@storybook/test':
         optional: true
       typescript:
         optional: true
 
-  "@storybook/source-loader@8.6.14":
-    resolution:
-      {
-        integrity: sha512-aFUqrkWh4XSXDmkrK0Nm8q4K94bfgnixFMmql8lBAFuEllFek9Rd3i2RwGOhLUtwzpM89f74nzEgR1kd/ijJ+g==,
-      }
+  '@storybook/source-loader@8.6.14':
+    resolution: {integrity: sha512-aFUqrkWh4XSXDmkrK0Nm8q4K94bfgnixFMmql8lBAFuEllFek9Rd3i2RwGOhLUtwzpM89f74nzEgR1kd/ijJ+g==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/test@8.6.14":
-    resolution:
-      {
-        integrity: sha512-GkPNBbbZmz+XRdrhMtkxPotCLOQ1BaGNp/gFZYdGDk2KmUWBKmvc5JxxOhtoXM2703IzNFlQHSSNnhrDZYuLlw==,
-      }
+  '@storybook/test@8.6.14':
+    resolution: {integrity: sha512-GkPNBbbZmz+XRdrhMtkxPotCLOQ1BaGNp/gFZYdGDk2KmUWBKmvc5JxxOhtoXM2703IzNFlQHSSNnhrDZYuLlw==}
     peerDependencies:
       storybook: ^8.6.14
 
-  "@storybook/theming@8.6.14":
-    resolution:
-      {
-        integrity: sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==,
-      }
+  '@storybook/theming@8.6.14':
+    resolution: {integrity: sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  "@tanstack/react-virtual@3.14.5":
-    resolution:
-      {
-        integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==,
-      }
+  '@tanstack/react-virtual@3.14.5':
+    resolution: {integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  "@tanstack/virtual-core@3.17.3":
-    resolution:
-      {
-        integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==,
-      }
+  '@tanstack/virtual-core@3.17.3':
+    resolution: {integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==}
 
-  "@testing-library/cypress@10.0.3":
-    resolution:
-      {
-        integrity: sha512-TeZJMCNtiS59cPWalra7LgADuufO5FtbqQBYxuAgdX6ZFAR2D9CtQwAG8VbgvFcchW3K414va/+7P4OkQ80UVg==,
-      }
-    engines: { node: ">=12", npm: ">=6" }
+  '@testing-library/cypress@10.0.3':
+    resolution: {integrity: sha512-TeZJMCNtiS59cPWalra7LgADuufO5FtbqQBYxuAgdX6ZFAR2D9CtQwAG8VbgvFcchW3K414va/+7P4OkQ80UVg==}
+    engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       cypress: ^12.0.0 || ^13.0.0 || ^14.0.0
 
-  "@testing-library/dom@10.4.0":
-    resolution:
-      {
-        integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==,
-      }
-    engines: { node: ">=18" }
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+    engines: {node: '>=18'}
 
-  "@testing-library/dom@10.4.1":
-    resolution:
-      {
-        integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==,
-      }
-    engines: { node: ">=18" }
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
 
-  "@testing-library/jest-dom@6.5.0":
-    resolution:
-      {
-        integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==,
-      }
-    engines: { node: ">=14", npm: ">=6", yarn: ">=1" }
+  '@testing-library/jest-dom@6.5.0':
+    resolution: {integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
-  "@testing-library/user-event@14.5.2":
-    resolution:
-      {
-        integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==,
-      }
-    engines: { node: ">=12", npm: ">=6" }
+  '@testing-library/user-event@14.5.2':
+    resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
+    engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
-      "@testing-library/dom": ">=7.21.4"
+      '@testing-library/dom': '>=7.21.4'
 
-  "@types/aria-query@5.0.4":
-    resolution:
-      {
-        integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==,
-      }
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
-  "@types/babel__core@7.20.5":
-    resolution:
-      {
-        integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==,
-      }
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
-  "@types/babel__generator@7.27.0":
-    resolution:
-      {
-        integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==,
-      }
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
 
-  "@types/babel__template@7.4.4":
-    resolution:
-      {
-        integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==,
-      }
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
 
-  "@types/babel__traverse@7.20.7":
-    resolution:
-      {
-        integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==,
-      }
+  '@types/babel__traverse@7.20.7':
+    resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
-  "@types/doctrine@0.0.9":
-    resolution:
-      {
-        integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==,
-      }
+  '@types/doctrine@0.0.9':
+    resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
-  "@types/estree@1.0.8":
-    resolution:
-      {
-        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
-      }
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  "@types/json-schema@7.0.15":
-    resolution:
-      {
-        integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
-      }
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  "@types/mdx@2.0.13":
-    resolution:
-      {
-        integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==,
-      }
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
-  "@types/node@24.1.0":
-    resolution:
-      {
-        integrity: sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==,
-      }
+  '@types/node@24.1.0':
+    resolution: {integrity: sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==}
 
-  "@types/react-dom@19.1.7":
-    resolution:
-      {
-        integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==,
-      }
+  '@types/react-dom@19.1.7':
+    resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
     peerDependencies:
-      "@types/react": ^19.0.0
+      '@types/react': ^19.0.0
 
-  "@types/react@19.1.9":
-    resolution:
-      {
-        integrity: sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==,
-      }
+  '@types/react@19.1.9':
+    resolution: {integrity: sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==}
 
-  "@types/resolve@1.20.6":
-    resolution:
-      {
-        integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==,
-      }
+  '@types/resolve@1.20.6':
+    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
-  "@types/sinonjs__fake-timers@8.1.1":
-    resolution:
-      {
-        integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==,
-      }
+  '@types/sinonjs__fake-timers@8.1.1':
+    resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
 
-  "@types/sizzle@2.3.9":
-    resolution:
-      {
-        integrity: sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==,
-      }
+  '@types/sizzle@2.3.9':
+    resolution: {integrity: sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==}
 
-  "@types/stylis@4.2.5":
-    resolution:
-      {
-        integrity: sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==,
-      }
+  '@types/stylis@4.2.5':
+    resolution: {integrity: sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==}
 
-  "@types/trusted-types@2.0.7":
-    resolution:
-      {
-        integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==,
-      }
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
-  "@types/uuid@9.0.8":
-    resolution:
-      {
-        integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==,
-      }
+  '@types/uuid@9.0.8':
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
-  "@types/yargs-parser@21.0.3":
-    resolution:
-      {
-        integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==,
-      }
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
-  "@types/yargs@17.0.33":
-    resolution:
-      {
-        integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==,
-      }
+  '@types/yargs@17.0.33':
+    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
-  "@types/yauzl@2.10.3":
-    resolution:
-      {
-        integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==,
-      }
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  "@typescript-eslint/eslint-plugin@8.38.0":
-    resolution:
-      {
-        integrity: sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/eslint-plugin@8.38.0':
+    resolution: {integrity: sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      "@typescript-eslint/parser": ^8.38.0
+      '@typescript-eslint/parser': ^8.38.0
       eslint: ^8.57.0 || ^9.0.0
-      typescript: ">=4.8.4 <5.9.0"
+      typescript: '>=4.8.4 <5.9.0'
 
-  "@typescript-eslint/parser@8.38.0":
-    resolution:
-      {
-        integrity: sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/parser@8.38.0':
+    resolution: {integrity: sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: ">=4.8.4 <5.9.0"
+      typescript: '>=4.8.4 <5.9.0'
 
-  "@typescript-eslint/project-service@8.38.0":
-    resolution:
-      {
-        integrity: sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/project-service@8.38.0':
+    resolution: {integrity: sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: ">=4.8.4 <5.9.0"
+      typescript: '>=4.8.4 <5.9.0'
 
-  "@typescript-eslint/scope-manager@8.38.0":
-    resolution:
-      {
-        integrity: sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/scope-manager@8.38.0':
+    resolution: {integrity: sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@typescript-eslint/tsconfig-utils@8.38.0":
-    resolution:
-      {
-        integrity: sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/tsconfig-utils@8.38.0':
+    resolution: {integrity: sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: ">=4.8.4 <5.9.0"
+      typescript: '>=4.8.4 <5.9.0'
 
-  "@typescript-eslint/type-utils@8.38.0":
-    resolution:
-      {
-        integrity: sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/type-utils@8.38.0':
+    resolution: {integrity: sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: ">=4.8.4 <5.9.0"
+      typescript: '>=4.8.4 <5.9.0'
 
-  "@typescript-eslint/types@8.38.0":
-    resolution:
-      {
-        integrity: sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/types@8.38.0':
+    resolution: {integrity: sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@typescript-eslint/typescript-estree@8.38.0":
-    resolution:
-      {
-        integrity: sha512-fooELKcAKzxux6fA6pxOflpNS0jc+nOQEEOipXFNjSlBS6fqrJOVY/whSn70SScHrcJ2LDsxWrneFoWYSVfqhQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/typescript-estree@8.38.0':
+    resolution: {integrity: sha512-fooELKcAKzxux6fA6pxOflpNS0jc+nOQEEOipXFNjSlBS6fqrJOVY/whSn70SScHrcJ2LDsxWrneFoWYSVfqhQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: ">=4.8.4 <5.9.0"
+      typescript: '>=4.8.4 <5.9.0'
 
-  "@typescript-eslint/utils@8.38.0":
-    resolution:
-      {
-        integrity: sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/utils@8.38.0':
+    resolution: {integrity: sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: ">=4.8.4 <5.9.0"
+      typescript: '>=4.8.4 <5.9.0'
 
-  "@typescript-eslint/visitor-keys@8.38.0":
-    resolution:
-      {
-        integrity: sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+  '@typescript-eslint/visitor-keys@8.38.0':
+    resolution: {integrity: sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  "@vitejs/plugin-react@4.7.0":
-    resolution:
-      {
-        integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==,
-      }
-    engines: { node: ^14.18.0 || >=16.0.0 }
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  "@vitest/expect@2.0.5":
-    resolution:
-      {
-        integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==,
-      }
+  '@vitest/expect@2.0.5':
+    resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
 
-  "@vitest/pretty-format@2.0.5":
-    resolution:
-      {
-        integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==,
-      }
+  '@vitest/pretty-format@2.0.5':
+    resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
 
-  "@vitest/pretty-format@2.1.9":
-    resolution:
-      {
-        integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==,
-      }
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
-  "@vitest/spy@2.0.5":
-    resolution:
-      {
-        integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==,
-      }
+  '@vitest/spy@2.0.5':
+    resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
 
-  "@vitest/utils@2.0.5":
-    resolution:
-      {
-        integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==,
-      }
+  '@vitest/utils@2.0.5':
+    resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
 
-  "@vitest/utils@2.1.9":
-    resolution:
-      {
-        integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==,
-      }
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   acorn-jsx@5.3.2:
-    resolution:
-      {
-        integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
-      }
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn@8.15.0:
-    resolution:
-      {
-        integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==,
-      }
-    engines: { node: ">=0.4.0" }
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
     hasBin: true
 
   aggregate-error@3.1.0:
-    resolution:
-      {
-        integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
 
   ajv@6.12.6:
-    resolution:
-      {
-        integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
-      }
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
   ansi-colors@4.1.3:
-    resolution:
-      {
-        integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
 
   ansi-escapes@4.3.2:
-    resolution:
-      {
-        integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
 
   ansi-regex@5.0.1:
-    resolution:
-      {
-        integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
 
   ansi-regex@6.1.0:
-    resolution:
-      {
-        integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
 
   ansi-styles@3.2.1:
-    resolution:
-      {
-        integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
 
   ansi-styles@4.3.0:
-    resolution:
-      {
-        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
 
   ansi-styles@5.2.0:
-    resolution:
-      {
-        integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansi-styles@6.2.1:
-    resolution:
-      {
-        integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
 
   arch@2.2.0:
-    resolution:
-      {
-        integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==,
-      }
+    resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
 
   argparse@2.0.1:
-    resolution:
-      {
-        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
-      }
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   aria-query@5.3.0:
-    resolution:
-      {
-        integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==,
-      }
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
-    resolution:
-      {
-        integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-buffer-byte-length@1.0.2:
-    resolution:
-      {
-        integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
 
   array-includes@3.1.9:
-    resolution:
-      {
-        integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
+    engines: {node: '>= 0.4'}
 
   array.prototype.findlast@1.2.5:
-    resolution:
-      {
-        integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
+    engines: {node: '>= 0.4'}
 
   array.prototype.flat@1.3.3:
-    resolution:
-      {
-        integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
+    engines: {node: '>= 0.4'}
 
   array.prototype.flatmap@1.3.3:
-    resolution:
-      {
-        integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
+    engines: {node: '>= 0.4'}
 
   array.prototype.tosorted@1.1.4:
-    resolution:
-      {
-        integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
+    engines: {node: '>= 0.4'}
 
   arraybuffer.prototype.slice@1.0.4:
-    resolution:
-      {
-        integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
 
   asn1@0.2.6:
-    resolution:
-      {
-        integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==,
-      }
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
   assert-plus@1.0.0:
-    resolution:
-      {
-        integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==,
-      }
-    engines: { node: ">=0.8" }
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
 
   assertion-error@2.0.1:
-    resolution:
-      {
-        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types@0.16.1:
-    resolution:
-      {
-        integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
 
   astral-regex@2.0.0:
-    resolution:
-      {
-        integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
 
   async-function@1.0.0:
-    resolution:
-      {
-        integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
 
   async@3.2.6:
-    resolution:
-      {
-        integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==,
-      }
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
   asynckit@0.4.0:
-    resolution:
-      {
-        integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
-      }
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   at-least-node@1.0.0:
-    resolution:
-      {
-        integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==,
-      }
-    engines: { node: ">= 4.0.0" }
+    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
+    engines: {node: '>= 4.0.0'}
 
   available-typed-arrays@1.0.7:
-    resolution:
-      {
-        integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
 
   aws-sign2@0.7.0:
-    resolution:
-      {
-        integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==,
-      }
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
 
   aws4@1.13.2:
-    resolution:
-      {
-        integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==,
-      }
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
   balanced-match@1.0.2:
-    resolution:
-      {
-        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
-      }
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   barrelsby@2.8.1:
-    resolution:
-      {
-        integrity: sha512-barN2MVKqUVwmjRy3JLSMYufrBDcdWUc2pjlR0V9P8S3aMvvJ4StFz1GJMzEi5GBoQlnBIWOcCxBDzI2xfaaGw==,
-      }
-    engines: { node: ">=6.0.0" }
+    resolution: {integrity: sha512-barN2MVKqUVwmjRy3JLSMYufrBDcdWUc2pjlR0V9P8S3aMvvJ4StFz1GJMzEi5GBoQlnBIWOcCxBDzI2xfaaGw==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   base64-js@1.5.1:
-    resolution:
-      {
-        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
-      }
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   bcrypt-pbkdf@1.0.2:
-    resolution:
-      {
-        integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==,
-      }
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   better-opn@3.0.2:
-    resolution:
-      {
-        integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
+    engines: {node: '>=12.0.0'}
 
   blob-util@2.0.2:
-    resolution:
-      {
-        integrity: sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==,
-      }
+    resolution: {integrity: sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==}
 
   bluebird@3.7.2:
-    resolution:
-      {
-        integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==,
-      }
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
   brace-expansion@1.1.12:
-    resolution:
-      {
-        integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==,
-      }
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@2.0.2:
-    resolution:
-      {
-        integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==,
-      }
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   braces@3.0.3:
-    resolution:
-      {
-        integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
 
   browser-assert@1.2.1:
-    resolution:
-      {
-        integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==,
-      }
+    resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
 
   browserslist@4.25.1:
-    resolution:
-      {
-        integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==,
-      }
-    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
+    resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
   buffer-crc32@0.2.13:
-    resolution:
-      {
-        integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==,
-      }
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-from@1.1.2:
-    resolution:
-      {
-        integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
-      }
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   buffer@5.7.1:
-    resolution:
-      {
-        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
-      }
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   cachedir@2.4.0:
-    resolution:
-      {
-        integrity: sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==}
+    engines: {node: '>=6'}
 
   call-bind-apply-helpers@1.0.2:
-    resolution:
-      {
-        integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   call-bind@1.0.8:
-    resolution:
-      {
-        integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
-    resolution:
-      {
-        integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
-    resolution:
-      {
-        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
 
   camelize@1.0.1:
-    resolution:
-      {
-        integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==,
-      }
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
   caniuse-lite@1.0.30001731:
-    resolution:
-      {
-        integrity: sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==,
-      }
+    resolution: {integrity: sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==}
 
   caseless@0.12.0:
-    resolution:
-      {
-        integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==,
-      }
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
   chai@5.2.1:
-    resolution:
-      {
-        integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
-    resolution:
-      {
-        integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
 
   chalk@3.0.0:
-    resolution:
-      {
-        integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
 
   chalk@4.1.2:
-    resolution:
-      {
-        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   check-error@2.1.1:
-    resolution:
-      {
-        integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==,
-      }
-    engines: { node: ">= 16" }
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   check-more-types@2.24.0:
-    resolution:
-      {
-        integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==,
-      }
-    engines: { node: ">= 0.8.0" }
+    resolution: {integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==}
+    engines: {node: '>= 0.8.0'}
 
   ci-info@4.3.0:
-    resolution:
-      {
-        integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
+    engines: {node: '>=8'}
 
   clean-stack@2.2.0:
-    resolution:
-      {
-        integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
 
   cli-cursor@3.1.0:
-    resolution:
-      {
-        integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
 
   cli-table3@0.6.1:
-    resolution:
-      {
-        integrity: sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==,
-      }
-    engines: { node: 10.* || >= 12.* }
+    resolution: {integrity: sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==}
+    engines: {node: 10.* || >= 12.*}
 
   cli-truncate@2.1.0:
-    resolution:
-      {
-        integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
+    engines: {node: '>=8'}
 
   cliui@8.0.1:
-    resolution:
-      {
-        integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   color-convert@1.9.3:
-    resolution:
-      {
-        integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==,
-      }
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
 
   color-convert@2.0.1:
-    resolution:
-      {
-        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
-      }
-    engines: { node: ">=7.0.0" }
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
 
   color-name@1.1.3:
-    resolution:
-      {
-        integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==,
-      }
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
-    resolution:
-      {
-        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
-      }
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   colorette@2.0.20:
-    resolution:
-      {
-        integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
-      }
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
   colors@1.4.0:
-    resolution:
-      {
-        integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==,
-      }
-    engines: { node: ">=0.1.90" }
+    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
+    engines: {node: '>=0.1.90'}
 
   combined-stream@1.0.8:
-    resolution:
-      {
-        integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==,
-      }
-    engines: { node: ">= 0.8" }
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@2.20.3:
-    resolution:
-      {
-        integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==,
-      }
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   commander@6.2.1:
-    resolution:
-      {
-        integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==,
-      }
-    engines: { node: ">= 6" }
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
+    engines: {node: '>= 6'}
 
   common-tags@1.8.2:
-    resolution:
-      {
-        integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==,
-      }
-    engines: { node: ">=4.0.0" }
+    resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
+    engines: {node: '>=4.0.0'}
 
   concat-map@0.0.1:
-    resolution:
-      {
-        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
-      }
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
-    resolution:
-      {
-        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
-      }
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   core-util-is@1.0.2:
-    resolution:
-      {
-        integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==,
-      }
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
   cross-spawn@7.0.6:
-    resolution:
-      {
-        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
-      }
-    engines: { node: ">= 8" }
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css-color-keywords@1.0.0:
-    resolution:
-      {
-        integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
 
   css-to-react-native@3.2.0:
-    resolution:
-      {
-        integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==,
-      }
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css.escape@1.5.1:
-    resolution:
-      {
-        integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==,
-      }
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   csstype@3.1.3:
-    resolution:
-      {
-        integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==,
-      }
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   cypress-real-events@1.14.0:
-    resolution:
-      {
-        integrity: sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==,
-      }
+    resolution: {integrity: sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==}
     peerDependencies:
       cypress: ^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x || ^14.x
 
   cypress@14.5.3:
-    resolution:
-      {
-        integrity: sha512-syLwKjDeMg77FRRx68bytLdlqHXDT4yBVh0/PPkcgesChYDjUZbwxLqMXuryYKzAyJsPsQHUDW1YU74/IYEUIA==,
-      }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    resolution: {integrity: sha512-syLwKjDeMg77FRRx68bytLdlqHXDT4yBVh0/PPkcgesChYDjUZbwxLqMXuryYKzAyJsPsQHUDW1YU74/IYEUIA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   dashdash@1.14.1:
-    resolution:
-      {
-        integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==,
-      }
-    engines: { node: ">=0.10" }
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
 
   data-view-buffer@1.0.2:
-    resolution:
-      {
-        integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
 
   data-view-byte-length@1.0.2:
-    resolution:
-      {
-        integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
 
   data-view-byte-offset@1.0.1:
-    resolution:
-      {
-        integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
 
   dayjs@1.11.13:
-    resolution:
-      {
-        integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==,
-      }
+    resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
   debug@3.2.7:
-    resolution:
-      {
-        integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==,
-      }
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
-      supports-color: "*"
+      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
 
   debug@4.4.1:
-    resolution:
-      {
-        integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==,
-      }
-    engines: { node: ">=6.0" }
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
     peerDependencies:
-      supports-color: "*"
+      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
 
   deep-eql@5.0.2:
-    resolution:
-      {
-        integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-is@0.1.4:
-    resolution:
-      {
-        integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
-      }
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   define-data-property@1.1.4:
-    resolution:
-      {
-        integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
 
   define-lazy-prop@2.0.0:
-    resolution:
-      {
-        integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
 
   define-properties@1.2.1:
-    resolution:
-      {
-        integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   delayed-stream@1.0.0:
-    resolution:
-      {
-        integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
-      }
-    engines: { node: ">=0.4.0" }
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
-    resolution:
-      {
-        integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.0.4:
-    resolution:
-      {
-        integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+    engines: {node: '>=8'}
 
   doctrine@2.1.0:
-    resolution:
-      {
-        integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    engines: {node: '>=0.10.0'}
 
   doctrine@3.0.0:
-    resolution:
-      {
-        integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==,
-      }
-    engines: { node: ">=6.0.0" }
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
 
   dom-accessibility-api@0.5.16:
-    resolution:
-      {
-        integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==,
-      }
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-accessibility-api@0.6.3:
-    resolution:
-      {
-        integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==,
-      }
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dompurify@3.2.7:
-    resolution:
-      {
-        integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==,
-      }
+    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
   dotenv@17.2.1:
-    resolution:
-      {
-        integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
-    resolution:
-      {
-        integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   eastasianwidth@0.2.0:
-    resolution:
-      {
-        integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
-      }
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   ecc-jsbn@0.1.2:
-    resolution:
-      {
-        integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==,
-      }
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
 
   electron-to-chromium@1.5.192:
-    resolution:
-      {
-        integrity: sha512-rP8Ez0w7UNw/9j5eSXCe10o1g/8B1P5SM90PCCMVkIRQn2R0LEHWz4Eh9RnxkniuDe1W0cTSOB3MLlkTGDcuCg==,
-      }
+    resolution: {integrity: sha512-rP8Ez0w7UNw/9j5eSXCe10o1g/8B1P5SM90PCCMVkIRQn2R0LEHWz4Eh9RnxkniuDe1W0cTSOB3MLlkTGDcuCg==}
 
   emoji-regex@8.0.0:
-    resolution:
-      {
-        integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
-      }
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   emoji-regex@9.2.2:
-    resolution:
-      {
-        integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==,
-      }
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   end-of-stream@1.4.5:
-    resolution:
-      {
-        integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
-      }
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
-    resolution:
-      {
-        integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==,
-      }
-    engines: { node: ">=8.6" }
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
 
   error-ex@1.3.2:
-    resolution:
-      {
-        integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==,
-      }
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
   es-abstract@1.24.0:
-    resolution:
-      {
-        integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
+    engines: {node: '>= 0.4'}
 
   es-define-property@1.0.1:
-    resolution:
-      {
-        integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
 
   es-errors@1.3.0:
-    resolution:
-      {
-        integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
 
   es-iterator-helpers@1.2.1:
-    resolution:
-      {
-        integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==}
+    engines: {node: '>= 0.4'}
 
   es-object-atoms@1.1.1:
-    resolution:
-      {
-        integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   es-set-tostringtag@2.1.0:
-    resolution:
-      {
-        integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   es-shim-unscopables@1.1.0:
-    resolution:
-      {
-        integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
 
   es-to-primitive@1.3.0:
-    resolution:
-      {
-        integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
+    engines: {node: '>= 0.4'}
 
   es-toolkit@1.39.8:
-    resolution:
-      {
-        integrity: sha512-A8QO9TfF+rltS8BXpdu8OS+rpGgEdnRhqIVxO/ZmNvnXBYgOdSsxukT55ELyP94gZIntWJ+Li9QRrT2u1Kitpg==,
-      }
+    resolution: {integrity: sha512-A8QO9TfF+rltS8BXpdu8OS+rpGgEdnRhqIVxO/ZmNvnXBYgOdSsxukT55ELyP94gZIntWJ+Li9QRrT2u1Kitpg==}
 
   esbuild-register@3.6.0:
-    resolution:
-      {
-        integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==,
-      }
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
-      esbuild: ">=0.12 <1"
+      esbuild: '>=0.12 <1'
 
   esbuild@0.25.8:
-    resolution:
-      {
-        integrity: sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
-    resolution:
-      {
-        integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@1.0.5:
-    resolution:
-      {
-        integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==,
-      }
-    engines: { node: ">=0.8.0" }
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
 
   escape-string-regexp@4.0.0:
-    resolution:
-      {
-        integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   eslint-plugin-cypress@5.1.0:
-    resolution:
-      {
-        integrity: sha512-tdLXm4aq9vX2hTtKJTUFD3gdNseMKqsf8+P6hI4TtOPdz1LU4xvTpQBd1++qPAsPZP2lyYh71B5mvzu2lBr4Ow==,
-      }
+    resolution: {integrity: sha512-tdLXm4aq9vX2hTtKJTUFD3gdNseMKqsf8+P6hI4TtOPdz1LU4xvTpQBd1++qPAsPZP2lyYh71B5mvzu2lBr4Ow==}
     peerDependencies:
-      eslint: ">=9"
+      eslint: '>=9'
 
   eslint-plugin-react@7.37.5:
-    resolution:
-      {
-        integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
+    engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
   eslint-scope@8.4.0:
-    resolution:
-      {
-        integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-visitor-keys@3.4.3:
-    resolution:
-      {
-        integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==,
-      }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   eslint-visitor-keys@4.2.1:
-    resolution:
-      {
-        integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint@9.32.0:
-    resolution:
-      {
-        integrity: sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    resolution: {integrity: sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
-      jiti: "*"
+      jiti: '*'
     peerDependenciesMeta:
       jiti:
         optional: true
 
   espree@10.4.0:
-    resolution:
-      {
-        integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   esprima@4.0.1:
-    resolution:
-      {
-        integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
     hasBin: true
 
   esquery@1.6.0:
-    resolution:
-      {
-        integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==,
-      }
-    engines: { node: ">=0.10" }
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
-    resolution:
-      {
-        integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
-      }
-    engines: { node: ">=4.0" }
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
-    resolution:
-      {
-        integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
-      }
-    engines: { node: ">=4.0" }
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
 
   estree-walker@2.0.2:
-    resolution:
-      {
-        integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
-      }
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
-    resolution:
-      {
-        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
-      }
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   esutils@2.0.3:
-    resolution:
-      {
-        integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   eventemitter2@6.4.7:
-    resolution:
-      {
-        integrity: sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==,
-      }
+    resolution: {integrity: sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==}
 
   execa@4.1.0:
-    resolution:
-      {
-        integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
+    engines: {node: '>=10'}
 
   executable@4.1.1:
-    resolution:
-      {
-        integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==}
+    engines: {node: '>=4'}
 
   extend@3.0.2:
-    resolution:
-      {
-        integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
-      }
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   extract-zip@2.0.1:
-    resolution:
-      {
-        integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==,
-      }
-    engines: { node: ">= 10.17.0" }
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
     hasBin: true
 
   extsprintf@1.3.0:
-    resolution:
-      {
-        integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==,
-      }
-    engines: { "0": node >=0.6.0 }
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
 
   fast-deep-equal@3.1.3:
-    resolution:
-      {
-        integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
-      }
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-glob@3.3.3:
-    resolution:
-      {
-        integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==,
-      }
-    engines: { node: ">=8.6.0" }
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
 
   fast-json-stable-stringify@2.1.0:
-    resolution:
-      {
-        integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
-      }
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
-    resolution:
-      {
-        integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
-      }
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
   fastq@1.19.1:
-    resolution:
-      {
-        integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==,
-      }
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
   fd-slicer@1.1.0:
-    resolution:
-      {
-        integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==,
-      }
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.4.6:
-    resolution:
-      {
-        integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==,
-      }
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -2983,98 +1731,59 @@ packages:
         optional: true
 
   figures@2.0.0:
-    resolution:
-      {
-        integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
+    engines: {node: '>=4'}
 
   figures@3.2.0:
-    resolution:
-      {
-        integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
 
   file-entry-cache@8.0.0:
-    resolution:
-      {
-        integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
-      }
-    engines: { node: ">=16.0.0" }
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
 
   fill-range@7.1.1:
-    resolution:
-      {
-        integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   find-up@2.1.0:
-    resolution:
-      {
-        integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
+    engines: {node: '>=4'}
 
   find-up@5.0.0:
-    resolution:
-      {
-        integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
 
   flat-cache@4.0.1:
-    resolution:
-      {
-        integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==,
-      }
-    engines: { node: ">=16" }
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
 
   flatted@3.3.3:
-    resolution:
-      {
-        integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==,
-      }
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
   for-each@0.3.5:
-    resolution:
-      {
-        integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
 
   foreground-child@3.3.1:
-    resolution:
-      {
-        integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==,
-      }
-    engines: { node: ">=14" }
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
 
   forever-agent@0.6.1:
-    resolution:
-      {
-        integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==,
-      }
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
   form-data@4.0.4:
-    resolution:
-      {
-        integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==,
-      }
-    engines: { node: ">= 6" }
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
 
   framer-motion@12.23.12:
-    resolution:
-      {
-        integrity: sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==,
-      }
+    resolution: {integrity: sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==}
     peerDependencies:
-      "@emotion/is-prop-valid": "*"
+      '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
-      "@emotion/is-prop-valid":
+      '@emotion/is-prop-valid':
         optional: true
       react:
         optional: true
@@ -3082,1813 +1791,1017 @@ packages:
         optional: true
 
   fs-extra@11.3.4:
-    resolution:
-      {
-        integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==,
-      }
-    engines: { node: ">=14.14" }
+    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
+    engines: {node: '>=14.14'}
 
   fs-extra@9.1.0:
-    resolution:
-      {
-        integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+    engines: {node: '>=10'}
 
   fsevents@2.3.3:
-    resolution:
-      {
-        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
-      }
-    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
   function-bind@1.1.2:
-    resolution:
-      {
-        integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
-      }
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   function.prototype.name@1.1.8:
-    resolution:
-      {
-        integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
+    engines: {node: '>= 0.4'}
 
   functions-have-names@1.2.3:
-    resolution:
-      {
-        integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==,
-      }
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
   gensync@1.0.0-beta.2:
-    resolution:
-      {
-        integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
-      }
-    engines: { node: ">=6.9.0" }
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
-    resolution:
-      {
-        integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
-      }
-    engines: { node: 6.* || 8.* || >= 10.* }
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
-    resolution:
-      {
-        integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
 
   get-proto@1.0.1:
-    resolution:
-      {
-        integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@5.2.0:
-    resolution:
-      {
-        integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
 
   get-symbol-description@1.1.0:
-    resolution:
-      {
-        integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
 
   getos@3.2.1:
-    resolution:
-      {
-        integrity: sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==,
-      }
+    resolution: {integrity: sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==}
 
   getpass@0.1.7:
-    resolution:
-      {
-        integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==,
-      }
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
 
   glob-parent@5.1.2:
-    resolution:
-      {
-        integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
-      }
-    engines: { node: ">= 6" }
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   glob-parent@6.0.2:
-    resolution:
-      {
-        integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
-      }
-    engines: { node: ">=10.13.0" }
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
 
   glob@10.4.5:
-    resolution:
-      {
-        integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==,
-      }
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
   global-dirs@3.0.1:
-    resolution:
-      {
-        integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
+    engines: {node: '>=10'}
 
   globals@14.0.0:
-    resolution:
-      {
-        integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
 
   globals@15.15.0:
-    resolution:
-      {
-        integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
+    engines: {node: '>=18'}
 
   globals@16.3.0:
-    resolution:
-      {
-        integrity: sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==}
+    engines: {node: '>=18'}
 
   globalthis@1.0.4:
-    resolution:
-      {
-        integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
 
   gopd@1.2.0:
-    resolution:
-      {
-        integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
-    resolution:
-      {
-        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
-      }
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   graphemer@1.4.0:
-    resolution:
-      {
-        integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==,
-      }
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   has-bigints@1.1.0:
-    resolution:
-      {
-        integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
 
   has-flag@3.0.0:
-    resolution:
-      {
-        integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
 
   has-flag@4.0.0:
-    resolution:
-      {
-        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   has-property-descriptors@1.0.2:
-    resolution:
-      {
-        integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==,
-      }
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-proto@1.2.0:
-    resolution:
-      {
-        integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
 
   has-symbols@1.1.0:
-    resolution:
-      {
-        integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
 
   has-tostringtag@1.0.2:
-    resolution:
-      {
-        integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hasha@5.2.2:
-    resolution:
-      {
-        integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
+    engines: {node: '>=8'}
 
   hasown@2.0.2:
-    resolution:
-      {
-        integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   http-signature@1.4.0:
-    resolution:
-      {
-        integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==,
-      }
-    engines: { node: ">=0.10" }
+    resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
+    engines: {node: '>=0.10'}
 
   human-signals@1.1.1:
-    resolution:
-      {
-        integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==,
-      }
-    engines: { node: ">=8.12.0" }
+    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
+    engines: {node: '>=8.12.0'}
 
   ieee754@1.2.1:
-    resolution:
-      {
-        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
-      }
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
-    resolution:
-      {
-        integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
-      }
-    engines: { node: ">= 4" }
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
 
   ignore@7.0.5:
-    resolution:
-      {
-        integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
-      }
-    engines: { node: ">= 4" }
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
 
   import-fresh@3.3.1:
-    resolution:
-      {
-        integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
 
   imurmurhash@0.1.4:
-    resolution:
-      {
-        integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
-      }
-    engines: { node: ">=0.8.19" }
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
 
   indent-string@4.0.0:
-    resolution:
-      {
-        integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inherits@2.0.4:
-    resolution:
-      {
-        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
-      }
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ini@2.0.0:
-    resolution:
-      {
-        integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
+    engines: {node: '>=10'}
 
   internal-slot@1.1.0:
-    resolution:
-      {
-        integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
 
   is-arguments@1.2.0:
-    resolution:
-      {
-        integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
 
   is-array-buffer@3.0.5:
-    resolution:
-      {
-        integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
 
   is-arrayish@0.2.1:
-    resolution:
-      {
-        integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==,
-      }
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-async-function@2.1.1:
-    resolution:
-      {
-        integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
 
   is-bigint@1.1.0:
-    resolution:
-      {
-        integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
 
   is-boolean-object@1.2.2:
-    resolution:
-      {
-        integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
 
   is-callable@1.2.7:
-    resolution:
-      {
-        integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
 
   is-core-module@2.16.1:
-    resolution:
-      {
-        integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
 
   is-data-view@1.0.2:
-    resolution:
-      {
-        integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
 
   is-date-object@1.1.0:
-    resolution:
-      {
-        integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
 
   is-docker@2.2.1:
-    resolution:
-      {
-        integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
     hasBin: true
 
   is-extglob@2.1.1:
-    resolution:
-      {
-        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
 
   is-finalizationregistry@1.1.1:
-    resolution:
-      {
-        integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
 
   is-fullwidth-code-point@3.0.0:
-    resolution:
-      {
-        integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-generator-function@1.1.0:
-    resolution:
-      {
-        integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
+    engines: {node: '>= 0.4'}
 
   is-glob@4.0.3:
-    resolution:
-      {
-        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   is-installed-globally@0.4.0:
-    resolution:
-      {
-        integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==}
+    engines: {node: '>=10'}
 
   is-map@2.0.3:
-    resolution:
-      {
-        integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
 
   is-negative-zero@2.0.3:
-    resolution:
-      {
-        integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
 
   is-number-object@1.1.1:
-    resolution:
-      {
-        integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
 
   is-number@7.0.0:
-    resolution:
-      {
-        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
-      }
-    engines: { node: ">=0.12.0" }
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-path-inside@3.0.3:
-    resolution:
-      {
-        integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
 
   is-regex@1.2.1:
-    resolution:
-      {
-        integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
 
   is-set@2.0.3:
-    resolution:
-      {
-        integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
 
   is-shared-array-buffer@1.0.4:
-    resolution:
-      {
-        integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
 
   is-stream@2.0.1:
-    resolution:
-      {
-        integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-string@1.1.1:
-    resolution:
-      {
-        integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
 
   is-symbol@1.1.1:
-    resolution:
-      {
-        integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
 
   is-typed-array@1.1.15:
-    resolution:
-      {
-        integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
 
   is-typedarray@1.0.0:
-    resolution:
-      {
-        integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==,
-      }
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
 
   is-unicode-supported@0.1.0:
-    resolution:
-      {
-        integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
 
   is-weakmap@2.0.2:
-    resolution:
-      {
-        integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
 
   is-weakref@1.1.1:
-    resolution:
-      {
-        integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
 
   is-weakset@2.0.4:
-    resolution:
-      {
-        integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
 
   is-wsl@2.2.0:
-    resolution:
-      {
-        integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
 
   isarray@2.0.5:
-    resolution:
-      {
-        integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==,
-      }
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
-    resolution:
-      {
-        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
-      }
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   isstream@0.1.2:
-    resolution:
-      {
-        integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==,
-      }
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
   iterator.prototype@1.1.5:
-    resolution:
-      {
-        integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
+    engines: {node: '>= 0.4'}
 
   jackspeak@3.4.3:
-    resolution:
-      {
-        integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==,
-      }
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@2.5.1:
-    resolution:
-      {
-        integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==,
-      }
+    resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
 
   js-tokens@4.0.0:
-    resolution:
-      {
-        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
-      }
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.1.0:
-    resolution:
-      {
-        integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==,
-      }
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
   jsbn@0.1.1:
-    resolution:
-      {
-        integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==,
-      }
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
 
   jsdoc-type-pratt-parser@4.1.0:
-    resolution:
-      {
-        integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==}
+    engines: {node: '>=12.0.0'}
 
   jsesc@3.1.0:
-    resolution:
-      {
-        integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json-buffer@3.0.1:
-    resolution:
-      {
-        integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
-      }
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
   json-parse-better-errors@1.0.2:
-    resolution:
-      {
-        integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==,
-      }
+    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
 
   json-schema-traverse@0.4.1:
-    resolution:
-      {
-        integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
-      }
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   json-schema@0.4.0:
-    resolution:
-      {
-        integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==,
-      }
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
-    resolution:
-      {
-        integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
-      }
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   json-stringify-safe@5.0.1:
-    resolution:
-      {
-        integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==,
-      }
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
   json5@2.2.3:
-    resolution:
-      {
-        integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
     hasBin: true
 
   jsonfile@6.1.0:
-    resolution:
-      {
-        integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==,
-      }
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
   jsprim@2.0.2:
-    resolution:
-      {
-        integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==,
-      }
-    engines: { "0": node >=0.6.0 }
+    resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
+    engines: {'0': node >=0.6.0}
 
   jsx-ast-utils@3.3.5:
-    resolution:
-      {
-        integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==,
-      }
-    engines: { node: ">=4.0" }
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+    engines: {node: '>=4.0'}
 
   keyv@4.5.4:
-    resolution:
-      {
-        integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
-      }
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   lazy-ass@1.6.0:
-    resolution:
-      {
-        integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==,
-      }
-    engines: { node: "> 0.8" }
+    resolution: {integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==}
+    engines: {node: '> 0.8'}
 
   levn@0.4.1:
-    resolution:
-      {
-        integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
-      }
-    engines: { node: ">= 0.8.0" }
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-darwin-arm64@1.30.1:
-    resolution:
-      {
-        integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.30.1:
-    resolution:
-      {
-        integrity: sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
   lightningcss-freebsd-x64@1.30.1:
-    resolution:
-      {
-        integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
   lightningcss-linux-arm-gnueabihf@1.30.1:
-    resolution:
-      {
-        integrity: sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
   lightningcss-linux-arm64-gnu@1.30.1:
-    resolution:
-      {
-        integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
 
   lightningcss-linux-arm64-musl@1.30.1:
-    resolution:
-      {
-        integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
 
   lightningcss-linux-x64-gnu@1.30.1:
-    resolution:
-      {
-        integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
 
   lightningcss-linux-x64-musl@1.30.1:
-    resolution:
-      {
-        integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
 
   lightningcss-win32-arm64-msvc@1.30.1:
-    resolution:
-      {
-        integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.30.1:
-    resolution:
-      {
-        integrity: sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
 
   lightningcss@1.30.1:
-    resolution:
-      {
-        integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
+    engines: {node: '>= 12.0.0'}
 
   listr2@3.14.0:
-    resolution:
-      {
-        integrity: sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==,
-      }
-    engines: { node: ">=10.0.0" }
+    resolution: {integrity: sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==}
+    engines: {node: '>=10.0.0'}
     peerDependencies:
-      enquirer: ">= 2.3.0 < 3"
+      enquirer: '>= 2.3.0 < 3'
     peerDependenciesMeta:
       enquirer:
         optional: true
 
   load-json-file@4.0.0:
-    resolution:
-      {
-        integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
+    engines: {node: '>=4'}
 
   locate-path@2.0.0:
-    resolution:
-      {
-        integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
+    engines: {node: '>=4'}
 
   locate-path@6.0.0:
-    resolution:
-      {
-        integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   lodash.merge@4.6.2:
-    resolution:
-      {
-        integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
-      }
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   lodash.once@4.1.1:
-    resolution:
-      {
-        integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==,
-      }
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash@4.17.21:
-    resolution:
-      {
-        integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
-      }
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   log-symbols@4.1.0:
-    resolution:
-      {
-        integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
 
   log-update@4.0.0:
-    resolution:
-      {
-        integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
+    engines: {node: '>=10'}
 
   loose-envify@1.4.0:
-    resolution:
-      {
-        integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==,
-      }
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
   loupe@3.2.0:
-    resolution:
-      {
-        integrity: sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==,
-      }
+    resolution: {integrity: sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==}
 
   lru-cache@10.4.3:
-    resolution:
-      {
-        integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==,
-      }
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
-    resolution:
-      {
-        integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
-      }
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lz-string@1.5.0:
-    resolution:
-      {
-        integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==,
-      }
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
   magic-string@0.27.0:
-    resolution:
-      {
-        integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.17:
-    resolution:
-      {
-        integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==,
-      }
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   map-or-similar@1.5.0:
-    resolution:
-      {
-        integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==,
-      }
+    resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
 
   marked@14.0.0:
-    resolution:
-      {
-        integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==,
-      }
-    engines: { node: ">= 18" }
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
     hasBin: true
 
   math-intrinsics@1.1.0:
-    resolution:
-      {
-        integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   memoizerific@1.11.3:
-    resolution:
-      {
-        integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==,
-      }
+    resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
 
   merge-stream@2.0.0:
-    resolution:
-      {
-        integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==,
-      }
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
-    resolution:
-      {
-        integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
-      }
-    engines: { node: ">= 8" }
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
 
   micromatch@4.0.8:
-    resolution:
-      {
-        integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
-      }
-    engines: { node: ">=8.6" }
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
 
   mime-db@1.52.0:
-    resolution:
-      {
-        integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
-    resolution:
-      {
-        integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mimic-fn@2.1.0:
-    resolution:
-      {
-        integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   min-indent@1.0.1:
-    resolution:
-      {
-        integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
-    resolution:
-      {
-        integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==,
-      }
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
   minimatch@9.0.5:
-    resolution:
-      {
-        integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==,
-      }
-    engines: { node: ">=16 || 14 >=14.17" }
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
-    resolution:
-      {
-        integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
-      }
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.2:
-    resolution:
-      {
-        integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==,
-      }
-    engines: { node: ">=16 || 14 >=14.17" }
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   monaco-editor@0.55.1:
-    resolution:
-      {
-        integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==,
-      }
+    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
   motion-dom@12.23.12:
-    resolution:
-      {
-        integrity: sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==,
-      }
+    resolution: {integrity: sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==}
 
   motion-utils@12.23.6:
-    resolution:
-      {
-        integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==,
-      }
+    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
 
   ms@2.1.3:
-    resolution:
-      {
-        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
-      }
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
-    resolution:
-      {
-        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
-      }
-    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
   natural-compare@1.4.0:
-    resolution:
-      {
-        integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
-      }
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   node-releases@2.0.19:
-    resolution:
-      {
-        integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==,
-      }
+    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
   npm-run-path@4.0.1:
-    resolution:
-      {
-        integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
 
   object-assign@4.1.1:
-    resolution:
-      {
-        integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
-    resolution:
-      {
-        integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   object-keys@1.1.1:
-    resolution:
-      {
-        integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
 
   object.assign@4.1.7:
-    resolution:
-      {
-        integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
 
   object.entries@1.1.9:
-    resolution:
-      {
-        integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
+    engines: {node: '>= 0.4'}
 
   object.fromentries@2.0.8:
-    resolution:
-      {
-        integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
 
   object.values@1.2.1:
-    resolution:
-      {
-        integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
+    engines: {node: '>= 0.4'}
 
   once@1.4.0:
-    resolution:
-      {
-        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
-      }
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
-    resolution:
-      {
-        integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
 
   open@8.4.2:
-    resolution:
-      {
-        integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
 
   optionator@0.9.4:
-    resolution:
-      {
-        integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
-      }
-    engines: { node: ">= 0.8.0" }
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
 
   ospath@1.2.2:
-    resolution:
-      {
-        integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==,
-      }
+    resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
 
   own-keys@1.0.1:
-    resolution:
-      {
-        integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==,
-      }
-    engines: { node: ">= 0.4" }
-
-  oxfmt@0.62.0:
-    resolution:
-      {
-        integrity: sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    hasBin: true
-    peerDependencies:
-      svelte: ^5.0.0
-      vite-plus: "*"
-    peerDependenciesMeta:
-      svelte:
-        optional: true
-      vite-plus:
-        optional: true
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
 
   p-limit@1.3.0:
-    resolution:
-      {
-        integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
+    engines: {node: '>=4'}
 
   p-limit@3.1.0:
-    resolution:
-      {
-        integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
 
   p-locate@2.0.0:
-    resolution:
-      {
-        integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
+    engines: {node: '>=4'}
 
   p-locate@5.0.0:
-    resolution:
-      {
-        integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   p-map@4.0.0:
-    resolution:
-      {
-        integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
 
   p-try@1.0.0:
-    resolution:
-      {
-        integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
+    engines: {node: '>=4'}
 
   package-json-from-dist@1.0.1:
-    resolution:
-      {
-        integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==,
-      }
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   parent-module@1.0.1:
-    resolution:
-      {
-        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
 
   parse-json@4.0.0:
-    resolution:
-      {
-        integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
+    engines: {node: '>=4'}
 
   path-exists@3.0.0:
-    resolution:
-      {
-        integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
+    engines: {node: '>=4'}
 
   path-exists@4.0.0:
-    resolution:
-      {
-        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-key@3.1.1:
-    resolution:
-      {
-        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   path-parse@1.0.7:
-    resolution:
-      {
-        integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
-      }
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   path-scurry@1.11.1:
-    resolution:
-      {
-        integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==,
-      }
-    engines: { node: ">=16 || 14 >=14.18" }
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathval@2.0.1:
-    resolution:
-      {
-        integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
-      }
-    engines: { node: ">= 14.16" }
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pdfjs-dist@5.4.54:
-    resolution:
-      {
-        integrity: sha512-TBAiTfQw89gU/Z4LW98Vahzd2/LoCFprVGvGbTgFt+QCB1F+woyOPmNNVgLa6djX9Z9GGTnj7qE1UzpOVJiINw==,
-      }
-    engines: { node: ">=20.16.0 || >=22.3.0" }
+    resolution: {integrity: sha512-TBAiTfQw89gU/Z4LW98Vahzd2/LoCFprVGvGbTgFt+QCB1F+woyOPmNNVgLa6djX9Z9GGTnj7qE1UzpOVJiINw==}
+    engines: {node: '>=20.16.0 || >=22.3.0'}
 
   pend@1.2.0:
-    resolution:
-      {
-        integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==,
-      }
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   performance-now@2.1.0:
-    resolution:
-      {
-        integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==,
-      }
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   picocolors@1.1.1:
-    resolution:
-      {
-        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
-      }
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.1:
-    resolution:
-      {
-        integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
-      }
-    engines: { node: ">=8.6" }
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.3:
-    resolution:
-      {
-        integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   pify@2.3.0:
-    resolution:
-      {
-        integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
 
   pify@3.0.0:
-    resolution:
-      {
-        integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
+    engines: {node: '>=4'}
 
   pkg-conf@2.1.0:
-    resolution:
-      {
-        integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
+    engines: {node: '>=4'}
 
   polished@4.3.1:
-    resolution:
-      {
-        integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
+    engines: {node: '>=10'}
 
   possible-typed-array-names@1.1.0:
-    resolution:
-      {
-        integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postcss-value-parser@4.2.0:
-    resolution:
-      {
-        integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
-      }
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.4.49:
-    resolution:
-      {
-        integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==,
-      }
-    engines: { node: ^10 || ^12 || >=14 }
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
-    resolution:
-      {
-        integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==,
-      }
-    engines: { node: ^10 || ^12 || >=14 }
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
-    resolution:
-      {
-        integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
-      }
-    engines: { node: ">= 0.8.0" }
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
 
   prettier@3.6.2:
-    resolution:
-      {
-        integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==,
-      }
-    engines: { node: ">=14" }
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
     hasBin: true
 
   pretty-bytes@5.6.0:
-    resolution:
-      {
-        integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
+    engines: {node: '>=6'}
 
   pretty-format@27.5.1:
-    resolution:
-      {
-        integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==,
-      }
-    engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   process@0.11.10:
-    resolution:
-      {
-        integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==,
-      }
-    engines: { node: ">= 0.6.0" }
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
 
   prop-types@15.8.1:
-    resolution:
-      {
-        integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==,
-      }
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   proxy-from-env@1.0.0:
-    resolution:
-      {
-        integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==,
-      }
+    resolution: {integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==}
 
   pump@3.0.3:
-    resolution:
-      {
-        integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==,
-      }
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
   punycode@2.3.1:
-    resolution:
-      {
-        integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.14.0:
-    resolution:
-      {
-        integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==,
-      }
-    engines: { node: ">=0.6" }
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
-    resolution:
-      {
-        integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
-      }
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   react-docgen-typescript@2.4.0:
-    resolution:
-      {
-        integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==,
-      }
+    resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
     peerDependencies:
-      typescript: ">= 4.3.x"
+      typescript: '>= 4.3.x'
 
   react-docgen@7.1.1:
-    resolution:
-      {
-        integrity: sha512-hlSJDQ2synMPKFZOsKo9Hi8WWZTC7POR8EmWvTSjow+VDgKzkmjQvFm2fk0tmRw+f0vTOIYKlarR0iL4996pdg==,
-      }
-    engines: { node: ">=16.14.0" }
+    resolution: {integrity: sha512-hlSJDQ2synMPKFZOsKo9Hi8WWZTC7POR8EmWvTSjow+VDgKzkmjQvFm2fk0tmRw+f0vTOIYKlarR0iL4996pdg==}
+    engines: {node: '>=16.14.0'}
 
   react-dom@19.1.1:
-    resolution:
-      {
-        integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==,
-      }
+    resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
     peerDependencies:
       react: ^19.1.1
 
   react-hook-form@7.61.1:
-    resolution:
-      {
-        integrity: sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==,
-      }
-    engines: { node: ">=18.0.0" }
+    resolution: {integrity: sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
-    resolution:
-      {
-        integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==,
-      }
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@17.0.2:
-    resolution:
-      {
-        integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==,
-      }
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.17.0:
-    resolution:
-      {
-        integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
 
   react-swipeable@7.0.2:
-    resolution:
-      {
-        integrity: sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==,
-      }
+    resolution: {integrity: sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==}
     peerDependencies:
       react: ^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc
 
   react@19.1.1:
-    resolution:
-      {
-        integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
+    engines: {node: '>=0.10.0'}
 
   recast@0.23.11:
-    resolution:
-      {
-        integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==,
-      }
-    engines: { node: ">= 4" }
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
 
   redent@3.0.0:
-    resolution:
-      {
-        integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
-    resolution:
-      {
-        integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
 
   regexp.prototype.flags@1.5.4:
-    resolution:
-      {
-        integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
 
   request-progress@3.0.0:
-    resolution:
-      {
-        integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==,
-      }
+    resolution: {integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==}
 
   require-directory@2.1.1:
-    resolution:
-      {
-        integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
-    resolution:
-      {
-        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
 
   resolve@1.22.10:
-    resolution:
-      {
-        integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
     hasBin: true
 
   resolve@2.0.0-next.5:
-    resolution:
-      {
-        integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==,
-      }
+    resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
   restore-cursor@3.1.0:
-    resolution:
-      {
-        integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
 
   reusify@1.1.0:
-    resolution:
-      {
-        integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
-      }
-    engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rfdc@1.4.1:
-    resolution:
-      {
-        integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
-      }
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rollup@4.46.2:
-    resolution:
-      {
-        integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==,
-      }
-    engines: { node: ">=18.0.0", npm: ">=8.0.0" }
+    resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   run-parallel@1.2.0:
-    resolution:
-      {
-        integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
-      }
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   rxjs@7.8.2:
-    resolution:
-      {
-        integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==,
-      }
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-array-concat@1.1.3:
-    resolution:
-      {
-        integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==,
-      }
-    engines: { node: ">=0.4" }
+    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
+    engines: {node: '>=0.4'}
 
   safe-buffer@5.2.1:
-    resolution:
-      {
-        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
-      }
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
-    resolution:
-      {
-        integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
 
   safe-regex-test@1.1.0:
-    resolution:
-      {
-        integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
 
   safer-buffer@2.1.2:
-    resolution:
-      {
-        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
-      }
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.26.0:
-    resolution:
-      {
-        integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==,
-      }
+    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
   semver@6.3.1:
-    resolution:
-      {
-        integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
-      }
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
   semver@7.7.2:
-    resolution:
-      {
-        integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   set-function-length@1.2.2:
-    resolution:
-      {
-        integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
 
   set-function-name@2.0.2:
-    resolution:
-      {
-        integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
 
   set-proto@1.0.0:
-    resolution:
-      {
-        integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
 
   shallowequal@1.1.0:
-    resolution:
-      {
-        integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==,
-      }
+    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
   shebang-command@2.0.0:
-    resolution:
-      {
-        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
 
   shebang-regex@3.0.0:
-    resolution:
-      {
-        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   side-channel-list@1.0.0:
-    resolution:
-      {
-        integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
-    resolution:
-      {
-        integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
 
   side-channel-weakmap@1.0.2:
-    resolution:
-      {
-        integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
 
   side-channel@1.1.0:
-    resolution:
-      {
-        integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
-    resolution:
-      {
-        integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==,
-      }
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
-    resolution:
-      {
-        integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
-      }
-    engines: { node: ">=14" }
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   signale@1.4.0:
-    resolution:
-      {
-        integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==}
+    engines: {node: '>=6'}
 
   slice-ansi@3.0.0:
-    resolution:
-      {
-        integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
+    engines: {node: '>=8'}
 
   slice-ansi@4.0.0:
-    resolution:
-      {
-        integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
 
   source-map-js@1.2.1:
-    resolution:
-      {
-        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.21:
-    resolution:
-      {
-        integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==,
-      }
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
   source-map@0.6.1:
-    resolution:
-      {
-        integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
 
   sshpk@1.18.0:
-    resolution:
-      {
-        integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
     hasBin: true
 
   stop-iteration-iterator@1.1.0:
-    resolution:
-      {
-        integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
 
   storybook@8.6.14:
-    resolution:
-      {
-        integrity: sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==,
-      }
+    resolution: {integrity: sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==}
     hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
@@ -4897,448 +2810,258 @@ packages:
         optional: true
 
   string-width@4.2.3:
-    resolution:
-      {
-        integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
 
   string-width@5.1.2:
-    resolution:
-      {
-        integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string.prototype.matchall@4.0.12:
-    resolution:
-      {
-        integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
+    engines: {node: '>= 0.4'}
 
   string.prototype.repeat@1.0.0:
-    resolution:
-      {
-        integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==,
-      }
+    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
 
   string.prototype.trim@1.2.10:
-    resolution:
-      {
-        integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+    engines: {node: '>= 0.4'}
 
   string.prototype.trimend@1.0.9:
-    resolution:
-      {
-        integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+    engines: {node: '>= 0.4'}
 
   string.prototype.trimstart@1.0.8:
-    resolution:
-      {
-        integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
 
   strip-ansi@6.0.1:
-    resolution:
-      {
-        integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-ansi@7.1.0:
-    resolution:
-      {
-        integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
-    resolution:
-      {
-        integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
 
   strip-final-newline@2.0.0:
-    resolution:
-      {
-        integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
 
   strip-indent@3.0.0:
-    resolution:
-      {
-        integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-indent@4.0.0:
-    resolution:
-      {
-        integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==}
+    engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
-    resolution:
-      {
-        integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
 
   styled-components@6.1.19:
-    resolution:
-      {
-        integrity: sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==,
-      }
-    engines: { node: ">= 16" }
+    resolution: {integrity: sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==}
+    engines: {node: '>= 16'}
     peerDependencies:
-      react: ">= 16.8.0"
-      react-dom: ">= 16.8.0"
+      react: '>= 16.8.0'
+      react-dom: '>= 16.8.0'
 
   stylis@4.3.2:
-    resolution:
-      {
-        integrity: sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==,
-      }
+    resolution: {integrity: sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==}
 
   supports-color@5.5.0:
-    resolution:
-      {
-        integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==,
-      }
-    engines: { node: ">=4" }
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
 
   supports-color@7.2.0:
-    resolution:
-      {
-        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   supports-color@8.1.1:
-    resolution:
-      {
-        integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
 
   supports-preserve-symlinks-flag@1.0.0:
-    resolution:
-      {
-        integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   tabbable@6.2.0:
-    resolution:
-      {
-        integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==,
-      }
+    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
 
   terser@5.43.1:
-    resolution:
-      {
-        integrity: sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==}
+    engines: {node: '>=10'}
     hasBin: true
 
   throttleit@1.0.1:
-    resolution:
-      {
-        integrity: sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==,
-      }
+    resolution: {integrity: sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==}
 
   through@2.3.8:
-    resolution:
-      {
-        integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==,
-      }
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   tiny-invariant@1.3.3:
-    resolution:
-      {
-        integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==,
-      }
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinyglobby@0.2.14:
-    resolution:
-      {
-        integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==,
-      }
-    engines: { node: ">=12.0.0" }
-
-  tinypool@2.1.0:
-    resolution:
-      {
-        integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==,
-      }
-    engines: { node: ^20.0.0 || >=22.0.0 }
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
 
   tinyrainbow@1.2.0:
-    resolution:
-      {
-        integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==,
-      }
-    engines: { node: ">=14.0.0" }
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
 
   tinyspy@3.0.2:
-    resolution:
-      {
-        integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==,
-      }
-    engines: { node: ">=14.0.0" }
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
-    resolution:
-      {
-        integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==,
-      }
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
   tldts@6.1.86:
-    resolution:
-      {
-        integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==,
-      }
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
   tmp@0.2.3:
-    resolution:
-      {
-        integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==,
-      }
-    engines: { node: ">=14.14" }
+    resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
+    engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
-    resolution:
-      {
-        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
-      }
-    engines: { node: ">=8.0" }
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   tough-cookie@5.1.2:
-    resolution:
-      {
-        integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==,
-      }
-    engines: { node: ">=16" }
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
 
   tree-kill@1.2.2:
-    resolution:
-      {
-        integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
-      }
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
   ts-api-utils@2.1.0:
-    resolution:
-      {
-        integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==,
-      }
-    engines: { node: ">=18.12" }
+    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
     peerDependencies:
-      typescript: ">=4.8.4"
+      typescript: '>=4.8.4'
 
   ts-dedent@2.2.0:
-    resolution:
-      {
-        integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==,
-      }
-    engines: { node: ">=6.10" }
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   tsconfig-paths@4.2.0:
-    resolution:
-      {
-        integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@2.6.2:
-    resolution:
-      {
-        integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==,
-      }
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
   tslib@2.8.1:
-    resolution:
-      {
-        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
-      }
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tunnel-agent@0.6.0:
-    resolution:
-      {
-        integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
-      }
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   tweetnacl@0.14.5:
-    resolution:
-      {
-        integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==,
-      }
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-check@0.4.0:
-    resolution:
-      {
-        integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
-      }
-    engines: { node: ">= 0.8.0" }
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
 
   type-fest@0.21.3:
-    resolution:
-      {
-        integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
 
   type-fest@0.8.1:
-    resolution:
-      {
-        integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
 
   typed-array-buffer@1.0.3:
-    resolution:
-      {
-        integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
 
   typed-array-byte-length@1.0.3:
-    resolution:
-      {
-        integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
 
   typed-array-byte-offset@1.0.4:
-    resolution:
-      {
-        integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
 
   typed-array-length@1.0.7:
-    resolution:
-      {
-        integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
+    engines: {node: '>= 0.4'}
 
   typescript@5.8.3:
-    resolution:
-      {
-        integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==,
-      }
-    engines: { node: ">=14.17" }
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   unbox-primitive@1.1.0:
-    resolution:
-      {
-        integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
 
   undici-types@7.8.0:
-    resolution:
-      {
-        integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==,
-      }
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
   universalify@2.0.1:
-    resolution:
-      {
-        integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==,
-      }
-    engines: { node: ">= 10.0.0" }
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   unplugin@1.16.1:
-    resolution:
-      {
-        integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==,
-      }
-    engines: { node: ">=14.0.0" }
+    resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
+    engines: {node: '>=14.0.0'}
 
   untildify@4.0.0:
-    resolution:
-      {
-        integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
+    engines: {node: '>=8'}
 
   update-browserslist-db@1.1.3:
-    resolution:
-      {
-        integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==,
-      }
+    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
     hasBin: true
     peerDependencies:
-      browserslist: ">= 4.21.0"
+      browserslist: '>= 4.21.0'
 
   uri-js@4.4.1:
-    resolution:
-      {
-        integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
-      }
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util@0.12.5:
-    resolution:
-      {
-        integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==,
-      }
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   uuid@8.3.2:
-    resolution:
-      {
-        integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
-      }
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
 
   uuid@9.0.1:
-    resolution:
-      {
-        integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==,
-      }
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
   verror@1.10.0:
-    resolution:
-      {
-        integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==,
-      }
-    engines: { "0": node >=0.6.0 }
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
 
   vite@6.3.5:
-    resolution:
-      {
-        integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==,
-      }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: ">=1.21.0"
-      less: "*"
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
       lightningcss: ^1.21.0
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
-      "@types/node":
+      '@types/node':
         optional: true
       jiti:
         optional: true
@@ -5362,90 +3085,54 @@ packages:
         optional: true
 
   webpack-virtual-modules@0.6.2:
-    resolution:
-      {
-        integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==,
-      }
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   which-boxed-primitive@1.1.1:
-    resolution:
-      {
-        integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
 
   which-builtin-type@1.2.1:
-    resolution:
-      {
-        integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
 
   which-collection@1.0.2:
-    resolution:
-      {
-        integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
 
   which-typed-array@1.1.19:
-    resolution:
-      {
-        integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
-    resolution:
-      {
-        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
-      }
-    engines: { node: ">= 8" }
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
     hasBin: true
 
   word-wrap@1.2.5:
-    resolution:
-      {
-        integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   wrap-ansi@6.2.0:
-    resolution:
-      {
-        integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
 
   wrap-ansi@7.0.0:
-    resolution:
-      {
-        integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
 
   wrap-ansi@8.1.0:
-    resolution:
-      {
-        integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
-    resolution:
-      {
-        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
-      }
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.18.3:
-    resolution:
-      {
-        integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==,
-      }
-    engines: { node: ">=10.0.0" }
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
-      utf-8-validate: ">=5.0.2"
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -5453,86 +3140,66 @@ packages:
         optional: true
 
   y18n@5.0.8:
-    resolution:
-      {
-        integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
 
   yallist@3.1.1:
-    resolution:
-      {
-        integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
-      }
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yargs-parser@21.1.1:
-    resolution:
-      {
-        integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
 
   yargs@17.7.2:
-    resolution:
-      {
-        integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yauzl@2.10.0:
-    resolution:
-      {
-        integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==,
-      }
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
-    resolution:
-      {
-        integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
-      }
-    engines: { node: ">=10" }
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   zod@3.25.76:
-    resolution:
-      {
-        integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
-      }
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
-  "@adobe/css-tools@4.4.3":
+
+  '@adobe/css-tools@4.4.3':
     optional: true
 
-  "@ampproject/remapping@2.3.0":
+  '@ampproject/remapping@2.3.0':
     dependencies:
-      "@jridgewell/gen-mapping": 0.3.12
-      "@jridgewell/trace-mapping": 0.3.29
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
 
-  "@babel/code-frame@7.27.1":
+  '@babel/code-frame@7.27.1':
     dependencies:
-      "@babel/helper-validator-identifier": 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  "@babel/code-frame@7.29.0":
+  '@babel/code-frame@7.29.0':
     dependencies:
-      "@babel/helper-validator-identifier": 7.28.5
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  "@babel/compat-data@7.28.0": {}
+  '@babel/compat-data@7.28.0': {}
 
-  "@babel/core@7.28.0":
+  '@babel/core@7.28.0':
     dependencies:
-      "@ampproject/remapping": 2.3.0
-      "@babel/code-frame": 7.27.1
-      "@babel/generator": 7.28.0
-      "@babel/helper-compilation-targets": 7.27.2
-      "@babel/helper-module-transforms": 7.27.3(@babel/core@7.28.0)
-      "@babel/helpers": 7.28.2
-      "@babel/parser": 7.29.2
-      "@babel/template": 7.27.2
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.28.2
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.0
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
+      '@babel/helpers': 7.28.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.28.2
       convert-source-map: 2.0.0
       debug: 4.4.1(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
@@ -5541,114 +3208,114 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/generator@7.28.0":
+  '@babel/generator@7.28.0':
     dependencies:
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.28.2
-      "@jridgewell/gen-mapping": 0.3.12
-      "@jridgewell/trace-mapping": 0.3.29
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.28.2
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
       jsesc: 3.1.0
 
-  "@babel/generator@7.29.1":
+  '@babel/generator@7.29.1':
     dependencies:
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.29.0
-      "@jridgewell/gen-mapping": 0.3.12
-      "@jridgewell/trace-mapping": 0.3.29
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
       jsesc: 3.1.0
 
-  "@babel/helper-compilation-targets@7.27.2":
+  '@babel/helper-compilation-targets@7.27.2':
     dependencies:
-      "@babel/compat-data": 7.28.0
-      "@babel/helper-validator-option": 7.27.1
+      '@babel/compat-data': 7.28.0
+      '@babel/helper-validator-option': 7.27.1
       browserslist: 4.25.1
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  "@babel/helper-globals@7.28.0": {}
+  '@babel/helper-globals@7.28.0': {}
 
-  "@babel/helper-module-imports@7.27.1":
+  '@babel/helper-module-imports@7.27.1':
     dependencies:
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.28.2
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0)":
+  '@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0)':
     dependencies:
-      "@babel/core": 7.28.0
-      "@babel/helper-module-imports": 7.27.1
-      "@babel/helper-validator-identifier": 7.27.1
-      "@babel/traverse": 7.29.0
+      '@babel/core': 7.28.0
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/helper-plugin-utils@7.27.1": {}
+  '@babel/helper-plugin-utils@7.27.1': {}
 
-  "@babel/helper-string-parser@7.27.1": {}
+  '@babel/helper-string-parser@7.27.1': {}
 
-  "@babel/helper-validator-identifier@7.27.1": {}
+  '@babel/helper-validator-identifier@7.27.1': {}
 
-  "@babel/helper-validator-identifier@7.28.5": {}
+  '@babel/helper-validator-identifier@7.28.5': {}
 
-  "@babel/helper-validator-option@7.27.1": {}
+  '@babel/helper-validator-option@7.27.1': {}
 
-  "@babel/helpers@7.28.2":
+  '@babel/helpers@7.28.2':
     dependencies:
-      "@babel/template": 7.27.2
-      "@babel/types": 7.28.2
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.2
 
-  "@babel/parser@7.29.2":
+  '@babel/parser@7.29.2':
     dependencies:
-      "@babel/types": 7.29.0
+      '@babel/types': 7.29.0
 
-  "@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.0)":
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.0)':
     dependencies:
-      "@babel/core": 7.28.0
-      "@babel/helper-plugin-utils": 7.27.1
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
 
-  "@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.0)":
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.0)':
     dependencies:
-      "@babel/core": 7.28.0
-      "@babel/helper-plugin-utils": 7.27.1
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
 
-  "@babel/runtime@7.28.2": {}
+  '@babel/runtime@7.28.2': {}
 
-  "@babel/template@7.27.2":
+  '@babel/template@7.27.2':
     dependencies:
-      "@babel/code-frame": 7.27.1
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.28.2
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.28.2
 
-  "@babel/template@7.28.6":
+  '@babel/template@7.28.6':
     dependencies:
-      "@babel/code-frame": 7.29.0
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.29.0
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
-  "@babel/traverse@7.29.0":
+  '@babel/traverse@7.29.0':
     dependencies:
-      "@babel/code-frame": 7.29.0
-      "@babel/generator": 7.29.1
-      "@babel/helper-globals": 7.28.0
-      "@babel/parser": 7.29.2
-      "@babel/template": 7.28.6
-      "@babel/types": 7.29.0
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
       debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/types@7.28.2":
+  '@babel/types@7.28.2':
     dependencies:
-      "@babel/helper-string-parser": 7.27.1
-      "@babel/helper-validator-identifier": 7.27.1
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
 
-  "@babel/types@7.29.0":
+  '@babel/types@7.29.0':
     dependencies:
-      "@babel/helper-string-parser": 7.27.1
-      "@babel/helper-validator-identifier": 7.28.5
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
-  "@cypress/request@3.0.9":
+  '@cypress/request@3.0.9':
     dependencies:
       aws-sign2: 0.7.0
       aws4: 1.13.2
@@ -5669,121 +3336,121 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  "@cypress/xvfb@1.2.4(supports-color@8.1.1)":
+  '@cypress/xvfb@1.2.4(supports-color@8.1.1)':
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
       lodash.once: 4.1.1
     transitivePeerDependencies:
       - supports-color
 
-  "@emotion/is-prop-valid@1.2.2":
+  '@emotion/is-prop-valid@1.2.2':
     dependencies:
-      "@emotion/memoize": 0.8.1
+      '@emotion/memoize': 0.8.1
 
-  "@emotion/memoize@0.8.1": {}
+  '@emotion/memoize@0.8.1': {}
 
-  "@emotion/unitless@0.8.1": {}
+  '@emotion/unitless@0.8.1': {}
 
-  "@esbuild/aix-ppc64@0.25.8":
+  '@esbuild/aix-ppc64@0.25.8':
     optional: true
 
-  "@esbuild/android-arm64@0.25.8":
+  '@esbuild/android-arm64@0.25.8':
     optional: true
 
-  "@esbuild/android-arm@0.25.8":
+  '@esbuild/android-arm@0.25.8':
     optional: true
 
-  "@esbuild/android-x64@0.25.8":
+  '@esbuild/android-x64@0.25.8':
     optional: true
 
-  "@esbuild/darwin-arm64@0.25.8":
+  '@esbuild/darwin-arm64@0.25.8':
     optional: true
 
-  "@esbuild/darwin-x64@0.25.8":
+  '@esbuild/darwin-x64@0.25.8':
     optional: true
 
-  "@esbuild/freebsd-arm64@0.25.8":
+  '@esbuild/freebsd-arm64@0.25.8':
     optional: true
 
-  "@esbuild/freebsd-x64@0.25.8":
+  '@esbuild/freebsd-x64@0.25.8':
     optional: true
 
-  "@esbuild/linux-arm64@0.25.8":
+  '@esbuild/linux-arm64@0.25.8':
     optional: true
 
-  "@esbuild/linux-arm@0.25.8":
+  '@esbuild/linux-arm@0.25.8':
     optional: true
 
-  "@esbuild/linux-ia32@0.25.8":
+  '@esbuild/linux-ia32@0.25.8':
     optional: true
 
-  "@esbuild/linux-loong64@0.25.8":
+  '@esbuild/linux-loong64@0.25.8':
     optional: true
 
-  "@esbuild/linux-mips64el@0.25.8":
+  '@esbuild/linux-mips64el@0.25.8':
     optional: true
 
-  "@esbuild/linux-ppc64@0.25.8":
+  '@esbuild/linux-ppc64@0.25.8':
     optional: true
 
-  "@esbuild/linux-riscv64@0.25.8":
+  '@esbuild/linux-riscv64@0.25.8':
     optional: true
 
-  "@esbuild/linux-s390x@0.25.8":
+  '@esbuild/linux-s390x@0.25.8':
     optional: true
 
-  "@esbuild/linux-x64@0.25.8":
+  '@esbuild/linux-x64@0.25.8':
     optional: true
 
-  "@esbuild/netbsd-arm64@0.25.8":
+  '@esbuild/netbsd-arm64@0.25.8':
     optional: true
 
-  "@esbuild/netbsd-x64@0.25.8":
+  '@esbuild/netbsd-x64@0.25.8':
     optional: true
 
-  "@esbuild/openbsd-arm64@0.25.8":
+  '@esbuild/openbsd-arm64@0.25.8':
     optional: true
 
-  "@esbuild/openbsd-x64@0.25.8":
+  '@esbuild/openbsd-x64@0.25.8':
     optional: true
 
-  "@esbuild/openharmony-arm64@0.25.8":
+  '@esbuild/openharmony-arm64@0.25.8':
     optional: true
 
-  "@esbuild/sunos-x64@0.25.8":
+  '@esbuild/sunos-x64@0.25.8':
     optional: true
 
-  "@esbuild/win32-arm64@0.25.8":
+  '@esbuild/win32-arm64@0.25.8':
     optional: true
 
-  "@esbuild/win32-ia32@0.25.8":
+  '@esbuild/win32-ia32@0.25.8':
     optional: true
 
-  "@esbuild/win32-x64@0.25.8":
+  '@esbuild/win32-x64@0.25.8':
     optional: true
 
-  "@eslint-community/eslint-utils@4.7.0(eslint@9.32.0(jiti@2.5.1))":
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.32.0(jiti@2.5.1))':
     dependencies:
       eslint: 9.32.0(jiti@2.5.1)
       eslint-visitor-keys: 3.4.3
 
-  "@eslint-community/regexpp@4.12.1": {}
+  '@eslint-community/regexpp@4.12.1': {}
 
-  "@eslint/config-array@0.21.0":
+  '@eslint/config-array@0.21.0':
     dependencies:
-      "@eslint/object-schema": 2.1.6
+      '@eslint/object-schema': 2.1.6
       debug: 4.4.1(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
 
-  "@eslint/config-helpers@0.3.0": {}
+  '@eslint/config-helpers@0.3.0': {}
 
-  "@eslint/core@0.15.1":
+  '@eslint/core@0.15.1':
     dependencies:
-      "@types/json-schema": 7.0.15
+      '@types/json-schema': 7.0.15
 
-  "@eslint/eslintrc@3.3.1":
+  '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
       debug: 4.4.1(supports-color@8.1.1)
@@ -5797,59 +3464,59 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@eslint/js@9.32.0": {}
+  '@eslint/js@9.32.0': {}
 
-  "@eslint/object-schema@2.1.6": {}
+  '@eslint/object-schema@2.1.6': {}
 
-  "@eslint/plugin-kit@0.3.4":
+  '@eslint/plugin-kit@0.3.4':
     dependencies:
-      "@eslint/core": 0.15.1
+      '@eslint/core': 0.15.1
       levn: 0.4.1
 
-  "@floating-ui/core@1.7.3":
+  '@floating-ui/core@1.7.3':
     dependencies:
-      "@floating-ui/utils": 0.2.10
+      '@floating-ui/utils': 0.2.10
 
-  "@floating-ui/dom@1.7.3":
+  '@floating-ui/dom@1.7.3':
     dependencies:
-      "@floating-ui/core": 1.7.3
-      "@floating-ui/utils": 0.2.10
+      '@floating-ui/core': 1.7.3
+      '@floating-ui/utils': 0.2.10
 
-  "@floating-ui/react-dom@2.1.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
+  '@floating-ui/react-dom@2.1.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
-      "@floating-ui/dom": 1.7.3
+      '@floating-ui/dom': 1.7.3
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  "@floating-ui/react@0.27.15(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
+  '@floating-ui/react@0.27.15(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
-      "@floating-ui/react-dom": 2.1.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      "@floating-ui/utils": 0.2.10
+      '@floating-ui/react-dom': 2.1.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@floating-ui/utils': 0.2.10
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       tabbable: 6.2.0
 
-  "@floating-ui/utils@0.2.10": {}
+  '@floating-ui/utils@0.2.10': {}
 
-  "@hookform/resolvers@5.2.1(react-hook-form@7.61.1(react@19.1.1))":
+  '@hookform/resolvers@5.2.1(react-hook-form@7.61.1(react@19.1.1))':
     dependencies:
-      "@standard-schema/utils": 0.3.0
+      '@standard-schema/utils': 0.3.0
       react-hook-form: 7.61.1(react@19.1.1)
 
-  "@humanfs/core@0.19.1": {}
+  '@humanfs/core@0.19.1': {}
 
-  "@humanfs/node@0.16.6":
+  '@humanfs/node@0.16.6':
     dependencies:
-      "@humanfs/core": 0.19.1
-      "@humanwhocodes/retry": 0.3.1
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.3.1
 
-  "@humanwhocodes/module-importer@1.0.1": {}
+  '@humanwhocodes/module-importer@1.0.1': {}
 
-  "@humanwhocodes/retry@0.3.1": {}
+  '@humanwhocodes/retry@0.3.1': {}
 
-  "@humanwhocodes/retry@0.4.3": {}
+  '@humanwhocodes/retry@0.4.3': {}
 
-  "@isaacs/cliui@8.0.2":
+  '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
@@ -5858,7 +3525,7 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  "@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))":
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.27.0
@@ -5867,341 +3534,284 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  "@jridgewell/gen-mapping@0.3.12":
+  '@jridgewell/gen-mapping@0.3.12':
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.4
-      "@jridgewell/trace-mapping": 0.3.29
+      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/trace-mapping': 0.3.29
 
-  "@jridgewell/resolve-uri@3.1.2": {}
+  '@jridgewell/resolve-uri@3.1.2': {}
 
-  "@jridgewell/source-map@0.3.11":
+  '@jridgewell/source-map@0.3.11':
     dependencies:
-      "@jridgewell/gen-mapping": 0.3.12
-      "@jridgewell/trace-mapping": 0.3.29
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
     optional: true
 
-  "@jridgewell/sourcemap-codec@1.5.4": {}
+  '@jridgewell/sourcemap-codec@1.5.4': {}
 
-  "@jridgewell/trace-mapping@0.3.29":
+  '@jridgewell/trace-mapping@0.3.29':
     dependencies:
-      "@jridgewell/resolve-uri": 3.1.2
-      "@jridgewell/sourcemap-codec": 1.5.4
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.4
 
-  "@mdx-js/react@3.1.0(@types/react@19.1.9)(react@19.1.1)":
+  '@mdx-js/react@3.1.0(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
-      "@types/mdx": 2.0.13
-      "@types/react": 19.1.9
+      '@types/mdx': 2.0.13
+      '@types/react': 19.1.9
       react: 19.1.1
 
-  "@napi-rs/canvas-android-arm64@0.1.99":
+  '@napi-rs/canvas-android-arm64@0.1.99':
     optional: true
 
-  "@napi-rs/canvas-darwin-arm64@0.1.99":
+  '@napi-rs/canvas-darwin-arm64@0.1.99':
     optional: true
 
-  "@napi-rs/canvas-darwin-x64@0.1.99":
+  '@napi-rs/canvas-darwin-x64@0.1.99':
     optional: true
 
-  "@napi-rs/canvas-linux-arm-gnueabihf@0.1.99":
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.99':
     optional: true
 
-  "@napi-rs/canvas-linux-arm64-gnu@0.1.99":
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.99':
     optional: true
 
-  "@napi-rs/canvas-linux-arm64-musl@0.1.99":
+  '@napi-rs/canvas-linux-arm64-musl@0.1.99':
     optional: true
 
-  "@napi-rs/canvas-linux-riscv64-gnu@0.1.99":
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.99':
     optional: true
 
-  "@napi-rs/canvas-linux-x64-gnu@0.1.99":
+  '@napi-rs/canvas-linux-x64-gnu@0.1.99':
     optional: true
 
-  "@napi-rs/canvas-linux-x64-musl@0.1.99":
+  '@napi-rs/canvas-linux-x64-musl@0.1.99':
     optional: true
 
-  "@napi-rs/canvas-win32-arm64-msvc@0.1.99":
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.99':
     optional: true
 
-  "@napi-rs/canvas-win32-x64-msvc@0.1.99":
+  '@napi-rs/canvas-win32-x64-msvc@0.1.99':
     optional: true
 
-  "@napi-rs/canvas@0.1.99":
+  '@napi-rs/canvas@0.1.99':
     optionalDependencies:
-      "@napi-rs/canvas-android-arm64": 0.1.99
-      "@napi-rs/canvas-darwin-arm64": 0.1.99
-      "@napi-rs/canvas-darwin-x64": 0.1.99
-      "@napi-rs/canvas-linux-arm-gnueabihf": 0.1.99
-      "@napi-rs/canvas-linux-arm64-gnu": 0.1.99
-      "@napi-rs/canvas-linux-arm64-musl": 0.1.99
-      "@napi-rs/canvas-linux-riscv64-gnu": 0.1.99
-      "@napi-rs/canvas-linux-x64-gnu": 0.1.99
-      "@napi-rs/canvas-linux-x64-musl": 0.1.99
-      "@napi-rs/canvas-win32-arm64-msvc": 0.1.99
-      "@napi-rs/canvas-win32-x64-msvc": 0.1.99
+      '@napi-rs/canvas-android-arm64': 0.1.99
+      '@napi-rs/canvas-darwin-arm64': 0.1.99
+      '@napi-rs/canvas-darwin-x64': 0.1.99
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.99
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.99
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.99
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.99
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.99
+      '@napi-rs/canvas-linux-x64-musl': 0.1.99
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.99
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.99
     optional: true
 
-  "@nodelib/fs.scandir@2.1.5":
+  '@nodelib/fs.scandir@2.1.5':
     dependencies:
-      "@nodelib/fs.stat": 2.0.5
+      '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
 
-  "@nodelib/fs.stat@2.0.5": {}
+  '@nodelib/fs.stat@2.0.5': {}
 
-  "@nodelib/fs.walk@1.2.8":
+  '@nodelib/fs.walk@1.2.8':
     dependencies:
-      "@nodelib/fs.scandir": 2.1.5
+      '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  "@oxfmt/binding-android-arm-eabi@0.62.0":
+  '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  "@oxfmt/binding-android-arm64@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-darwin-arm64@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-darwin-x64@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-freebsd-x64@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-linux-arm-gnueabihf@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-linux-arm-musleabihf@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-linux-arm64-gnu@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-linux-arm64-musl@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-linux-ppc64-gnu@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-linux-riscv64-gnu@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-linux-riscv64-musl@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-linux-s390x-gnu@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-linux-x64-gnu@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-linux-x64-musl@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-openharmony-arm64@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-win32-arm64-msvc@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-win32-ia32-msvc@0.62.0":
-    optional: true
-
-  "@oxfmt/binding-win32-x64-msvc@0.62.0":
-    optional: true
-
-  "@pkgjs/parseargs@0.11.0":
-    optional: true
-
-  "@remixicon/react@4.6.0(react@19.1.1)":
+  '@remixicon/react@4.6.0(react@19.1.1)':
     dependencies:
       react: 19.1.1
 
-  "@rolldown/pluginutils@1.0.0-beta.27": {}
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
-  "@rollup/pluginutils@5.2.0(rollup@4.46.2)":
+  '@rollup/pluginutils@5.2.0(rollup@4.46.2)':
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.46.2
 
-  "@rollup/rollup-android-arm-eabi@4.46.2":
+  '@rollup/rollup-android-arm-eabi@4.46.2':
     optional: true
 
-  "@rollup/rollup-android-arm64@4.46.2":
+  '@rollup/rollup-android-arm64@4.46.2':
     optional: true
 
-  "@rollup/rollup-darwin-arm64@4.46.2":
+  '@rollup/rollup-darwin-arm64@4.46.2':
     optional: true
 
-  "@rollup/rollup-darwin-x64@4.46.2":
+  '@rollup/rollup-darwin-x64@4.46.2':
     optional: true
 
-  "@rollup/rollup-freebsd-arm64@4.46.2":
+  '@rollup/rollup-freebsd-arm64@4.46.2':
     optional: true
 
-  "@rollup/rollup-freebsd-x64@4.46.2":
+  '@rollup/rollup-freebsd-x64@4.46.2':
     optional: true
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.46.2":
+  '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
     optional: true
 
-  "@rollup/rollup-linux-arm-musleabihf@4.46.2":
+  '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     optional: true
 
-  "@rollup/rollup-linux-arm64-gnu@4.46.2":
+  '@rollup/rollup-linux-arm64-gnu@4.46.2':
     optional: true
 
-  "@rollup/rollup-linux-arm64-musl@4.46.2":
+  '@rollup/rollup-linux-arm64-musl@4.46.2':
     optional: true
 
-  "@rollup/rollup-linux-loongarch64-gnu@4.46.2":
+  '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
     optional: true
 
-  "@rollup/rollup-linux-ppc64-gnu@4.46.2":
+  '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     optional: true
 
-  "@rollup/rollup-linux-riscv64-gnu@4.46.2":
+  '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     optional: true
 
-  "@rollup/rollup-linux-riscv64-musl@4.46.2":
+  '@rollup/rollup-linux-riscv64-musl@4.46.2':
     optional: true
 
-  "@rollup/rollup-linux-s390x-gnu@4.46.2":
+  '@rollup/rollup-linux-s390x-gnu@4.46.2':
     optional: true
 
-  "@rollup/rollup-linux-x64-gnu@4.46.2":
+  '@rollup/rollup-linux-x64-gnu@4.46.2':
     optional: true
 
-  "@rollup/rollup-linux-x64-musl@4.46.2":
+  '@rollup/rollup-linux-x64-musl@4.46.2':
     optional: true
 
-  "@rollup/rollup-win32-arm64-msvc@4.46.2":
+  '@rollup/rollup-win32-arm64-msvc@4.46.2':
     optional: true
 
-  "@rollup/rollup-win32-ia32-msvc@4.46.2":
+  '@rollup/rollup-win32-ia32-msvc@4.46.2':
     optional: true
 
-  "@rollup/rollup-win32-x64-msvc@4.46.2":
+  '@rollup/rollup-win32-x64-msvc@4.46.2':
     optional: true
 
-  "@standard-schema/utils@0.3.0": {}
+  '@standard-schema/utils@0.3.0': {}
 
-  "@storybook/addon-actions@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/addon-actions@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@storybook/global": 5.0.0
-      "@types/uuid": 9.0.8
+      '@storybook/global': 5.0.0
+      '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
       storybook: 8.6.14(prettier@3.6.2)
       uuid: 9.0.1
 
-  "@storybook/addon-backgrounds@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/addon-backgrounds@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@storybook/global": 5.0.0
+      '@storybook/global': 5.0.0
       memoizerific: 1.11.3
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  "@storybook/addon-controls@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/addon-controls@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@storybook/global": 5.0.0
+      '@storybook/global': 5.0.0
       dequal: 2.0.3
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  "@storybook/addon-docs@8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/addon-docs@8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@mdx-js/react": 3.1.0(@types/react@19.1.9)(react@19.1.1)
-      "@storybook/blocks": 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/csf-plugin": 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/react-dom-shim": 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
+      '@mdx-js/react': 3.1.0(@types/react@19.1.9)(react@19.1.1)
+      '@storybook/blocks': 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/react-dom-shim': 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
-      - "@types/react"
+      - '@types/react'
 
-  "@storybook/addon-essentials@8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/addon-essentials@8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@storybook/addon-actions": 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/addon-backgrounds": 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/addon-controls": 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/addon-docs": 8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/addon-highlight": 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/addon-measure": 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/addon-outline": 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/addon-toolbars": 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/addon-viewport": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/addon-actions': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/addon-backgrounds': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/addon-controls': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/addon-docs': 8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/addon-highlight': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/addon-measure': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/addon-outline': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/addon-toolbars': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/addon-viewport': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
-      - "@types/react"
+      - '@types/react'
 
-  "@storybook/addon-highlight@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/addon-highlight@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@storybook/global": 5.0.0
+      '@storybook/global': 5.0.0
       storybook: 8.6.14(prettier@3.6.2)
 
-  "@storybook/addon-measure@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/addon-measure@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@storybook/global": 5.0.0
+      '@storybook/global': 5.0.0
       storybook: 8.6.14(prettier@3.6.2)
       tiny-invariant: 1.3.3
 
-  "@storybook/addon-outline@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/addon-outline@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@storybook/global": 5.0.0
+      '@storybook/global': 5.0.0
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  "@storybook/addon-storysource@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/addon-storysource@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@storybook/source-loader": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/source-loader': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       estraverse: 5.3.0
       storybook: 8.6.14(prettier@3.6.2)
       tiny-invariant: 1.3.3
 
-  "@storybook/addon-toolbars@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/addon-toolbars@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  "@storybook/addon-viewport@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/addon-viewport@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       memoizerific: 1.11.3
       storybook: 8.6.14(prettier@3.6.2)
 
-  "@storybook/blocks@8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/blocks@8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@storybook/icons": 1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@storybook/icons': 1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  "@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))":
+  '@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))':
     dependencies:
-      "@storybook/csf-plugin": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       browser-assert: 1.2.1
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
       vite: 6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)
 
-  "@storybook/components@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/components@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  "@storybook/core-events@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/core-events@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  "@storybook/core@8.6.14(prettier@3.6.2)(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/core@8.6.14(prettier@3.6.2)(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@storybook/theming": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/theming': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       better-opn: 3.0.2
       browser-assert: 1.2.1
       esbuild: 0.25.8
@@ -6220,45 +3830,45 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  "@storybook/csf-plugin@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/csf-plugin@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
       unplugin: 1.16.1
 
-  "@storybook/global@5.0.0": {}
+  '@storybook/global@5.0.0': {}
 
-  "@storybook/icons@1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
+  '@storybook/icons@1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  "@storybook/instrumenter@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/instrumenter@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@storybook/global": 5.0.0
-      "@vitest/utils": 2.1.9
+      '@storybook/global': 5.0.0
+      '@vitest/utils': 2.1.9
       storybook: 8.6.14(prettier@3.6.2)
     optional: true
 
-  "@storybook/manager-api@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/manager-api@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  "@storybook/preview-api@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/preview-api@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  "@storybook/react-dom-shim@8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/react-dom-shim@8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       storybook: 8.6.14(prettier@3.6.2)
 
-  "@storybook/react-vite@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))":
+  '@storybook/react-vite@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))':
     dependencies:
-      "@joshwooding/vite-plugin-react-docgen-typescript": 0.5.0(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
-      "@rollup/pluginutils": 5.2.0(rollup@4.46.2)
-      "@storybook/builder-vite": 8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
-      "@storybook/react": 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
+      '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      '@storybook/react': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)
       find-up: 5.0.0
       magic-string: 0.30.17
       react: 19.1.1
@@ -6269,69 +3879,69 @@ snapshots:
       tsconfig-paths: 4.2.0
       vite: 6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)
     optionalDependencies:
-      "@storybook/test": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.6.2))
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  "@storybook/react@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)":
+  '@storybook/react@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)':
     dependencies:
-      "@storybook/components": 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/global": 5.0.0
-      "@storybook/manager-api": 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/preview-api": 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/react-dom-shim": 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
-      "@storybook/theming": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/components': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/global': 5.0.0
+      '@storybook/manager-api': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/preview-api': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/react-dom-shim': 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/theming': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       storybook: 8.6.14(prettier@3.6.2)
     optionalDependencies:
-      "@storybook/test": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       typescript: 5.8.3
 
-  "@storybook/source-loader@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/source-loader@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       es-toolkit: 1.39.8
       estraverse: 5.3.0
       prettier: 3.6.2
       storybook: 8.6.14(prettier@3.6.2)
 
-  "@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      "@storybook/global": 5.0.0
-      "@storybook/instrumenter": 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      "@testing-library/dom": 10.4.0
-      "@testing-library/jest-dom": 6.5.0
-      "@testing-library/user-event": 14.5.2(@testing-library/dom@10.4.0)
-      "@vitest/expect": 2.0.5
-      "@vitest/spy": 2.0.5
+      '@storybook/global': 5.0.0
+      '@storybook/instrumenter': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      '@testing-library/dom': 10.4.0
+      '@testing-library/jest-dom': 6.5.0
+      '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
+      '@vitest/expect': 2.0.5
+      '@vitest/spy': 2.0.5
       storybook: 8.6.14(prettier@3.6.2)
     optional: true
 
-  "@storybook/theming@8.6.14(storybook@8.6.14(prettier@3.6.2))":
+  '@storybook/theming@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  "@tanstack/react-virtual@3.14.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
+  '@tanstack/react-virtual@3.14.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
-      "@tanstack/virtual-core": 3.17.3
+      '@tanstack/virtual-core': 3.17.3
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  "@tanstack/virtual-core@3.17.3": {}
+  '@tanstack/virtual-core@3.17.3': {}
 
-  "@testing-library/cypress@10.0.3(cypress@14.5.3)":
+  '@testing-library/cypress@10.0.3(cypress@14.5.3)':
     dependencies:
-      "@babel/runtime": 7.28.2
-      "@testing-library/dom": 10.4.1
+      '@babel/runtime': 7.28.2
+      '@testing-library/dom': 10.4.1
       cypress: 14.5.3
 
-  "@testing-library/dom@10.4.0":
+  '@testing-library/dom@10.4.0':
     dependencies:
-      "@babel/code-frame": 7.29.0
-      "@babel/runtime": 7.28.2
-      "@types/aria-query": 5.0.4
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.2
+      '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       chalk: 4.1.2
       dom-accessibility-api: 0.5.16
@@ -6339,20 +3949,20 @@ snapshots:
       pretty-format: 27.5.1
     optional: true
 
-  "@testing-library/dom@10.4.1":
+  '@testing-library/dom@10.4.1':
     dependencies:
-      "@babel/code-frame": 7.27.1
-      "@babel/runtime": 7.28.2
-      "@types/aria-query": 5.0.4
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.2
+      '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  "@testing-library/jest-dom@6.5.0":
+  '@testing-library/jest-dom@6.5.0':
     dependencies:
-      "@adobe/css-tools": 4.4.3
+      '@adobe/css-tools': 4.4.3
       aria-query: 5.3.2
       chalk: 3.0.0
       css.escape: 1.5.1
@@ -6361,87 +3971,87 @@ snapshots:
       redent: 3.0.0
     optional: true
 
-  "@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)":
+  '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
     dependencies:
-      "@testing-library/dom": 10.4.0
+      '@testing-library/dom': 10.4.0
     optional: true
 
-  "@types/aria-query@5.0.4": {}
+  '@types/aria-query@5.0.4': {}
 
-  "@types/babel__core@7.20.5":
+  '@types/babel__core@7.20.5':
     dependencies:
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.28.2
-      "@types/babel__generator": 7.27.0
-      "@types/babel__template": 7.4.4
-      "@types/babel__traverse": 7.20.7
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.28.2
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.20.7
 
-  "@types/babel__generator@7.27.0":
+  '@types/babel__generator@7.27.0':
     dependencies:
-      "@babel/types": 7.28.2
+      '@babel/types': 7.28.2
 
-  "@types/babel__template@7.4.4":
+  '@types/babel__template@7.4.4':
     dependencies:
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.28.2
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.28.2
 
-  "@types/babel__traverse@7.20.7":
+  '@types/babel__traverse@7.20.7':
     dependencies:
-      "@babel/types": 7.28.2
+      '@babel/types': 7.28.2
 
-  "@types/doctrine@0.0.9": {}
+  '@types/doctrine@0.0.9': {}
 
-  "@types/estree@1.0.8": {}
+  '@types/estree@1.0.8': {}
 
-  "@types/json-schema@7.0.15": {}
+  '@types/json-schema@7.0.15': {}
 
-  "@types/mdx@2.0.13": {}
+  '@types/mdx@2.0.13': {}
 
-  "@types/node@24.1.0":
+  '@types/node@24.1.0':
     dependencies:
       undici-types: 7.8.0
     optional: true
 
-  "@types/react-dom@19.1.7(@types/react@19.1.9)":
+  '@types/react-dom@19.1.7(@types/react@19.1.9)':
     dependencies:
-      "@types/react": 19.1.9
+      '@types/react': 19.1.9
 
-  "@types/react@19.1.9":
+  '@types/react@19.1.9':
     dependencies:
       csstype: 3.1.3
 
-  "@types/resolve@1.20.6": {}
+  '@types/resolve@1.20.6': {}
 
-  "@types/sinonjs__fake-timers@8.1.1": {}
+  '@types/sinonjs__fake-timers@8.1.1': {}
 
-  "@types/sizzle@2.3.9": {}
+  '@types/sizzle@2.3.9': {}
 
-  "@types/stylis@4.2.5": {}
+  '@types/stylis@4.2.5': {}
 
-  "@types/trusted-types@2.0.7":
+  '@types/trusted-types@2.0.7':
     optional: true
 
-  "@types/uuid@9.0.8": {}
+  '@types/uuid@9.0.8': {}
 
-  "@types/yargs-parser@21.0.3": {}
+  '@types/yargs-parser@21.0.3': {}
 
-  "@types/yargs@17.0.33":
+  '@types/yargs@17.0.33':
     dependencies:
-      "@types/yargs-parser": 21.0.3
+      '@types/yargs-parser': 21.0.3
 
-  "@types/yauzl@2.10.3":
+  '@types/yauzl@2.10.3':
     dependencies:
-      "@types/node": 24.1.0
+      '@types/node': 24.1.0
     optional: true
 
-  "@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)":
+  '@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
-      "@eslint-community/regexpp": 4.12.1
-      "@typescript-eslint/parser": 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      "@typescript-eslint/scope-manager": 8.38.0
-      "@typescript-eslint/type-utils": 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      "@typescript-eslint/utils": 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      "@typescript-eslint/visitor-keys": 8.38.0
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.38.0
+      '@typescript-eslint/type-utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.38.0
       eslint: 9.32.0(jiti@2.5.1)
       graphemer: 1.4.0
       ignore: 7.0.5
@@ -6451,41 +4061,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)":
+  '@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
-      "@typescript-eslint/scope-manager": 8.38.0
-      "@typescript-eslint/types": 8.38.0
-      "@typescript-eslint/typescript-estree": 8.38.0(typescript@5.8.3)
-      "@typescript-eslint/visitor-keys": 8.38.0
+      '@typescript-eslint/scope-manager': 8.38.0
+      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.38.0
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 9.32.0(jiti@2.5.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/project-service@8.38.0(typescript@5.8.3)":
+  '@typescript-eslint/project-service@8.38.0(typescript@5.8.3)':
     dependencies:
-      "@typescript-eslint/tsconfig-utils": 8.38.0(typescript@5.8.3)
-      "@typescript-eslint/types": 8.38.0
+      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.38.0
       debug: 4.4.1(supports-color@8.1.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/scope-manager@8.38.0":
+  '@typescript-eslint/scope-manager@8.38.0':
     dependencies:
-      "@typescript-eslint/types": 8.38.0
-      "@typescript-eslint/visitor-keys": 8.38.0
+      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/visitor-keys': 8.38.0
 
-  "@typescript-eslint/tsconfig-utils@8.38.0(typescript@5.8.3)":
+  '@typescript-eslint/tsconfig-utils@8.38.0(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
 
-  "@typescript-eslint/type-utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)":
+  '@typescript-eslint/type-utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
-      "@typescript-eslint/types": 8.38.0
-      "@typescript-eslint/typescript-estree": 8.38.0(typescript@5.8.3)
-      "@typescript-eslint/utils": 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 9.32.0(jiti@2.5.1)
       ts-api-utils: 2.1.0(typescript@5.8.3)
@@ -6493,14 +4103,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/types@8.38.0": {}
+  '@typescript-eslint/types@8.38.0': {}
 
-  "@typescript-eslint/typescript-estree@8.38.0(typescript@5.8.3)":
+  '@typescript-eslint/typescript-estree@8.38.0(typescript@5.8.3)':
     dependencies:
-      "@typescript-eslint/project-service": 8.38.0(typescript@5.8.3)
-      "@typescript-eslint/tsconfig-utils": 8.38.0(typescript@5.8.3)
-      "@typescript-eslint/types": 8.38.0
-      "@typescript-eslint/visitor-keys": 8.38.0
+      '@typescript-eslint/project-service': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/visitor-keys': 8.38.0
       debug: 4.4.1(supports-color@8.1.1)
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -6511,68 +4121,68 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)":
+  '@typescript-eslint/utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
-      "@eslint-community/eslint-utils": 4.7.0(eslint@9.32.0(jiti@2.5.1))
-      "@typescript-eslint/scope-manager": 8.38.0
-      "@typescript-eslint/types": 8.38.0
-      "@typescript-eslint/typescript-estree": 8.38.0(typescript@5.8.3)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@2.5.1))
+      '@typescript-eslint/scope-manager': 8.38.0
+      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
       eslint: 9.32.0(jiti@2.5.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/visitor-keys@8.38.0":
+  '@typescript-eslint/visitor-keys@8.38.0':
     dependencies:
-      "@typescript-eslint/types": 8.38.0
+      '@typescript-eslint/types': 8.38.0
       eslint-visitor-keys: 4.2.1
 
-  "@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))":
+  '@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))':
     dependencies:
-      "@babel/core": 7.28.0
-      "@babel/plugin-transform-react-jsx-self": 7.27.1(@babel/core@7.28.0)
-      "@babel/plugin-transform-react-jsx-source": 7.27.1(@babel/core@7.28.0)
-      "@rolldown/pluginutils": 1.0.0-beta.27
-      "@types/babel__core": 7.20.5
+      '@babel/core': 7.28.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@vitest/expect@2.0.5":
+  '@vitest/expect@2.0.5':
     dependencies:
-      "@vitest/spy": 2.0.5
-      "@vitest/utils": 2.0.5
+      '@vitest/spy': 2.0.5
+      '@vitest/utils': 2.0.5
       chai: 5.2.1
       tinyrainbow: 1.2.0
     optional: true
 
-  "@vitest/pretty-format@2.0.5":
+  '@vitest/pretty-format@2.0.5':
     dependencies:
       tinyrainbow: 1.2.0
     optional: true
 
-  "@vitest/pretty-format@2.1.9":
+  '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
     optional: true
 
-  "@vitest/spy@2.0.5":
+  '@vitest/spy@2.0.5':
     dependencies:
       tinyspy: 3.0.2
     optional: true
 
-  "@vitest/utils@2.0.5":
+  '@vitest/utils@2.0.5':
     dependencies:
-      "@vitest/pretty-format": 2.0.5
+      '@vitest/pretty-format': 2.0.5
       estree-walker: 3.0.3
       loupe: 3.2.0
       tinyrainbow: 1.2.0
     optional: true
 
-  "@vitest/utils@2.1.9":
+  '@vitest/utils@2.1.9':
     dependencies:
-      "@vitest/pretty-format": 2.1.9
+      '@vitest/pretty-format': 2.1.9
       loupe: 3.2.0
       tinyrainbow: 1.2.0
     optional: true
@@ -6720,7 +4330,7 @@ snapshots:
 
   barrelsby@2.8.1:
     dependencies:
-      "@types/yargs": 17.0.33
+      '@types/yargs': 17.0.33
       signale: 1.4.0
       yargs: 17.7.2
 
@@ -6912,10 +4522,10 @@ snapshots:
 
   cypress@14.5.3:
     dependencies:
-      "@cypress/request": 3.0.9
-      "@cypress/xvfb": 1.2.4(supports-color@8.1.1)
-      "@types/sinonjs__fake-timers": 8.1.1
-      "@types/sizzle": 2.3.9
+      '@cypress/request': 3.0.9
+      '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
+      '@types/sinonjs__fake-timers': 8.1.1
+      '@types/sizzle': 2.3.9
       arch: 2.2.0
       blob-util: 2.0.2
       bluebird: 3.7.2
@@ -7034,7 +4644,7 @@ snapshots:
 
   dompurify@3.2.7:
     optionalDependencies:
-      "@types/trusted-types": 2.0.7
+      '@types/trusted-types': 2.0.7
 
   dotenv@17.2.1: {}
 
@@ -7182,32 +4792,32 @@ snapshots:
 
   esbuild@0.25.8:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.25.8
-      "@esbuild/android-arm": 0.25.8
-      "@esbuild/android-arm64": 0.25.8
-      "@esbuild/android-x64": 0.25.8
-      "@esbuild/darwin-arm64": 0.25.8
-      "@esbuild/darwin-x64": 0.25.8
-      "@esbuild/freebsd-arm64": 0.25.8
-      "@esbuild/freebsd-x64": 0.25.8
-      "@esbuild/linux-arm": 0.25.8
-      "@esbuild/linux-arm64": 0.25.8
-      "@esbuild/linux-ia32": 0.25.8
-      "@esbuild/linux-loong64": 0.25.8
-      "@esbuild/linux-mips64el": 0.25.8
-      "@esbuild/linux-ppc64": 0.25.8
-      "@esbuild/linux-riscv64": 0.25.8
-      "@esbuild/linux-s390x": 0.25.8
-      "@esbuild/linux-x64": 0.25.8
-      "@esbuild/netbsd-arm64": 0.25.8
-      "@esbuild/netbsd-x64": 0.25.8
-      "@esbuild/openbsd-arm64": 0.25.8
-      "@esbuild/openbsd-x64": 0.25.8
-      "@esbuild/openharmony-arm64": 0.25.8
-      "@esbuild/sunos-x64": 0.25.8
-      "@esbuild/win32-arm64": 0.25.8
-      "@esbuild/win32-ia32": 0.25.8
-      "@esbuild/win32-x64": 0.25.8
+      '@esbuild/aix-ppc64': 0.25.8
+      '@esbuild/android-arm': 0.25.8
+      '@esbuild/android-arm64': 0.25.8
+      '@esbuild/android-x64': 0.25.8
+      '@esbuild/darwin-arm64': 0.25.8
+      '@esbuild/darwin-x64': 0.25.8
+      '@esbuild/freebsd-arm64': 0.25.8
+      '@esbuild/freebsd-x64': 0.25.8
+      '@esbuild/linux-arm': 0.25.8
+      '@esbuild/linux-arm64': 0.25.8
+      '@esbuild/linux-ia32': 0.25.8
+      '@esbuild/linux-loong64': 0.25.8
+      '@esbuild/linux-mips64el': 0.25.8
+      '@esbuild/linux-ppc64': 0.25.8
+      '@esbuild/linux-riscv64': 0.25.8
+      '@esbuild/linux-s390x': 0.25.8
+      '@esbuild/linux-x64': 0.25.8
+      '@esbuild/netbsd-arm64': 0.25.8
+      '@esbuild/netbsd-x64': 0.25.8
+      '@esbuild/openbsd-arm64': 0.25.8
+      '@esbuild/openbsd-x64': 0.25.8
+      '@esbuild/openharmony-arm64': 0.25.8
+      '@esbuild/sunos-x64': 0.25.8
+      '@esbuild/win32-arm64': 0.25.8
+      '@esbuild/win32-ia32': 0.25.8
+      '@esbuild/win32-x64': 0.25.8
 
   escalade@3.2.0: {}
 
@@ -7253,19 +4863,19 @@ snapshots:
 
   eslint@9.32.0(jiti@2.5.1):
     dependencies:
-      "@eslint-community/eslint-utils": 4.7.0(eslint@9.32.0(jiti@2.5.1))
-      "@eslint-community/regexpp": 4.12.1
-      "@eslint/config-array": 0.21.0
-      "@eslint/config-helpers": 0.3.0
-      "@eslint/core": 0.15.1
-      "@eslint/eslintrc": 3.3.1
-      "@eslint/js": 9.32.0
-      "@eslint/plugin-kit": 0.3.4
-      "@humanfs/node": 0.16.6
-      "@humanwhocodes/module-importer": 1.0.1
-      "@humanwhocodes/retry": 0.4.3
-      "@types/estree": 1.0.8
-      "@types/json-schema": 7.0.15
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@2.5.1))
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.21.0
+      '@eslint/config-helpers': 0.3.0
+      '@eslint/core': 0.15.1
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.32.0
+      '@eslint/plugin-kit': 0.3.4
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -7315,7 +4925,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
     optional: true
 
   esutils@2.0.3: {}
@@ -7346,7 +4956,7 @@ snapshots:
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
-      "@types/yauzl": 2.10.3
+      '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7356,8 +4966,8 @@ snapshots:
 
   fast-glob@3.3.3:
     dependencies:
-      "@nodelib/fs.stat": 2.0.5
-      "@nodelib/fs.walk": 1.2.8
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
@@ -7435,7 +5045,7 @@ snapshots:
       motion-utils: 12.23.6
       tslib: 2.8.1
     optionalDependencies:
-      "@emotion/is-prop-valid": 1.2.2
+      '@emotion/is-prop-valid': 1.2.2
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
@@ -7760,9 +5370,9 @@ snapshots:
 
   jackspeak@3.4.3:
     dependencies:
-      "@isaacs/cliui": 8.0.2
+      '@isaacs/cliui': 8.0.2
     optionalDependencies:
-      "@pkgjs/parseargs": 0.11.0
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@2.5.1:
     optional: true
@@ -7934,11 +5544,11 @@ snapshots:
 
   magic-string@0.27.0:
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   magic-string@0.30.17:
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   map-or-similar@1.5.0: {}
 
@@ -8071,30 +5681,6 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxfmt@0.62.0:
-    dependencies:
-      tinypool: 2.1.0
-    optionalDependencies:
-      "@oxfmt/binding-android-arm-eabi": 0.62.0
-      "@oxfmt/binding-android-arm64": 0.62.0
-      "@oxfmt/binding-darwin-arm64": 0.62.0
-      "@oxfmt/binding-darwin-x64": 0.62.0
-      "@oxfmt/binding-freebsd-x64": 0.62.0
-      "@oxfmt/binding-linux-arm-gnueabihf": 0.62.0
-      "@oxfmt/binding-linux-arm-musleabihf": 0.62.0
-      "@oxfmt/binding-linux-arm64-gnu": 0.62.0
-      "@oxfmt/binding-linux-arm64-musl": 0.62.0
-      "@oxfmt/binding-linux-ppc64-gnu": 0.62.0
-      "@oxfmt/binding-linux-riscv64-gnu": 0.62.0
-      "@oxfmt/binding-linux-riscv64-musl": 0.62.0
-      "@oxfmt/binding-linux-s390x-gnu": 0.62.0
-      "@oxfmt/binding-linux-x64-gnu": 0.62.0
-      "@oxfmt/binding-linux-x64-musl": 0.62.0
-      "@oxfmt/binding-openharmony-arm64": 0.62.0
-      "@oxfmt/binding-win32-arm64-msvc": 0.62.0
-      "@oxfmt/binding-win32-ia32-msvc": 0.62.0
-      "@oxfmt/binding-win32-x64-msvc": 0.62.0
-
   p-limit@1.3.0:
     dependencies:
       p-try: 1.0.0
@@ -8146,7 +5732,7 @@ snapshots:
 
   pdfjs-dist@5.4.54:
     optionalDependencies:
-      "@napi-rs/canvas": 0.1.99
+      '@napi-rs/canvas': 0.1.99
 
   pend@1.2.0: {}
 
@@ -8169,7 +5755,7 @@ snapshots:
 
   polished@4.3.1:
     dependencies:
-      "@babel/runtime": 7.28.2
+      '@babel/runtime': 7.28.2
 
   possible-typed-array-names@1.1.0: {}
 
@@ -8228,13 +5814,13 @@ snapshots:
 
   react-docgen@7.1.1:
     dependencies:
-      "@babel/core": 7.28.0
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.28.2
-      "@types/babel__core": 7.20.5
-      "@types/babel__traverse": 7.20.7
-      "@types/doctrine": 0.0.9
-      "@types/resolve": 1.20.6
+      '@babel/core': 7.28.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.28.2
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.20.7
+      '@types/doctrine': 0.0.9
+      '@types/resolve': 1.20.6
       doctrine: 3.0.0
       resolve: 1.22.10
       strip-indent: 4.0.0
@@ -8327,28 +5913,28 @@ snapshots:
 
   rollup@4.46.2:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
     optionalDependencies:
-      "@rollup/rollup-android-arm-eabi": 4.46.2
-      "@rollup/rollup-android-arm64": 4.46.2
-      "@rollup/rollup-darwin-arm64": 4.46.2
-      "@rollup/rollup-darwin-x64": 4.46.2
-      "@rollup/rollup-freebsd-arm64": 4.46.2
-      "@rollup/rollup-freebsd-x64": 4.46.2
-      "@rollup/rollup-linux-arm-gnueabihf": 4.46.2
-      "@rollup/rollup-linux-arm-musleabihf": 4.46.2
-      "@rollup/rollup-linux-arm64-gnu": 4.46.2
-      "@rollup/rollup-linux-arm64-musl": 4.46.2
-      "@rollup/rollup-linux-loongarch64-gnu": 4.46.2
-      "@rollup/rollup-linux-ppc64-gnu": 4.46.2
-      "@rollup/rollup-linux-riscv64-gnu": 4.46.2
-      "@rollup/rollup-linux-riscv64-musl": 4.46.2
-      "@rollup/rollup-linux-s390x-gnu": 4.46.2
-      "@rollup/rollup-linux-x64-gnu": 4.46.2
-      "@rollup/rollup-linux-x64-musl": 4.46.2
-      "@rollup/rollup-win32-arm64-msvc": 4.46.2
-      "@rollup/rollup-win32-ia32-msvc": 4.46.2
-      "@rollup/rollup-win32-x64-msvc": 4.46.2
+      '@rollup/rollup-android-arm-eabi': 4.46.2
+      '@rollup/rollup-android-arm64': 4.46.2
+      '@rollup/rollup-darwin-arm64': 4.46.2
+      '@rollup/rollup-darwin-x64': 4.46.2
+      '@rollup/rollup-freebsd-arm64': 4.46.2
+      '@rollup/rollup-freebsd-x64': 4.46.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.46.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.46.2
+      '@rollup/rollup-linux-arm64-gnu': 4.46.2
+      '@rollup/rollup-linux-arm64-musl': 4.46.2
+      '@rollup/rollup-linux-loongarch64-gnu': 4.46.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.46.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.46.2
+      '@rollup/rollup-linux-riscv64-musl': 4.46.2
+      '@rollup/rollup-linux-s390x-gnu': 4.46.2
+      '@rollup/rollup-linux-x64-gnu': 4.46.2
+      '@rollup/rollup-linux-x64-musl': 4.46.2
+      '@rollup/rollup-win32-arm64-msvc': 4.46.2
+      '@rollup/rollup-win32-ia32-msvc': 4.46.2
+      '@rollup/rollup-win32-x64-msvc': 4.46.2
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -8497,7 +6083,7 @@ snapshots:
 
   storybook@8.6.14(prettier@3.6.2):
     dependencies:
-      "@storybook/core": 8.6.14(prettier@3.6.2)(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/core': 8.6.14(prettier@3.6.2)(storybook@8.6.14(prettier@3.6.2))
     optionalDependencies:
       prettier: 3.6.2
     transitivePeerDependencies:
@@ -8586,9 +6172,9 @@ snapshots:
 
   styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
-      "@emotion/is-prop-valid": 1.2.2
-      "@emotion/unitless": 0.8.1
-      "@types/stylis": 4.2.5
+      '@emotion/is-prop-valid': 1.2.2
+      '@emotion/unitless': 0.8.1
+      '@types/stylis': 4.2.5
       css-to-react-native: 3.2.0
       csstype: 3.1.3
       postcss: 8.4.49
@@ -8618,7 +6204,7 @@ snapshots:
 
   terser@5.43.1:
     dependencies:
-      "@jridgewell/source-map": 0.3.11
+      '@jridgewell/source-map': 0.3.11
       acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
@@ -8634,8 +6220,6 @@ snapshots:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.3)
       picomatch: 4.0.3
-
-  tinypool@2.1.0: {}
 
   tinyrainbow@1.2.0:
     optional: true
@@ -8782,7 +6366,7 @@ snapshots:
       rollup: 4.46.2
       tinyglobby: 0.2.14
     optionalDependencies:
-      "@types/node": 24.1.0
+      '@types/node': 24.1.0
       fsevents: 2.3.3
       jiti: 2.5.1
       lightningcss: 1.30.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,23 +1,22 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     dependencies:
-      '@floating-ui/react':
+      "@floating-ui/react":
         specifier: ^0.27.8
         version: 0.27.15(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@hookform/resolvers':
+      "@hookform/resolvers":
         specifier: ^5.0.1
         version: 5.2.1(react-hook-form@7.61.1(react@19.1.1))
-      '@remixicon/react':
+      "@remixicon/react":
         specifier: ^4.6.0
         version: 4.6.0(react@19.1.1)
-      '@tanstack/react-virtual':
+      "@tanstack/react-virtual":
         specifier: ^3.14.5
         version: 3.14.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       framer-motion:
@@ -48,58 +47,58 @@ importers:
         specifier: ^3.24.4
         version: 3.25.76
     devDependencies:
-      '@babel/parser':
+      "@babel/parser":
         specifier: ^7.29.2
         version: 7.29.2
-      '@babel/traverse':
+      "@babel/traverse":
         specifier: ^7.29.0
         version: 7.29.0
-      '@eslint/js':
+      "@eslint/js":
         specifier: ^9.26.0
         version: 9.32.0
-      '@storybook/addon-essentials':
+      "@storybook/addon-essentials":
         specifier: ^8.6.14
         version: 8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/addon-storysource':
+      "@storybook/addon-storysource":
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/blocks':
+      "@storybook/blocks":
         specifier: ^8.6.14
         version: 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/core-events':
+      "@storybook/core-events":
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/manager-api':
+      "@storybook/manager-api":
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/preview-api':
+      "@storybook/preview-api":
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/react':
+      "@storybook/react":
         specifier: ^8.6.14
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)
-      '@storybook/react-vite':
+      "@storybook/react-vite":
         specifier: ^8.6.14
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
-      '@storybook/theming':
+      "@storybook/theming":
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@testing-library/cypress':
+      "@testing-library/cypress":
         specifier: ^10.0.3
         version: 10.0.3(cypress@14.5.3)
-      '@types/react':
+      "@types/react":
         specifier: ^19.1.9
         version: 19.1.9
-      '@types/react-dom':
+      "@types/react-dom":
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
-      '@typescript-eslint/eslint-plugin':
+      "@typescript-eslint/eslint-plugin":
         specifier: ^8.32.1
         version: 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/parser':
+      "@typescript-eslint/parser":
         specifier: ^8.32.1
         version: 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      '@vitejs/plugin-react':
+      "@vitejs/plugin-react":
         specifier: ^4.4.1
         version: 4.7.0(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
       barrelsby:
@@ -149,789 +148,1259 @@ importers:
         version: 6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)
 
 packages:
+  "@adobe/css-tools@4.4.3":
+    resolution:
+      {
+        integrity: sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==,
+      }
 
-  '@adobe/css-tools@4.4.3':
-    resolution: {integrity: sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==}
+  "@ampproject/remapping@2.3.0":
+    resolution:
+      {
+        integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==,
+      }
+    engines: { node: ">=6.0.0" }
 
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
+  "@babel/code-frame@7.27.1":
+    resolution:
+      {
+        integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/code-frame@7.27.1':
-    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
-    engines: {node: '>=6.9.0'}
+  "@babel/code-frame@7.29.0":
+    resolution:
+      {
+        integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/compat-data@7.28.0":
+    resolution:
+      {
+        integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/compat-data@7.28.0':
-    resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/core@7.28.0":
+    resolution:
+      {
+        integrity: sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/core@7.28.0':
-    resolution: {integrity: sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==}
-    engines: {node: '>=6.9.0'}
+  "@babel/generator@7.28.0":
+    resolution:
+      {
+        integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/generator@7.28.0':
-    resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
-    engines: {node: '>=6.9.0'}
+  "@babel/generator@7.29.1":
+    resolution:
+      {
+        integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-compilation-targets@7.27.2":
+    resolution:
+      {
+        integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-globals@7.28.0":
+    resolution:
+      {
+        integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-module-imports@7.27.1":
+    resolution:
+      {
+        integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.27.3':
-    resolution: {integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-module-transforms@7.27.3":
+    resolution:
+      {
+        integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==,
+      }
+    engines: { node: ">=6.9.0" }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      "@babel/core": ^7.0.0
 
-  '@babel/helper-plugin-utils@7.27.1':
-    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-plugin-utils@7.27.1":
+    resolution:
+      {
+        integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-string-parser@7.27.1":
+    resolution:
+      {
+        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-validator-identifier@7.27.1':
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-validator-identifier@7.27.1":
+    resolution:
+      {
+        integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-validator-identifier@7.28.5":
+    resolution:
+      {
+        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-validator-option@7.27.1":
+    resolution:
+      {
+        integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helpers@7.28.2':
-    resolution: {integrity: sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helpers@7.28.2":
+    resolution:
+      {
+        integrity: sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
-    engines: {node: '>=6.0.0'}
+  "@babel/parser@7.29.2":
+    resolution:
+      {
+        integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==,
+      }
+    engines: { node: ">=6.0.0" }
     hasBin: true
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/plugin-transform-react-jsx-self@7.27.1":
+    resolution:
+      {
+        integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==,
+      }
+    engines: { node: ">=6.9.0" }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      "@babel/core": ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/plugin-transform-react-jsx-source@7.27.1":
+    resolution:
+      {
+        integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==,
+      }
+    engines: { node: ">=6.9.0" }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      "@babel/core": ^7.0.0-0
 
-  '@babel/runtime@7.28.2':
-    resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/runtime@7.28.2":
+    resolution:
+      {
+        integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/template@7.27.2":
+    resolution:
+      {
+        integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
-    engines: {node: '>=6.9.0'}
+  "@babel/template@7.28.6":
+    resolution:
+      {
+        integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
+  "@babel/traverse@7.29.0":
+    resolution:
+      {
+        integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/types@7.28.2':
-    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
-    engines: {node: '>=6.9.0'}
+  "@babel/types@7.28.2":
+    resolution:
+      {
+        integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
-    engines: {node: '>=6.9.0'}
+  "@babel/types@7.29.0":
+    resolution:
+      {
+        integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@cypress/request@3.0.9':
-    resolution: {integrity: sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==}
-    engines: {node: '>= 6'}
+  "@cypress/request@3.0.9":
+    resolution:
+      {
+        integrity: sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==,
+      }
+    engines: { node: ">= 6" }
 
-  '@cypress/xvfb@1.2.4':
-    resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
+  "@cypress/xvfb@1.2.4":
+    resolution:
+      {
+        integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==,
+      }
 
-  '@emotion/is-prop-valid@1.2.2':
-    resolution: {integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==}
+  "@emotion/is-prop-valid@1.2.2":
+    resolution:
+      {
+        integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==,
+      }
 
-  '@emotion/memoize@0.8.1':
-    resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
+  "@emotion/memoize@0.8.1":
+    resolution:
+      {
+        integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==,
+      }
 
-  '@emotion/unitless@0.8.1':
-    resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
+  "@emotion/unitless@0.8.1":
+    resolution:
+      {
+        integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==,
+      }
 
-  '@esbuild/aix-ppc64@0.25.8':
-    resolution: {integrity: sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==}
-    engines: {node: '>=18'}
+  "@esbuild/aix-ppc64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.8':
-    resolution: {integrity: sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==}
-    engines: {node: '>=18'}
+  "@esbuild/android-arm64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.8':
-    resolution: {integrity: sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==}
-    engines: {node: '>=18'}
+  "@esbuild/android-arm@0.25.8":
+    resolution:
+      {
+        integrity: sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.8':
-    resolution: {integrity: sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==}
-    engines: {node: '>=18'}
+  "@esbuild/android-x64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.8':
-    resolution: {integrity: sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==}
-    engines: {node: '>=18'}
+  "@esbuild/darwin-arm64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.8':
-    resolution: {integrity: sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==}
-    engines: {node: '>=18'}
+  "@esbuild/darwin-x64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.8':
-    resolution: {integrity: sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==}
-    engines: {node: '>=18'}
+  "@esbuild/freebsd-arm64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.8':
-    resolution: {integrity: sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==}
-    engines: {node: '>=18'}
+  "@esbuild/freebsd-x64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.8':
-    resolution: {integrity: sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-arm64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.8':
-    resolution: {integrity: sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-arm@0.25.8":
+    resolution:
+      {
+        integrity: sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.8':
-    resolution: {integrity: sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-ia32@0.25.8":
+    resolution:
+      {
+        integrity: sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==,
+      }
+    engines: { node: ">=18" }
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.8':
-    resolution: {integrity: sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-loong64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.8':
-    resolution: {integrity: sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-mips64el@0.25.8":
+    resolution:
+      {
+        integrity: sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==,
+      }
+    engines: { node: ">=18" }
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.8':
-    resolution: {integrity: sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-ppc64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.8':
-    resolution: {integrity: sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-riscv64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==,
+      }
+    engines: { node: ">=18" }
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.8':
-    resolution: {integrity: sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-s390x@0.25.8":
+    resolution:
+      {
+        integrity: sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==,
+      }
+    engines: { node: ">=18" }
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.8':
-    resolution: {integrity: sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==}
-    engines: {node: '>=18'}
+  "@esbuild/linux-x64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.8':
-    resolution: {integrity: sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==}
-    engines: {node: '>=18'}
+  "@esbuild/netbsd-arm64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.8':
-    resolution: {integrity: sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==}
-    engines: {node: '>=18'}
+  "@esbuild/netbsd-x64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.8':
-    resolution: {integrity: sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==}
-    engines: {node: '>=18'}
+  "@esbuild/openbsd-arm64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.8':
-    resolution: {integrity: sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==}
-    engines: {node: '>=18'}
+  "@esbuild/openbsd-x64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.8':
-    resolution: {integrity: sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==}
-    engines: {node: '>=18'}
+  "@esbuild/openharmony-arm64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.25.8':
-    resolution: {integrity: sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==}
-    engines: {node: '>=18'}
+  "@esbuild/sunos-x64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.8':
-    resolution: {integrity: sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-arm64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==,
+      }
+    engines: { node: ">=18" }
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.8':
-    resolution: {integrity: sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-ia32@0.25.8":
+    resolution:
+      {
+        integrity: sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==,
+      }
+    engines: { node: ">=18" }
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.8':
-    resolution: {integrity: sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==}
-    engines: {node: '>=18'}
+  "@esbuild/win32-x64@0.25.8":
+    resolution:
+      {
+        integrity: sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==,
+      }
+    engines: { node: ">=18" }
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.7.0':
-    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  "@eslint-community/eslint-utils@4.7.0":
+    resolution:
+      {
+        integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/regexpp@4.12.1':
-    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+  "@eslint-community/regexpp@4.12.1":
+    resolution:
+      {
+        integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==,
+      }
+    engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
 
-  '@eslint/config-array@0.21.0':
-    resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/config-array@0.21.0":
+    resolution:
+      {
+        integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/config-helpers@0.3.0':
-    resolution: {integrity: sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/config-helpers@0.3.0":
+    resolution:
+      {
+        integrity: sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/core@0.15.1':
-    resolution: {integrity: sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/core@0.15.1":
+    resolution:
+      {
+        integrity: sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/eslintrc@3.3.1':
-    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/eslintrc@3.3.1":
+    resolution:
+      {
+        integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/js@9.32.0':
-    resolution: {integrity: sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/js@9.32.0":
+    resolution:
+      {
+        integrity: sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/object-schema@2.1.6':
-    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/object-schema@2.1.6":
+    resolution:
+      {
+        integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@eslint/plugin-kit@0.3.4':
-    resolution: {integrity: sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@eslint/plugin-kit@0.3.4":
+    resolution:
+      {
+        integrity: sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@floating-ui/core@1.7.3':
-    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+  "@floating-ui/core@1.7.3":
+    resolution:
+      {
+        integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==,
+      }
 
-  '@floating-ui/dom@1.7.3':
-    resolution: {integrity: sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==}
+  "@floating-ui/dom@1.7.3":
+    resolution:
+      {
+        integrity: sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==,
+      }
 
-  '@floating-ui/react-dom@2.1.5':
-    resolution: {integrity: sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==}
+  "@floating-ui/react-dom@2.1.5":
+    resolution:
+      {
+        integrity: sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==,
+      }
     peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+      react: ">=16.8.0"
+      react-dom: ">=16.8.0"
 
-  '@floating-ui/react@0.27.15':
-    resolution: {integrity: sha512-0LGxhBi3BB1DwuSNQAmuaSuertFzNAerlMdPbotjTVnvPtdOs7CkrHLaev5NIXemhzDXNC0tFzuseut7cWA5mw==}
+  "@floating-ui/react@0.27.15":
+    resolution:
+      {
+        integrity: sha512-0LGxhBi3BB1DwuSNQAmuaSuertFzNAerlMdPbotjTVnvPtdOs7CkrHLaev5NIXemhzDXNC0tFzuseut7cWA5mw==,
+      }
     peerDependencies:
-      react: '>=17.0.0'
-      react-dom: '>=17.0.0'
+      react: ">=17.0.0"
+      react-dom: ">=17.0.0"
 
-  '@floating-ui/utils@0.2.10':
-    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+  "@floating-ui/utils@0.2.10":
+    resolution:
+      {
+        integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==,
+      }
 
-  '@hookform/resolvers@5.2.1':
-    resolution: {integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==}
+  "@hookform/resolvers@5.2.1":
+    resolution:
+      {
+        integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==,
+      }
     peerDependencies:
       react-hook-form: ^7.55.0
 
-  '@humanfs/core@0.19.1':
-    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
-    engines: {node: '>=18.18.0'}
+  "@humanfs/core@0.19.1":
+    resolution:
+      {
+        integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
+      }
+    engines: { node: ">=18.18.0" }
 
-  '@humanfs/node@0.16.6':
-    resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
-    engines: {node: '>=18.18.0'}
+  "@humanfs/node@0.16.6":
+    resolution:
+      {
+        integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==,
+      }
+    engines: { node: ">=18.18.0" }
 
-  '@humanwhocodes/module-importer@1.0.1':
-    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
-    engines: {node: '>=12.22'}
+  "@humanwhocodes/module-importer@1.0.1":
+    resolution:
+      {
+        integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==,
+      }
+    engines: { node: ">=12.22" }
 
-  '@humanwhocodes/retry@0.3.1':
-    resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
-    engines: {node: '>=18.18'}
+  "@humanwhocodes/retry@0.3.1":
+    resolution:
+      {
+        integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==,
+      }
+    engines: { node: ">=18.18" }
 
-  '@humanwhocodes/retry@0.4.3':
-    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
-    engines: {node: '>=18.18'}
+  "@humanwhocodes/retry@0.4.3":
+    resolution:
+      {
+        integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
+      }
+    engines: { node: ">=18.18" }
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
+  "@isaacs/cliui@8.0.2":
+    resolution:
+      {
+        integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==,
+      }
+    engines: { node: ">=12" }
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0':
-    resolution: {integrity: sha512-qYDdL7fPwLRI+bJNurVcis+tNgJmvWjH4YTBGXTA8xMuxFrnAz6E5o35iyzyKbq5J5Lr8mJGfrR5GXl+WGwhgQ==}
+  "@joshwooding/vite-plugin-react-docgen-typescript@0.5.0":
+    resolution:
+      {
+        integrity: sha512-qYDdL7fPwLRI+bJNurVcis+tNgJmvWjH4YTBGXTA8xMuxFrnAz6E5o35iyzyKbq5J5Lr8mJGfrR5GXl+WGwhgQ==,
+      }
     peerDependencies:
-      typescript: '>= 4.3.x'
+      typescript: ">= 4.3.x"
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@jridgewell/gen-mapping@0.3.12':
-    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
+  "@jridgewell/gen-mapping@0.3.12":
+    resolution:
+      {
+        integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==,
+      }
 
-  '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
+  "@jridgewell/resolve-uri@3.1.2":
+    resolution:
+      {
+        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+      }
+    engines: { node: ">=6.0.0" }
 
-  '@jridgewell/source-map@0.3.11':
-    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+  "@jridgewell/source-map@0.3.11":
+    resolution:
+      {
+        integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==,
+      }
 
-  '@jridgewell/sourcemap-codec@1.5.4':
-    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+  "@jridgewell/sourcemap-codec@1.5.4":
+    resolution:
+      {
+        integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==,
+      }
 
-  '@jridgewell/trace-mapping@0.3.29':
-    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
+  "@jridgewell/trace-mapping@0.3.29":
+    resolution:
+      {
+        integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==,
+      }
 
-  '@mdx-js/react@3.1.0':
-    resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
+  "@mdx-js/react@3.1.0":
+    resolution:
+      {
+        integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==,
+      }
     peerDependencies:
-      '@types/react': '>=16'
-      react: '>=16'
+      "@types/react": ">=16"
+      react: ">=16"
 
-  '@napi-rs/canvas-android-arm64@0.1.99':
-    resolution: {integrity: sha512-9OCRt8VVxA17m32NWZKyNC2qamdaS/SC5CEOIQwFngRq0DIeVm4PDal+6Ljnhqm2whZiC63DNuKZ4xSp2nbj9w==}
-    engines: {node: '>= 10'}
+  "@napi-rs/canvas-android-arm64@0.1.99":
+    resolution:
+      {
+        integrity: sha512-9OCRt8VVxA17m32NWZKyNC2qamdaS/SC5CEOIQwFngRq0DIeVm4PDal+6Ljnhqm2whZiC63DNuKZ4xSp2nbj9w==,
+      }
+    engines: { node: ">= 10" }
     cpu: [arm64]
     os: [android]
 
-  '@napi-rs/canvas-darwin-arm64@0.1.99':
-    resolution: {integrity: sha512-lupMDMy1+H38dhyCcLirOKKVUyzzlxi7j7rGPLI3vViMHOoPjcXO1b10ivy+ad+q6MiwHfoLjKTCoLke5ySOBg==}
-    engines: {node: '>= 10'}
+  "@napi-rs/canvas-darwin-arm64@0.1.99":
+    resolution:
+      {
+        integrity: sha512-lupMDMy1+H38dhyCcLirOKKVUyzzlxi7j7rGPLI3vViMHOoPjcXO1b10ivy+ad+q6MiwHfoLjKTCoLke5ySOBg==,
+      }
+    engines: { node: ">= 10" }
     cpu: [arm64]
     os: [darwin]
 
-  '@napi-rs/canvas-darwin-x64@0.1.99':
-    resolution: {integrity: sha512-fdz02t4w8n6Ii/rYhWig6STb/zcTmCC/6YZTGmjoDeidDwn9Wf0ukQVynhCPEs29vqUc66wHZKsuIgMs9tycCg==}
-    engines: {node: '>= 10'}
+  "@napi-rs/canvas-darwin-x64@0.1.99":
+    resolution:
+      {
+        integrity: sha512-fdz02t4w8n6Ii/rYhWig6STb/zcTmCC/6YZTGmjoDeidDwn9Wf0ukQVynhCPEs29vqUc66wHZKsuIgMs9tycCg==,
+      }
+    engines: { node: ">= 10" }
     cpu: [x64]
     os: [darwin]
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.99':
-    resolution: {integrity: sha512-w4FwVwlNo00ezeRhfY62IVIyt6G3u8wodkPtiqWc52BUHx+VDBUM2vkS3ogfANaLI7hnf3s6WK4LyZVUjBg1lA==}
-    engines: {node: '>= 10'}
+  "@napi-rs/canvas-linux-arm-gnueabihf@0.1.99":
+    resolution:
+      {
+        integrity: sha512-w4FwVwlNo00ezeRhfY62IVIyt6G3u8wodkPtiqWc52BUHx+VDBUM2vkS3ogfANaLI7hnf3s6WK4LyZVUjBg1lA==,
+      }
+    engines: { node: ">= 10" }
     cpu: [arm]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.99':
-    resolution: {integrity: sha512-8JvHeexKQ8c7g0q7YJ29NVQwnf1ePghP9ys9ZN0R0qzyqJQ9Uw6N9qnDINArlm3IYHexB7LjzArIfhQiqSDGvQ==}
-    engines: {node: '>= 10'}
+  "@napi-rs/canvas-linux-arm64-gnu@0.1.99":
+    resolution:
+      {
+        integrity: sha512-8JvHeexKQ8c7g0q7YJ29NVQwnf1ePghP9ys9ZN0R0qzyqJQ9Uw6N9qnDINArlm3IYHexB7LjzArIfhQiqSDGvQ==,
+      }
+    engines: { node: ">= 10" }
     cpu: [arm64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.99':
-    resolution: {integrity: sha512-Z+6nyLdJXWzLPVxi4H6g9TJop4DwN3KSgHWto5JCbZV5/uKoVqcSynPs0tGlUHOoWI8S8tEvJspz51GQkvr07w==}
-    engines: {node: '>= 10'}
+  "@napi-rs/canvas-linux-arm64-musl@0.1.99":
+    resolution:
+      {
+        integrity: sha512-Z+6nyLdJXWzLPVxi4H6g9TJop4DwN3KSgHWto5JCbZV5/uKoVqcSynPs0tGlUHOoWI8S8tEvJspz51GQkvr07w==,
+      }
+    engines: { node: ">= 10" }
     cpu: [arm64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.99':
-    resolution: {integrity: sha512-jAnfOUv4IO1l8Levk5t85oVtEBOXLa07KnIUgWo1CDlPxiqpxS3uBfiE38Lvj/CQgHaNF6Nxk/SaemwLgsVJgw==}
-    engines: {node: '>= 10'}
+  "@napi-rs/canvas-linux-riscv64-gnu@0.1.99":
+    resolution:
+      {
+        integrity: sha512-jAnfOUv4IO1l8Levk5t85oVtEBOXLa07KnIUgWo1CDlPxiqpxS3uBfiE38Lvj/CQgHaNF6Nxk/SaemwLgsVJgw==,
+      }
+    engines: { node: ">= 10" }
     cpu: [riscv64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-x64-gnu@0.1.99':
-    resolution: {integrity: sha512-mIkXw3fGmbYyFjSmfWEvty4jN+rwEOmv0+Dy9bRvvTzLYWCgm3RMgUEQVfAKFw96nIRFnyNZiK83KNQaVVFjng==}
-    engines: {node: '>= 10'}
+  "@napi-rs/canvas-linux-x64-gnu@0.1.99":
+    resolution:
+      {
+        integrity: sha512-mIkXw3fGmbYyFjSmfWEvty4jN+rwEOmv0+Dy9bRvvTzLYWCgm3RMgUEQVfAKFw96nIRFnyNZiK83KNQaVVFjng==,
+      }
+    engines: { node: ">= 10" }
     cpu: [x64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.99':
-    resolution: {integrity: sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==}
-    engines: {node: '>= 10'}
+  "@napi-rs/canvas-linux-x64-musl@0.1.99":
+    resolution:
+      {
+        integrity: sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==,
+      }
+    engines: { node: ">= 10" }
     cpu: [x64]
     os: [linux]
 
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.99':
-    resolution: {integrity: sha512-XE6KUkfqRsCNejcoRMiMr3RaUeObxNf6y7dut3hrq2rn7PzfRTZgrjF1F/B2C7FcdgqY/vSHWpQeMuNz1vTNHg==}
-    engines: {node: '>= 10'}
+  "@napi-rs/canvas-win32-arm64-msvc@0.1.99":
+    resolution:
+      {
+        integrity: sha512-XE6KUkfqRsCNejcoRMiMr3RaUeObxNf6y7dut3hrq2rn7PzfRTZgrjF1F/B2C7FcdgqY/vSHWpQeMuNz1vTNHg==,
+      }
+    engines: { node: ">= 10" }
     cpu: [arm64]
     os: [win32]
 
-  '@napi-rs/canvas-win32-x64-msvc@0.1.99':
-    resolution: {integrity: sha512-plMYGVbc/vmmPF9MtmHbwNk1rL1Aj53vQZt+Gnv1oZn6gmd9jEHHJ0n9Nd2nxa5sKH7TS5IjkCDM6289O0d6PQ==}
-    engines: {node: '>= 10'}
+  "@napi-rs/canvas-win32-x64-msvc@0.1.99":
+    resolution:
+      {
+        integrity: sha512-plMYGVbc/vmmPF9MtmHbwNk1rL1Aj53vQZt+Gnv1oZn6gmd9jEHHJ0n9Nd2nxa5sKH7TS5IjkCDM6289O0d6PQ==,
+      }
+    engines: { node: ">= 10" }
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/canvas@0.1.99':
-    resolution: {integrity: sha512-zN4eQlK3eBf7aJBcTHZilpBH3tDekBzPMIWC8r0s94Ecl73XfOyFi4w7yKFMRVUT0lvNQjtOL8YSrwqQj6mZFg==}
-    engines: {node: '>= 10'}
+  "@napi-rs/canvas@0.1.99":
+    resolution:
+      {
+        integrity: sha512-zN4eQlK3eBf7aJBcTHZilpBH3tDekBzPMIWC8r0s94Ecl73XfOyFi4w7yKFMRVUT0lvNQjtOL8YSrwqQj6mZFg==,
+      }
+    engines: { node: ">= 10" }
 
-  '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
+  "@nodelib/fs.scandir@2.1.5":
+    resolution:
+      {
+        integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
+      }
+    engines: { node: ">= 8" }
 
-  '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
+  "@nodelib/fs.stat@2.0.5":
+    resolution:
+      {
+        integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
+      }
+    engines: { node: ">= 8" }
 
-  '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
+  "@nodelib/fs.walk@1.2.8":
+    resolution:
+      {
+        integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
+      }
+    engines: { node: ">= 8" }
 
-  '@oxfmt/binding-android-arm-eabi@0.62.0':
-    resolution: {integrity: sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-android-arm-eabi@0.62.0":
+    resolution:
+      {
+        integrity: sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.62.0':
-    resolution: {integrity: sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-android-arm64@0.62.0":
+    resolution:
+      {
+        integrity: sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.62.0':
-    resolution: {integrity: sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-darwin-arm64@0.62.0":
+    resolution:
+      {
+        integrity: sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.62.0':
-    resolution: {integrity: sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-darwin-x64@0.62.0":
+    resolution:
+      {
+        integrity: sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.62.0':
-    resolution: {integrity: sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-freebsd-x64@0.62.0":
+    resolution:
+      {
+        integrity: sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.62.0':
-    resolution: {integrity: sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-linux-arm-gnueabihf@0.62.0":
+    resolution:
+      {
+        integrity: sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.62.0':
-    resolution: {integrity: sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-linux-arm-musleabihf@0.62.0":
+    resolution:
+      {
+        integrity: sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.62.0':
-    resolution: {integrity: sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-linux-arm64-gnu@0.62.0":
+    resolution:
+      {
+        integrity: sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-musl@0.62.0':
-    resolution: {integrity: sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-linux-arm64-musl@0.62.0":
+    resolution:
+      {
+        integrity: sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
-    resolution: {integrity: sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-linux-ppc64-gnu@0.62.0":
+    resolution:
+      {
+        integrity: sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
-    resolution: {integrity: sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-linux-riscv64-gnu@0.62.0":
+    resolution:
+      {
+        integrity: sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.62.0':
-    resolution: {integrity: sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-linux-riscv64-musl@0.62.0":
+    resolution:
+      {
+        integrity: sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.62.0':
-    resolution: {integrity: sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-linux-s390x-gnu@0.62.0":
+    resolution:
+      {
+        integrity: sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
 
-  '@oxfmt/binding-linux-x64-gnu@0.62.0':
-    resolution: {integrity: sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-linux-x64-gnu@0.62.0":
+    resolution:
+      {
+        integrity: sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
 
-  '@oxfmt/binding-linux-x64-musl@0.62.0':
-    resolution: {integrity: sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-linux-x64-musl@0.62.0":
+    resolution:
+      {
+        integrity: sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
 
-  '@oxfmt/binding-openharmony-arm64@0.62.0':
-    resolution: {integrity: sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-openharmony-arm64@0.62.0":
+    resolution:
+      {
+        integrity: sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.62.0':
-    resolution: {integrity: sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-win32-arm64-msvc@0.62.0":
+    resolution:
+      {
+        integrity: sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.62.0':
-    resolution: {integrity: sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-win32-ia32-msvc@0.62.0":
+    resolution:
+      {
+        integrity: sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.62.0':
-    resolution: {integrity: sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  "@oxfmt/binding-win32-x64-msvc@0.62.0":
+    resolution:
+      {
+        integrity: sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [win32]
 
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
+  "@pkgjs/parseargs@0.11.0":
+    resolution:
+      {
+        integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==,
+      }
+    engines: { node: ">=14" }
 
-  '@remixicon/react@4.6.0':
-    resolution: {integrity: sha512-bY56maEgT5IYUSRotqy9h03IAKJC85vlKtWFg2FKzfs8JPrkdBAYSa9dxoUSKFwGzup8Ux6vjShs9Aec3jvr2w==}
+  "@remixicon/react@4.6.0":
+    resolution:
+      {
+        integrity: sha512-bY56maEgT5IYUSRotqy9h03IAKJC85vlKtWFg2FKzfs8JPrkdBAYSa9dxoUSKFwGzup8Ux6vjShs9Aec3jvr2w==,
+      }
     peerDependencies:
-      react: '>=18.2.0'
+      react: ">=18.2.0"
 
-  '@rolldown/pluginutils@1.0.0-beta.27':
-    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+  "@rolldown/pluginutils@1.0.0-beta.27":
+    resolution:
+      {
+        integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==,
+      }
 
-  '@rollup/pluginutils@5.2.0':
-    resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
-    engines: {node: '>=14.0.0'}
+  "@rollup/pluginutils@5.2.0":
+    resolution:
+      {
+        integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==,
+      }
+    engines: { node: ">=14.0.0" }
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.46.2':
-    resolution: {integrity: sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==}
+  "@rollup/rollup-android-arm-eabi@4.46.2":
+    resolution:
+      {
+        integrity: sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==,
+      }
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.46.2':
-    resolution: {integrity: sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==}
+  "@rollup/rollup-android-arm64@4.46.2":
+    resolution:
+      {
+        integrity: sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==,
+      }
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.46.2':
-    resolution: {integrity: sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==}
+  "@rollup/rollup-darwin-arm64@4.46.2":
+    resolution:
+      {
+        integrity: sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==,
+      }
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.46.2':
-    resolution: {integrity: sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==}
+  "@rollup/rollup-darwin-x64@4.46.2":
+    resolution:
+      {
+        integrity: sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==,
+      }
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.46.2':
-    resolution: {integrity: sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==}
+  "@rollup/rollup-freebsd-arm64@4.46.2":
+    resolution:
+      {
+        integrity: sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==,
+      }
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.46.2':
-    resolution: {integrity: sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==}
+  "@rollup/rollup-freebsd-x64@4.46.2":
+    resolution:
+      {
+        integrity: sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==,
+      }
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
-    resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
+  "@rollup/rollup-linux-arm-gnueabihf@4.46.2":
+    resolution:
+      {
+        integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==,
+      }
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.46.2':
-    resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
+  "@rollup/rollup-linux-arm-musleabihf@4.46.2":
+    resolution:
+      {
+        integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==,
+      }
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.46.2':
-    resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
+  "@rollup/rollup-linux-arm64-gnu@4.46.2":
+    resolution:
+      {
+        integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==,
+      }
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.46.2':
-    resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
+  "@rollup/rollup-linux-arm64-musl@4.46.2":
+    resolution:
+      {
+        integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==,
+      }
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
-    resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
+  "@rollup/rollup-linux-loongarch64-gnu@4.46.2":
+    resolution:
+      {
+        integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==,
+      }
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.46.2':
-    resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
+  "@rollup/rollup-linux-ppc64-gnu@4.46.2":
+    resolution:
+      {
+        integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==,
+      }
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.46.2':
-    resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
+  "@rollup/rollup-linux-riscv64-gnu@4.46.2":
+    resolution:
+      {
+        integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==,
+      }
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.46.2':
-    resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
+  "@rollup/rollup-linux-riscv64-musl@4.46.2":
+    resolution:
+      {
+        integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==,
+      }
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.46.2':
-    resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
+  "@rollup/rollup-linux-s390x-gnu@4.46.2":
+    resolution:
+      {
+        integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==,
+      }
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.46.2':
-    resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
+  "@rollup/rollup-linux-x64-gnu@4.46.2":
+    resolution:
+      {
+        integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==,
+      }
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.46.2':
-    resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
+  "@rollup/rollup-linux-x64-musl@4.46.2":
+    resolution:
+      {
+        integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==,
+      }
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.46.2':
-    resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
+  "@rollup/rollup-win32-arm64-msvc@4.46.2":
+    resolution:
+      {
+        integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==,
+      }
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.46.2':
-    resolution: {integrity: sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==}
+  "@rollup/rollup-win32-ia32-msvc@4.46.2":
+    resolution:
+      {
+        integrity: sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==,
+      }
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.46.2':
-    resolution: {integrity: sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==}
+  "@rollup/rollup-win32-x64-msvc@4.46.2":
+    resolution:
+      {
+        integrity: sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==,
+      }
     cpu: [x64]
     os: [win32]
 
-  '@standard-schema/utils@0.3.0':
-    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+  "@standard-schema/utils@0.3.0":
+    resolution:
+      {
+        integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==,
+      }
 
-  '@storybook/addon-actions@8.6.14':
-    resolution: {integrity: sha512-mDQxylxGGCQSK7tJPkD144J8jWh9IU9ziJMHfB84PKpI/V5ZgqMDnpr2bssTrUaGDqU5e1/z8KcRF+Melhs9pQ==}
+  "@storybook/addon-actions@8.6.14":
+    resolution:
+      {
+        integrity: sha512-mDQxylxGGCQSK7tJPkD144J8jWh9IU9ziJMHfB84PKpI/V5ZgqMDnpr2bssTrUaGDqU5e1/z8KcRF+Melhs9pQ==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/addon-backgrounds@8.6.14':
-    resolution: {integrity: sha512-l9xS8qWe5n4tvMwth09QxH2PmJbCctEvBAc1tjjRasAfrd69f7/uFK4WhwJAstzBTNgTc8VXI4w8ZR97i1sFbg==}
+  "@storybook/addon-backgrounds@8.6.14":
+    resolution:
+      {
+        integrity: sha512-l9xS8qWe5n4tvMwth09QxH2PmJbCctEvBAc1tjjRasAfrd69f7/uFK4WhwJAstzBTNgTc8VXI4w8ZR97i1sFbg==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/addon-controls@8.6.14':
-    resolution: {integrity: sha512-IiQpkNJdiRyA4Mq9mzjZlvQugL/aE7hNgVxBBGPiIZG6wb6Ht9hNnBYpap5ZXXFKV9p2qVI0FZK445ONmAa+Cw==}
+  "@storybook/addon-controls@8.6.14":
+    resolution:
+      {
+        integrity: sha512-IiQpkNJdiRyA4Mq9mzjZlvQugL/aE7hNgVxBBGPiIZG6wb6Ht9hNnBYpap5ZXXFKV9p2qVI0FZK445ONmAa+Cw==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/addon-docs@8.6.14':
-    resolution: {integrity: sha512-Obpd0OhAF99JyU5pp5ci17YmpcQtMNgqW2pTXV8jAiiipWpwO++hNDeQmLmlSXB399XjtRDOcDVkoc7rc6JzdQ==}
+  "@storybook/addon-docs@8.6.14":
+    resolution:
+      {
+        integrity: sha512-Obpd0OhAF99JyU5pp5ci17YmpcQtMNgqW2pTXV8jAiiipWpwO++hNDeQmLmlSXB399XjtRDOcDVkoc7rc6JzdQ==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/addon-essentials@8.6.14':
-    resolution: {integrity: sha512-5ZZSHNaW9mXMOFkoPyc3QkoNGdJHETZydI62/OASR0lmPlJ1065TNigEo5dJddmZNn0/3bkE8eKMAzLnO5eIdA==}
+  "@storybook/addon-essentials@8.6.14":
+    resolution:
+      {
+        integrity: sha512-5ZZSHNaW9mXMOFkoPyc3QkoNGdJHETZydI62/OASR0lmPlJ1065TNigEo5dJddmZNn0/3bkE8eKMAzLnO5eIdA==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/addon-highlight@8.6.14':
-    resolution: {integrity: sha512-4H19OJlapkofiE9tM6K/vsepf4ir9jMm9T+zw5L85blJZxhKZIbJ6FO0TCG9PDc4iPt3L6+aq5B0X29s9zicNQ==}
+  "@storybook/addon-highlight@8.6.14":
+    resolution:
+      {
+        integrity: sha512-4H19OJlapkofiE9tM6K/vsepf4ir9jMm9T+zw5L85blJZxhKZIbJ6FO0TCG9PDc4iPt3L6+aq5B0X29s9zicNQ==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/addon-measure@8.6.14':
-    resolution: {integrity: sha512-1Tlyb72NX8aAqm6I6OICsUuGOP6hgnXcuFlXucyhKomPa6j3Eu2vKu561t/f0oGtAK2nO93Z70kVaEh5X+vaGw==}
+  "@storybook/addon-measure@8.6.14":
+    resolution:
+      {
+        integrity: sha512-1Tlyb72NX8aAqm6I6OICsUuGOP6hgnXcuFlXucyhKomPa6j3Eu2vKu561t/f0oGtAK2nO93Z70kVaEh5X+vaGw==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/addon-outline@8.6.14':
-    resolution: {integrity: sha512-CW857JvN6OxGWElqjlzJO2S69DHf+xO3WsEfT5mT3ZtIjmsvRDukdWfDU9bIYUFyA2lFvYjncBGjbK+I91XR7w==}
+  "@storybook/addon-outline@8.6.14":
+    resolution:
+      {
+        integrity: sha512-CW857JvN6OxGWElqjlzJO2S69DHf+xO3WsEfT5mT3ZtIjmsvRDukdWfDU9bIYUFyA2lFvYjncBGjbK+I91XR7w==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/addon-storysource@8.6.14':
-    resolution: {integrity: sha512-/eDCNUHPdsVDF53B+Ebi9gHSNcRrA3puo1UCDio8wMN+jBMoWh6E5wSjXDsxWaOyp0Zwuq8XUx8AdgTlg/rcrw==}
+  "@storybook/addon-storysource@8.6.14":
+    resolution:
+      {
+        integrity: sha512-/eDCNUHPdsVDF53B+Ebi9gHSNcRrA3puo1UCDio8wMN+jBMoWh6E5wSjXDsxWaOyp0Zwuq8XUx8AdgTlg/rcrw==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/addon-toolbars@8.6.14':
-    resolution: {integrity: sha512-W/wEXT8h3VyZTVfWK/84BAcjAxTdtRiAkT2KAN0nbSHxxB5KEM1MjKpKu2upyzzMa3EywITqbfy4dP6lpkVTwQ==}
+  "@storybook/addon-toolbars@8.6.14":
+    resolution:
+      {
+        integrity: sha512-W/wEXT8h3VyZTVfWK/84BAcjAxTdtRiAkT2KAN0nbSHxxB5KEM1MjKpKu2upyzzMa3EywITqbfy4dP6lpkVTwQ==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/addon-viewport@8.6.14':
-    resolution: {integrity: sha512-gNzVQbMqRC+/4uQTPI2ZrWuRHGquTMZpdgB9DrD88VTEjNudP+J6r8myLfr2VvGksBbUMHkGHMXHuIhrBEnXYA==}
+  "@storybook/addon-viewport@8.6.14":
+    resolution:
+      {
+        integrity: sha512-gNzVQbMqRC+/4uQTPI2ZrWuRHGquTMZpdgB9DrD88VTEjNudP+J6r8myLfr2VvGksBbUMHkGHMXHuIhrBEnXYA==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/blocks@8.6.14':
-    resolution: {integrity: sha512-rBMHAfA39AGHgkrDze4RmsnQTMw1ND5fGWobr9pDcJdnDKWQWNRD7Nrlxj0gFlN3n4D9lEZhWGdFrCbku7FVAQ==}
+  "@storybook/blocks@8.6.14":
+    resolution:
+      {
+        integrity: sha512-rBMHAfA39AGHgkrDze4RmsnQTMw1ND5fGWobr9pDcJdnDKWQWNRD7Nrlxj0gFlN3n4D9lEZhWGdFrCbku7FVAQ==,
+      }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -942,905 +1411,1571 @@ packages:
       react-dom:
         optional: true
 
-  '@storybook/builder-vite@8.6.14':
-    resolution: {integrity: sha512-ajWYhy32ksBWxwWHrjwZzyC0Ii5ZTeu5lsqA95Q/EQBB0P5qWlHWGM3AVyv82Mz/ND03ebGy123uVwgf6olnYQ==}
+  "@storybook/builder-vite@8.6.14":
+    resolution:
+      {
+        integrity: sha512-ajWYhy32ksBWxwWHrjwZzyC0Ii5ZTeu5lsqA95Q/EQBB0P5qWlHWGM3AVyv82Mz/ND03ebGy123uVwgf6olnYQ==,
+      }
     peerDependencies:
       storybook: ^8.6.14
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
 
-  '@storybook/components@8.6.14':
-    resolution: {integrity: sha512-HNR2mC5I4Z5ek8kTrVZlIY/B8gJGs5b3XdZPBPBopTIN6U/YHXiDyOjY3JlaS4fSG1fVhp/Qp1TpMn1w/9m1pw==}
+  "@storybook/components@8.6.14":
+    resolution:
+      {
+        integrity: sha512-HNR2mC5I4Z5ek8kTrVZlIY/B8gJGs5b3XdZPBPBopTIN6U/YHXiDyOjY3JlaS4fSG1fVhp/Qp1TpMn1w/9m1pw==,
+      }
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@storybook/core-events@8.6.14':
-    resolution: {integrity: sha512-RrJ95u3HuIE4Nk8VmZP0tc/u0vYoE2v9fYlMw6K2GUSExzKDITs3voy6WMIY7Q3qbQun8XUXVlmqkuFzTEy/pA==}
+  "@storybook/core-events@8.6.14":
+    resolution:
+      {
+        integrity: sha512-RrJ95u3HuIE4Nk8VmZP0tc/u0vYoE2v9fYlMw6K2GUSExzKDITs3voy6WMIY7Q3qbQun8XUXVlmqkuFzTEy/pA==,
+      }
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@storybook/core@8.6.14':
-    resolution: {integrity: sha512-1P/w4FSNRqP8j3JQBOi3yGt8PVOgSRbP66Ok520T78eJBeqx9ukCfl912PQZ7SPbW3TIunBwLXMZOjZwBB/JmA==}
+  "@storybook/core@8.6.14":
+    resolution:
+      {
+        integrity: sha512-1P/w4FSNRqP8j3JQBOi3yGt8PVOgSRbP66Ok520T78eJBeqx9ukCfl912PQZ7SPbW3TIunBwLXMZOjZwBB/JmA==,
+      }
     peerDependencies:
       prettier: ^2 || ^3
     peerDependenciesMeta:
       prettier:
         optional: true
 
-  '@storybook/csf-plugin@8.6.14':
-    resolution: {integrity: sha512-dErtc9teAuN+eelN8FojzFE635xlq9cNGGGEu0WEmMUQ4iJ8pingvBO1N8X3scz4Ry7KnxX++NNf3J3gpxS8qQ==}
+  "@storybook/csf-plugin@8.6.14":
+    resolution:
+      {
+        integrity: sha512-dErtc9teAuN+eelN8FojzFE635xlq9cNGGGEu0WEmMUQ4iJ8pingvBO1N8X3scz4Ry7KnxX++NNf3J3gpxS8qQ==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/global@5.0.0':
-    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+  "@storybook/global@5.0.0":
+    resolution:
+      {
+        integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==,
+      }
 
-  '@storybook/icons@1.4.0':
-    resolution: {integrity: sha512-Td73IeJxOyalzvjQL+JXx72jlIYHgs+REaHiREOqfpo3A2AYYG71AUbcv+lg7mEDIweKVCxsMQ0UKo634c8XeA==}
-    engines: {node: '>=14.0.0'}
+  "@storybook/icons@1.4.0":
+    resolution:
+      {
+        integrity: sha512-Td73IeJxOyalzvjQL+JXx72jlIYHgs+REaHiREOqfpo3A2AYYG71AUbcv+lg7mEDIweKVCxsMQ0UKo634c8XeA==,
+      }
+    engines: { node: ">=14.0.0" }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
 
-  '@storybook/instrumenter@8.6.14':
-    resolution: {integrity: sha512-iG4MlWCcz1L7Yu8AwgsnfVAmMbvyRSk700Mfy2g4c8y5O+Cv1ejshE1LBBsCwHgkuqU0H4R0qu4g23+6UnUemQ==}
+  "@storybook/instrumenter@8.6.14":
+    resolution:
+      {
+        integrity: sha512-iG4MlWCcz1L7Yu8AwgsnfVAmMbvyRSk700Mfy2g4c8y5O+Cv1ejshE1LBBsCwHgkuqU0H4R0qu4g23+6UnUemQ==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/manager-api@8.6.14':
-    resolution: {integrity: sha512-ez0Zihuy17udLbfHZQXkGqwtep0mSGgHcNzGN7iZrMP1m+VmNo+7aGCJJdvXi7+iU3yq8weXSQFWg5DqWgLS7g==}
+  "@storybook/manager-api@8.6.14":
+    resolution:
+      {
+        integrity: sha512-ez0Zihuy17udLbfHZQXkGqwtep0mSGgHcNzGN7iZrMP1m+VmNo+7aGCJJdvXi7+iU3yq8weXSQFWg5DqWgLS7g==,
+      }
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@storybook/preview-api@8.6.14':
-    resolution: {integrity: sha512-2GhcCd4dNMrnD7eooEfvbfL4I83qAqEyO0CO7JQAmIO6Rxb9BsOLLI/GD5HkvQB73ArTJ+PT50rfaO820IExOQ==}
+  "@storybook/preview-api@8.6.14":
+    resolution:
+      {
+        integrity: sha512-2GhcCd4dNMrnD7eooEfvbfL4I83qAqEyO0CO7JQAmIO6Rxb9BsOLLI/GD5HkvQB73ArTJ+PT50rfaO820IExOQ==,
+      }
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@storybook/react-dom-shim@8.6.14':
-    resolution: {integrity: sha512-0hixr3dOy3f3M+HBofp3jtMQMS+sqzjKNgl7Arfuj3fvjmyXOks/yGjDImySR4imPtEllvPZfhiQNlejheaInw==}
+  "@storybook/react-dom-shim@8.6.14":
+    resolution:
+      {
+        integrity: sha512-0hixr3dOy3f3M+HBofp3jtMQMS+sqzjKNgl7Arfuj3fvjmyXOks/yGjDImySR4imPtEllvPZfhiQNlejheaInw==,
+      }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^8.6.14
 
-  '@storybook/react-vite@8.6.14':
-    resolution: {integrity: sha512-FZU0xMPxa4/TO87FgcWwappOxLBHZV5HSRK5K+2bJD7rFJAoNorbHvB4Q1zvIAk7eCMjkr2GPCPHx9PRB9vJFg==}
-    engines: {node: '>=18.0.0'}
+  "@storybook/react-vite@8.6.14":
+    resolution:
+      {
+        integrity: sha512-FZU0xMPxa4/TO87FgcWwappOxLBHZV5HSRK5K+2bJD7rFJAoNorbHvB4Q1zvIAk7eCMjkr2GPCPHx9PRB9vJFg==,
+      }
+    engines: { node: ">=18.0.0" }
     peerDependencies:
-      '@storybook/test': 8.6.14
+      "@storybook/test": 8.6.14
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^8.6.14
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
-      '@storybook/test':
+      "@storybook/test":
         optional: true
 
-  '@storybook/react@8.6.14':
-    resolution: {integrity: sha512-BOepx5bBFwl/CPI+F+LnmMmsG1wQYmrX/UQXgUbHQUU9Tj7E2ndTnNbpIuSLc8IrM03ru+DfwSg1Co3cxWtT+g==}
-    engines: {node: '>=18.0.0'}
+  "@storybook/react@8.6.14":
+    resolution:
+      {
+        integrity: sha512-BOepx5bBFwl/CPI+F+LnmMmsG1wQYmrX/UQXgUbHQUU9Tj7E2ndTnNbpIuSLc8IrM03ru+DfwSg1Co3cxWtT+g==,
+      }
+    engines: { node: ">=18.0.0" }
     peerDependencies:
-      '@storybook/test': 8.6.14
+      "@storybook/test": 8.6.14
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^8.6.14
-      typescript: '>= 4.2.x'
+      typescript: ">= 4.2.x"
     peerDependenciesMeta:
-      '@storybook/test':
+      "@storybook/test":
         optional: true
       typescript:
         optional: true
 
-  '@storybook/source-loader@8.6.14':
-    resolution: {integrity: sha512-aFUqrkWh4XSXDmkrK0Nm8q4K94bfgnixFMmql8lBAFuEllFek9Rd3i2RwGOhLUtwzpM89f74nzEgR1kd/ijJ+g==}
+  "@storybook/source-loader@8.6.14":
+    resolution:
+      {
+        integrity: sha512-aFUqrkWh4XSXDmkrK0Nm8q4K94bfgnixFMmql8lBAFuEllFek9Rd3i2RwGOhLUtwzpM89f74nzEgR1kd/ijJ+g==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/test@8.6.14':
-    resolution: {integrity: sha512-GkPNBbbZmz+XRdrhMtkxPotCLOQ1BaGNp/gFZYdGDk2KmUWBKmvc5JxxOhtoXM2703IzNFlQHSSNnhrDZYuLlw==}
+  "@storybook/test@8.6.14":
+    resolution:
+      {
+        integrity: sha512-GkPNBbbZmz+XRdrhMtkxPotCLOQ1BaGNp/gFZYdGDk2KmUWBKmvc5JxxOhtoXM2703IzNFlQHSSNnhrDZYuLlw==,
+      }
     peerDependencies:
       storybook: ^8.6.14
 
-  '@storybook/theming@8.6.14':
-    resolution: {integrity: sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==}
+  "@storybook/theming@8.6.14":
+    resolution:
+      {
+        integrity: sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==,
+      }
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@tanstack/react-virtual@3.14.5':
-    resolution: {integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==}
+  "@tanstack/react-virtual@3.14.5":
+    resolution:
+      {
+        integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==,
+      }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/virtual-core@3.17.3':
-    resolution: {integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==}
+  "@tanstack/virtual-core@3.17.3":
+    resolution:
+      {
+        integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==,
+      }
 
-  '@testing-library/cypress@10.0.3':
-    resolution: {integrity: sha512-TeZJMCNtiS59cPWalra7LgADuufO5FtbqQBYxuAgdX6ZFAR2D9CtQwAG8VbgvFcchW3K414va/+7P4OkQ80UVg==}
-    engines: {node: '>=12', npm: '>=6'}
+  "@testing-library/cypress@10.0.3":
+    resolution:
+      {
+        integrity: sha512-TeZJMCNtiS59cPWalra7LgADuufO5FtbqQBYxuAgdX6ZFAR2D9CtQwAG8VbgvFcchW3K414va/+7P4OkQ80UVg==,
+      }
+    engines: { node: ">=12", npm: ">=6" }
     peerDependencies:
       cypress: ^12.0.0 || ^13.0.0 || ^14.0.0
 
-  '@testing-library/dom@10.4.0':
-    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
-    engines: {node: '>=18'}
+  "@testing-library/dom@10.4.0":
+    resolution:
+      {
+        integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==,
+      }
+    engines: { node: ">=18" }
 
-  '@testing-library/dom@10.4.1':
-    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
-    engines: {node: '>=18'}
+  "@testing-library/dom@10.4.1":
+    resolution:
+      {
+        integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==,
+      }
+    engines: { node: ">=18" }
 
-  '@testing-library/jest-dom@6.5.0':
-    resolution: {integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==}
-    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+  "@testing-library/jest-dom@6.5.0":
+    resolution:
+      {
+        integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==,
+      }
+    engines: { node: ">=14", npm: ">=6", yarn: ">=1" }
 
-  '@testing-library/user-event@14.5.2':
-    resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
-    engines: {node: '>=12', npm: '>=6'}
+  "@testing-library/user-event@14.5.2":
+    resolution:
+      {
+        integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==,
+      }
+    engines: { node: ">=12", npm: ">=6" }
     peerDependencies:
-      '@testing-library/dom': '>=7.21.4'
+      "@testing-library/dom": ">=7.21.4"
 
-  '@types/aria-query@5.0.4':
-    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+  "@types/aria-query@5.0.4":
+    resolution:
+      {
+        integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==,
+      }
 
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+  "@types/babel__core@7.20.5":
+    resolution:
+      {
+        integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==,
+      }
 
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+  "@types/babel__generator@7.27.0":
+    resolution:
+      {
+        integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==,
+      }
 
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+  "@types/babel__template@7.4.4":
+    resolution:
+      {
+        integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==,
+      }
 
-  '@types/babel__traverse@7.20.7':
-    resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
+  "@types/babel__traverse@7.20.7":
+    resolution:
+      {
+        integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==,
+      }
 
-  '@types/doctrine@0.0.9':
-    resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
+  "@types/doctrine@0.0.9":
+    resolution:
+      {
+        integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==,
+      }
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+  "@types/estree@1.0.8":
+    resolution:
+      {
+        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+      }
 
-  '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+  "@types/json-schema@7.0.15":
+    resolution:
+      {
+        integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+      }
 
-  '@types/mdx@2.0.13':
-    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+  "@types/mdx@2.0.13":
+    resolution:
+      {
+        integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==,
+      }
 
-  '@types/node@24.1.0':
-    resolution: {integrity: sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==}
+  "@types/node@24.1.0":
+    resolution:
+      {
+        integrity: sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==,
+      }
 
-  '@types/react-dom@19.1.7':
-    resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
+  "@types/react-dom@19.1.7":
+    resolution:
+      {
+        integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==,
+      }
     peerDependencies:
-      '@types/react': ^19.0.0
+      "@types/react": ^19.0.0
 
-  '@types/react@19.1.9':
-    resolution: {integrity: sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==}
+  "@types/react@19.1.9":
+    resolution:
+      {
+        integrity: sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==,
+      }
 
-  '@types/resolve@1.20.6':
-    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+  "@types/resolve@1.20.6":
+    resolution:
+      {
+        integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==,
+      }
 
-  '@types/sinonjs__fake-timers@8.1.1':
-    resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
+  "@types/sinonjs__fake-timers@8.1.1":
+    resolution:
+      {
+        integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==,
+      }
 
-  '@types/sizzle@2.3.9':
-    resolution: {integrity: sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==}
+  "@types/sizzle@2.3.9":
+    resolution:
+      {
+        integrity: sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==,
+      }
 
-  '@types/stylis@4.2.5':
-    resolution: {integrity: sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==}
+  "@types/stylis@4.2.5":
+    resolution:
+      {
+        integrity: sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==,
+      }
 
-  '@types/trusted-types@2.0.7':
-    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+  "@types/trusted-types@2.0.7":
+    resolution:
+      {
+        integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==,
+      }
 
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
+  "@types/uuid@9.0.8":
+    resolution:
+      {
+        integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==,
+      }
 
-  '@types/yargs-parser@21.0.3':
-    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+  "@types/yargs-parser@21.0.3":
+    resolution:
+      {
+        integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==,
+      }
 
-  '@types/yargs@17.0.33':
-    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+  "@types/yargs@17.0.33":
+    resolution:
+      {
+        integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==,
+      }
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+  "@types/yauzl@2.10.3":
+    resolution:
+      {
+        integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==,
+      }
 
-  '@typescript-eslint/eslint-plugin@8.38.0':
-    resolution: {integrity: sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/eslint-plugin@8.38.0":
+    resolution:
+      {
+        integrity: sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      '@typescript-eslint/parser': ^8.38.0
+      "@typescript-eslint/parser": ^8.38.0
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
+      typescript: ">=4.8.4 <5.9.0"
 
-  '@typescript-eslint/parser@8.38.0':
-    resolution: {integrity: sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/parser@8.38.0":
+    resolution:
+      {
+        integrity: sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
+      typescript: ">=4.8.4 <5.9.0"
 
-  '@typescript-eslint/project-service@8.38.0':
-    resolution: {integrity: sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/project-service@8.38.0":
+    resolution:
+      {
+        integrity: sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      typescript: '>=4.8.4 <5.9.0'
+      typescript: ">=4.8.4 <5.9.0"
 
-  '@typescript-eslint/scope-manager@8.38.0':
-    resolution: {integrity: sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/scope-manager@8.38.0":
+    resolution:
+      {
+        integrity: sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@typescript-eslint/tsconfig-utils@8.38.0':
-    resolution: {integrity: sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/tsconfig-utils@8.38.0":
+    resolution:
+      {
+        integrity: sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      typescript: '>=4.8.4 <5.9.0'
+      typescript: ">=4.8.4 <5.9.0"
 
-  '@typescript-eslint/type-utils@8.38.0':
-    resolution: {integrity: sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
-
-  '@typescript-eslint/types@8.38.0':
-    resolution: {integrity: sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.38.0':
-    resolution: {integrity: sha512-fooELKcAKzxux6fA6pxOflpNS0jc+nOQEEOipXFNjSlBS6fqrJOVY/whSn70SScHrcJ2LDsxWrneFoWYSVfqhQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <5.9.0'
-
-  '@typescript-eslint/utils@8.38.0':
-    resolution: {integrity: sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/type-utils@8.38.0":
+    resolution:
+      {
+        integrity: sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
+      typescript: ">=4.8.4 <5.9.0"
 
-  '@typescript-eslint/visitor-keys@8.38.0':
-    resolution: {integrity: sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  "@typescript-eslint/types@8.38.0":
+    resolution:
+      {
+        integrity: sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@vitejs/plugin-react@4.7.0':
-    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  "@typescript-eslint/typescript-estree@8.38.0":
+    resolution:
+      {
+        integrity: sha512-fooELKcAKzxux6fA6pxOflpNS0jc+nOQEEOipXFNjSlBS6fqrJOVY/whSn70SScHrcJ2LDsxWrneFoWYSVfqhQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <5.9.0"
+
+  "@typescript-eslint/utils@8.38.0":
+    resolution:
+      {
+        integrity: sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: ">=4.8.4 <5.9.0"
+
+  "@typescript-eslint/visitor-keys@8.38.0":
+    resolution:
+      {
+        integrity: sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@vitejs/plugin-react@4.7.0":
+    resolution:
+      {
+        integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==,
+      }
+    engines: { node: ^14.18.0 || >=16.0.0 }
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/expect@2.0.5':
-    resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
+  "@vitest/expect@2.0.5":
+    resolution:
+      {
+        integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==,
+      }
 
-  '@vitest/pretty-format@2.0.5':
-    resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
+  "@vitest/pretty-format@2.0.5":
+    resolution:
+      {
+        integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==,
+      }
 
-  '@vitest/pretty-format@2.1.9':
-    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+  "@vitest/pretty-format@2.1.9":
+    resolution:
+      {
+        integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==,
+      }
 
-  '@vitest/spy@2.0.5':
-    resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
+  "@vitest/spy@2.0.5":
+    resolution:
+      {
+        integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==,
+      }
 
-  '@vitest/utils@2.0.5':
-    resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
+  "@vitest/utils@2.0.5":
+    resolution:
+      {
+        integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==,
+      }
 
-  '@vitest/utils@2.1.9':
-    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+  "@vitest/utils@2.1.9":
+    resolution:
+      {
+        integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==,
+      }
 
   acorn-jsx@5.3.2:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    resolution:
+      {
+        integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
+      }
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==,
+      }
+    engines: { node: ">=0.4.0" }
     hasBin: true
 
   aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==,
+      }
+    engines: { node: ">=8" }
 
   ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+    resolution:
+      {
+        integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
+      }
 
   ansi-colors@4.1.3:
-    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==,
+      }
+    engines: { node: ">=6" }
 
   ansi-escapes@4.3.2:
-    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==,
+      }
+    engines: { node: ">=8" }
 
   ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
+      }
+    engines: { node: ">=8" }
 
   ansi-regex@6.1.0:
-    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==,
+      }
+    engines: { node: ">=12" }
 
   ansi-styles@3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==,
+      }
+    engines: { node: ">=4" }
 
   ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+      }
+    engines: { node: ">=8" }
 
   ansi-styles@5.2.0:
-    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==,
+      }
+    engines: { node: ">=10" }
 
   ansi-styles@6.2.1:
-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==,
+      }
+    engines: { node: ">=12" }
 
   arch@2.2.0:
-    resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
+    resolution:
+      {
+        integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==,
+      }
 
   argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    resolution:
+      {
+        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
+      }
 
   aria-query@5.3.0:
-    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+    resolution:
+      {
+        integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==,
+      }
 
   aria-query@5.3.2:
-    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==,
+      }
+    engines: { node: ">= 0.4" }
 
   array-buffer-byte-length@1.0.2:
-    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==,
+      }
+    engines: { node: ">= 0.4" }
 
   array-includes@3.1.9:
-    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   array.prototype.findlast@1.2.5:
-    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   array.prototype.flat@1.3.3:
-    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==,
+      }
+    engines: { node: ">= 0.4" }
 
   array.prototype.flatmap@1.3.3:
-    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==,
+      }
+    engines: { node: ">= 0.4" }
 
   array.prototype.tosorted@1.1.4:
-    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==,
+      }
+    engines: { node: ">= 0.4" }
 
   arraybuffer.prototype.slice@1.0.4:
-    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   asn1@0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+    resolution:
+      {
+        integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==,
+      }
 
   assert-plus@1.0.0:
-    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==,
+      }
+    engines: { node: ">=0.8" }
 
   assertion-error@2.0.1:
-    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
+      }
+    engines: { node: ">=12" }
 
   ast-types@0.16.1:
-    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==,
+      }
+    engines: { node: ">=4" }
 
   astral-regex@2.0.0:
-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==,
+      }
+    engines: { node: ">=8" }
 
   async-function@1.0.0:
-    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==,
+      }
+    engines: { node: ">= 0.4" }
 
   async@3.2.6:
-    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+    resolution:
+      {
+        integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==,
+      }
 
   asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    resolution:
+      {
+        integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
+      }
 
   at-least-node@1.0.0:
-    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
-    engines: {node: '>= 4.0.0'}
+    resolution:
+      {
+        integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==,
+      }
+    engines: { node: ">= 4.0.0" }
 
   available-typed-arrays@1.0.7:
-    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   aws-sign2@0.7.0:
-    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+    resolution:
+      {
+        integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==,
+      }
 
   aws4@1.13.2:
-    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
+    resolution:
+      {
+        integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==,
+      }
 
   balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    resolution:
+      {
+        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
+      }
 
   barrelsby@2.8.1:
-    resolution: {integrity: sha512-barN2MVKqUVwmjRy3JLSMYufrBDcdWUc2pjlR0V9P8S3aMvvJ4StFz1GJMzEi5GBoQlnBIWOcCxBDzI2xfaaGw==}
-    engines: {node: '>=6.0.0'}
+    resolution:
+      {
+        integrity: sha512-barN2MVKqUVwmjRy3JLSMYufrBDcdWUc2pjlR0V9P8S3aMvvJ4StFz1GJMzEi5GBoQlnBIWOcCxBDzI2xfaaGw==,
+      }
+    engines: { node: ">=6.0.0" }
     hasBin: true
 
   base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    resolution:
+      {
+        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
+      }
 
   bcrypt-pbkdf@1.0.2:
-    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+    resolution:
+      {
+        integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==,
+      }
 
   better-opn@3.0.2:
-    resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==,
+      }
+    engines: { node: ">=12.0.0" }
 
   blob-util@2.0.2:
-    resolution: {integrity: sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==}
+    resolution:
+      {
+        integrity: sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==,
+      }
 
   bluebird@3.7.2:
-    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+    resolution:
+      {
+        integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==,
+      }
 
   brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+    resolution:
+      {
+        integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==,
+      }
 
   brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+    resolution:
+      {
+        integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==,
+      }
 
   braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
+      }
+    engines: { node: ">=8" }
 
   browser-assert@1.2.1:
-    resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
+    resolution:
+      {
+        integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==,
+      }
 
   browserslist@4.25.1:
-    resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    resolution:
+      {
+        integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==,
+      }
+    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
 
   buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+    resolution:
+      {
+        integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==,
+      }
 
   buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    resolution:
+      {
+        integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
+      }
 
   buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+    resolution:
+      {
+        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
+      }
 
   cachedir@2.4.0:
-    resolution: {integrity: sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==,
+      }
+    engines: { node: ">=6" }
 
   call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   call-bind@1.0.8:
-    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==,
+      }
+    engines: { node: ">= 0.4" }
 
   call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==,
+      }
+    engines: { node: ">= 0.4" }
 
   callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
+      }
+    engines: { node: ">=6" }
 
   camelize@1.0.1:
-    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
+    resolution:
+      {
+        integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==,
+      }
 
   caniuse-lite@1.0.30001731:
-    resolution: {integrity: sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==}
+    resolution:
+      {
+        integrity: sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==,
+      }
 
   caseless@0.12.0:
-    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
+    resolution:
+      {
+        integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==,
+      }
 
   chai@5.2.1:
-    resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==,
+      }
+    engines: { node: ">=18" }
 
   chalk@2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==,
+      }
+    engines: { node: ">=4" }
 
   chalk@3.0.0:
-    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==,
+      }
+    engines: { node: ">=8" }
 
   chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
+      }
+    engines: { node: ">=10" }
 
   check-error@2.1.1:
-    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
-    engines: {node: '>= 16'}
+    resolution:
+      {
+        integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==,
+      }
+    engines: { node: ">= 16" }
 
   check-more-types@2.24.0:
-    resolution: {integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   ci-info@4.3.0:
-    resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==,
+      }
+    engines: { node: ">=8" }
 
   clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==,
+      }
+    engines: { node: ">=6" }
 
   cli-cursor@3.1.0:
-    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==,
+      }
+    engines: { node: ">=8" }
 
   cli-table3@0.6.1:
-    resolution: {integrity: sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==}
-    engines: {node: 10.* || >= 12.*}
+    resolution:
+      {
+        integrity: sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==,
+      }
+    engines: { node: 10.* || >= 12.* }
 
   cli-truncate@2.1.0:
-    resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==,
+      }
+    engines: { node: ">=8" }
 
   cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==,
+      }
+    engines: { node: ">=12" }
 
   color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    resolution:
+      {
+        integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==,
+      }
 
   color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+      }
+    engines: { node: ">=7.0.0" }
 
   color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    resolution:
+      {
+        integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==,
+      }
 
   color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    resolution:
+      {
+        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+      }
 
   colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+    resolution:
+      {
+        integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
+      }
 
   colors@1.4.0:
-    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
-    engines: {node: '>=0.1.90'}
+    resolution:
+      {
+        integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==,
+      }
+    engines: { node: ">=0.1.90" }
 
   combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==,
+      }
+    engines: { node: ">= 0.8" }
 
   commander@2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    resolution:
+      {
+        integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==,
+      }
 
   commander@6.2.1:
-    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==,
+      }
+    engines: { node: ">= 6" }
 
   common-tags@1.8.2:
-    resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
-    engines: {node: '>=4.0.0'}
+    resolution:
+      {
+        integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==,
+      }
+    engines: { node: ">=4.0.0" }
 
   concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution:
+      {
+        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
+      }
 
   convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+    resolution:
+      {
+        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
+      }
 
   core-util-is@1.0.2:
-    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+    resolution:
+      {
+        integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==,
+      }
 
   cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
+      }
+    engines: { node: ">= 8" }
 
   css-color-keywords@1.0.0:
-    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==,
+      }
+    engines: { node: ">=4" }
 
   css-to-react-native@3.2.0:
-    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
+    resolution:
+      {
+        integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==,
+      }
 
   css.escape@1.5.1:
-    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+    resolution:
+      {
+        integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==,
+      }
 
   csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+    resolution:
+      {
+        integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==,
+      }
 
   cypress-real-events@1.14.0:
-    resolution: {integrity: sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==}
+    resolution:
+      {
+        integrity: sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==,
+      }
     peerDependencies:
       cypress: ^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x || ^14.x
 
   cypress@14.5.3:
-    resolution: {integrity: sha512-syLwKjDeMg77FRRx68bytLdlqHXDT4yBVh0/PPkcgesChYDjUZbwxLqMXuryYKzAyJsPsQHUDW1YU74/IYEUIA==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    resolution:
+      {
+        integrity: sha512-syLwKjDeMg77FRRx68bytLdlqHXDT4yBVh0/PPkcgesChYDjUZbwxLqMXuryYKzAyJsPsQHUDW1YU74/IYEUIA==,
+      }
+    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
     hasBin: true
 
   dashdash@1.14.1:
-    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
-    engines: {node: '>=0.10'}
+    resolution:
+      {
+        integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==,
+      }
+    engines: { node: ">=0.10" }
 
   data-view-buffer@1.0.2:
-    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   data-view-byte-length@1.0.2:
-    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   data-view-byte-offset@1.0.1:
-    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   dayjs@1.11.13:
-    resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
+    resolution:
+      {
+        integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==,
+      }
 
   debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    resolution:
+      {
+        integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==,
+      }
     peerDependencies:
-      supports-color: '*'
+      supports-color: "*"
     peerDependenciesMeta:
       supports-color:
         optional: true
 
   debug@4.4.1:
-    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
-    engines: {node: '>=6.0'}
+    resolution:
+      {
+        integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==,
+      }
+    engines: { node: ">=6.0" }
     peerDependencies:
-      supports-color: '*'
+      supports-color: "*"
     peerDependenciesMeta:
       supports-color:
         optional: true
 
   deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
+      }
+    engines: { node: ">=6" }
 
   deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    resolution:
+      {
+        integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
+      }
 
   define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==,
+      }
+    engines: { node: ">= 0.4" }
 
   define-lazy-prop@2.0.0:
-    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==,
+      }
+    engines: { node: ">=8" }
 
   define-properties@1.2.1:
-    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==,
+      }
+    engines: { node: ">= 0.4" }
 
   delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
+      }
+    engines: { node: ">=0.4.0" }
 
   dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
+      }
+    engines: { node: ">=6" }
 
   detect-libc@2.0.4:
-    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==,
+      }
+    engines: { node: ">=8" }
 
   doctrine@2.1.0:
-    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==,
+      }
+    engines: { node: ">=0.10.0" }
 
   doctrine@3.0.0:
-    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
-    engines: {node: '>=6.0.0'}
+    resolution:
+      {
+        integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==,
+      }
+    engines: { node: ">=6.0.0" }
 
   dom-accessibility-api@0.5.16:
-    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+    resolution:
+      {
+        integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==,
+      }
 
   dom-accessibility-api@0.6.3:
-    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+    resolution:
+      {
+        integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==,
+      }
 
   dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+    resolution:
+      {
+        integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==,
+      }
 
   dotenv@17.2.1:
-    resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==,
+      }
+    engines: { node: ">=12" }
 
   dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
+      }
+    engines: { node: ">= 0.4" }
 
   eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    resolution:
+      {
+        integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
+      }
 
   ecc-jsbn@0.1.2:
-    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+    resolution:
+      {
+        integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==,
+      }
 
   electron-to-chromium@1.5.192:
-    resolution: {integrity: sha512-rP8Ez0w7UNw/9j5eSXCe10o1g/8B1P5SM90PCCMVkIRQn2R0LEHWz4Eh9RnxkniuDe1W0cTSOB3MLlkTGDcuCg==}
+    resolution:
+      {
+        integrity: sha512-rP8Ez0w7UNw/9j5eSXCe10o1g/8B1P5SM90PCCMVkIRQn2R0LEHWz4Eh9RnxkniuDe1W0cTSOB3MLlkTGDcuCg==,
+      }
 
   emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    resolution:
+      {
+        integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+      }
 
   emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    resolution:
+      {
+        integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==,
+      }
 
   end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+    resolution:
+      {
+        integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
+      }
 
   enquirer@2.4.1:
-    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==,
+      }
+    engines: { node: ">=8.6" }
 
   error-ex@1.3.2:
-    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+    resolution:
+      {
+        integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==,
+      }
 
   es-abstract@1.24.0:
-    resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-iterator-helpers@1.2.1:
-    resolution: {integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-shim-unscopables@1.1.0:
-    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-to-primitive@1.3.0:
-    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==,
+      }
+    engines: { node: ">= 0.4" }
 
   es-toolkit@1.39.8:
-    resolution: {integrity: sha512-A8QO9TfF+rltS8BXpdu8OS+rpGgEdnRhqIVxO/ZmNvnXBYgOdSsxukT55ELyP94gZIntWJ+Li9QRrT2u1Kitpg==}
+    resolution:
+      {
+        integrity: sha512-A8QO9TfF+rltS8BXpdu8OS+rpGgEdnRhqIVxO/ZmNvnXBYgOdSsxukT55ELyP94gZIntWJ+Li9QRrT2u1Kitpg==,
+      }
 
   esbuild-register@3.6.0:
-    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    resolution:
+      {
+        integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==,
+      }
     peerDependencies:
-      esbuild: '>=0.12 <1'
+      esbuild: ">=0.12 <1"
 
   esbuild@0.25.8:
-    resolution: {integrity: sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
+      }
+    engines: { node: ">=6" }
 
   escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
+    resolution:
+      {
+        integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==,
+      }
+    engines: { node: ">=0.8.0" }
 
   escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
+      }
+    engines: { node: ">=10" }
 
   eslint-plugin-cypress@5.1.0:
-    resolution: {integrity: sha512-tdLXm4aq9vX2hTtKJTUFD3gdNseMKqsf8+P6hI4TtOPdz1LU4xvTpQBd1++qPAsPZP2lyYh71B5mvzu2lBr4Ow==}
+    resolution:
+      {
+        integrity: sha512-tdLXm4aq9vX2hTtKJTUFD3gdNseMKqsf8+P6hI4TtOPdz1LU4xvTpQBd1++qPAsPZP2lyYh71B5mvzu2lBr4Ow==,
+      }
     peerDependencies:
-      eslint: '>=9'
+      eslint: ">=9"
 
   eslint-plugin-react@7.37.5:
-    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==,
+      }
+    engines: { node: ">=4" }
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
   eslint-scope@8.4.0:
-    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   eslint-visitor-keys@3.4.3:
-    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
   eslint-visitor-keys@4.2.1:
-    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   eslint@9.32.0:
-    resolution: {integrity: sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     hasBin: true
     peerDependencies:
-      jiti: '*'
+      jiti: "*"
     peerDependenciesMeta:
       jiti:
         optional: true
 
   espree@10.4.0:
-    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
+      }
+    engines: { node: ">=4" }
     hasBin: true
 
   esquery@1.6.0:
-    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
-    engines: {node: '>=0.10'}
+    resolution:
+      {
+        integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==,
+      }
+    engines: { node: ">=0.10" }
 
   esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
+      }
+    engines: { node: ">=4.0" }
 
   estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
+      }
+    engines: { node: ">=4.0" }
 
   estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    resolution:
+      {
+        integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
+      }
 
   estree-walker@3.0.3:
-    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    resolution:
+      {
+        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+      }
 
   esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
+      }
+    engines: { node: ">=0.10.0" }
 
   eventemitter2@6.4.7:
-    resolution: {integrity: sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==}
+    resolution:
+      {
+        integrity: sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==,
+      }
 
   execa@4.1.0:
-    resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==,
+      }
+    engines: { node: ">=10" }
 
   executable@4.1.1:
-    resolution: {integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==,
+      }
+    engines: { node: ">=4" }
 
   extend@3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    resolution:
+      {
+        integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
+      }
 
   extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
+    resolution:
+      {
+        integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==,
+      }
+    engines: { node: ">= 10.17.0" }
     hasBin: true
 
   extsprintf@1.3.0:
-    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
-    engines: {'0': node >=0.6.0}
+    resolution:
+      {
+        integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==,
+      }
+    engines: { "0": node >=0.6.0 }
 
   fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    resolution:
+      {
+        integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+      }
 
   fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
+    resolution:
+      {
+        integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==,
+      }
+    engines: { node: ">=8.6.0" }
 
   fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    resolution:
+      {
+        integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
+      }
 
   fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    resolution:
+      {
+        integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
+      }
 
   fastq@1.19.1:
-    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+    resolution:
+      {
+        integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==,
+      }
 
   fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+    resolution:
+      {
+        integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==,
+      }
 
   fdir@6.4.6:
-    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+    resolution:
+      {
+        integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==,
+      }
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -1848,59 +2983,98 @@ packages:
         optional: true
 
   figures@2.0.0:
-    resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==,
+      }
+    engines: { node: ">=4" }
 
   figures@3.2.0:
-    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==,
+      }
+    engines: { node: ">=8" }
 
   file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
+    resolution:
+      {
+        integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
+      }
+    engines: { node: ">=16.0.0" }
 
   fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
+      }
+    engines: { node: ">=8" }
 
   find-up@2.1.0:
-    resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==,
+      }
+    engines: { node: ">=4" }
 
   find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
+      }
+    engines: { node: ">=10" }
 
   flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==,
+      }
+    engines: { node: ">=16" }
 
   flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+    resolution:
+      {
+        integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==,
+      }
 
   for-each@0.3.5:
-    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==,
+      }
+    engines: { node: ">= 0.4" }
 
   foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==,
+      }
+    engines: { node: ">=14" }
 
   forever-agent@0.6.1:
-    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+    resolution:
+      {
+        integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==,
+      }
 
   form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==,
+      }
+    engines: { node: ">= 6" }
 
   framer-motion@12.23.12:
-    resolution: {integrity: sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==}
+    resolution:
+      {
+        integrity: sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==,
+      }
     peerDependencies:
-      '@emotion/is-prop-valid': '*'
+      "@emotion/is-prop-valid": "*"
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
-      '@emotion/is-prop-valid':
+      "@emotion/is-prop-valid":
         optional: true
       react:
         optional: true
@@ -1908,666 +3082,1170 @@ packages:
         optional: true
 
   fs-extra@11.3.4:
-    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
-    engines: {node: '>=14.14'}
+    resolution:
+      {
+        integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==,
+      }
+    engines: { node: ">=14.14" }
 
   fs-extra@9.1.0:
-    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==,
+      }
+    engines: { node: ">=10" }
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    resolution:
+      {
+        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
 
   function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    resolution:
+      {
+        integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
+      }
 
   function.prototype.name@1.1.8:
-    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==,
+      }
+    engines: { node: ">= 0.4" }
 
   functions-have-names@1.2.3:
-    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+    resolution:
+      {
+        integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==,
+      }
 
   gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
+      }
+    engines: { node: ">=6.9.0" }
 
   get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
+    resolution:
+      {
+        integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
+      }
+    engines: { node: 6.* || 8.* || >= 10.* }
 
   get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
+      }
+    engines: { node: ">= 0.4" }
 
   get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==,
+      }
+    engines: { node: ">=8" }
 
   get-symbol-description@1.1.0:
-    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==,
+      }
+    engines: { node: ">= 0.4" }
 
   getos@3.2.1:
-    resolution: {integrity: sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==}
+    resolution:
+      {
+        integrity: sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==,
+      }
 
   getpass@0.1.7:
-    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+    resolution:
+      {
+        integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==,
+      }
 
   glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
+      }
+    engines: { node: ">= 6" }
 
   glob-parent@6.0.2:
-    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
+      }
+    engines: { node: ">=10.13.0" }
 
   glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    resolution:
+      {
+        integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==,
+      }
     hasBin: true
 
   global-dirs@3.0.1:
-    resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==,
+      }
+    engines: { node: ">=10" }
 
   globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
+      }
+    engines: { node: ">=18" }
 
   globals@15.15.0:
-    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==,
+      }
+    engines: { node: ">=18" }
 
   globals@16.3.0:
-    resolution: {integrity: sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==,
+      }
+    engines: { node: ">=18" }
 
   globalthis@1.0.4:
-    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
+      }
+    engines: { node: ">= 0.4" }
 
   graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    resolution:
+      {
+        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+      }
 
   graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+    resolution:
+      {
+        integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==,
+      }
 
   has-bigints@1.1.0:
-    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==,
+      }
+    engines: { node: ">= 0.4" }
 
   has-flag@3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==,
+      }
+    engines: { node: ">=4" }
 
   has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+      }
+    engines: { node: ">=8" }
 
   has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+    resolution:
+      {
+        integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==,
+      }
 
   has-proto@1.2.0:
-    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
+      }
+    engines: { node: ">= 0.4" }
 
   hasha@5.2.2:
-    resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==,
+      }
+    engines: { node: ">=8" }
 
   hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   http-signature@1.4.0:
-    resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
-    engines: {node: '>=0.10'}
+    resolution:
+      {
+        integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==,
+      }
+    engines: { node: ">=0.10" }
 
   human-signals@1.1.1:
-    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
-    engines: {node: '>=8.12.0'}
+    resolution:
+      {
+        integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==,
+      }
+    engines: { node: ">=8.12.0" }
 
   ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    resolution:
+      {
+        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
+      }
 
   ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
+      }
+    engines: { node: ">= 4" }
 
   ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
+      }
+    engines: { node: ">= 4" }
 
   import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
+      }
+    engines: { node: ">=6" }
 
   imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
+    resolution:
+      {
+        integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
+      }
+    engines: { node: ">=0.8.19" }
 
   indent-string@4.0.0:
-    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==,
+      }
+    engines: { node: ">=8" }
 
   inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    resolution:
+      {
+        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+      }
 
   ini@2.0.0:
-    resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==,
+      }
+    engines: { node: ">=10" }
 
   internal-slot@1.1.0:
-    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-arguments@1.2.0:
-    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-array-buffer@3.0.5:
-    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    resolution:
+      {
+        integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==,
+      }
 
   is-async-function@2.1.1:
-    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-bigint@1.1.0:
-    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-boolean-object@1.2.2:
-    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-callable@1.2.7:
-    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-data-view@1.0.2:
-    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-date-object@1.1.0:
-    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-docker@2.2.1:
-    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==,
+      }
+    engines: { node: ">=8" }
     hasBin: true
 
   is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   is-finalizationregistry@1.1.1:
-    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
+      }
+    engines: { node: ">=8" }
 
   is-generator-function@1.1.0:
-    resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
+      }
+    engines: { node: ">=0.10.0" }
 
   is-installed-globally@0.4.0:
-    resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==,
+      }
+    engines: { node: ">=10" }
 
   is-map@2.0.3:
-    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-negative-zero@2.0.3:
-    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-number-object@1.1.1:
-    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
+    resolution:
+      {
+        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
+      }
+    engines: { node: ">=0.12.0" }
 
   is-path-inside@3.0.3:
-    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==,
+      }
+    engines: { node: ">=8" }
 
   is-regex@1.2.1:
-    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-set@2.0.3:
-    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-shared-array-buffer@1.0.4:
-    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==,
+      }
+    engines: { node: ">=8" }
 
   is-string@1.1.1:
-    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-symbol@1.1.1:
-    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-typed-array@1.1.15:
-    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-typedarray@1.0.0:
-    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+    resolution:
+      {
+        integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==,
+      }
 
   is-unicode-supported@0.1.0:
-    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==,
+      }
+    engines: { node: ">=10" }
 
   is-weakmap@2.0.2:
-    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-weakref@1.1.1:
-    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-weakset@2.0.4:
-    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-wsl@2.2.0:
-    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==,
+      }
+    engines: { node: ">=8" }
 
   isarray@2.0.5:
-    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+    resolution:
+      {
+        integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==,
+      }
 
   isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    resolution:
+      {
+        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+      }
 
   isstream@0.1.2:
-    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
+    resolution:
+      {
+        integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==,
+      }
 
   iterator.prototype@1.1.5:
-    resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==,
+      }
+    engines: { node: ">= 0.4" }
 
   jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+    resolution:
+      {
+        integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==,
+      }
 
   jiti@2.5.1:
-    resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
+    resolution:
+      {
+        integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==,
+      }
     hasBin: true
 
   js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    resolution:
+      {
+        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
+      }
 
   js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    resolution:
+      {
+        integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==,
+      }
     hasBin: true
 
   jsbn@0.1.1:
-    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+    resolution:
+      {
+        integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==,
+      }
 
   jsdoc-type-pratt-parser@4.1.0:
-    resolution: {integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==,
+      }
+    engines: { node: ">=12.0.0" }
 
   jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
+      }
+    engines: { node: ">=6" }
     hasBin: true
 
   json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    resolution:
+      {
+        integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
+      }
 
   json-parse-better-errors@1.0.2:
-    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
+    resolution:
+      {
+        integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==,
+      }
 
   json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    resolution:
+      {
+        integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+      }
 
   json-schema@0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+    resolution:
+      {
+        integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==,
+      }
 
   json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+    resolution:
+      {
+        integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
+      }
 
   json-stringify-safe@5.0.1:
-    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+    resolution:
+      {
+        integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==,
+      }
 
   json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
+      }
+    engines: { node: ">=6" }
     hasBin: true
 
   jsonfile@6.1.0:
-    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    resolution:
+      {
+        integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==,
+      }
 
   jsprim@2.0.2:
-    resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
-    engines: {'0': node >=0.6.0}
+    resolution:
+      {
+        integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==,
+      }
+    engines: { "0": node >=0.6.0 }
 
   jsx-ast-utils@3.3.5:
-    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==,
+      }
+    engines: { node: ">=4.0" }
 
   keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+    resolution:
+      {
+        integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
+      }
 
   lazy-ass@1.6.0:
-    resolution: {integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==}
-    engines: {node: '> 0.8'}
+    resolution:
+      {
+        integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==,
+      }
+    engines: { node: "> 0.8" }
 
   levn@0.4.1:
-    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   lightningcss-darwin-arm64@1.30.1:
-    resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [arm64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.30.1:
-    resolution: {integrity: sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [x64]
     os: [darwin]
 
   lightningcss-freebsd-x64@1.30.1:
-    resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [x64]
     os: [freebsd]
 
   lightningcss-linux-arm-gnueabihf@1.30.1:
-    resolution: {integrity: sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [arm]
     os: [linux]
 
   lightningcss-linux-arm64-gnu@1.30.1:
-    resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [arm64]
     os: [linux]
 
   lightningcss-linux-arm64-musl@1.30.1:
-    resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [arm64]
     os: [linux]
 
   lightningcss-linux-x64-gnu@1.30.1:
-    resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [x64]
     os: [linux]
 
   lightningcss-linux-x64-musl@1.30.1:
-    resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [x64]
     os: [linux]
 
   lightningcss-win32-arm64-msvc@1.30.1:
-    resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [arm64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.30.1:
-    resolution: {integrity: sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==,
+      }
+    engines: { node: ">= 12.0.0" }
     cpu: [x64]
     os: [win32]
 
   lightningcss@1.30.1:
-    resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
-    engines: {node: '>= 12.0.0'}
+    resolution:
+      {
+        integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==,
+      }
+    engines: { node: ">= 12.0.0" }
 
   listr2@3.14.0:
-    resolution: {integrity: sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==}
-    engines: {node: '>=10.0.0'}
+    resolution:
+      {
+        integrity: sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==,
+      }
+    engines: { node: ">=10.0.0" }
     peerDependencies:
-      enquirer: '>= 2.3.0 < 3'
+      enquirer: ">= 2.3.0 < 3"
     peerDependenciesMeta:
       enquirer:
         optional: true
 
   load-json-file@4.0.0:
-    resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==,
+      }
+    engines: { node: ">=4" }
 
   locate-path@2.0.0:
-    resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==,
+      }
+    engines: { node: ">=4" }
 
   locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
+      }
+    engines: { node: ">=10" }
 
   lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    resolution:
+      {
+        integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
+      }
 
   lodash.once@4.1.1:
-    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+    resolution:
+      {
+        integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==,
+      }
 
   lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    resolution:
+      {
+        integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
+      }
 
   log-symbols@4.1.0:
-    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==,
+      }
+    engines: { node: ">=10" }
 
   log-update@4.0.0:
-    resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==,
+      }
+    engines: { node: ">=10" }
 
   loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    resolution:
+      {
+        integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==,
+      }
     hasBin: true
 
   loupe@3.2.0:
-    resolution: {integrity: sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==}
+    resolution:
+      {
+        integrity: sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==,
+      }
 
   lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+    resolution:
+      {
+        integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==,
+      }
 
   lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+    resolution:
+      {
+        integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
+      }
 
   lz-string@1.5.0:
-    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    resolution:
+      {
+        integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==,
+      }
     hasBin: true
 
   magic-string@0.27.0:
-    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==,
+      }
+    engines: { node: ">=12" }
 
   magic-string@0.30.17:
-    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+    resolution:
+      {
+        integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==,
+      }
 
   map-or-similar@1.5.0:
-    resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
+    resolution:
+      {
+        integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==,
+      }
 
   marked@14.0.0:
-    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==,
+      }
+    engines: { node: ">= 18" }
     hasBin: true
 
   math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
+      }
+    engines: { node: ">= 0.4" }
 
   memoizerific@1.11.3:
-    resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
+    resolution:
+      {
+        integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==,
+      }
 
   merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+    resolution:
+      {
+        integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==,
+      }
 
   merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
+      }
+    engines: { node: ">= 8" }
 
   micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
+      }
+    engines: { node: ">=8.6" }
 
   mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
+      }
+    engines: { node: ">= 0.6" }
 
   mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
+      }
+    engines: { node: ">= 0.6" }
 
   mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==,
+      }
+    engines: { node: ">=6" }
 
   min-indent@1.0.1:
-    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==,
+      }
+    engines: { node: ">=4" }
 
   minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+    resolution:
+      {
+        integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==,
+      }
 
   minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
+    resolution:
+      {
+        integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==,
+      }
+    engines: { node: ">=16 || 14 >=14.17" }
 
   minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    resolution:
+      {
+        integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
+      }
 
   minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
+    resolution:
+      {
+        integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==,
+      }
+    engines: { node: ">=16 || 14 >=14.17" }
 
   monaco-editor@0.55.1:
-    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
+    resolution:
+      {
+        integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==,
+      }
 
   motion-dom@12.23.12:
-    resolution: {integrity: sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==}
+    resolution:
+      {
+        integrity: sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==,
+      }
 
   motion-utils@12.23.6:
-    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
+    resolution:
+      {
+        integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==,
+      }
 
   ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
 
   nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    resolution:
+      {
+        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
   natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    resolution:
+      {
+        integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
+      }
 
   node-releases@2.0.19:
-    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+    resolution:
+      {
+        integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==,
+      }
 
   npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==,
+      }
+    engines: { node: ">=8" }
 
   object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
+      }
+    engines: { node: ">=0.10.0" }
 
   object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==,
+      }
+    engines: { node: ">= 0.4" }
 
   object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==,
+      }
+    engines: { node: ">= 0.4" }
 
   object.assign@4.1.7:
-    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==,
+      }
+    engines: { node: ">= 0.4" }
 
   object.entries@1.1.9:
-    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==,
+      }
+    engines: { node: ">= 0.4" }
 
   object.fromentries@2.0.8:
-    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   object.values@1.2.1:
-    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==,
+      }
+    engines: { node: ">= 0.4" }
 
   once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    resolution:
+      {
+        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
+      }
 
   onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==,
+      }
+    engines: { node: ">=6" }
 
   open@8.4.2:
-    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==,
+      }
+    engines: { node: ">=12" }
 
   optionator@0.9.4:
-    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   ospath@1.2.2:
-    resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
+    resolution:
+      {
+        integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==,
+      }
 
   own-keys@1.0.1:
-    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==,
+      }
+    engines: { node: ">= 0.4" }
 
   oxfmt@0.62.0:
-    resolution: {integrity: sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+    resolution:
+      {
+        integrity: sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
       svelte: ^5.0.0
-      vite-plus: '*'
+      vite-plus: "*"
     peerDependenciesMeta:
       svelte:
         optional: true
@@ -2575,363 +4253,642 @@ packages:
         optional: true
 
   p-limit@1.3.0:
-    resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==,
+      }
+    engines: { node: ">=4" }
 
   p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
+      }
+    engines: { node: ">=10" }
 
   p-locate@2.0.0:
-    resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==,
+      }
+    engines: { node: ">=4" }
 
   p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
+      }
+    engines: { node: ">=10" }
 
   p-map@4.0.0:
-    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==,
+      }
+    engines: { node: ">=10" }
 
   p-try@1.0.0:
-    resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==,
+      }
+    engines: { node: ">=4" }
 
   package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+    resolution:
+      {
+        integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==,
+      }
 
   parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
+      }
+    engines: { node: ">=6" }
 
   parse-json@4.0.0:
-    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==,
+      }
+    engines: { node: ">=4" }
 
   path-exists@3.0.0:
-    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==,
+      }
+    engines: { node: ">=4" }
 
   path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
+      }
+    engines: { node: ">=8" }
 
   path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+      }
+    engines: { node: ">=8" }
 
   path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    resolution:
+      {
+        integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
+      }
 
   path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
+    resolution:
+      {
+        integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==,
+      }
+    engines: { node: ">=16 || 14 >=14.18" }
 
   pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
+    resolution:
+      {
+        integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
+      }
+    engines: { node: ">= 14.16" }
 
   pdfjs-dist@5.4.54:
-    resolution: {integrity: sha512-TBAiTfQw89gU/Z4LW98Vahzd2/LoCFprVGvGbTgFt+QCB1F+woyOPmNNVgLa6djX9Z9GGTnj7qE1UzpOVJiINw==}
-    engines: {node: '>=20.16.0 || >=22.3.0'}
+    resolution:
+      {
+        integrity: sha512-TBAiTfQw89gU/Z4LW98Vahzd2/LoCFprVGvGbTgFt+QCB1F+woyOPmNNVgLa6djX9Z9GGTnj7qE1UzpOVJiINw==,
+      }
+    engines: { node: ">=20.16.0 || >=22.3.0" }
 
   pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+    resolution:
+      {
+        integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==,
+      }
 
   performance-now@2.1.0:
-    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+    resolution:
+      {
+        integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==,
+      }
 
   picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    resolution:
+      {
+        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+      }
 
   picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
+      }
+    engines: { node: ">=8.6" }
 
   picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+      }
+    engines: { node: ">=12" }
 
   pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==,
+      }
+    engines: { node: ">=0.10.0" }
 
   pify@3.0.0:
-    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==,
+      }
+    engines: { node: ">=4" }
 
   pkg-conf@2.1.0:
-    resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==,
+      }
+    engines: { node: ">=4" }
 
   polished@4.3.1:
-    resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==,
+      }
+    engines: { node: ">=10" }
 
   possible-typed-array-names@1.1.0:
-    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==,
+      }
+    engines: { node: ">= 0.4" }
 
   postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+    resolution:
+      {
+        integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
+      }
 
   postcss@8.4.49:
-    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
-    engines: {node: ^10 || ^12 || >=14}
+    resolution:
+      {
+        integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
 
   postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
-    engines: {node: ^10 || ^12 || >=14}
+    resolution:
+      {
+        integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
 
   prelude-ls@1.2.1:
-    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   prettier@3.6.2:
-    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==,
+      }
+    engines: { node: ">=14" }
     hasBin: true
 
   pretty-bytes@5.6.0:
-    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==,
+      }
+    engines: { node: ">=6" }
 
   pretty-format@27.5.1:
-    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    resolution:
+      {
+        integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==,
+      }
+    engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
 
   process@0.11.10:
-    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
-    engines: {node: '>= 0.6.0'}
+    resolution:
+      {
+        integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==,
+      }
+    engines: { node: ">= 0.6.0" }
 
   prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+    resolution:
+      {
+        integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==,
+      }
 
   proxy-from-env@1.0.0:
-    resolution: {integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==}
+    resolution:
+      {
+        integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==,
+      }
 
   pump@3.0.3:
-    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+    resolution:
+      {
+        integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==,
+      }
 
   punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
+      }
+    engines: { node: ">=6" }
 
   qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
+    resolution:
+      {
+        integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==,
+      }
+    engines: { node: ">=0.6" }
 
   queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    resolution:
+      {
+        integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
+      }
 
   react-docgen-typescript@2.4.0:
-    resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
+    resolution:
+      {
+        integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==,
+      }
     peerDependencies:
-      typescript: '>= 4.3.x'
+      typescript: ">= 4.3.x"
 
   react-docgen@7.1.1:
-    resolution: {integrity: sha512-hlSJDQ2synMPKFZOsKo9Hi8WWZTC7POR8EmWvTSjow+VDgKzkmjQvFm2fk0tmRw+f0vTOIYKlarR0iL4996pdg==}
-    engines: {node: '>=16.14.0'}
+    resolution:
+      {
+        integrity: sha512-hlSJDQ2synMPKFZOsKo9Hi8WWZTC7POR8EmWvTSjow+VDgKzkmjQvFm2fk0tmRw+f0vTOIYKlarR0iL4996pdg==,
+      }
+    engines: { node: ">=16.14.0" }
 
   react-dom@19.1.1:
-    resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
+    resolution:
+      {
+        integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==,
+      }
     peerDependencies:
       react: ^19.1.1
 
   react-hook-form@7.61.1:
-    resolution: {integrity: sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==}
-    engines: {node: '>=18.0.0'}
+    resolution:
+      {
+        integrity: sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==,
+      }
+    engines: { node: ">=18.0.0" }
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+    resolution:
+      {
+        integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==,
+      }
 
   react-is@17.0.2:
-    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+    resolution:
+      {
+        integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==,
+      }
 
   react-refresh@0.17.0:
-    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   react-swipeable@7.0.2:
-    resolution: {integrity: sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==}
+    resolution:
+      {
+        integrity: sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==,
+      }
     peerDependencies:
       react: ^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc
 
   react@19.1.1:
-    resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   recast@0.23.11:
-    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==,
+      }
+    engines: { node: ">= 4" }
 
   redent@3.0.0:
-    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==,
+      }
+    engines: { node: ">=8" }
 
   reflect.getprototypeof@1.0.10:
-    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==,
+      }
+    engines: { node: ">= 0.4" }
 
   regexp.prototype.flags@1.5.4:
-    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==,
+      }
+    engines: { node: ">= 0.4" }
 
   request-progress@3.0.0:
-    resolution: {integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==}
+    resolution:
+      {
+        integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==,
+      }
 
   require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==,
+      }
+    engines: { node: ">=0.10.0" }
 
   resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
+      }
+    engines: { node: ">=4" }
 
   resolve@1.22.10:
-    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==,
+      }
+    engines: { node: ">= 0.4" }
     hasBin: true
 
   resolve@2.0.0-next.5:
-    resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
+    resolution:
+      {
+        integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==,
+      }
     hasBin: true
 
   restore-cursor@3.1.0:
-    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==,
+      }
+    engines: { node: ">=8" }
 
   reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
+      }
+    engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
 
   rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+    resolution:
+      {
+        integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
+      }
 
   rollup@4.46.2:
-    resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==,
+      }
+    engines: { node: ">=18.0.0", npm: ">=8.0.0" }
     hasBin: true
 
   run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+    resolution:
+      {
+        integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
+      }
 
   rxjs@7.8.2:
-    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+    resolution:
+      {
+        integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==,
+      }
 
   safe-array-concat@1.1.3:
-    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
-    engines: {node: '>=0.4'}
+    resolution:
+      {
+        integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==,
+      }
+    engines: { node: ">=0.4" }
 
   safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    resolution:
+      {
+        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+      }
 
   safe-push-apply@1.0.0:
-    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==,
+      }
+    engines: { node: ">= 0.4" }
 
   safe-regex-test@1.1.0:
-    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==,
+      }
+    engines: { node: ">= 0.4" }
 
   safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    resolution:
+      {
+        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
+      }
 
   scheduler@0.26.0:
-    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+    resolution:
+      {
+        integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==,
+      }
 
   semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    resolution:
+      {
+        integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
+      }
     hasBin: true
 
   semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==,
+      }
+    engines: { node: ">=10" }
     hasBin: true
 
   set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==,
+      }
+    engines: { node: ">= 0.4" }
 
   set-function-name@2.0.2:
-    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   set-proto@1.0.0:
-    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==,
+      }
+    engines: { node: ">= 0.4" }
 
   shallowequal@1.1.0:
-    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
+    resolution:
+      {
+        integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==,
+      }
 
   shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+      }
+    engines: { node: ">=8" }
 
   shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+      }
+    engines: { node: ">=8" }
 
   side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==,
+      }
+    engines: { node: ">= 0.4" }
 
   side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==,
+      }
+    engines: { node: ">= 0.4" }
 
   side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==,
+      }
+    engines: { node: ">= 0.4" }
 
   side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==,
+      }
+    engines: { node: ">= 0.4" }
 
   signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    resolution:
+      {
+        integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==,
+      }
 
   signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
+      }
+    engines: { node: ">=14" }
 
   signale@1.4.0:
-    resolution: {integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==,
+      }
+    engines: { node: ">=6" }
 
   slice-ansi@3.0.0:
-    resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==,
+      }
+    engines: { node: ">=8" }
 
   slice-ansi@4.0.0:
-    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==,
+      }
+    engines: { node: ">=10" }
 
   source-map-js@1.2.1:
-    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+      }
+    engines: { node: ">=0.10.0" }
 
   source-map-support@0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    resolution:
+      {
+        integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==,
+      }
 
   source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
+      }
+    engines: { node: ">=0.10.0" }
 
   sshpk@1.18.0:
-    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==,
+      }
+    engines: { node: ">=0.10.0" }
     hasBin: true
 
   stop-iteration-iterator@1.1.0:
-    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   storybook@8.6.14:
-    resolution: {integrity: sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==}
+    resolution:
+      {
+        integrity: sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==,
+      }
     hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
@@ -2940,262 +4897,448 @@ packages:
         optional: true
 
   string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
+      }
+    engines: { node: ">=8" }
 
   string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==,
+      }
+    engines: { node: ">=12" }
 
   string.prototype.matchall@4.0.12:
-    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==,
+      }
+    engines: { node: ">= 0.4" }
 
   string.prototype.repeat@1.0.0:
-    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
+    resolution:
+      {
+        integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==,
+      }
 
   string.prototype.trim@1.2.10:
-    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==,
+      }
+    engines: { node: ">= 0.4" }
 
   string.prototype.trimend@1.0.9:
-    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   string.prototype.trimstart@1.0.8:
-    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==,
+      }
+    engines: { node: ">= 0.4" }
 
   strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
+      }
+    engines: { node: ">=8" }
 
   strip-ansi@7.1.0:
-    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==,
+      }
+    engines: { node: ">=12" }
 
   strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==,
+      }
+    engines: { node: ">=4" }
 
   strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==,
+      }
+    engines: { node: ">=6" }
 
   strip-indent@3.0.0:
-    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==,
+      }
+    engines: { node: ">=8" }
 
   strip-indent@4.0.0:
-    resolution: {integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==,
+      }
+    engines: { node: ">=12" }
 
   strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
+      }
+    engines: { node: ">=8" }
 
   styled-components@6.1.19:
-    resolution: {integrity: sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==}
-    engines: {node: '>= 16'}
+    resolution:
+      {
+        integrity: sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==,
+      }
+    engines: { node: ">= 16" }
     peerDependencies:
-      react: '>= 16.8.0'
-      react-dom: '>= 16.8.0'
+      react: ">= 16.8.0"
+      react-dom: ">= 16.8.0"
 
   stylis@4.3.2:
-    resolution: {integrity: sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==}
+    resolution:
+      {
+        integrity: sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==,
+      }
 
   supports-color@5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==,
+      }
+    engines: { node: ">=4" }
 
   supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
+      }
+    engines: { node: ">=8" }
 
   supports-color@8.1.1:
-    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==,
+      }
+    engines: { node: ">=10" }
 
   supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
+      }
+    engines: { node: ">= 0.4" }
 
   tabbable@6.2.0:
-    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+    resolution:
+      {
+        integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==,
+      }
 
   terser@5.43.1:
-    resolution: {integrity: sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==,
+      }
+    engines: { node: ">=10" }
     hasBin: true
 
   throttleit@1.0.1:
-    resolution: {integrity: sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==}
+    resolution:
+      {
+        integrity: sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==,
+      }
 
   through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+    resolution:
+      {
+        integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==,
+      }
 
   tiny-invariant@1.3.3:
-    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+    resolution:
+      {
+        integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==,
+      }
 
   tinyglobby@0.2.14:
-    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==,
+      }
+    engines: { node: ">=12.0.0" }
 
   tinypool@2.1.0:
-    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
-    engines: {node: ^20.0.0 || >=22.0.0}
+    resolution:
+      {
+        integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==,
+      }
+    engines: { node: ^20.0.0 || >=22.0.0 }
 
   tinyrainbow@1.2.0:
-    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==,
+      }
+    engines: { node: ">=14.0.0" }
 
   tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==,
+      }
+    engines: { node: ">=14.0.0" }
 
   tldts-core@6.1.86:
-    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+    resolution:
+      {
+        integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==,
+      }
 
   tldts@6.1.86:
-    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    resolution:
+      {
+        integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==,
+      }
     hasBin: true
 
   tmp@0.2.3:
-    resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
-    engines: {node: '>=14.14'}
+    resolution:
+      {
+        integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==,
+      }
+    engines: { node: ">=14.14" }
 
   to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
+    resolution:
+      {
+        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
+      }
+    engines: { node: ">=8.0" }
 
   tough-cookie@5.1.2:
-    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==,
+      }
+    engines: { node: ">=16" }
 
   tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    resolution:
+      {
+        integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
+      }
     hasBin: true
 
   ts-api-utils@2.1.0:
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
-    engines: {node: '>=18.12'}
+    resolution:
+      {
+        integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==,
+      }
+    engines: { node: ">=18.12" }
     peerDependencies:
-      typescript: '>=4.8.4'
+      typescript: ">=4.8.4"
 
   ts-dedent@2.2.0:
-    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
-    engines: {node: '>=6.10'}
+    resolution:
+      {
+        integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==,
+      }
+    engines: { node: ">=6.10" }
 
   tsconfig-paths@4.2.0:
-    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==,
+      }
+    engines: { node: ">=6" }
 
   tslib@2.6.2:
-    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+    resolution:
+      {
+        integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==,
+      }
 
   tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
 
   tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+    resolution:
+      {
+        integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
+      }
 
   tweetnacl@0.14.5:
-    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+    resolution:
+      {
+        integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==,
+      }
 
   type-check@0.4.0:
-    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   type-fest@0.21.3:
-    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==,
+      }
+    engines: { node: ">=10" }
 
   type-fest@0.8.1:
-    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==,
+      }
+    engines: { node: ">=8" }
 
   typed-array-buffer@1.0.3:
-    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==,
+      }
+    engines: { node: ">= 0.4" }
 
   typed-array-byte-length@1.0.3:
-    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==,
+      }
+    engines: { node: ">= 0.4" }
 
   typed-array-byte-offset@1.0.4:
-    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   typed-array-length@1.0.7:
-    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==,
+      }
+    engines: { node: ">= 0.4" }
 
   typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
-    engines: {node: '>=14.17'}
+    resolution:
+      {
+        integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==,
+      }
+    engines: { node: ">=14.17" }
     hasBin: true
 
   unbox-primitive@1.1.0:
-    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==,
+      }
+    engines: { node: ">= 0.4" }
 
   undici-types@7.8.0:
-    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+    resolution:
+      {
+        integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==,
+      }
 
   universalify@2.0.1:
-    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
-    engines: {node: '>= 10.0.0'}
+    resolution:
+      {
+        integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==,
+      }
+    engines: { node: ">= 10.0.0" }
 
   unplugin@1.16.1:
-    resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==,
+      }
+    engines: { node: ">=14.0.0" }
 
   untildify@4.0.0:
-    resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==,
+      }
+    engines: { node: ">=8" }
 
   update-browserslist-db@1.1.3:
-    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+    resolution:
+      {
+        integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==,
+      }
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: ">= 4.21.0"
 
   uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    resolution:
+      {
+        integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
+      }
 
   util@0.12.5:
-    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+    resolution:
+      {
+        integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==,
+      }
 
   uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    resolution:
+      {
+        integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
+      }
     hasBin: true
 
   uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    resolution:
+      {
+        integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==,
+      }
     hasBin: true
 
   verror@1.10.0:
-    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
-    engines: {'0': node >=0.6.0}
+    resolution:
+      {
+        integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==,
+      }
+    engines: { "0": node >=0.6.0 }
 
   vite@6.3.5:
-    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    resolution:
+      {
+        integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==,
+      }
+    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
+      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: ">=1.21.0"
+      less: "*"
       lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
+      sass: "*"
+      sass-embedded: "*"
+      stylus: "*"
+      sugarss: "*"
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
-      '@types/node':
+      "@types/node":
         optional: true
       jiti:
         optional: true
@@ -3219,54 +5362,90 @@ packages:
         optional: true
 
   webpack-virtual-modules@0.6.2:
-    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+    resolution:
+      {
+        integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==,
+      }
 
   which-boxed-primitive@1.1.1:
-    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==,
+      }
+    engines: { node: ">= 0.4" }
 
   which-builtin-type@1.2.1:
-    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==,
+      }
+    engines: { node: ">= 0.4" }
 
   which-collection@1.0.2:
-    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==,
+      }
+    engines: { node: ">= 0.4" }
 
   which-typed-array@1.1.19:
-    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==,
+      }
+    engines: { node: ">= 0.4" }
 
   which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+      }
+    engines: { node: ">= 8" }
     hasBin: true
 
   word-wrap@1.2.5:
-    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
+      }
+    engines: { node: ">=0.10.0" }
 
   wrap-ansi@6.2.0:
-    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==,
+      }
+    engines: { node: ">=8" }
 
   wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
+      }
+    engines: { node: ">=10" }
 
   wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==,
+      }
+    engines: { node: ">=12" }
 
   wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    resolution:
+      {
+        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
+      }
 
   ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
+    resolution:
+      {
+        integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==,
+      }
+    engines: { node: ">=10.0.0" }
     peerDependencies:
       bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
+      utf-8-validate: ">=5.0.2"
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -3274,66 +5453,86 @@ packages:
         optional: true
 
   y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
+      }
+    engines: { node: ">=10" }
 
   yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+    resolution:
+      {
+        integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
+      }
 
   yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
+      }
+    engines: { node: ">=12" }
 
   yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==,
+      }
+    engines: { node: ">=12" }
 
   yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+    resolution:
+      {
+        integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==,
+      }
 
   yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
+      }
+    engines: { node: ">=10" }
 
   zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+    resolution:
+      {
+        integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
+      }
 
 snapshots:
-
-  '@adobe/css-tools@4.4.3':
+  "@adobe/css-tools@4.4.3":
     optional: true
 
-  '@ampproject/remapping@2.3.0':
+  "@ampproject/remapping@2.3.0":
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      "@jridgewell/gen-mapping": 0.3.12
+      "@jridgewell/trace-mapping": 0.3.29
 
-  '@babel/code-frame@7.27.1':
+  "@babel/code-frame@7.27.1":
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      "@babel/helper-validator-identifier": 7.27.1
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/code-frame@7.29.0':
+  "@babel/code-frame@7.29.0":
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      "@babel/helper-validator-identifier": 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.28.0': {}
+  "@babel/compat-data@7.28.0": {}
 
-  '@babel/core@7.28.0':
+  "@babel/core@7.28.0":
     dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
-      '@babel/helpers': 7.28.2
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.28.2
+      "@ampproject/remapping": 2.3.0
+      "@babel/code-frame": 7.27.1
+      "@babel/generator": 7.28.0
+      "@babel/helper-compilation-targets": 7.27.2
+      "@babel/helper-module-transforms": 7.27.3(@babel/core@7.28.0)
+      "@babel/helpers": 7.28.2
+      "@babel/parser": 7.29.2
+      "@babel/template": 7.27.2
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.28.2
       convert-source-map: 2.0.0
       debug: 4.4.1(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
@@ -3342,114 +5541,114 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.28.0':
+  "@babel/generator@7.28.0":
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.28.2
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.28.2
+      "@jridgewell/gen-mapping": 0.3.12
+      "@jridgewell/trace-mapping": 0.3.29
       jsesc: 3.1.0
 
-  '@babel/generator@7.29.1':
+  "@babel/generator@7.29.1":
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
+      "@jridgewell/gen-mapping": 0.3.12
+      "@jridgewell/trace-mapping": 0.3.29
       jsesc: 3.1.0
 
-  '@babel/helper-compilation-targets@7.27.2':
+  "@babel/helper-compilation-targets@7.27.2":
     dependencies:
-      '@babel/compat-data': 7.28.0
-      '@babel/helper-validator-option': 7.27.1
+      "@babel/compat-data": 7.28.0
+      "@babel/helper-validator-option": 7.27.1
       browserslist: 4.25.1
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-globals@7.28.0': {}
+  "@babel/helper-globals@7.28.0": {}
 
-  '@babel/helper-module-imports@7.27.1':
+  "@babel/helper-module-imports@7.27.1":
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.28.2
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.28.2
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0)':
+  "@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0)":
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.29.0
+      "@babel/core": 7.28.0
+      "@babel/helper-module-imports": 7.27.1
+      "@babel/helper-validator-identifier": 7.27.1
+      "@babel/traverse": 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-plugin-utils@7.27.1': {}
+  "@babel/helper-plugin-utils@7.27.1": {}
 
-  '@babel/helper-string-parser@7.27.1': {}
+  "@babel/helper-string-parser@7.27.1": {}
 
-  '@babel/helper-validator-identifier@7.27.1': {}
+  "@babel/helper-validator-identifier@7.27.1": {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  "@babel/helper-validator-identifier@7.28.5": {}
 
-  '@babel/helper-validator-option@7.27.1': {}
+  "@babel/helper-validator-option@7.27.1": {}
 
-  '@babel/helpers@7.28.2':
+  "@babel/helpers@7.28.2":
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
+      "@babel/template": 7.27.2
+      "@babel/types": 7.28.2
 
-  '@babel/parser@7.29.2':
+  "@babel/parser@7.29.2":
     dependencies:
-      '@babel/types': 7.29.0
+      "@babel/types": 7.29.0
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.0)':
+  "@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.0)":
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      "@babel/core": 7.28.0
+      "@babel/helper-plugin-utils": 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.0)':
+  "@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.0)":
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      "@babel/core": 7.28.0
+      "@babel/helper-plugin-utils": 7.27.1
 
-  '@babel/runtime@7.28.2': {}
+  "@babel/runtime@7.28.2": {}
 
-  '@babel/template@7.27.2':
+  "@babel/template@7.27.2":
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.28.2
+      "@babel/code-frame": 7.27.1
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.28.2
 
-  '@babel/template@7.28.6':
+  "@babel/template@7.28.6":
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      "@babel/code-frame": 7.29.0
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
 
-  '@babel/traverse@7.29.0':
+  "@babel/traverse@7.29.0":
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      "@babel/code-frame": 7.29.0
+      "@babel/generator": 7.29.1
+      "@babel/helper-globals": 7.28.0
+      "@babel/parser": 7.29.2
+      "@babel/template": 7.28.6
+      "@babel/types": 7.29.0
       debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.28.2':
+  "@babel/types@7.28.2":
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      "@babel/helper-string-parser": 7.27.1
+      "@babel/helper-validator-identifier": 7.27.1
 
-  '@babel/types@7.29.0':
+  "@babel/types@7.29.0":
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      "@babel/helper-string-parser": 7.27.1
+      "@babel/helper-validator-identifier": 7.28.5
 
-  '@cypress/request@3.0.9':
+  "@cypress/request@3.0.9":
     dependencies:
       aws-sign2: 0.7.0
       aws4: 1.13.2
@@ -3470,121 +5669,121 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  '@cypress/xvfb@1.2.4(supports-color@8.1.1)':
+  "@cypress/xvfb@1.2.4(supports-color@8.1.1)":
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
       lodash.once: 4.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@emotion/is-prop-valid@1.2.2':
+  "@emotion/is-prop-valid@1.2.2":
     dependencies:
-      '@emotion/memoize': 0.8.1
+      "@emotion/memoize": 0.8.1
 
-  '@emotion/memoize@0.8.1': {}
+  "@emotion/memoize@0.8.1": {}
 
-  '@emotion/unitless@0.8.1': {}
+  "@emotion/unitless@0.8.1": {}
 
-  '@esbuild/aix-ppc64@0.25.8':
+  "@esbuild/aix-ppc64@0.25.8":
     optional: true
 
-  '@esbuild/android-arm64@0.25.8':
+  "@esbuild/android-arm64@0.25.8":
     optional: true
 
-  '@esbuild/android-arm@0.25.8':
+  "@esbuild/android-arm@0.25.8":
     optional: true
 
-  '@esbuild/android-x64@0.25.8':
+  "@esbuild/android-x64@0.25.8":
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.8':
+  "@esbuild/darwin-arm64@0.25.8":
     optional: true
 
-  '@esbuild/darwin-x64@0.25.8':
+  "@esbuild/darwin-x64@0.25.8":
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.8':
+  "@esbuild/freebsd-arm64@0.25.8":
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.8':
+  "@esbuild/freebsd-x64@0.25.8":
     optional: true
 
-  '@esbuild/linux-arm64@0.25.8':
+  "@esbuild/linux-arm64@0.25.8":
     optional: true
 
-  '@esbuild/linux-arm@0.25.8':
+  "@esbuild/linux-arm@0.25.8":
     optional: true
 
-  '@esbuild/linux-ia32@0.25.8':
+  "@esbuild/linux-ia32@0.25.8":
     optional: true
 
-  '@esbuild/linux-loong64@0.25.8':
+  "@esbuild/linux-loong64@0.25.8":
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.8':
+  "@esbuild/linux-mips64el@0.25.8":
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.8':
+  "@esbuild/linux-ppc64@0.25.8":
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.8':
+  "@esbuild/linux-riscv64@0.25.8":
     optional: true
 
-  '@esbuild/linux-s390x@0.25.8':
+  "@esbuild/linux-s390x@0.25.8":
     optional: true
 
-  '@esbuild/linux-x64@0.25.8':
+  "@esbuild/linux-x64@0.25.8":
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.8':
+  "@esbuild/netbsd-arm64@0.25.8":
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.8':
+  "@esbuild/netbsd-x64@0.25.8":
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.8':
+  "@esbuild/openbsd-arm64@0.25.8":
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.8':
+  "@esbuild/openbsd-x64@0.25.8":
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.8':
+  "@esbuild/openharmony-arm64@0.25.8":
     optional: true
 
-  '@esbuild/sunos-x64@0.25.8':
+  "@esbuild/sunos-x64@0.25.8":
     optional: true
 
-  '@esbuild/win32-arm64@0.25.8':
+  "@esbuild/win32-arm64@0.25.8":
     optional: true
 
-  '@esbuild/win32-ia32@0.25.8':
+  "@esbuild/win32-ia32@0.25.8":
     optional: true
 
-  '@esbuild/win32-x64@0.25.8':
+  "@esbuild/win32-x64@0.25.8":
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.32.0(jiti@2.5.1))':
+  "@eslint-community/eslint-utils@4.7.0(eslint@9.32.0(jiti@2.5.1))":
     dependencies:
       eslint: 9.32.0(jiti@2.5.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/regexpp@4.12.1': {}
+  "@eslint-community/regexpp@4.12.1": {}
 
-  '@eslint/config-array@0.21.0':
+  "@eslint/config-array@0.21.0":
     dependencies:
-      '@eslint/object-schema': 2.1.6
+      "@eslint/object-schema": 2.1.6
       debug: 4.4.1(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.3.0': {}
+  "@eslint/config-helpers@0.3.0": {}
 
-  '@eslint/core@0.15.1':
+  "@eslint/core@0.15.1":
     dependencies:
-      '@types/json-schema': 7.0.15
+      "@types/json-schema": 7.0.15
 
-  '@eslint/eslintrc@3.3.1':
+  "@eslint/eslintrc@3.3.1":
     dependencies:
       ajv: 6.12.6
       debug: 4.4.1(supports-color@8.1.1)
@@ -3598,59 +5797,59 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.32.0': {}
+  "@eslint/js@9.32.0": {}
 
-  '@eslint/object-schema@2.1.6': {}
+  "@eslint/object-schema@2.1.6": {}
 
-  '@eslint/plugin-kit@0.3.4':
+  "@eslint/plugin-kit@0.3.4":
     dependencies:
-      '@eslint/core': 0.15.1
+      "@eslint/core": 0.15.1
       levn: 0.4.1
 
-  '@floating-ui/core@1.7.3':
+  "@floating-ui/core@1.7.3":
     dependencies:
-      '@floating-ui/utils': 0.2.10
+      "@floating-ui/utils": 0.2.10
 
-  '@floating-ui/dom@1.7.3':
+  "@floating-ui/dom@1.7.3":
     dependencies:
-      '@floating-ui/core': 1.7.3
-      '@floating-ui/utils': 0.2.10
+      "@floating-ui/core": 1.7.3
+      "@floating-ui/utils": 0.2.10
 
-  '@floating-ui/react-dom@2.1.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  "@floating-ui/react-dom@2.1.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
     dependencies:
-      '@floating-ui/dom': 1.7.3
+      "@floating-ui/dom": 1.7.3
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@floating-ui/react@0.27.15(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  "@floating-ui/react@0.27.15(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
     dependencies:
-      '@floating-ui/react-dom': 2.1.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@floating-ui/utils': 0.2.10
+      "@floating-ui/react-dom": 2.1.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@floating-ui/utils": 0.2.10
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       tabbable: 6.2.0
 
-  '@floating-ui/utils@0.2.10': {}
+  "@floating-ui/utils@0.2.10": {}
 
-  '@hookform/resolvers@5.2.1(react-hook-form@7.61.1(react@19.1.1))':
+  "@hookform/resolvers@5.2.1(react-hook-form@7.61.1(react@19.1.1))":
     dependencies:
-      '@standard-schema/utils': 0.3.0
+      "@standard-schema/utils": 0.3.0
       react-hook-form: 7.61.1(react@19.1.1)
 
-  '@humanfs/core@0.19.1': {}
+  "@humanfs/core@0.19.1": {}
 
-  '@humanfs/node@0.16.6':
+  "@humanfs/node@0.16.6":
     dependencies:
-      '@humanfs/core': 0.19.1
-      '@humanwhocodes/retry': 0.3.1
+      "@humanfs/core": 0.19.1
+      "@humanwhocodes/retry": 0.3.1
 
-  '@humanwhocodes/module-importer@1.0.1': {}
+  "@humanwhocodes/module-importer@1.0.1": {}
 
-  '@humanwhocodes/retry@0.3.1': {}
+  "@humanwhocodes/retry@0.3.1": {}
 
-  '@humanwhocodes/retry@0.4.3': {}
+  "@humanwhocodes/retry@0.4.3": {}
 
-  '@isaacs/cliui@8.0.2':
+  "@isaacs/cliui@8.0.2":
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
@@ -3659,7 +5858,7 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))':
+  "@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))":
     dependencies:
       glob: 10.4.5
       magic-string: 0.27.0
@@ -3668,341 +5867,341 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  '@jridgewell/gen-mapping@0.3.12':
+  "@jridgewell/gen-mapping@0.3.12":
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
-      '@jridgewell/trace-mapping': 0.3.29
+      "@jridgewell/sourcemap-codec": 1.5.4
+      "@jridgewell/trace-mapping": 0.3.29
 
-  '@jridgewell/resolve-uri@3.1.2': {}
+  "@jridgewell/resolve-uri@3.1.2": {}
 
-  '@jridgewell/source-map@0.3.11':
+  "@jridgewell/source-map@0.3.11":
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      "@jridgewell/gen-mapping": 0.3.12
+      "@jridgewell/trace-mapping": 0.3.29
     optional: true
 
-  '@jridgewell/sourcemap-codec@1.5.4': {}
+  "@jridgewell/sourcemap-codec@1.5.4": {}
 
-  '@jridgewell/trace-mapping@0.3.29':
+  "@jridgewell/trace-mapping@0.3.29":
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
+      "@jridgewell/resolve-uri": 3.1.2
+      "@jridgewell/sourcemap-codec": 1.5.4
 
-  '@mdx-js/react@3.1.0(@types/react@19.1.9)(react@19.1.1)':
+  "@mdx-js/react@3.1.0(@types/react@19.1.9)(react@19.1.1)":
     dependencies:
-      '@types/mdx': 2.0.13
-      '@types/react': 19.1.9
+      "@types/mdx": 2.0.13
+      "@types/react": 19.1.9
       react: 19.1.1
 
-  '@napi-rs/canvas-android-arm64@0.1.99':
+  "@napi-rs/canvas-android-arm64@0.1.99":
     optional: true
 
-  '@napi-rs/canvas-darwin-arm64@0.1.99':
+  "@napi-rs/canvas-darwin-arm64@0.1.99":
     optional: true
 
-  '@napi-rs/canvas-darwin-x64@0.1.99':
+  "@napi-rs/canvas-darwin-x64@0.1.99":
     optional: true
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.99':
+  "@napi-rs/canvas-linux-arm-gnueabihf@0.1.99":
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.99':
+  "@napi-rs/canvas-linux-arm64-gnu@0.1.99":
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.99':
+  "@napi-rs/canvas-linux-arm64-musl@0.1.99":
     optional: true
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.99':
+  "@napi-rs/canvas-linux-riscv64-gnu@0.1.99":
     optional: true
 
-  '@napi-rs/canvas-linux-x64-gnu@0.1.99':
+  "@napi-rs/canvas-linux-x64-gnu@0.1.99":
     optional: true
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.99':
+  "@napi-rs/canvas-linux-x64-musl@0.1.99":
     optional: true
 
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.99':
+  "@napi-rs/canvas-win32-arm64-msvc@0.1.99":
     optional: true
 
-  '@napi-rs/canvas-win32-x64-msvc@0.1.99':
+  "@napi-rs/canvas-win32-x64-msvc@0.1.99":
     optional: true
 
-  '@napi-rs/canvas@0.1.99':
+  "@napi-rs/canvas@0.1.99":
     optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.99
-      '@napi-rs/canvas-darwin-arm64': 0.1.99
-      '@napi-rs/canvas-darwin-x64': 0.1.99
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.99
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.99
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.99
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.99
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.99
-      '@napi-rs/canvas-linux-x64-musl': 0.1.99
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.99
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.99
+      "@napi-rs/canvas-android-arm64": 0.1.99
+      "@napi-rs/canvas-darwin-arm64": 0.1.99
+      "@napi-rs/canvas-darwin-x64": 0.1.99
+      "@napi-rs/canvas-linux-arm-gnueabihf": 0.1.99
+      "@napi-rs/canvas-linux-arm64-gnu": 0.1.99
+      "@napi-rs/canvas-linux-arm64-musl": 0.1.99
+      "@napi-rs/canvas-linux-riscv64-gnu": 0.1.99
+      "@napi-rs/canvas-linux-x64-gnu": 0.1.99
+      "@napi-rs/canvas-linux-x64-musl": 0.1.99
+      "@napi-rs/canvas-win32-arm64-msvc": 0.1.99
+      "@napi-rs/canvas-win32-x64-msvc": 0.1.99
     optional: true
 
-  '@nodelib/fs.scandir@2.1.5':
+  "@nodelib/fs.scandir@2.1.5":
     dependencies:
-      '@nodelib/fs.stat': 2.0.5
+      "@nodelib/fs.stat": 2.0.5
       run-parallel: 1.2.0
 
-  '@nodelib/fs.stat@2.0.5': {}
+  "@nodelib/fs.stat@2.0.5": {}
 
-  '@nodelib/fs.walk@1.2.8':
+  "@nodelib/fs.walk@1.2.8":
     dependencies:
-      '@nodelib/fs.scandir': 2.1.5
+      "@nodelib/fs.scandir": 2.1.5
       fastq: 1.19.1
 
-  '@oxfmt/binding-android-arm-eabi@0.62.0':
+  "@oxfmt/binding-android-arm-eabi@0.62.0":
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.62.0':
+  "@oxfmt/binding-android-arm64@0.62.0":
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.62.0':
+  "@oxfmt/binding-darwin-arm64@0.62.0":
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.62.0':
+  "@oxfmt/binding-darwin-x64@0.62.0":
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.62.0':
+  "@oxfmt/binding-freebsd-x64@0.62.0":
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.62.0':
+  "@oxfmt/binding-linux-arm-gnueabihf@0.62.0":
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.62.0':
+  "@oxfmt/binding-linux-arm-musleabihf@0.62.0":
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.62.0':
+  "@oxfmt/binding-linux-arm64-gnu@0.62.0":
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.62.0':
+  "@oxfmt/binding-linux-arm64-musl@0.62.0":
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
+  "@oxfmt/binding-linux-ppc64-gnu@0.62.0":
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
+  "@oxfmt/binding-linux-riscv64-gnu@0.62.0":
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.62.0':
+  "@oxfmt/binding-linux-riscv64-musl@0.62.0":
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.62.0':
+  "@oxfmt/binding-linux-s390x-gnu@0.62.0":
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.62.0':
+  "@oxfmt/binding-linux-x64-gnu@0.62.0":
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.62.0':
+  "@oxfmt/binding-linux-x64-musl@0.62.0":
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.62.0':
+  "@oxfmt/binding-openharmony-arm64@0.62.0":
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.62.0':
+  "@oxfmt/binding-win32-arm64-msvc@0.62.0":
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.62.0':
+  "@oxfmt/binding-win32-ia32-msvc@0.62.0":
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.62.0':
+  "@oxfmt/binding-win32-x64-msvc@0.62.0":
     optional: true
 
-  '@pkgjs/parseargs@0.11.0':
+  "@pkgjs/parseargs@0.11.0":
     optional: true
 
-  '@remixicon/react@4.6.0(react@19.1.1)':
+  "@remixicon/react@4.6.0(react@19.1.1)":
     dependencies:
       react: 19.1.1
 
-  '@rolldown/pluginutils@1.0.0-beta.27': {}
+  "@rolldown/pluginutils@1.0.0-beta.27": {}
 
-  '@rollup/pluginutils@5.2.0(rollup@4.46.2)':
+  "@rollup/pluginutils@5.2.0(rollup@4.46.2)":
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.46.2
 
-  '@rollup/rollup-android-arm-eabi@4.46.2':
+  "@rollup/rollup-android-arm-eabi@4.46.2":
     optional: true
 
-  '@rollup/rollup-android-arm64@4.46.2':
+  "@rollup/rollup-android-arm64@4.46.2":
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.46.2':
+  "@rollup/rollup-darwin-arm64@4.46.2":
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.46.2':
+  "@rollup/rollup-darwin-x64@4.46.2":
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.46.2':
+  "@rollup/rollup-freebsd-arm64@4.46.2":
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.46.2':
+  "@rollup/rollup-freebsd-x64@4.46.2":
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
+  "@rollup/rollup-linux-arm-gnueabihf@4.46.2":
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.46.2':
+  "@rollup/rollup-linux-arm-musleabihf@4.46.2":
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.46.2':
+  "@rollup/rollup-linux-arm64-gnu@4.46.2":
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.46.2':
+  "@rollup/rollup-linux-arm64-musl@4.46.2":
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
+  "@rollup/rollup-linux-loongarch64-gnu@4.46.2":
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.46.2':
+  "@rollup/rollup-linux-ppc64-gnu@4.46.2":
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.46.2':
+  "@rollup/rollup-linux-riscv64-gnu@4.46.2":
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.46.2':
+  "@rollup/rollup-linux-riscv64-musl@4.46.2":
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.46.2':
+  "@rollup/rollup-linux-s390x-gnu@4.46.2":
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.46.2':
+  "@rollup/rollup-linux-x64-gnu@4.46.2":
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.46.2':
+  "@rollup/rollup-linux-x64-musl@4.46.2":
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.46.2':
+  "@rollup/rollup-win32-arm64-msvc@4.46.2":
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.46.2':
+  "@rollup/rollup-win32-ia32-msvc@4.46.2":
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.46.2':
+  "@rollup/rollup-win32-x64-msvc@4.46.2":
     optional: true
 
-  '@standard-schema/utils@0.3.0': {}
+  "@standard-schema/utils@0.3.0": {}
 
-  '@storybook/addon-actions@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/addon-actions@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@storybook/global': 5.0.0
-      '@types/uuid': 9.0.8
+      "@storybook/global": 5.0.0
+      "@types/uuid": 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
       storybook: 8.6.14(prettier@3.6.2)
       uuid: 9.0.1
 
-  '@storybook/addon-backgrounds@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/addon-backgrounds@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@storybook/global': 5.0.0
+      "@storybook/global": 5.0.0
       memoizerific: 1.11.3
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/addon-controls@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@storybook/global': 5.0.0
+      "@storybook/global": 5.0.0
       dequal: 2.0.3
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/addon-docs@8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@mdx-js/react': 3.1.0(@types/react@19.1.9)(react@19.1.1)
-      '@storybook/blocks': 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
+      "@mdx-js/react": 3.1.0(@types/react@19.1.9)(react@19.1.1)
+      "@storybook/blocks": 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/csf-plugin": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/react-dom-shim": 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
-      - '@types/react'
+      - "@types/react"
 
-  '@storybook/addon-essentials@8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/addon-essentials@8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@storybook/addon-actions': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/addon-backgrounds': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/addon-controls': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/addon-docs': 8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/addon-highlight': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/addon-measure': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/addon-outline': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/addon-toolbars': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/addon-viewport': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/addon-actions": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/addon-backgrounds": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/addon-controls": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/addon-docs": 8.6.14(@types/react@19.1.9)(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/addon-highlight": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/addon-measure": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/addon-outline": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/addon-toolbars": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/addon-viewport": 8.6.14(storybook@8.6.14(prettier@3.6.2))
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
-      - '@types/react'
+      - "@types/react"
 
-  '@storybook/addon-highlight@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/addon-highlight@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@storybook/global': 5.0.0
+      "@storybook/global": 5.0.0
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@storybook/addon-measure@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/addon-measure@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@storybook/global': 5.0.0
+      "@storybook/global": 5.0.0
       storybook: 8.6.14(prettier@3.6.2)
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-outline@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/addon-outline@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@storybook/global': 5.0.0
+      "@storybook/global": 5.0.0
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-storysource@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/addon-storysource@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@storybook/source-loader': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/source-loader": 8.6.14(storybook@8.6.14(prettier@3.6.2))
       estraverse: 5.3.0
       storybook: 8.6.14(prettier@3.6.2)
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-toolbars@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/addon-toolbars@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@storybook/addon-viewport@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/addon-viewport@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
       memoizerific: 1.11.3
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@storybook/blocks@8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/blocks@8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@storybook/icons': 1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@storybook/icons": 1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))':
+  "@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))":
     dependencies:
-      '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/csf-plugin": 8.6.14(storybook@8.6.14(prettier@3.6.2))
       browser-assert: 1.2.1
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
       vite: 6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)
 
-  '@storybook/components@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/components@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@storybook/core-events@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/core-events@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@storybook/core@8.6.14(prettier@3.6.2)(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/core@8.6.14(prettier@3.6.2)(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@storybook/theming': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/theming": 8.6.14(storybook@8.6.14(prettier@3.6.2))
       better-opn: 3.0.2
       browser-assert: 1.2.1
       esbuild: 0.25.8
@@ -4021,45 +6220,45 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@storybook/csf-plugin@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/csf-plugin@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
       unplugin: 1.16.1
 
-  '@storybook/global@5.0.0': {}
+  "@storybook/global@5.0.0": {}
 
-  '@storybook/icons@1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  "@storybook/icons@1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@storybook/instrumenter@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/instrumenter@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@storybook/global': 5.0.0
-      '@vitest/utils': 2.1.9
+      "@storybook/global": 5.0.0
+      "@vitest/utils": 2.1.9
       storybook: 8.6.14(prettier@3.6.2)
     optional: true
 
-  '@storybook/manager-api@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/manager-api@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@storybook/preview-api@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/preview-api@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@storybook/react-dom-shim@8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/react-dom-shim@8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@storybook/react-vite@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))':
+  "@storybook/react-vite@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))":
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
-      '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
-      '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
-      '@storybook/react': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)
+      "@joshwooding/vite-plugin-react-docgen-typescript": 0.5.0(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      "@rollup/pluginutils": 5.2.0(rollup@4.46.2)
+      "@storybook/builder-vite": 8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))
+      "@storybook/react": 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)
       find-up: 5.0.0
       magic-string: 0.30.17
       react: 19.1.1
@@ -4070,69 +6269,69 @@ snapshots:
       tsconfig-paths: 4.2.0
       vite: 6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)
     optionalDependencies:
-      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/test": 8.6.14(storybook@8.6.14(prettier@3.6.2))
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@storybook/react@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)':
+  "@storybook/react@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.8.3)":
     dependencies:
-      '@storybook/components': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/preview-api': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/theming': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/components": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/global": 5.0.0
+      "@storybook/manager-api": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/preview-api": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/react-dom-shim": 8.6.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/theming": 8.6.14(storybook@8.6.14(prettier@3.6.2))
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       storybook: 8.6.14(prettier@3.6.2)
     optionalDependencies:
-      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/test": 8.6.14(storybook@8.6.14(prettier@3.6.2))
       typescript: 5.8.3
 
-  '@storybook/source-loader@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/source-loader@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
       es-toolkit: 1.39.8
       estraverse: 5.3.0
       prettier: 3.6.2
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
-      '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@testing-library/dom': 10.4.0
-      '@testing-library/jest-dom': 6.5.0
-      '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/expect': 2.0.5
-      '@vitest/spy': 2.0.5
+      "@storybook/global": 5.0.0
+      "@storybook/instrumenter": 8.6.14(storybook@8.6.14(prettier@3.6.2))
+      "@testing-library/dom": 10.4.0
+      "@testing-library/jest-dom": 6.5.0
+      "@testing-library/user-event": 14.5.2(@testing-library/dom@10.4.0)
+      "@vitest/expect": 2.0.5
+      "@vitest/spy": 2.0.5
       storybook: 8.6.14(prettier@3.6.2)
     optional: true
 
-  '@storybook/theming@8.6.14(storybook@8.6.14(prettier@3.6.2))':
+  "@storybook/theming@8.6.14(storybook@8.6.14(prettier@3.6.2))":
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@tanstack/react-virtual@3.14.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  "@tanstack/react-virtual@3.14.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
     dependencies:
-      '@tanstack/virtual-core': 3.17.3
+      "@tanstack/virtual-core": 3.17.3
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@tanstack/virtual-core@3.17.3': {}
+  "@tanstack/virtual-core@3.17.3": {}
 
-  '@testing-library/cypress@10.0.3(cypress@14.5.3)':
+  "@testing-library/cypress@10.0.3(cypress@14.5.3)":
     dependencies:
-      '@babel/runtime': 7.28.2
-      '@testing-library/dom': 10.4.1
+      "@babel/runtime": 7.28.2
+      "@testing-library/dom": 10.4.1
       cypress: 14.5.3
 
-  '@testing-library/dom@10.4.0':
+  "@testing-library/dom@10.4.0":
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.2
-      '@types/aria-query': 5.0.4
+      "@babel/code-frame": 7.29.0
+      "@babel/runtime": 7.28.2
+      "@types/aria-query": 5.0.4
       aria-query: 5.3.0
       chalk: 4.1.2
       dom-accessibility-api: 0.5.16
@@ -4140,20 +6339,20 @@ snapshots:
       pretty-format: 27.5.1
     optional: true
 
-  '@testing-library/dom@10.4.1':
+  "@testing-library/dom@10.4.1":
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.28.2
-      '@types/aria-query': 5.0.4
+      "@babel/code-frame": 7.27.1
+      "@babel/runtime": 7.28.2
+      "@types/aria-query": 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.5.0':
+  "@testing-library/jest-dom@6.5.0":
     dependencies:
-      '@adobe/css-tools': 4.4.3
+      "@adobe/css-tools": 4.4.3
       aria-query: 5.3.2
       chalk: 3.0.0
       css.escape: 1.5.1
@@ -4162,87 +6361,87 @@ snapshots:
       redent: 3.0.0
     optional: true
 
-  '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
+  "@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)":
     dependencies:
-      '@testing-library/dom': 10.4.0
+      "@testing-library/dom": 10.4.0
     optional: true
 
-  '@types/aria-query@5.0.4': {}
+  "@types/aria-query@5.0.4": {}
 
-  '@types/babel__core@7.20.5':
+  "@types/babel__core@7.20.5":
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.28.2
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.20.7
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.28.2
+      "@types/babel__generator": 7.27.0
+      "@types/babel__template": 7.4.4
+      "@types/babel__traverse": 7.20.7
 
-  '@types/babel__generator@7.27.0':
+  "@types/babel__generator@7.27.0":
     dependencies:
-      '@babel/types': 7.28.2
+      "@babel/types": 7.28.2
 
-  '@types/babel__template@7.4.4':
+  "@types/babel__template@7.4.4":
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.28.2
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.28.2
 
-  '@types/babel__traverse@7.20.7':
+  "@types/babel__traverse@7.20.7":
     dependencies:
-      '@babel/types': 7.28.2
+      "@babel/types": 7.28.2
 
-  '@types/doctrine@0.0.9': {}
+  "@types/doctrine@0.0.9": {}
 
-  '@types/estree@1.0.8': {}
+  "@types/estree@1.0.8": {}
 
-  '@types/json-schema@7.0.15': {}
+  "@types/json-schema@7.0.15": {}
 
-  '@types/mdx@2.0.13': {}
+  "@types/mdx@2.0.13": {}
 
-  '@types/node@24.1.0':
+  "@types/node@24.1.0":
     dependencies:
       undici-types: 7.8.0
     optional: true
 
-  '@types/react-dom@19.1.7(@types/react@19.1.9)':
+  "@types/react-dom@19.1.7(@types/react@19.1.9)":
     dependencies:
-      '@types/react': 19.1.9
+      "@types/react": 19.1.9
 
-  '@types/react@19.1.9':
+  "@types/react@19.1.9":
     dependencies:
       csstype: 3.1.3
 
-  '@types/resolve@1.20.6': {}
+  "@types/resolve@1.20.6": {}
 
-  '@types/sinonjs__fake-timers@8.1.1': {}
+  "@types/sinonjs__fake-timers@8.1.1": {}
 
-  '@types/sizzle@2.3.9': {}
+  "@types/sizzle@2.3.9": {}
 
-  '@types/stylis@4.2.5': {}
+  "@types/stylis@4.2.5": {}
 
-  '@types/trusted-types@2.0.7':
+  "@types/trusted-types@2.0.7":
     optional: true
 
-  '@types/uuid@9.0.8': {}
+  "@types/uuid@9.0.8": {}
 
-  '@types/yargs-parser@21.0.3': {}
+  "@types/yargs-parser@21.0.3": {}
 
-  '@types/yargs@17.0.33':
+  "@types/yargs@17.0.33":
     dependencies:
-      '@types/yargs-parser': 21.0.3
+      "@types/yargs-parser": 21.0.3
 
-  '@types/yauzl@2.10.3':
+  "@types/yauzl@2.10.3":
     dependencies:
-      '@types/node': 24.1.0
+      "@types/node": 24.1.0
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)':
+  "@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)":
     dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/scope-manager': 8.38.0
-      '@typescript-eslint/type-utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.38.0
+      "@eslint-community/regexpp": 4.12.1
+      "@typescript-eslint/parser": 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      "@typescript-eslint/scope-manager": 8.38.0
+      "@typescript-eslint/type-utils": 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      "@typescript-eslint/utils": 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      "@typescript-eslint/visitor-keys": 8.38.0
       eslint: 9.32.0(jiti@2.5.1)
       graphemer: 1.4.0
       ignore: 7.0.5
@@ -4252,41 +6451,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)':
+  "@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)":
     dependencies:
-      '@typescript-eslint/scope-manager': 8.38.0
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.38.0
+      "@typescript-eslint/scope-manager": 8.38.0
+      "@typescript-eslint/types": 8.38.0
+      "@typescript-eslint/typescript-estree": 8.38.0(typescript@5.8.3)
+      "@typescript-eslint/visitor-keys": 8.38.0
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 9.32.0(jiti@2.5.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.38.0(typescript@5.8.3)':
+  "@typescript-eslint/project-service@8.38.0(typescript@5.8.3)":
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.8.3)
-      '@typescript-eslint/types': 8.38.0
+      "@typescript-eslint/tsconfig-utils": 8.38.0(typescript@5.8.3)
+      "@typescript-eslint/types": 8.38.0
       debug: 4.4.1(supports-color@8.1.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.38.0':
+  "@typescript-eslint/scope-manager@8.38.0":
     dependencies:
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/visitor-keys': 8.38.0
+      "@typescript-eslint/types": 8.38.0
+      "@typescript-eslint/visitor-keys": 8.38.0
 
-  '@typescript-eslint/tsconfig-utils@8.38.0(typescript@5.8.3)':
+  "@typescript-eslint/tsconfig-utils@8.38.0(typescript@5.8.3)":
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)':
+  "@typescript-eslint/type-utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)":
     dependencies:
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+      "@typescript-eslint/types": 8.38.0
+      "@typescript-eslint/typescript-estree": 8.38.0(typescript@5.8.3)
+      "@typescript-eslint/utils": 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 9.32.0(jiti@2.5.1)
       ts-api-utils: 2.1.0(typescript@5.8.3)
@@ -4294,14 +6493,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.38.0': {}
+  "@typescript-eslint/types@8.38.0": {}
 
-  '@typescript-eslint/typescript-estree@8.38.0(typescript@5.8.3)':
+  "@typescript-eslint/typescript-estree@8.38.0(typescript@5.8.3)":
     dependencies:
-      '@typescript-eslint/project-service': 8.38.0(typescript@5.8.3)
-      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.8.3)
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/visitor-keys': 8.38.0
+      "@typescript-eslint/project-service": 8.38.0(typescript@5.8.3)
+      "@typescript-eslint/tsconfig-utils": 8.38.0(typescript@5.8.3)
+      "@typescript-eslint/types": 8.38.0
+      "@typescript-eslint/visitor-keys": 8.38.0
       debug: 4.4.1(supports-color@8.1.1)
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -4312,68 +6511,68 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)':
+  "@typescript-eslint/utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)":
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@2.5.1))
-      '@typescript-eslint/scope-manager': 8.38.0
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
+      "@eslint-community/eslint-utils": 4.7.0(eslint@9.32.0(jiti@2.5.1))
+      "@typescript-eslint/scope-manager": 8.38.0
+      "@typescript-eslint/types": 8.38.0
+      "@typescript-eslint/typescript-estree": 8.38.0(typescript@5.8.3)
       eslint: 9.32.0(jiti@2.5.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.38.0':
+  "@typescript-eslint/visitor-keys@8.38.0":
     dependencies:
-      '@typescript-eslint/types': 8.38.0
+      "@typescript-eslint/types": 8.38.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))':
+  "@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1))":
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.0)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
+      "@babel/core": 7.28.0
+      "@babel/plugin-transform-react-jsx-self": 7.27.1(@babel/core@7.28.0)
+      "@babel/plugin-transform-react-jsx-source": 7.27.1(@babel/core@7.28.0)
+      "@rolldown/pluginutils": 1.0.0-beta.27
+      "@types/babel__core": 7.20.5
       react-refresh: 0.17.0
       vite: 6.3.5(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.0.5':
+  "@vitest/expect@2.0.5":
     dependencies:
-      '@vitest/spy': 2.0.5
-      '@vitest/utils': 2.0.5
+      "@vitest/spy": 2.0.5
+      "@vitest/utils": 2.0.5
       chai: 5.2.1
       tinyrainbow: 1.2.0
     optional: true
 
-  '@vitest/pretty-format@2.0.5':
+  "@vitest/pretty-format@2.0.5":
     dependencies:
       tinyrainbow: 1.2.0
     optional: true
 
-  '@vitest/pretty-format@2.1.9':
+  "@vitest/pretty-format@2.1.9":
     dependencies:
       tinyrainbow: 1.2.0
     optional: true
 
-  '@vitest/spy@2.0.5':
+  "@vitest/spy@2.0.5":
     dependencies:
       tinyspy: 3.0.2
     optional: true
 
-  '@vitest/utils@2.0.5':
+  "@vitest/utils@2.0.5":
     dependencies:
-      '@vitest/pretty-format': 2.0.5
+      "@vitest/pretty-format": 2.0.5
       estree-walker: 3.0.3
       loupe: 3.2.0
       tinyrainbow: 1.2.0
     optional: true
 
-  '@vitest/utils@2.1.9':
+  "@vitest/utils@2.1.9":
     dependencies:
-      '@vitest/pretty-format': 2.1.9
+      "@vitest/pretty-format": 2.1.9
       loupe: 3.2.0
       tinyrainbow: 1.2.0
     optional: true
@@ -4521,7 +6720,7 @@ snapshots:
 
   barrelsby@2.8.1:
     dependencies:
-      '@types/yargs': 17.0.33
+      "@types/yargs": 17.0.33
       signale: 1.4.0
       yargs: 17.7.2
 
@@ -4713,10 +6912,10 @@ snapshots:
 
   cypress@14.5.3:
     dependencies:
-      '@cypress/request': 3.0.9
-      '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
-      '@types/sinonjs__fake-timers': 8.1.1
-      '@types/sizzle': 2.3.9
+      "@cypress/request": 3.0.9
+      "@cypress/xvfb": 1.2.4(supports-color@8.1.1)
+      "@types/sinonjs__fake-timers": 8.1.1
+      "@types/sizzle": 2.3.9
       arch: 2.2.0
       blob-util: 2.0.2
       bluebird: 3.7.2
@@ -4835,7 +7034,7 @@ snapshots:
 
   dompurify@3.2.7:
     optionalDependencies:
-      '@types/trusted-types': 2.0.7
+      "@types/trusted-types": 2.0.7
 
   dotenv@17.2.1: {}
 
@@ -4983,32 +7182,32 @@ snapshots:
 
   esbuild@0.25.8:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.8
-      '@esbuild/android-arm': 0.25.8
-      '@esbuild/android-arm64': 0.25.8
-      '@esbuild/android-x64': 0.25.8
-      '@esbuild/darwin-arm64': 0.25.8
-      '@esbuild/darwin-x64': 0.25.8
-      '@esbuild/freebsd-arm64': 0.25.8
-      '@esbuild/freebsd-x64': 0.25.8
-      '@esbuild/linux-arm': 0.25.8
-      '@esbuild/linux-arm64': 0.25.8
-      '@esbuild/linux-ia32': 0.25.8
-      '@esbuild/linux-loong64': 0.25.8
-      '@esbuild/linux-mips64el': 0.25.8
-      '@esbuild/linux-ppc64': 0.25.8
-      '@esbuild/linux-riscv64': 0.25.8
-      '@esbuild/linux-s390x': 0.25.8
-      '@esbuild/linux-x64': 0.25.8
-      '@esbuild/netbsd-arm64': 0.25.8
-      '@esbuild/netbsd-x64': 0.25.8
-      '@esbuild/openbsd-arm64': 0.25.8
-      '@esbuild/openbsd-x64': 0.25.8
-      '@esbuild/openharmony-arm64': 0.25.8
-      '@esbuild/sunos-x64': 0.25.8
-      '@esbuild/win32-arm64': 0.25.8
-      '@esbuild/win32-ia32': 0.25.8
-      '@esbuild/win32-x64': 0.25.8
+      "@esbuild/aix-ppc64": 0.25.8
+      "@esbuild/android-arm": 0.25.8
+      "@esbuild/android-arm64": 0.25.8
+      "@esbuild/android-x64": 0.25.8
+      "@esbuild/darwin-arm64": 0.25.8
+      "@esbuild/darwin-x64": 0.25.8
+      "@esbuild/freebsd-arm64": 0.25.8
+      "@esbuild/freebsd-x64": 0.25.8
+      "@esbuild/linux-arm": 0.25.8
+      "@esbuild/linux-arm64": 0.25.8
+      "@esbuild/linux-ia32": 0.25.8
+      "@esbuild/linux-loong64": 0.25.8
+      "@esbuild/linux-mips64el": 0.25.8
+      "@esbuild/linux-ppc64": 0.25.8
+      "@esbuild/linux-riscv64": 0.25.8
+      "@esbuild/linux-s390x": 0.25.8
+      "@esbuild/linux-x64": 0.25.8
+      "@esbuild/netbsd-arm64": 0.25.8
+      "@esbuild/netbsd-x64": 0.25.8
+      "@esbuild/openbsd-arm64": 0.25.8
+      "@esbuild/openbsd-x64": 0.25.8
+      "@esbuild/openharmony-arm64": 0.25.8
+      "@esbuild/sunos-x64": 0.25.8
+      "@esbuild/win32-arm64": 0.25.8
+      "@esbuild/win32-ia32": 0.25.8
+      "@esbuild/win32-x64": 0.25.8
 
   escalade@3.2.0: {}
 
@@ -5054,19 +7253,19 @@ snapshots:
 
   eslint@9.32.0(jiti@2.5.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@2.5.1))
-      '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.21.0
-      '@eslint/config-helpers': 0.3.0
-      '@eslint/core': 0.15.1
-      '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.32.0
-      '@eslint/plugin-kit': 0.3.4
-      '@humanfs/node': 0.16.6
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
+      "@eslint-community/eslint-utils": 4.7.0(eslint@9.32.0(jiti@2.5.1))
+      "@eslint-community/regexpp": 4.12.1
+      "@eslint/config-array": 0.21.0
+      "@eslint/config-helpers": 0.3.0
+      "@eslint/core": 0.15.1
+      "@eslint/eslintrc": 3.3.1
+      "@eslint/js": 9.32.0
+      "@eslint/plugin-kit": 0.3.4
+      "@humanfs/node": 0.16.6
+      "@humanwhocodes/module-importer": 1.0.1
+      "@humanwhocodes/retry": 0.4.3
+      "@types/estree": 1.0.8
+      "@types/json-schema": 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -5116,7 +7315,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
     optional: true
 
   esutils@2.0.3: {}
@@ -5147,7 +7346,7 @@ snapshots:
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
-      '@types/yauzl': 2.10.3
+      "@types/yauzl": 2.10.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5157,8 +7356,8 @@ snapshots:
 
   fast-glob@3.3.3:
     dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
+      "@nodelib/fs.stat": 2.0.5
+      "@nodelib/fs.walk": 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
@@ -5236,7 +7435,7 @@ snapshots:
       motion-utils: 12.23.6
       tslib: 2.8.1
     optionalDependencies:
-      '@emotion/is-prop-valid': 1.2.2
+      "@emotion/is-prop-valid": 1.2.2
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
@@ -5561,9 +7760,9 @@ snapshots:
 
   jackspeak@3.4.3:
     dependencies:
-      '@isaacs/cliui': 8.0.2
+      "@isaacs/cliui": 8.0.2
     optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
+      "@pkgjs/parseargs": 0.11.0
 
   jiti@2.5.1:
     optional: true
@@ -5735,11 +7934,11 @@ snapshots:
 
   magic-string@0.27.0:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
+      "@jridgewell/sourcemap-codec": 1.5.4
 
   magic-string@0.30.17:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
+      "@jridgewell/sourcemap-codec": 1.5.4
 
   map-or-similar@1.5.0: {}
 
@@ -5876,25 +8075,25 @@ snapshots:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.62.0
-      '@oxfmt/binding-android-arm64': 0.62.0
-      '@oxfmt/binding-darwin-arm64': 0.62.0
-      '@oxfmt/binding-darwin-x64': 0.62.0
-      '@oxfmt/binding-freebsd-x64': 0.62.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.62.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.62.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.62.0
-      '@oxfmt/binding-linux-arm64-musl': 0.62.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.62.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.62.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.62.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.62.0
-      '@oxfmt/binding-linux-x64-gnu': 0.62.0
-      '@oxfmt/binding-linux-x64-musl': 0.62.0
-      '@oxfmt/binding-openharmony-arm64': 0.62.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.62.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.62.0
-      '@oxfmt/binding-win32-x64-msvc': 0.62.0
+      "@oxfmt/binding-android-arm-eabi": 0.62.0
+      "@oxfmt/binding-android-arm64": 0.62.0
+      "@oxfmt/binding-darwin-arm64": 0.62.0
+      "@oxfmt/binding-darwin-x64": 0.62.0
+      "@oxfmt/binding-freebsd-x64": 0.62.0
+      "@oxfmt/binding-linux-arm-gnueabihf": 0.62.0
+      "@oxfmt/binding-linux-arm-musleabihf": 0.62.0
+      "@oxfmt/binding-linux-arm64-gnu": 0.62.0
+      "@oxfmt/binding-linux-arm64-musl": 0.62.0
+      "@oxfmt/binding-linux-ppc64-gnu": 0.62.0
+      "@oxfmt/binding-linux-riscv64-gnu": 0.62.0
+      "@oxfmt/binding-linux-riscv64-musl": 0.62.0
+      "@oxfmt/binding-linux-s390x-gnu": 0.62.0
+      "@oxfmt/binding-linux-x64-gnu": 0.62.0
+      "@oxfmt/binding-linux-x64-musl": 0.62.0
+      "@oxfmt/binding-openharmony-arm64": 0.62.0
+      "@oxfmt/binding-win32-arm64-msvc": 0.62.0
+      "@oxfmt/binding-win32-ia32-msvc": 0.62.0
+      "@oxfmt/binding-win32-x64-msvc": 0.62.0
 
   p-limit@1.3.0:
     dependencies:
@@ -5947,7 +8146,7 @@ snapshots:
 
   pdfjs-dist@5.4.54:
     optionalDependencies:
-      '@napi-rs/canvas': 0.1.99
+      "@napi-rs/canvas": 0.1.99
 
   pend@1.2.0: {}
 
@@ -5970,7 +8169,7 @@ snapshots:
 
   polished@4.3.1:
     dependencies:
-      '@babel/runtime': 7.28.2
+      "@babel/runtime": 7.28.2
 
   possible-typed-array-names@1.1.0: {}
 
@@ -6029,13 +8228,13 @@ snapshots:
 
   react-docgen@7.1.1:
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.28.2
-      '@types/babel__core': 7.20.5
-      '@types/babel__traverse': 7.20.7
-      '@types/doctrine': 0.0.9
-      '@types/resolve': 1.20.6
+      "@babel/core": 7.28.0
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.28.2
+      "@types/babel__core": 7.20.5
+      "@types/babel__traverse": 7.20.7
+      "@types/doctrine": 0.0.9
+      "@types/resolve": 1.20.6
       doctrine: 3.0.0
       resolve: 1.22.10
       strip-indent: 4.0.0
@@ -6128,28 +8327,28 @@ snapshots:
 
   rollup@4.46.2:
     dependencies:
-      '@types/estree': 1.0.8
+      "@types/estree": 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.46.2
-      '@rollup/rollup-android-arm64': 4.46.2
-      '@rollup/rollup-darwin-arm64': 4.46.2
-      '@rollup/rollup-darwin-x64': 4.46.2
-      '@rollup/rollup-freebsd-arm64': 4.46.2
-      '@rollup/rollup-freebsd-x64': 4.46.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.46.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.46.2
-      '@rollup/rollup-linux-arm64-gnu': 4.46.2
-      '@rollup/rollup-linux-arm64-musl': 4.46.2
-      '@rollup/rollup-linux-loongarch64-gnu': 4.46.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.46.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.46.2
-      '@rollup/rollup-linux-riscv64-musl': 4.46.2
-      '@rollup/rollup-linux-s390x-gnu': 4.46.2
-      '@rollup/rollup-linux-x64-gnu': 4.46.2
-      '@rollup/rollup-linux-x64-musl': 4.46.2
-      '@rollup/rollup-win32-arm64-msvc': 4.46.2
-      '@rollup/rollup-win32-ia32-msvc': 4.46.2
-      '@rollup/rollup-win32-x64-msvc': 4.46.2
+      "@rollup/rollup-android-arm-eabi": 4.46.2
+      "@rollup/rollup-android-arm64": 4.46.2
+      "@rollup/rollup-darwin-arm64": 4.46.2
+      "@rollup/rollup-darwin-x64": 4.46.2
+      "@rollup/rollup-freebsd-arm64": 4.46.2
+      "@rollup/rollup-freebsd-x64": 4.46.2
+      "@rollup/rollup-linux-arm-gnueabihf": 4.46.2
+      "@rollup/rollup-linux-arm-musleabihf": 4.46.2
+      "@rollup/rollup-linux-arm64-gnu": 4.46.2
+      "@rollup/rollup-linux-arm64-musl": 4.46.2
+      "@rollup/rollup-linux-loongarch64-gnu": 4.46.2
+      "@rollup/rollup-linux-ppc64-gnu": 4.46.2
+      "@rollup/rollup-linux-riscv64-gnu": 4.46.2
+      "@rollup/rollup-linux-riscv64-musl": 4.46.2
+      "@rollup/rollup-linux-s390x-gnu": 4.46.2
+      "@rollup/rollup-linux-x64-gnu": 4.46.2
+      "@rollup/rollup-linux-x64-musl": 4.46.2
+      "@rollup/rollup-win32-arm64-msvc": 4.46.2
+      "@rollup/rollup-win32-ia32-msvc": 4.46.2
+      "@rollup/rollup-win32-x64-msvc": 4.46.2
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -6298,7 +8497,7 @@ snapshots:
 
   storybook@8.6.14(prettier@3.6.2):
     dependencies:
-      '@storybook/core': 8.6.14(prettier@3.6.2)(storybook@8.6.14(prettier@3.6.2))
+      "@storybook/core": 8.6.14(prettier@3.6.2)(storybook@8.6.14(prettier@3.6.2))
     optionalDependencies:
       prettier: 3.6.2
     transitivePeerDependencies:
@@ -6387,9 +8586,9 @@ snapshots:
 
   styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
-      '@emotion/is-prop-valid': 1.2.2
-      '@emotion/unitless': 0.8.1
-      '@types/stylis': 4.2.5
+      "@emotion/is-prop-valid": 1.2.2
+      "@emotion/unitless": 0.8.1
+      "@types/stylis": 4.2.5
       css-to-react-native: 3.2.0
       csstype: 3.1.3
       postcss: 8.4.49
@@ -6419,7 +8618,7 @@ snapshots:
 
   terser@5.43.1:
     dependencies:
-      '@jridgewell/source-map': 0.3.11
+      "@jridgewell/source-map": 0.3.11
       acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
@@ -6583,7 +8782,7 @@ snapshots:
       rollup: 4.46.2
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 24.1.0
+      "@types/node": 24.1.0
       fsevents: 2.3.3
       jiti: 2.5.1
       lightningcss: 1.30.1

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -4,31 +4,31 @@ import {
   FormFieldType,
   StatefulForm,
   StatefulFormProps,
-} from "./../../components/stateful-form"
-import { COUNTRY_CODES } from "./../../constants/countries"
-import { Boxbar } from "./../../components/boxbar"
-import { Badge, BadgeProps } from "./../../components/badge"
-import { css } from "styled-components"
-import { SelectboxOption } from "./../../components/selectbox"
-import { CapsuleTab } from "./../../components/capsule"
-import { useEffect, useMemo, useState } from "react"
+} from "./../../components/stateful-form";
+import { COUNTRY_CODES } from "./../../constants/countries";
+import { Boxbar } from "./../../components/boxbar";
+import { Badge, BadgeProps } from "./../../components/badge";
+import { css } from "styled-components";
+import { SelectboxOption } from "./../../components/selectbox";
+import { CapsuleTab } from "./../../components/capsule";
+import { useEffect, useMemo, useState } from "react";
 import {
   OnCompleteFunctionArgs,
   FileDropBox,
   OnFileDroppedFunctionArgs,
-} from "./../../components/file-drop-box"
-import { Table } from "./../../components/table"
-import { RiDeleteBin2Fill } from "@remixicon/react"
-import z from "zod"
-import { PinboxParts } from "./../../components/pinbox"
+} from "./../../components/file-drop-box";
+import { Table } from "./../../components/table";
+import { RiDeleteBin2Fill } from "@remixicon/react";
+import z from "zod";
+import { PinboxParts } from "./../../components/pinbox";
 
 const DEFAULT_COUNTRY_CODES = (() => {
   const code =
-    COUNTRY_CODES.find((data) => data.id === "US") ?? COUNTRY_CODES[206]
+    COUNTRY_CODES.find((data) => data.id === "US") ?? COUNTRY_CODES[206];
   if (!code)
-    throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
-  return code
-})()
+    throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
+  return code;
+})();
 
 const FRUIT_OPTIONS: SelectboxOption[] = [
   { text: "Apple", value: "1" },
@@ -38,7 +38,7 @@ const FRUIT_OPTIONS: SelectboxOption[] = [
   { text: "Pineapple", value: "5" },
   { text: "Strawberry", value: "6" },
   { text: "Watermelon", value: "7" },
-]
+];
 
 const MONTH_NAMES = [
   { text: "JAN", value: "1" },
@@ -53,12 +53,12 @@ const MONTH_NAMES = [
   { text: "OCT", value: "10" },
   { text: "NOV", value: "11" },
   { text: "DEC", value: "12" },
-]
+];
 
 const CAPSULE_TABS: CapsuleTab[] = [
   { id: "paid", title: "Paid" },
   { id: "unpaid", title: "Unpaid" },
-]
+];
 
 const PARTS_INPUT: PinboxParts[] = [
   { type: "static", text: "S" },
@@ -66,7 +66,7 @@ const PARTS_INPUT: PinboxParts[] = [
   { type: "digit" },
   { type: "alphabet" },
   { type: "static", text: "-" },
-]
+];
 
 const BADGE_OPTIONS_FULL = [
   { id: 1, caption: "Anime" },
@@ -79,12 +79,12 @@ const BADGE_OPTIONS_FULL = [
   { id: 8, caption: "Music" },
   { id: 9, caption: "Games" },
   { id: 10, caption: "Webtoons" },
-]
+];
 
 const BADGE_OPTIONS_SHORT: BadgeProps[] = [
   { id: "1", caption: "Anime" },
   { id: "2", caption: "Manga" },
-]
+];
 
 const TYPE_TO_ID_PREFIX: Record<FormFieldType, string> = {
   text: "textbox",
@@ -114,7 +114,7 @@ const TYPE_TO_ID_PREFIX: Record<FormFieldType, string> = {
   chips: "chips",
   custom: "custom",
   frame: "frame",
-}
+};
 
 const allValue = {
   text: "",
@@ -141,7 +141,7 @@ const allValue = {
   signature: "",
   capsule: "",
   country_code: DEFAULT_COUNTRY_CODES,
-}
+};
 
 const ALL_INPUT: FormFieldGroup[] = [
   [
@@ -315,7 +315,7 @@ const ALL_INPUT: FormFieldGroup[] = [
       tabs: CAPSULE_TABS,
     },
   },
-]
+];
 
 const FIELD_HELPERS: Record<string, string> = {
   text: "Enter any text value.",
@@ -341,26 +341,28 @@ const FIELD_HELPERS: Record<string, string> = {
   toggle: "Toggle the switch.",
   chips: "Select one or more chips.",
   capsule: "Choose a monetary option.",
-}
+};
 
 const flattenFields = (groups: FormFieldGroup[]): FormFieldProps[] =>
   groups.flatMap((group) =>
-    Array.isArray(group) ? flattenFields(group) : [group],
-  )
+    Array.isArray(group) ? flattenFields(group) : [group]
+  );
 
 describe("StatefulForm", () => {
   context("general", () => {
     function StatefulFormWithAsync({
       state = "valid",
     }: {
-      state?: "valid" | "invalid" | "empty"
+      state?: "valid" | "invalid" | "empty";
     }) {
       const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
-        (data) => data.id === "US",
-      )
+        (data) => data.id === "US"
+      );
 
       if (!DEFAULT_COUNTRY_CODES) {
-        throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
+        throw new Error(
+          "Default country code 'US' not found in COUNTRY_CODES."
+        );
       }
 
       const [value, setValue] = useState({
@@ -368,9 +370,9 @@ describe("StatefulForm", () => {
         email: "",
         phone: "",
         country_code: DEFAULT_COUNTRY_CODES,
-      })
+      });
 
-      const [isFormValid, setIsFormValid] = useState(false)
+      const [isFormValid, setIsFormValid] = useState(false);
 
       useEffect(() => {
         const timer = setTimeout(() => {
@@ -381,8 +383,8 @@ describe("StatefulForm", () => {
                 name: "John Doe",
                 email: "john@example.com",
                 phone: "081234567890",
-              }))
-              break
+              }));
+              break;
 
             case "invalid":
               setValue((prev) => ({
@@ -390,17 +392,17 @@ describe("StatefulForm", () => {
                 name: "Jo",
                 email: "invalid-email",
                 phone: "123",
-              }))
-              break
+              }));
+              break;
 
             case "empty":
             default:
-              break
+              break;
           }
-        }, 300)
+        }, 300);
 
-        return () => clearTimeout(timer)
-      }, [state])
+        return () => clearTimeout(timer);
+      }, [state]);
 
       const employeeSchema = z.object({
         name: z
@@ -411,7 +413,7 @@ describe("StatefulForm", () => {
           .string()
           .regex(/^\d{10,15}$/, "Phone number must be between 10 and 15 digits")
           .optional(),
-      })
+      });
 
       const EMPLOYEE_FIELDS: FormFieldGroup[] = [
         {
@@ -449,7 +451,7 @@ describe("StatefulForm", () => {
           disabled: !isFormValid,
           rowJustifyPosition: "end",
         },
-      ]
+      ];
 
       return (
         <StatefulForm
@@ -462,121 +464,123 @@ describe("StatefulForm", () => {
             setValue((prev) => ({
               ...prev,
               ...currentState,
-            }))
+            }));
           }}
         />
-      )
+      );
     }
 
     context("when typing with invalid value", () => {
       context("while focused", () => {
         it("does not show the error", () => {
-          cy.mount(<StatefulFormWithAsync state="empty" />)
+          cy.mount(<StatefulFormWithAsync state="empty" />);
 
-          cy.findByPlaceholderText("Enter first name").type("T")
+          cy.findByPlaceholderText("Enter first name").type("T");
 
           cy.findByText("First name must be at least 3 characters long").should(
-            "not.exist",
-          )
-        })
-      })
+            "not.exist"
+          );
+        });
+      });
 
       context("after blur", () => {
         it("shows the error", () => {
-          cy.mount(<StatefulFormWithAsync state="empty" />)
+          cy.mount(<StatefulFormWithAsync state="empty" />);
           cy.findByText("First name must be at least 3 characters long").should(
-            "not.exist",
-          )
+            "not.exist"
+          );
 
-          cy.findByPlaceholderText("Enter first name").type("T")
-          cy.get("body").click("topRight")
+          cy.findByPlaceholderText("Enter first name").type("T");
+          cy.get("body").click("topRight");
 
           cy.findByText("First name must be at least 3 characters long").should(
-            "be.visible",
-          )
-        })
+            "be.visible"
+          );
+        });
 
         context("when typing in another field", () => {
           it("keeps the previous error", () => {
-            cy.mount(<StatefulFormWithAsync state="empty" />)
+            cy.mount(<StatefulFormWithAsync state="empty" />);
             cy.findByText(
-              "First name must be at least 3 characters long",
-            ).should("not.exist")
+              "First name must be at least 3 characters long"
+            ).should("not.exist");
 
-            cy.findByPlaceholderText("Enter first name").type("Te")
-            cy.get("body").click("topRight")
+            cy.findByPlaceholderText("Enter first name").type("Te");
+            cy.get("body").click("topRight");
 
             cy.findByText(
-              "First name must be at least 3 characters long",
-            ).should("be.visible")
+              "First name must be at least 3 characters long"
+            ).should("be.visible");
 
-            cy.findByPlaceholderText("Enter email address").type("iamalim@test")
+            cy.findByPlaceholderText("Enter email address").type(
+              "iamalim@test"
+            );
 
             // still shows if in focus
 
             cy.findByText(
-              "First name must be at least 3 characters long",
-            ).should("be.visible")
+              "First name must be at least 3 characters long"
+            ).should("be.visible");
 
-            cy.get("body").click("topRight")
+            cy.get("body").click("topRight");
 
             // still shows after unfocused
 
             cy.findByText(
-              "First name must be at least 3 characters long",
-            ).should("be.visible")
+              "First name must be at least 3 characters long"
+            ).should("be.visible");
             cy.findByText("Please enter a valid email address").should(
-              "be.visible",
-            )
-          })
-        })
-      })
-    })
+              "be.visible"
+            );
+          });
+        });
+      });
+    });
 
     context("async", () => {
       context("when data is valid", () => {
         it("renders without error", () => {
-          cy.mount(<StatefulFormWithAsync state="valid" />)
+          cy.mount(<StatefulFormWithAsync state="valid" />);
 
-          cy.wait(600)
+          cy.wait(600);
 
-          cy.findByDisplayValue("John Doe").should("exist")
-          cy.findByDisplayValue("john@example.com").should("exist")
-          cy.findByDisplayValue("081234567890").should("exist")
+          cy.findByDisplayValue("John Doe").should("exist");
+          cy.findByDisplayValue("john@example.com").should("exist");
+          cy.findByDisplayValue("081234567890").should("exist");
 
           cy.findByText("First name must be at least 3 characters long").should(
-            "not.exist",
-          )
+            "not.exist"
+          );
           cy.findByText("Please enter a valid email address").should(
-            "not.exist",
-          )
+            "not.exist"
+          );
           cy.findByText("Phone number must be between 10 and 15 digits").should(
-            "not.exist",
-          )
-        })
-      })
+            "not.exist"
+          );
+        });
+      });
 
       context("when data is invalid", () => {
         it("renders with error", () => {
-          cy.mount(<StatefulFormWithAsync state="invalid" />)
+          cy.mount(<StatefulFormWithAsync state="invalid" />);
 
-          cy.wait(600)
+          cy.wait(600);
 
-          cy.findByDisplayValue("Jo").should("exist")
-          cy.findByDisplayValue("invalid-email").should("exist")
-          cy.findByDisplayValue("123").should("exist")
+          cy.findByDisplayValue("Jo").should("exist");
+          cy.findByDisplayValue("invalid-email").should("exist");
+          cy.findByDisplayValue("123").should("exist");
 
           cy.findByText("First name must be at least 3 characters long").should(
-            "exist",
-          )
-          cy.findByText("Please enter a valid email address").should("exist")
+            "exist"
+          );
+          cy.findByText("Please enter a valid email address").should("exist");
           cy.findByText("Phone number must be between 10 and 15 digits").should(
-            "exist",
-          )
-        })
-      })
-    })
-  })
+            "exist"
+          );
+        });
+      });
+    });
+  });
 
   context("mobile", () => {
     context("styles", () => {
@@ -597,10 +601,10 @@ describe("StatefulForm", () => {
                   {FIELD_HELPERS[group.type]}
                 </span>
               ),
-            },
-      )
+            }
+      );
 
-      const FLAT_INPUT = INPUT_WITH_HELPER.flatMap((props) => props)
+      const FLAT_INPUT = INPUT_WITH_HELPER.flatMap((props) => props);
       context("helperArrowStyle", () => {
         context("when given green background", () => {
           it("renders with background with rgb(0, 255, 0)", () => {
@@ -614,21 +618,21 @@ describe("StatefulForm", () => {
                 fields={INPUT_WITH_HELPER}
                 formValues={allValue}
                 mode="onChange"
-              />,
-            )
+              />
+            );
 
             cy.findAllByLabelText("tooltip-trigger")
               .should("have.length", FLAT_INPUT.length)
               .each(($el, index) => {
-                cy.wrap($el).trigger("mouseover")
+                cy.wrap($el).trigger("mouseover");
 
                 cy.findAllByLabelText("tooltip-arrow")
                   .eq(index)
-                  .should("have.css", "background-color", "rgb(0, 255, 0)")
-              })
-          })
-        })
-      })
+                  .should("have.css", "background-color", "rgb(0, 255, 0)");
+              });
+          });
+        });
+      });
 
       context("helperIconStyle", () => {
         context("when given red color", () => {
@@ -645,22 +649,22 @@ describe("StatefulForm", () => {
                 fields={INPUT_WITH_HELPER}
                 formValues={allValue}
                 mode="onChange"
-              />,
-            )
+              />
+            );
 
             cy.findAllByLabelText("tooltip-trigger")
               .should("have.length", FLAT_INPUT.length)
               .each(($el, index) => {
-                cy.wrap($el).trigger("mouseover")
+                cy.wrap($el).trigger("mouseover");
 
                 cy.findAllByLabelText("tooltip-trigger")
                   .eq(index)
                   .find("svg")
-                  .should("have.css", "fill", "rgb(255, 0, 0)")
-              })
-          })
-        })
-      })
+                  .should("have.css", "fill", "rgb(255, 0, 0)");
+              });
+          });
+        });
+      });
 
       context("helperDrawerStyle", () => {
         context("when given background yellow", () => {
@@ -675,21 +679,21 @@ describe("StatefulForm", () => {
                 fields={INPUT_WITH_HELPER}
                 formValues={allValue}
                 mode="onChange"
-              />,
-            )
+              />
+            );
 
             cy.findAllByLabelText("tooltip-trigger")
               .should("have.length", FLAT_INPUT.length)
               .each(($el, index) => {
-                cy.wrap($el).trigger("mouseover")
+                cy.wrap($el).trigger("mouseover");
 
                 cy.findAllByLabelText("tooltip-drawer")
                   .eq(index)
-                  .should("have.css", "background-color", "rgb(255, 255, 0)")
-              })
-          })
-        })
-      })
+                  .should("have.css", "background-color", "rgb(255, 255, 0)");
+              });
+          });
+        });
+      });
 
       context("mobileFieldGroupStyle", () => {
         context("when given padding 30px", () => {
@@ -705,17 +709,17 @@ describe("StatefulForm", () => {
                     padding: 30px;
                   `,
                 }}
-              />,
-            )
+              />
+            );
 
             cy.findAllByLabelText("stateful-form-field-group").should(
               "have.css",
               "padding",
-              "30px",
-            )
-          })
-        })
-      })
+              "30px"
+            );
+          });
+        });
+      });
 
       context("mobileFieldGroupRowDividerStyle", () => {
         context("when given color red", () => {
@@ -731,18 +735,18 @@ describe("StatefulForm", () => {
                     background-color: red;
                   `,
                 }}
-              />,
-            )
+              />
+            );
 
             cy.findAllByLabelText("stateful-form-field-group-divider").should(
               "have.css",
               "background-color",
-              "rgb(255, 0, 0)",
-            )
-          })
-        })
-      })
-    })
+              "rgb(255, 0, 0)"
+            );
+          });
+        });
+      });
+    });
     it("renders with background rgb(236, 236, 236)", () => {
       cy.mount(
         <StatefulForm
@@ -750,15 +754,15 @@ describe("StatefulForm", () => {
           formValues={allValue}
           mode="onChange"
           mobile
-        />,
-      )
+        />
+      );
 
       cy.findAllByLabelText("stateful-form-field-group").should(
         "have.css",
         "background-color",
-        "rgb(236, 236, 236)",
-      )
-    })
+        "rgb(236, 236, 236)"
+      );
+    });
 
     it("renders row with radius 24px and padding 10px 20px", () => {
       cy.mount(
@@ -767,18 +771,18 @@ describe("StatefulForm", () => {
           formValues={allValue}
           mode="onChange"
           mobile
-        />,
-      )
+        />
+      );
 
       cy.findAllByLabelText("stateful-form-field-group")
         .should("have.css", "border-radius", "24px")
-        .and("have.css", "padding", "10px 20px")
-    })
+        .and("have.css", "padding", "10px 20px");
+    });
 
     context("radio", () => {
       context("clicking in center row element", () => {
         it("should give callback in onChanges", () => {
-          const onChangeValue = cy.stub().as("onChangeValue")
+          const onChangeValue = cy.stub().as("onChangeValue");
 
           cy.mount(
             <StatefulForm
@@ -794,21 +798,21 @@ describe("StatefulForm", () => {
               mode="onChange"
               onChange={() => onChangeValue()}
               mobile
-            />,
-          )
-          cy.get("@onChangeValue").should("not.have.been.calledOnce")
+            />
+          );
+          cy.get("@onChangeValue").should("not.have.been.calledOnce");
 
-          cy.findAllByLabelText("stateful-form-field-group").click("center")
+          cy.findAllByLabelText("stateful-form-field-group").click("center");
 
-          cy.get("@onChangeValue").should("have.been.calledOnce")
-        })
-      })
-    })
+          cy.get("@onChangeValue").should("have.been.calledOnce");
+        });
+      });
+    });
 
     context("checkbox", () => {
       context("clicking in center row element", () => {
         it("should give callback in onChanges", () => {
-          const onChangeValue = cy.stub().as("onChangeValue")
+          const onChangeValue = cy.stub().as("onChangeValue");
 
           cy.mount(
             <StatefulForm
@@ -824,21 +828,21 @@ describe("StatefulForm", () => {
               mode="onChange"
               onChange={() => onChangeValue()}
               mobile
-            />,
-          )
-          cy.get("@onChangeValue").should("not.have.been.calledOnce")
+            />
+          );
+          cy.get("@onChangeValue").should("not.have.been.calledOnce");
 
-          cy.findAllByLabelText("stateful-form-field-group").click("center")
+          cy.findAllByLabelText("stateful-form-field-group").click("center");
 
-          cy.get("@onChangeValue").should("have.been.calledOnce")
-        })
-      })
-    })
+          cy.get("@onChangeValue").should("have.been.calledOnce");
+        });
+      });
+    });
 
     context("button", () => {
       context("when given 2 or more button", () => {
         it("should separate with percentage in flex row", () => {
-          cy.viewport(500, 500)
+          cy.viewport(500, 500);
           cy.mount(
             <StatefulForm
               fields={[
@@ -865,22 +869,22 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />,
-          )
+            />
+          );
 
           cy.findAllByLabelText("stateful-form-field-group")
             .should("have.css", "flex-direction", "row")
-            .and("have.css", "width", "460px")
+            .and("have.css", "width", "460px");
 
-          cy.findAllByRole("button").should("have.length", 2)
-          cy.findAllByRole("button").eq(0).should("have.css", "width", "230px")
-          cy.findAllByRole("button").eq(1).should("have.css", "width", "230px")
-        })
-      })
+          cy.findAllByRole("button").should("have.length", 2);
+          cy.findAllByRole("button").eq(0).should("have.css", "width", "230px");
+          cy.findAllByRole("button").eq(1).should("have.css", "width", "230px");
+        });
+      });
 
       context("when given 2 or more button and 1 input", () => {
         it("should renders as usual with flex column", () => {
-          cy.viewport(500, 500)
+          cy.viewport(500, 500);
           cy.mount(
             <StatefulForm
               fields={[
@@ -914,30 +918,30 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />,
-          )
+            />
+          );
 
           cy.findAllByLabelText("stateful-form-field-group")
             .should("have.css", "flex-direction", "column")
-            .and("have.css", "width", "460px")
+            .and("have.css", "width", "460px");
 
-          cy.findAllByRole("button").should("have.length", 2)
+          cy.findAllByRole("button").should("have.length", 2);
           cy.findAllByRole("button")
             .eq(0)
-            .should("not.have.css", "width", "230px")
+            .should("not.have.css", "width", "230px");
           cy.findAllByRole("button")
             .eq(1)
-            .should("not.have.css", "width", "230px")
-        })
-      })
-    })
+            .should("not.have.css", "width", "230px");
+        });
+      });
+    });
 
     context("Capsule", () => {
       context("when error", () => {
         it("should not render the error icon", () => {
           const capsuleSchema = z.object({
             capsule: z.string().max(4, "Paid is required"),
-          })
+          });
 
           cy.mount(
             <StatefulForm
@@ -956,22 +960,22 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />,
-          )
+            />
+          );
 
-          cy.findByText("Paid is required").should("not.exist")
-          cy.get("body").find("svg").should("not.exist")
+          cy.findByText("Paid is required").should("not.exist");
+          cy.get("body").find("svg").should("not.exist");
 
-          cy.findByText("Unpaid").click()
+          cy.findByText("Unpaid").click();
 
-          cy.findByText("Paid is required").should("exist")
+          cy.findByText("Paid is required").should("exist");
           cy.get("body")
             .find("svg")
             .parent()
-            .should("have.css", "display", "none")
-        })
-      })
-    })
+            .should("have.css", "display", "none");
+        });
+      });
+    });
 
     context("textbox", () => {
       context("when given title", () => {
@@ -989,11 +993,11 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />,
-          )
+            />
+          );
 
-          cy.findByPlaceholderText("Text Placeholder").should("exist")
-        })
+          cy.findByPlaceholderText("Text Placeholder").should("exist");
+        });
 
         context("when given placeholder", () => {
           it("should replace the placeholder input text", () => {
@@ -1012,15 +1016,15 @@ describe("StatefulForm", () => {
                 formValues={{}}
                 mode="onChange"
                 mobile
-              />,
-            )
+              />
+            );
 
-            cy.findByPlaceholderText("Text Placeholder").should("not.exist")
-            cy.findByPlaceholderText("Enter text").should("not.exist")
-          })
-        })
-      })
-    })
+            cy.findByPlaceholderText("Text Placeholder").should("not.exist");
+            cy.findByPlaceholderText("Enter text").should("not.exist");
+          });
+        });
+      });
+    });
 
     context("colorbox", () => {
       it("renders with flex row-reverse", () => {
@@ -1038,14 +1042,14 @@ describe("StatefulForm", () => {
             formValues={{}}
             mode="onChange"
             mobile
-          />,
-        )
+          />
+        );
 
         cy.findByLabelText("colorbox")
           .should("exist")
-          .and("have.css", "flex-direction", "row-reverse")
-      })
-    })
+          .and("have.css", "flex-direction", "row-reverse");
+      });
+    });
 
     context("moneybox", () => {
       context("when clicking the currency button", () => {
@@ -1066,17 +1070,17 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />,
-          )
+            />
+          );
 
-          cy.findByLabelText("moneybox-currency-toggle").click()
+          cy.findByLabelText("moneybox-currency-toggle").click();
 
           cy.findByLabelText("combobox-drawer-mobile")
             .should("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed")
-        })
-      })
-    })
+            .and("have.css", "position", "fixed");
+        });
+      });
+    });
 
     context("chips", () => {
       function ProductStatefulChips() {
@@ -1085,7 +1089,7 @@ describe("StatefulForm", () => {
             selectedOptions: [],
             searchText: "",
           },
-        })
+        });
 
         return (
           <StatefulForm
@@ -1104,7 +1108,7 @@ describe("StatefulForm", () => {
               },
             ]}
             onChange={({ currentState }) => {
-              const [[key, value]] = Object.entries(currentState)
+              const [[key, value]] = Object.entries(currentState);
 
               setValue((prev) => ({
                 ...prev,
@@ -1118,46 +1122,46 @@ describe("StatefulForm", () => {
                       },
                     }
                   : currentState),
-              }))
+              }));
             }}
             formValues={value}
             mode="onChange"
           />
-        )
+        );
       }
 
       it("renders with row reverse", () => {
-        cy.mount(<ProductStatefulChips />)
+        cy.mount(<ProductStatefulChips />);
 
-        cy.findByLabelText("chips-container-input").click()
+        cy.findByLabelText("chips-container-input").click();
 
         cy.findByLabelText("combobox-drawer-mobile")
           .should("exist")
           .and("have.css", "bottom", "10px")
-          .and("have.css", "position", "fixed")
+          .and("have.css", "position", "fixed");
 
-        cy.findByText("Anime").click()
-        cy.findByText("Manga").click()
+        cy.findByText("Anime").click();
+        cy.findByText("Manga").click();
 
         cy.findByLabelText("chips-container-input").should(
           "have.css",
           "flex-direction",
-          "row-reverse",
-        )
-      })
+          "row-reverse"
+        );
+      });
       context("when clicking the button", () => {
         it("renders in the bottom of screen", () => {
-          cy.mount(<ProductStatefulChips />)
+          cy.mount(<ProductStatefulChips />);
 
-          cy.findByLabelText("chips-container-input").click()
+          cy.findByLabelText("chips-container-input").click();
 
           cy.findByLabelText("combobox-drawer-mobile")
             .should("exist")
             .and("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed")
-        })
-      })
-    })
+            .and("have.css", "position", "fixed");
+        });
+      });
+    });
 
     context("datebox", () => {
       context("when clicking the selectbox", () => {
@@ -1176,18 +1180,18 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />,
-          )
+            />
+          );
 
-          cy.findAllByPlaceholderText("Select a date").click()
+          cy.findAllByPlaceholderText("Select a date").click();
 
           cy.findByLabelText("calendar")
             .should("exist")
             .and("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed")
-        })
-      })
-    })
+            .and("have.css", "position", "fixed");
+        });
+      });
+    });
 
     context("phonebox", () => {
       context("renders in the text align to right side", () => {
@@ -1206,14 +1210,14 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />,
-          )
+            />
+          );
 
           cy.findByLabelText("phonebox-input-number")
             .should("exist")
-            .and("have.css", "text-align", "end")
-        })
-      })
+            .and("have.css", "text-align", "end");
+        });
+      });
 
       context("when clicking the countrybox", () => {
         it("renders drawer in the bottom of screen", () => {
@@ -1231,18 +1235,18 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />,
-          )
+            />
+          );
 
-          cy.findByLabelText("phonebox-country-toggle").click()
+          cy.findByLabelText("phonebox-country-toggle").click();
 
           cy.findByLabelText("combobox-drawer-mobile")
             .should("exist")
             .and("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed")
-        })
-      })
-    })
+            .and("have.css", "position", "fixed");
+        });
+      });
+    });
 
     context("timebox", () => {
       context("when clicking the input", () => {
@@ -1260,19 +1264,19 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />,
-          )
+            />
+          );
 
-          cy.findByLabelText("timebox-hour").click()
+          cy.findByLabelText("timebox-hour").click();
 
           cy.findByLabelText("wheel-container")
             .should("exist")
             .and("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed")
-        })
-      })
-    })
-  })
+            .and("have.css", "position", "fixed");
+        });
+      });
+    });
+  });
 
   context("chips", () => {
     function StatefulChips() {
@@ -1281,7 +1285,7 @@ describe("StatefulForm", () => {
           selectedOptions: [],
           searchText: "",
         },
-      })
+      });
       return (
         <StatefulForm
           fields={[
@@ -1298,7 +1302,7 @@ describe("StatefulForm", () => {
             },
           ]}
           onChange={({ currentState }) => {
-            const [[key, value]] = Object.entries(currentState)
+            const [[key, value]] = Object.entries(currentState);
 
             setValue((prev) => ({
               ...prev,
@@ -1311,37 +1315,37 @@ describe("StatefulForm", () => {
                     },
                   }
                 : currentState),
-            }))
+            }));
           }}
           formValues={value}
           mode="onChange"
         />
-      )
+      );
     }
 
     context("when select one option", () => {
       it("renders option selected", () => {
-        cy.mount(<StatefulChips />)
-        cy.findByRole("button").click()
+        cy.mount(<StatefulChips />);
+        cy.findByRole("button").click();
 
-        cy.findAllByLabelText("chips-selected").should("not.exist")
+        cy.findAllByLabelText("chips-selected").should("not.exist");
 
-        cy.findByText("Anime").click()
-        cy.findByText("Manga").click()
+        cy.findByText("Anime").click();
+        cy.findByText("Manga").click();
 
-        cy.wait(400)
+        cy.wait(400);
 
         cy.findAllByLabelText("chips-selected")
           .eq(0)
           .should("exist")
-          .should("have.css", "background-color", "rgb(255, 255, 255)")
+          .should("have.css", "background-color", "rgb(255, 255, 255)");
         cy.findAllByLabelText("chips-selected")
           .eq(1)
           .should("exist")
-          .should("have.css", "background-color", "rgb(255, 255, 255)")
-      })
-    })
-  })
+          .should("have.css", "background-color", "rgb(255, 255, 255)");
+      });
+    });
+  });
 
   context("height", () => {
     it("mostly renders with 34px", () => {
@@ -1350,12 +1354,12 @@ describe("StatefulForm", () => {
           fields={ALL_INPUT}
           formValues={allValue}
           mode="onChange"
-        />,
-      )
+        />
+      );
 
       flattenFields(ALL_INPUT).map((field) => {
         if (field.type === "frame" || field.type === "chips") {
-          return
+          return;
         } else if (
           field.type === "radio" ||
           field.type === "image" ||
@@ -1367,56 +1371,56 @@ describe("StatefulForm", () => {
           cy.findAllByLabelText("radio-input-container").should(
             "have.css",
             "height",
-            "16px",
-          )
+            "16px"
+          );
           cy.findAllByLabelText("file-input-box-wrapper").should(
             "have.css",
             "height",
-            "47px",
-          )
+            "47px"
+          );
           cy.findAllByLabelText("imagebox-input").should(
             "have.css",
             "height",
-            "120px",
-          )
+            "120px"
+          );
           cy.findAllByLabelText("signbox-canvas").should(
             "have.css",
             "height",
-            "200px",
-          )
+            "200px"
+          );
           cy.findAllByLabelText("file-drop-box-area").should(
             "have.css",
             "height",
-            "221px",
-          )
+            "221px"
+          );
           cy.findAllByLabelText("signbox-canvas").should(
             "have.css",
             "height",
-            "200px",
-          )
+            "200px"
+          );
           cy.findAllByLabelText("rating-wrapper").should(
             "have.css",
             "height",
-            "24px",
-          )
+            "24px"
+          );
         } else {
           cy.findAllByLabelText("field-lane-control").should(
             "have.css",
             "height",
-            "34px",
-          )
+            "34px"
+          );
         }
-      })
-    })
-  })
+      });
+    });
+  });
 
   context("combobox", () => {
     const comboField = flattenFields(ALL_INPUT).filter(
-      (field) => field.type === "combo",
-    )
+      (field) => field.type === "combo"
+    );
 
     function ComboboxInput(props: Partial<StatefulFormProps<any>>) {
-      const [value, setValue] = useState({ combo: ["4"] })
+      const [value, setValue] = useState({ combo: ["4"] });
 
       return (
         <StatefulForm
@@ -1427,20 +1431,20 @@ describe("StatefulForm", () => {
           }
           {...props}
         />
-      )
+      );
     }
 
     beforeEach(() => {
-      cy.mount(<ComboboxInput />)
-    })
+      cy.mount(<ComboboxInput />);
+    });
 
     it("should shows value from formValues", () => {
-      cy.get("#combobox-combo").should("have.value", "Grape")
-    })
+      cy.get("#combobox-combo").should("have.value", "Grape");
+    });
 
     context("when given four comboboxes in a row", () => {
       it("renders each with a width smaller than 140px (min-width)", () => {
-        cy.viewport(500, 750)
+        cy.viewport(500, 750);
         const fields = Array.from({ length: 4 }, (_, i) => ({
           id: `combo-${i + 1}`,
           name: `combo${i + 1}`,
@@ -1451,26 +1455,26 @@ describe("StatefulForm", () => {
           combobox: {
             options: FRUIT_OPTIONS,
           },
-        }))
-        cy.mount(<StatefulForm fields={[fields]} formValues={{}} />)
+        }));
+        cy.mount(<StatefulForm fields={[fields]} formValues={{}} />);
 
         cy.then(() => {
-          const widths: number[] = []
+          const widths: number[] = [];
 
           cy.wrap(fields).each((field: (typeof fields)[number]) => {
             cy.get(`#${field.id}`).then(($el) => {
-              widths.push($el[0].getBoundingClientRect().width)
-            })
-          })
+              widths.push($el[0].getBoundingClientRect().width);
+            });
+          });
 
           cy.then(() => {
             widths.forEach((width) => {
-              expect(width).to.be.closeTo(110.5, 1)
-            })
-          })
-        })
-      })
-    })
+              expect(width).to.be.closeTo(110.5, 1);
+            });
+          });
+        });
+      });
+    });
 
     context("when given value from selectedOptions", () => {
       const comboFieldWithValue = comboField.map((field) => ({
@@ -1479,25 +1483,25 @@ describe("StatefulForm", () => {
           ...field?.combobox,
           selectedOptions: ["1"],
         },
-      }))
+      }));
 
       beforeEach(() => {
-        cy.mount(<ComboboxInput fields={comboFieldWithValue} />)
-      })
+        cy.mount(<ComboboxInput fields={comboFieldWithValue} />);
+      });
       it("should shows value from formValues", () => {
-        cy.get("#combobox-combo").should("have.value", "Apple")
-      })
-    })
-  })
+        cy.get("#combobox-combo").should("have.value", "Apple");
+      });
+    });
+  });
 
   context("with type frame", () => {
     function StatefulWithFrame() {
-      const [isFormValid, setIsFormValid] = useState(false)
+      const [isFormValid, setIsFormValid] = useState(false);
       const [value, setValue] = useState({
         start_date: [""],
         end_date: [""],
         purpose: "",
-      })
+      });
 
       const EMPLOYEE_FIELDS: FormFieldGroup[] = [
         {
@@ -1542,19 +1546,19 @@ describe("StatefulForm", () => {
           disabled: !isFormValid,
           rowJustifyPosition: "end",
         },
-      ]
+      ];
 
       const dateArraySchema = z
         .array(
-          z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date"),
+          z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date")
         )
-        .min(1, "At least one date is required")
+        .min(1, "At least one date is required");
 
       const employeeSchema = z.object({
         start_date: dateArraySchema,
         end_date: dateArraySchema,
         purpose: z.string().min(10, "Business purpose is required"),
-      })
+      });
 
       return (
         <div
@@ -1572,7 +1576,7 @@ describe("StatefulForm", () => {
         >
           <StatefulForm
             onChange={({ currentState }) => {
-              setValue((prev) => ({ ...prev, ...currentState }))
+              setValue((prev) => ({ ...prev, ...currentState }));
             }}
             fields={EMPLOYEE_FIELDS}
             onValidityChange={setIsFormValid}
@@ -1581,107 +1585,107 @@ describe("StatefulForm", () => {
             mode="onChange"
           />
         </div>
-      )
+      );
     }
 
     const initializeFrame = () => {
-      cy.mount(<StatefulWithFrame />)
+      cy.mount(<StatefulWithFrame />);
       cy.findAllByLabelText("frame").then(() => {
-        cy.findAllByLabelText("stateful-form-row").should("have.length", 4)
-        cy.get("#datebox-start_date").should("exist")
-        cy.get("#datebox-end_date").should("exist")
-        cy.get("#textbox-purpose").should("exist")
-        cy.findByRole("button").should("exist").and("be.disabled")
-      })
-    }
+        cy.findAllByLabelText("stateful-form-row").should("have.length", 4);
+        cy.get("#datebox-start_date").should("exist");
+        cy.get("#datebox-end_date").should("exist");
+        cy.get("#textbox-purpose").should("exist");
+        cy.findByRole("button").should("exist").and("be.disabled");
+      });
+    };
 
     beforeEach(() => {
-      initializeFrame()
-    })
+      initializeFrame();
+    });
 
     it("shows the form fields inside of frame", () => {
       // shows from beforeEach
-    })
+    });
 
     context("when typing", () => {
       it("should added value", () => {
         cy.get("#datebox-start_date")
           .click()
           .then(($el) => {
-            cy.findByLabelText("calendar-select-date").click()
-            cy.findByLabelText("combobox-month").click()
-            cy.findByText("March").click()
-            cy.findByLabelText("combobox-year").click()
-            cy.findByText("2026").click()
-            cy.findByText("20").click()
-            cy.wrap($el).should("have.value", "03/20/2026")
-          })
+            cy.findByLabelText("calendar-select-date").click();
+            cy.findByLabelText("combobox-month").click();
+            cy.findByText("March").click();
+            cy.findByLabelText("combobox-year").click();
+            cy.findByText("2026").click();
+            cy.findByText("20").click();
+            cy.wrap($el).should("have.value", "03/20/2026");
+          });
         cy.get("#datebox-end_date")
           .click()
           .then(($el) => {
-            cy.findByLabelText("calendar-select-date").click()
-            cy.findByLabelText("combobox-month").click()
-            cy.findByText("March").click()
-            cy.findByLabelText("combobox-year").click()
-            cy.findByText("2026").click()
-            cy.findByText("20").click()
-            cy.wrap($el).should("have.value", "03/20/2026")
-          })
+            cy.findByLabelText("calendar-select-date").click();
+            cy.findByLabelText("combobox-month").click();
+            cy.findByText("March").click();
+            cy.findByLabelText("combobox-year").click();
+            cy.findByText("2026").click();
+            cy.findByText("20").click();
+            cy.wrap($el).should("have.value", "03/20/2026");
+          });
         cy.get("#textbox-purpose")
           .type("Getting better life")
-          .should("have.value", "Getting better life")
+          .should("have.value", "Getting better life");
 
-        cy.findByRole("button").should("exist").and("not.be.disabled")
-      })
-    })
+        cy.findByRole("button").should("exist").and("not.be.disabled");
+      });
+    });
 
     context("when typing but not fully", () => {
       it("renders error validation", () => {
-        cy.findByText("Business purpose is required").should("not.exist")
+        cy.findByText("Business purpose is required").should("not.exist");
 
         cy.get("#datebox-start_date")
           .click()
           .then(($el) => {
-            cy.findByLabelText("calendar-select-date").click()
-            cy.findByLabelText("combobox-month").click()
-            cy.findByText("March").click()
-            cy.findByLabelText("combobox-year").click()
-            cy.findByText("2026").click()
-            cy.findByText("20").click()
-            cy.wrap($el).should("have.value", "03/20/2026")
-          })
+            cy.findByLabelText("calendar-select-date").click();
+            cy.findByLabelText("combobox-month").click();
+            cy.findByText("March").click();
+            cy.findByLabelText("combobox-year").click();
+            cy.findByText("2026").click();
+            cy.findByText("20").click();
+            cy.wrap($el).should("have.value", "03/20/2026");
+          });
         cy.get("#datebox-end_date")
           .click()
           .then(($el) => {
-            cy.findByLabelText("calendar-select-date").click()
-            cy.findByLabelText("combobox-month").click()
-            cy.findByText("March").click()
-            cy.findByLabelText("combobox-year").click()
-            cy.findByText("2026").click()
-            cy.findByText("20").click()
-            cy.wrap($el).should("have.value", "03/20/2026")
-          })
+            cy.findByLabelText("calendar-select-date").click();
+            cy.findByLabelText("combobox-month").click();
+            cy.findByText("March").click();
+            cy.findByLabelText("combobox-year").click();
+            cy.findByText("2026").click();
+            cy.findByText("20").click();
+            cy.wrap($el).should("have.value", "03/20/2026");
+          });
         cy.get("#textbox-purpose")
           .type("Getting")
-          .should("have.value", "Getting")
-        cy.get("body").click("bottomRight")
+          .should("have.value", "Getting");
+        cy.get("body").click("bottomRight");
 
-        cy.findByText("Business purpose is required").should("exist")
-        cy.findByRole("button").should("exist").and("be.disabled")
-      })
-    })
-  })
+        cy.findByText("Business purpose is required").should("exist");
+        cy.findByRole("button").should("exist").and("be.disabled");
+      });
+    });
+  });
 
   context("conditional form", () => {
     function ConditionalStatefulForm() {
-      const [isFormValid, setIsFormValid] = useState(false)
+      const [isFormValid, setIsFormValid] = useState(false);
       const [formFields, setFormFields] = useState({
         quantType: "",
         compEffort: "",
         scheIterations: "",
         target: "",
         hostArch: "",
-      })
+      });
 
       const schema = z.object({
         quantType: z.string().optional(),
@@ -1692,46 +1696,46 @@ describe("StatefulForm", () => {
           .optional(),
         target: z.string().min(1, "Target is required"),
         hostArch: z.string().optional(),
-      })
+      });
 
       const HostArchitecture = {
         x86: 0,
         x64: 1,
         ARM: 2,
         ARM64: 3,
-      } as const
+      } as const;
 
       const CompilationTarget = {
         Interpreter: 0,
         Simulator: 1,
         IP: 2,
-      } as const
+      } as const;
 
       const CompilationEffort = {
         SimpleScheduling: 0,
         Performance: 1,
         Aggressive: 2,
-      } as const
+      } as const;
 
       const Quantization = {
         Int8: 0,
         Bf16: 1,
         Fp16: 2,
         Fp32: 3,
-      } as const
+      } as const;
 
       const HOST_ARCHITECTURE_OPTIONS: SelectboxOption[] = [
         { value: String(HostArchitecture.x86), text: "x86" },
         { value: String(HostArchitecture.x64), text: "x64" },
         { value: String(HostArchitecture.ARM), text: "ARM" },
         { value: String(HostArchitecture.ARM64), text: "ARM64" },
-      ]
+      ];
 
       const COMPILATION_TARGET_OPTIONS: SelectboxOption[] = [
         { value: String(CompilationTarget.Interpreter), text: "Interpreter" },
         { value: String(CompilationTarget.Simulator), text: "Simulator" },
         { value: String(CompilationTarget.IP), text: "IP" },
-      ]
+      ];
 
       const COMPILATION_EFFORT_OPTIONS: SelectboxOption[] = [
         {
@@ -1746,21 +1750,21 @@ describe("StatefulForm", () => {
           value: String(CompilationEffort.Aggressive),
           text: "Aggressive",
         },
-      ]
+      ];
 
       const QUANTIZATION_TYPE_OPTIONS: SelectboxOption[] = [
         { value: String(Quantization.Int8), text: "INT8" },
         { value: String(Quantization.Bf16), text: "BF16" },
         { value: String(Quantization.Fp16), text: "FP16" },
         { value: String(Quantization.Fp32), text: "FP32" },
-      ]
+      ];
 
       const COMPILATION_FIELDS: FormFieldGroup[] = useMemo(() => {
         const isInt8Quantization =
-          formFields.quantType === String(Quantization.Int8)
+          formFields.quantType === String(Quantization.Int8);
 
         const isPerfCompilation =
-          formFields.compEffort === String(CompilationEffort.Performance)
+          formFields.compEffort === String(CompilationEffort.Performance);
 
         return [
           {
@@ -1820,13 +1824,13 @@ describe("StatefulForm", () => {
             type: "button",
             disabled: !isFormValid,
           },
-        ]
-      }, [formFields.compEffort, formFields.quantType, isFormValid])
+        ];
+      }, [formFields.compEffort, formFields.quantType, isFormValid]);
 
       return (
         <StatefulForm
           onChange={({ currentState }) => {
-            setFormFields((prev) => ({ ...prev, ...currentState }))
+            setFormFields((prev) => ({ ...prev, ...currentState }));
           }}
           onValidityChange={setIsFormValid}
           validationSchema={schema}
@@ -1834,27 +1838,27 @@ describe("StatefulForm", () => {
           formValues={formFields}
           mode="onChange"
         />
-      )
+      );
     }
 
     context("when choosen option", () => {
       it("shows the value on the another field", () => {
-        cy.mount(<ConditionalStatefulForm />)
-        cy.findAllByLabelText("stateful-form-row").should("have.length", 4)
-        cy.findByText("Compilation Effort").should("not.exist")
-        cy.findByText("Precision").should("exist").click()
-        cy.findByText("INT8").should("exist").click()
+        cy.mount(<ConditionalStatefulForm />);
+        cy.findAllByLabelText("stateful-form-row").should("have.length", 4);
+        cy.findByText("Compilation Effort").should("not.exist");
+        cy.findByText("Precision").should("exist").click();
+        cy.findByText("INT8").should("exist").click();
 
-        cy.findAllByLabelText("stateful-form-row").should("have.length", 5)
-        cy.findByText("Compilation Effort").should("exist")
-      })
-    })
-  })
+        cy.findAllByLabelText("stateful-form-row").should("have.length", 5);
+        cy.findByText("Compilation Effort").should("exist");
+      });
+    });
+  });
 
   context("disabled", () => {
     context("when given by parent", () => {
       it("should render with cursor not-allowed and user-select none", () => {
-        const onChange = cy.spy().as("onChange")
+        const onChange = cy.spy().as("onChange");
         cy.mount(
           <StatefulForm
             fields={ALL_INPUT}
@@ -1862,23 +1866,23 @@ describe("StatefulForm", () => {
             disabled={true}
             mode="onChange"
             onChange={onChange}
-          />,
-        )
+          />
+        );
 
         cy.findAllByLabelText("field-lane-wrapper")
           .should("have.css", "cursor", "not-allowed")
-          .and("have.css", "user-select", "none")
+          .and("have.css", "user-select", "none");
         cy.findAllByLabelText("chips-container-input")
           .should("have.css", "cursor", "not-allowed")
-          .and("have.css", "user-select", "none")
+          .and("have.css", "user-select", "none");
         cy.findAllByLabelText("file-drop-box-container")
           .should("have.css", "cursor", "not-allowed")
-          .and("have.css", "user-select", "none")
-      })
+          .and("have.css", "user-select", "none");
+      });
 
       context("when trying to interact", () => {
         it("should not change value", () => {
-          const onChange = cy.spy().as("onChange")
+          const onChange = cy.spy().as("onChange");
           cy.mount(
             <StatefulForm
               fields={ALL_INPUT}
@@ -1886,19 +1890,19 @@ describe("StatefulForm", () => {
               disabled={true}
               mode="onChange"
               onChange={onChange}
-            />,
-          )
+            />
+          );
 
           cy.get("input, textarea, [role='radio'], [role='checkbox']").each(
             ($el) => {
-              cy.wrap($el).should("be.disabled").click({ force: true })
-            },
-          )
+              cy.wrap($el).should("be.disabled").click({ force: true });
+            }
+          );
 
-          cy.get("@onChange").should("not.have.been.called")
-        })
-      })
-    })
+          cy.get("@onChange").should("not.have.been.called");
+        });
+      });
+    });
 
     context("when given by per field", () => {
       const INPUT_WITH_DISABLED: FormFieldGroup[] = ALL_INPUT.map((group) =>
@@ -1910,8 +1914,8 @@ describe("StatefulForm", () => {
           : {
               ...group,
               disabled: true,
-            },
-      )
+            }
+      );
       context("when given true", () => {
         it("should render with cursor not-allowed and user-select none", () => {
           cy.mount(
@@ -1924,20 +1928,20 @@ describe("StatefulForm", () => {
                   width: 480px;
                 `,
               }}
-            />,
-          )
+            />
+          );
 
           cy.findAllByLabelText("field-lane-wrapper")
             .should("have.css", "cursor", "not-allowed")
-            .and("have.css", "user-select", "none")
+            .and("have.css", "user-select", "none");
           cy.findAllByLabelText("chips-container-input")
             .should("have.css", "cursor", "not-allowed")
-            .and("have.css", "user-select", "none")
+            .and("have.css", "user-select", "none");
           cy.findAllByLabelText("file-drop-box-container")
             .should("have.css", "cursor", "not-allowed")
-            .and("have.css", "user-select", "none")
-        })
-      })
+            .and("have.css", "user-select", "none");
+        });
+      });
 
       it("should renders with disabled each input", () => {
         cy.mount(
@@ -1945,17 +1949,17 @@ describe("StatefulForm", () => {
             fields={INPUT_WITH_DISABLED}
             formValues={allValue}
             mode="onChange"
-          />,
-        )
+          />
+        );
 
         cy.get("input, textarea, [role='radio'], [role='checkbox']").each(
           ($el) => {
-            cy.wrap($el).should("be.disabled")
-          },
-        )
-      })
-    })
-  })
+            cy.wrap($el).should("be.disabled");
+          }
+        );
+      });
+    });
+  });
 
   context("label", () => {
     context("labelPosition", () => {
@@ -1970,8 +1974,8 @@ describe("StatefulForm", () => {
               : {
                   ...group,
                   labelPosition: "left",
-                },
-        )
+                }
+        );
 
         it("should render with flex-row and 25% width label", () => {
           cy.mount(
@@ -1984,26 +1988,26 @@ describe("StatefulForm", () => {
                   width: 480px;
                 `,
               }}
-            />,
-          )
+            />
+          );
 
           cy.findAllByLabelText("stateful-form-label-wrapper").each(
             ($el, i) => {
               cy.wrap($el)
                 .invoke("css", "width")
                 .then((width) => {
-                  const w = width as unknown as string
+                  const w = width as unknown as string;
                   if (i < 2) {
-                    expect(parseFloat(w)).to.be.closeTo(45, 3)
+                    expect(parseFloat(w)).to.be.closeTo(45, 3);
                   } else {
-                    expect(parseFloat(w)).to.be.closeTo(90, 6)
+                    expect(parseFloat(w)).to.be.closeTo(90, 6);
                   }
-                })
-            },
-          )
-        })
-      })
-    })
+                });
+            }
+          );
+        });
+      });
+    });
 
     context("labelWidth", () => {
       context("when given 70%", () => {
@@ -2019,8 +2023,8 @@ describe("StatefulForm", () => {
                   ...group,
                   labelPosition: "left",
                   labelWidth: "70%",
-                },
-          )
+                }
+          );
 
         it("should render with 70% width", () => {
           cy.mount(
@@ -2033,26 +2037,26 @@ describe("StatefulForm", () => {
                   width: 480px;
                 `,
               }}
-            />,
-          )
+            />
+          );
 
           cy.findAllByLabelText("stateful-form-label-wrapper").each(
             ($el, i) => {
               cy.wrap($el)
                 .invoke("css", "width")
                 .then((width) => {
-                  const w = width as unknown as string
+                  const w = width as unknown as string;
                   if (i < 2) {
-                    expect(parseFloat(w)).to.be.closeTo(100, 6)
+                    expect(parseFloat(w)).to.be.closeTo(100, 6);
                   } else {
-                    expect(parseFloat(w)).to.be.closeTo(200, 12)
+                    expect(parseFloat(w)).to.be.closeTo(200, 12);
                   }
-                })
-            },
-          )
-        })
-      })
-    })
+                });
+            }
+          );
+        });
+      });
+    });
 
     context("labelGap", () => {
       context("when given 30px", () => {
@@ -2068,8 +2072,8 @@ describe("StatefulForm", () => {
                   ...group,
                   labelPosition: "left",
                   labelGap: 30,
-                },
-          )
+                }
+          );
 
         it("should render with 30px width", () => {
           cy.mount(
@@ -2077,23 +2081,23 @@ describe("StatefulForm", () => {
               fields={INPUT_WITH_LABEL_POSITION_AND_GAP}
               formValues={allValue}
               mode="onChange"
-            />,
-          )
+            />
+          );
 
           cy.findAllByLabelText("field-lane-wrapper")
             .should("have.length", 22)
             .each(($el) => {
-              cy.wrap($el).should("have.css", "gap", "30px")
-            })
+              cy.wrap($el).should("have.css", "gap", "30px");
+            });
           cy.findAllByLabelText("file-drop-box-container")
             .should("have.length", 1)
             .each(($el) => {
-              cy.wrap($el).should("have.css", "gap", "30px")
-            })
-        })
-      })
-    })
-  })
+              cy.wrap($el).should("have.css", "gap", "30px");
+            });
+        });
+      });
+    });
+  });
 
   context("asterisk", () => {
     context("when given required", () => {
@@ -2103,25 +2107,25 @@ describe("StatefulForm", () => {
             fields={ALL_INPUT}
             formValues={allValue}
             mode="onChange"
-          />,
-        )
+          />
+        );
 
         const inputWithRequired = flattenFields(ALL_INPUT).filter(
-          (props) => props.required,
-        )
+          (props) => props.required
+        );
 
         cy.findAllByLabelText("stateful-form-label-asterisk").should(
           "have.length",
-          inputWithRequired.length,
-        )
-      })
-    })
-  })
+          inputWithRequired.length
+        );
+      });
+    });
+  });
 
   context("pinbox", () => {
     const pinboxSchema = z.object({
       pin: z.string().min(4, "Pinbox does not follow the acceptable format"),
-    })
+    });
 
     const FIELDS: FormFieldGroup[] = [
       {
@@ -2134,10 +2138,10 @@ describe("StatefulForm", () => {
           parts: PARTS_INPUT,
         },
       },
-    ]
+    ];
 
     function PinboxProduct() {
-      const [state, setState] = useState({ pin: "" })
+      const [state, setState] = useState({ pin: "" });
       return (
         <StatefulForm
           validationSchema={pinboxSchema}
@@ -2145,36 +2149,36 @@ describe("StatefulForm", () => {
           fields={FIELDS}
           formValues={state}
         />
-      )
+      );
     }
 
     context("validation error", () => {
       context("when pressing 2 character (not eligible)", () => {
         it("should not show an error", () => {
-          cy.mount(<PinboxProduct />)
-          cy.findAllByRole("textbox").eq(1).type("23")
+          cy.mount(<PinboxProduct />);
+          cy.findAllByRole("textbox").eq(1).type("23");
           cy.findByText("Pinbox does not follow the acceptable format").should(
-            "not.exist",
-          )
-        })
+            "not.exist"
+          );
+        });
 
         context("when blurring from the input", () => {
           it("should displaying an error", () => {
-            cy.mount(<PinboxProduct />)
-            cy.findAllByRole("textbox").eq(1).type("23")
+            cy.mount(<PinboxProduct />);
+            cy.findAllByRole("textbox").eq(1).type("23");
             cy.findByText(
-              "Pinbox does not follow the acceptable format",
-            ).should("not.exist")
-            cy.get("body").click("top")
-            cy.wait(200)
+              "Pinbox does not follow the acceptable format"
+            ).should("not.exist");
+            cy.get("body").click("top");
+            cy.wait(200);
             cy.findByText(
-              "Pinbox does not follow the acceptable format",
-            ).should("exist")
-          })
-        })
-      })
-    })
-  })
+              "Pinbox does not follow the acceptable format"
+            ).should("exist");
+          });
+        });
+      });
+    });
+  });
 
   context("button", () => {
     const VARIANTS = [
@@ -2213,13 +2217,13 @@ describe("StatefulForm", () => {
         hover: "rgb(42, 115, 195)",
         active: "rgb(30, 91, 168)",
       },
-    ] as const
+    ] as const;
 
     context("when hover", () => {
       it("renders the the hover color", () => {
         cy.window().then((win) => {
-          cy.spy(win.console, "log").as("consoleLog")
-        })
+          cy.spy(win.console, "log").as("consoleLog");
+        });
 
         cy.mount(
           <StatefulForm
@@ -2234,25 +2238,25 @@ describe("StatefulForm", () => {
             }))}
             formValues={{}}
             mode="onChange"
-          />,
-        )
+          />
+        );
 
         VARIANTS.forEach(({ hover }, index) => {
           cy.findAllByRole("button")
             .eq(index)
             .realHover()
             .wait(200)
-            .should("have.css", "background-color", hover)
-        })
-      })
-    })
+            .should("have.css", "background-color", hover);
+        });
+      });
+    });
 
     context("when given an onClick", () => {
       context("when clicking", () => {
         it("renders the the active with usual color", () => {
           cy.window().then((win) => {
-            cy.spy(win.console, "log").as("consoleLog")
-          })
+            cy.spy(win.console, "log").as("consoleLog");
+          });
 
           cy.mount(
             <StatefulForm
@@ -2268,24 +2272,24 @@ describe("StatefulForm", () => {
               }))}
               formValues={{}}
               mode="onChange"
-            />,
-          )
+            />
+          );
 
           VARIANTS.forEach(({ active }, index) => {
-            cy.findAllByRole("button").eq(index).realMouseDown()
+            cy.findAllByRole("button").eq(index).realMouseDown();
 
             cy.findAllByRole("button")
               .eq(index)
-              .should("have.css", "background-color", active)
+              .should("have.css", "background-color", active);
 
-            cy.findAllByRole("button").eq(index).realMouseUp()
-          })
-        })
+            cy.findAllByRole("button").eq(index).realMouseUp();
+          });
+        });
 
         it("renders the callback from top-level", () => {
           cy.window().then((win) => {
-            cy.spy(win.console, "log").as("consoleLog")
-          })
+            cy.spy(win.console, "log").as("consoleLog");
+          });
 
           cy.mount(
             <StatefulForm
@@ -2300,24 +2304,24 @@ describe("StatefulForm", () => {
               ]}
               formValues={{}}
               mode="onChange"
-            />,
-          )
+            />
+          );
 
-          cy.findByRole("button").eq(0).click()
+          cy.findByRole("button").eq(0).click();
 
           cy.get("@consoleLog").should(
             "have.been.calledWith",
-            "this is callback from the top level",
-          )
-        })
-      })
+            "this is callback from the top level"
+          );
+        });
+      });
 
       context("when given a buttonProps.onClick", () => {
         context("when clicking", () => {
           it("renders the callback from buttonProps instead", () => {
             cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog")
-            })
+              cy.spy(win.console, "log").as("consoleLog");
+            });
 
             cy.mount(
               <StatefulForm
@@ -2336,20 +2340,20 @@ describe("StatefulForm", () => {
                 ]}
                 formValues={{}}
                 mode="onChange"
-              />,
-            )
+              />
+            );
 
-            cy.findByRole("button").eq(0).click()
+            cy.findByRole("button").eq(0).click();
 
             cy.get("@consoleLog").should(
               "have.been.calledWith",
-              "this is callback from the specific level",
-            )
-          })
-        })
-      })
-    })
-  })
+              "this is callback from the specific level"
+            );
+          });
+        });
+      });
+    });
+  });
 
   context("when array of array", () => {
     const value = {
@@ -2360,7 +2364,7 @@ describe("StatefulForm", () => {
       note: "",
       access: false,
       country_code: DEFAULT_COUNTRY_CODES,
-    }
+    };
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
@@ -2407,7 +2411,7 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ]
+    ];
 
     it("render in the one row", () => {
       cy.mount(
@@ -2415,20 +2419,20 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS}
           formValues={value}
           mode="onChange"
-        />,
-      )
+        />
+      );
       cy.findAllByLabelText("stateful-form-row")
         .eq(0)
         .within(() => {
-          cy.contains("First Name").should("exist")
-          cy.contains("Last Name").should("exist")
+          cy.contains("First Name").should("exist");
+          cy.contains("Last Name").should("exist");
 
-          cy.contains("Email").should("not.exist")
-          cy.contains("Phone Number").should("not.exist")
-          cy.contains("Note").should("not.exist")
-          cy.contains("Has access to login").should("not.exist")
-        })
-    })
+          cy.contains("Email").should("not.exist");
+          cy.contains("Phone Number").should("not.exist");
+          cy.contains("Note").should("not.exist");
+          cy.contains("Has access to login").should("not.exist");
+        });
+    });
 
     context("when given without title", () => {
       const FIELDS_WITHOUT_TITLE: FormFieldGroup[] = [
@@ -2481,63 +2485,63 @@ describe("StatefulForm", () => {
             type: "button",
           },
         ],
-      ]
+      ];
 
       it("should not break the height", () => {
-        cy.viewport(1000, 900)
+        cy.viewport(1000, 900);
         cy.mount(
           <StatefulForm
             fields={FIELDS_WITHOUT_TITLE}
             formValues={value}
             mode="onChange"
-          />,
-        )
+          />
+        );
 
         cy.findAllByLabelText("stateful-form-row")
           .eq(0)
           .within(() => {
-            cy.contains("First Name").should("exist")
-            cy.contains("Last Name").should("not.exist")
-            cy.contains("Phone").should("not.exist")
-            cy.contains("Combo").should("not.exist")
+            cy.contains("First Name").should("exist");
+            cy.contains("Last Name").should("not.exist");
+            cy.contains("Phone").should("not.exist");
+            cy.contains("Combo").should("not.exist");
           })
-          .should("have.css", "height", "60px")
+          .should("have.css", "height", "60px");
 
         cy.get("#textbox-first_name")
           .parent()
           .parent()
-          .should("have.css", "height", "60px")
+          .should("have.css", "height", "60px");
         cy.get("#textbox-last_name")
           .parent()
           .parent()
-          .should("have.css", "height", "60px")
+          .should("have.css", "height", "60px");
         cy.get("#phonebox-phone")
           .parent()
           .parent()
           .parent()
-          .should("have.css", "height", "60px")
+          .should("have.css", "height", "60px");
         cy.get("#capsule-capsule")
           .parent()
           .parent()
           .parent()
-          .should("have.css", "height", "60px")
+          .should("have.css", "height", "60px");
         cy.get("#combobox-combo")
           .parent()
           .parent()
           .parent()
-          .should("have.css", "height", "60px")
+          .should("have.css", "height", "60px");
         cy.get("#datebox-date")
           .parent()
           .parent()
           .parent()
-          .should("have.css", "height", "60px")
+          .should("have.css", "height", "60px");
         cy.findAllByRole("button")
           .eq(1)
           .parent()
-          .should("have.css", "margin-top", "26px")
-      })
-    })
-  })
+          .should("have.css", "margin-top", "26px");
+      });
+    });
+  });
 
   context("id", () => {
     it("renders each field with a proper and unique ID", () => {
@@ -2546,26 +2550,26 @@ describe("StatefulForm", () => {
           fields={ALL_INPUT}
           formValues={allValue}
           mode="onChange"
-        />,
-      )
+        />
+      );
 
       flattenFields(ALL_INPUT).map((field) => {
         if (field.type === "frame" || field.type === "chips") {
-          return
+          return;
         } else if (field.type === "radio") {
-          cy.get(`#radio-value-radio`).should("exist")
+          cy.get(`#radio-value-radio`).should("exist");
         } else {
           const prefix =
             TYPE_TO_ID_PREFIX[field.type] ??
-            field.type.replace(/\s+/g, "_").toLowerCase()
+            field.type.replace(/\s+/g, "_").toLowerCase();
           const expectedId = field.name
             ? `${prefix}-${field.name.replace(/\s+/g, "_").toLowerCase()}`
-            : prefix
+            : prefix;
 
-          cy.get(`#${expectedId}`).should("exist")
+          cy.get(`#${expectedId}`).should("exist");
         }
-      })
-    })
+      });
+    });
 
     context("when given with non-ASCII IDs", () => {
       const FIELDS_NOT_NORMAL_ASCII: FormFieldGroup[] = [
@@ -2694,7 +2698,7 @@ describe("StatefulForm", () => {
           required: false,
           id: "field-signature-✍️ sign here!",
         },
-      ]
+      ];
 
       it("renders sanitized ASCII-only IDs for input elements", () => {
         cy.mount(
@@ -2702,12 +2706,12 @@ describe("StatefulForm", () => {
             fields={FIELDS_NOT_NORMAL_ASCII}
             formValues={allValue}
             mode="onChange"
-          />,
-        )
+          />
+        );
 
         const sanitized = flattenFields(FIELDS_NOT_NORMAL_ASCII).map((field) =>
-          StatefulForm.sanitizeId({ id: field.id }),
-        )
+          StatefulForm.sanitizeId({ id: field.id })
+        );
 
         const expected = [
           "field-text-_hello_world",
@@ -2726,14 +2730,14 @@ describe("StatefulForm", () => {
           "field-money-_1000",
           "field-phone-_askdaosdk",
           "field-signature-_sign_here",
-        ]
+        ];
 
         sanitized.map((result, i) => {
-          expect(result).to.equal(expected[i])
-        })
-      })
-    })
-  })
+          expect(result).to.equal(expected[i]);
+        });
+      });
+    });
+  });
 
   context("with type custom", () => {
     function StatefulFormCustom() {
@@ -2741,9 +2745,9 @@ describe("StatefulForm", () => {
         first_name: "",
         access: false,
         files: [],
-      })
+      });
 
-      const [isFormValid, setIsFormValid] = useState(false)
+      const [isFormValid, setIsFormValid] = useState(false);
 
       const onFileDropped = async ({
         error,
@@ -2751,28 +2755,28 @@ describe("StatefulForm", () => {
         setProgressLabel,
         succeed,
       }: OnFileDroppedFunctionArgs) => {
-        const file = files[0]
-        setValue((prev) => ({ ...prev, files: [...prev.files, file] }))
-        setProgressLabel(`Uploading ${file.name}`)
+        const file = files[0];
+        setValue((prev) => ({ ...prev, files: [...prev.files, file] }));
+        setProgressLabel(`Uploading ${file.name}`);
 
         return new Promise<void>((resolve) => {
-          let progress = 0
+          let progress = 0;
           const interval = setInterval(() => {
-            progress += 20
+            progress += 20;
 
             if (progress >= 100) {
-              clearInterval(interval)
+              clearInterval(interval);
               if (file === null) {
-                error(file, `file ${file.name} is not uploaded`)
+                error(file, `file ${file.name} is not uploaded`);
               } else {
-                succeed(file)
+                succeed(file);
               }
-              setProgressLabel(`Uploaded ${files[0].name}`)
-              resolve()
+              setProgressLabel(`Uploaded ${files[0].name}`);
+              resolve();
             }
-          }, 300)
-        })
-      }
+          }, 300);
+        });
+      };
 
       const onComplete = async ({
         failedFiles,
@@ -2781,14 +2785,14 @@ describe("StatefulForm", () => {
         hideProgressLabel,
         showUploaderForm,
       }: OnCompleteFunctionArgs) => {
-        console.log(succeedFiles, "This is succeedFiles")
-        console.log(failedFiles, "This is failedFiles")
+        console.log(succeedFiles, "This is succeedFiles");
+        console.log(failedFiles, "This is failedFiles");
         await setProgressLabel(
-          `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`,
-        )
-        await hideProgressLabel()
-        await showUploaderForm()
-      }
+          `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`
+        );
+        await hideProgressLabel();
+        await showUploaderForm();
+      };
 
       const CUSTOM_FIELDS: FormFieldGroup[] = [
         {
@@ -2865,9 +2869,9 @@ describe("StatefulForm", () => {
                             setValue((prev) => ({
                               ...prev,
                               files: prev.files.filter(
-                                (val) => val.name !== id,
+                                (val) => val.name !== id
                               ),
-                            }))
+                            }));
                           }
                         },
                       },
@@ -2901,7 +2905,7 @@ describe("StatefulForm", () => {
           disabled: !isFormValid,
           rowJustifyPosition: "end",
         },
-      ]
+      ];
 
       const customSchema = z.object({
         first_name: z
@@ -2914,29 +2918,29 @@ describe("StatefulForm", () => {
           .array(
             z.instanceof(File).refine(
               (file) => {
-                if (!file) return false
+                if (!file) return false;
 
-                const allowedExtensions = ["png", "jpg", "jpeg", "gif"]
-                const ext = file.name.split(".").pop()?.toLowerCase()
+                const allowedExtensions = ["png", "jpg", "jpeg", "gif"];
+                const ext = file.name.split(".").pop()?.toLowerCase();
 
                 const isImage =
                   (file.type && file.type.startsWith("image/")) ||
-                  (ext ? allowedExtensions.includes(ext) : false)
+                  (ext ? allowedExtensions.includes(ext) : false);
 
-                if (!isImage) return false
+                if (!isImage) return false;
 
-                if (file.size > 5 * 1024 * 1024) return false
+                if (file.size > 5 * 1024 * 1024) return false;
 
-                return true
+                return true;
               },
               {
                 message:
                   "File must be an image (png, jpg, jpeg, gif) and ≤ 5 MB",
-              },
-            ),
+              }
+            )
           )
           .min(1, "At least one file must be selected"),
-      })
+      });
 
       return (
         <StatefulForm
@@ -2949,25 +2953,25 @@ describe("StatefulForm", () => {
           }
           mode="onChange"
         />
-      )
+      );
     }
 
     it("should render custom renderer", () => {
-      cy.mount(<StatefulFormCustom />)
+      cy.mount(<StatefulFormCustom />);
 
-      cy.findByLabelText("boxbar-toggle").click()
+      cy.findByLabelText("boxbar-toggle").click();
 
       BADGE_OPTIONS_FULL.map((data) => {
-        cy.findByText(data.caption).should("exist")
-      })
-    })
+        cy.findByText(data.caption).should("exist");
+      });
+    });
 
     context("when given validationSchema", () => {
       it("should synchronize values after all fields valid", () => {
-        cy.mount(<StatefulFormCustom />)
-        cy.findAllByRole("button").eq(1).and("be.disabled")
+        cy.mount(<StatefulFormCustom />);
+        cy.findAllByRole("button").eq(1).and("be.disabled");
 
-        cy.get("#textbox-first_name").type("Alim Naufal")
+        cy.get("#textbox-first_name").type("Alim Naufal");
         cy.findByLabelText("file-drop-box-area").selectFile(
           [
             "test/fixtures/test-images/sample-1.jpg",
@@ -2976,21 +2980,21 @@ describe("StatefulForm", () => {
           {
             action: "drag-drop",
             force: true,
-          },
-        )
-        cy.wait(1000)
+          }
+        );
+        cy.wait(1000);
 
         cy.findByLabelText("file-drop-box-area").then(($input) => {
-          cy.spy($input[0], "click").as("fileClick")
-        })
-        cy.findByText("sample-1.jpg").should("be.visible").click()
-        cy.findByText("sample-2.jpg").should("be.visible").click()
-        cy.findByText("Access").should("be.visible").click()
+          cy.spy($input[0], "click").as("fileClick");
+        });
+        cy.findByText("sample-1.jpg").should("be.visible").click();
+        cy.findByText("sample-2.jpg").should("be.visible").click();
+        cy.findByText("Access").should("be.visible").click();
 
-        cy.findAllByRole("button").eq(1).and("not.be.disabled")
-      })
-    })
-  })
+        cy.findAllByRole("button").eq(1).and("not.be.disabled");
+      });
+    });
+  });
 
   context("helper", () => {
     const INPUT_WITH_HELPER = ALL_INPUT.map((group) =>
@@ -3002,10 +3006,10 @@ describe("StatefulForm", () => {
         : {
             ...group,
             helper: FIELD_HELPERS[group.type],
-          },
-    )
+          }
+    );
 
-    const FLAT_INPUT = INPUT_WITH_HELPER.flatMap((props) => props)
+    const FLAT_INPUT = INPUT_WITH_HELPER.flatMap((props) => props);
 
     it("renders with tooltip", () => {
       cy.mount(
@@ -3013,17 +3017,17 @@ describe("StatefulForm", () => {
           fields={INPUT_WITH_HELPER}
           formValues={allValue}
           mode="onChange"
-        />,
-      )
+        />
+      );
 
       cy.findAllByLabelText("tooltip-trigger")
         .should("have.length", FLAT_INPUT.length)
         .each(($el, index) => {
-          cy.wrap($el).trigger("mouseover")
+          cy.wrap($el).trigger("mouseover");
 
-          cy.findByText(String(FLAT_INPUT[index].helper))
-        })
-    })
+          cy.findByText(String(FLAT_INPUT[index].helper));
+        });
+    });
 
     context("with reactNode", () => {
       const INPUT_WITH_HELPER_REACTNODE = ALL_INPUT.map(
@@ -3052,22 +3056,22 @@ describe("StatefulForm", () => {
               fields={INPUT_WITH_HELPER_REACTNODE}
               formValues={allValue}
               mode="onChange"
-            />,
-          )
+            />
+          );
 
           cy.findAllByLabelText("tooltip-trigger")
             .should("have.length", FLAT_INPUT.length)
             .each(($el, index) => {
-              cy.wrap($el).trigger("mouseover")
+              cy.wrap($el).trigger("mouseover");
 
               cy.findAllByLabelText("helper-with-react-node")
                 .eq(index)
-                .should("have.text", FLAT_INPUT[index].helper)
-            })
-        }),
-      )
-    })
-  })
+                .should("have.text", FLAT_INPUT[index].helper);
+            });
+        })
+      );
+    });
+  });
 
   context("with style", () => {
     context("when given background wheat", () => {
@@ -3222,7 +3226,7 @@ describe("StatefulForm", () => {
             },
           },
         },
-      }
+      };
 
       const INPUT_WITH_STYLE = ALL_INPUT.map((group) =>
         Array.isArray(group)
@@ -3233,8 +3237,8 @@ describe("StatefulForm", () => {
           : {
               ...group,
               ...FIELD_STYLES[group.type],
-            },
-      )
+            }
+      );
 
       it("renders with background wheat", () => {
         cy.mount(
@@ -3242,15 +3246,15 @@ describe("StatefulForm", () => {
             fields={INPUT_WITH_STYLE}
             formValues={allValue}
             mode="onChange"
-          />,
-        )
+          />
+        );
 
         const isFieldWithPlaceholder = (
-          field: FormFieldGroup,
+          field: FormFieldGroup
         ): field is FormFieldProps & { placeholder: string } =>
           !Array.isArray(field) &&
           "placeholder" in field &&
-          typeof field.placeholder === "string"
+          typeof field.placeholder === "string";
 
         const PLACEHOLDER_FIELDS = INPUT_WITH_STYLE.filter(
           (field): field is FormFieldProps & { placeholder: string } =>
@@ -3268,48 +3272,48 @@ describe("StatefulForm", () => {
               "date",
               "signature",
               "image",
-            ].includes(field.type),
-        )
+            ].includes(field.type)
+        );
 
         PLACEHOLDER_FIELDS.forEach((field) => {
           if (field.type === "image") {
             cy.findByPlaceholderText("imagebox-input")
               .should("exist")
-              .and("have.css", "background-color", "rgb(245, 222, 179)")
+              .and("have.css", "background-color", "rgb(245, 222, 179)");
           } else if (field.type === "signbox") {
             cy.findByPlaceholderText("signbox-canvas")
               .should("exist")
-              .and("have.css", "background-color", "rgb(245, 222, 179)")
+              .and("have.css", "background-color", "rgb(245, 222, 179)");
           } else if (field.type === "phone") {
             cy.findByPlaceholderText(field.placeholder)
               .should("exist")
               .parent()
-              .and("have.css", "background-color", "rgb(245, 222, 179)")
+              .and("have.css", "background-color", "rgb(245, 222, 179)");
           } else if (field.type === "color") {
             cy.findByPlaceholderText(field.placeholder)
               .should("exist")
               .parent()
               .parent()
-              .and("have.css", "background-color", "rgb(245, 222, 179)")
+              .and("have.css", "background-color", "rgb(245, 222, 179)");
           } else if (field.type === "money") {
             cy.findByPlaceholderText(field.placeholder)
               .should("exist")
               .parent()
-              .and("have.css", "background-color", "rgb(245, 222, 179)")
+              .and("have.css", "background-color", "rgb(245, 222, 179)");
           } else {
             cy.findByPlaceholderText(field.placeholder)
               .should("exist")
-              .and("have.css", "background-color", "rgb(245, 222, 179)")
+              .and("have.css", "background-color", "rgb(245, 222, 179)");
           }
-        })
-      })
-    })
-  })
+        });
+      });
+    });
+  });
 
   context("radio", () => {
     const value = {
       access: false,
-    }
+    };
 
     const RADIO_FIELDS: FormFieldGroup[] = [
       {
@@ -3319,7 +3323,7 @@ describe("StatefulForm", () => {
         type: "radio",
         required: false,
       },
-    ]
+    ];
     context("with title", () => {
       it("should render on the label field", () => {
         cy.mount(
@@ -3327,12 +3331,12 @@ describe("StatefulForm", () => {
             fields={RADIO_FIELDS}
             formValues={value}
             mode="onChange"
-          />,
-        )
+          />
+        );
 
-        cy.findAllByText(RADIO_FIELDS[0]["title"]).eq(0).should("be.visible")
-      })
-    })
+        cy.findAllByText(RADIO_FIELDS[0]["title"]).eq(0).should("be.visible");
+      });
+    });
 
     context("with placeholder", () => {
       it("should render on the right side", () => {
@@ -3341,21 +3345,21 @@ describe("StatefulForm", () => {
             fields={RADIO_FIELDS}
             formValues={value}
             mode="onChange"
-          />,
-        )
+          />
+        );
 
         cy.findByLabelText("radio-label-wrapper").should(
           "have.text",
-          RADIO_FIELDS[0]["placeholder"],
-        )
-      })
-    })
-  })
+          RADIO_FIELDS[0]["placeholder"]
+        );
+      });
+    });
+  });
 
   context("capsule", () => {
     const value = {
       capsule: "unpaid",
-    }
+    };
 
     context("when initial value", () => {
       const CHECKBOX_TITLE_FIELDS: FormFieldGroup[] = [
@@ -3368,7 +3372,7 @@ describe("StatefulForm", () => {
             tabs: CAPSULE_TABS,
           },
         },
-      ]
+      ];
 
       it("should render active related with id value", () => {
         cy.mount(
@@ -3376,23 +3380,23 @@ describe("StatefulForm", () => {
             fields={CHECKBOX_TITLE_FIELDS}
             formValues={value}
             mode="onChange"
-          />,
-        )
+          />
+        );
 
-        cy.findByText("Paid").should("have.css", "color", "rgb(17, 24, 39)")
+        cy.findByText("Paid").should("have.css", "color", "rgb(17, 24, 39)");
         cy.findByText("Unpaid").should(
           "have.css",
           "color",
-          "rgb(255, 255, 255)",
-        )
-      })
-    })
-  })
+          "rgb(255, 255, 255)"
+        );
+      });
+    });
+  });
 
   context("checkbox", () => {
     const value = {
       access: false,
-    }
+    };
 
     const CHECKBOX_TITLE_FIELDS: FormFieldGroup[] = [
       {
@@ -3402,7 +3406,7 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ]
+    ];
 
     const statefulForCheckbox = () =>
       cy.mount(
@@ -3410,49 +3414,49 @@ describe("StatefulForm", () => {
           fields={CHECKBOX_TITLE_FIELDS}
           formValues={value}
           mode="onChange"
-        />,
-      )
+        />
+      );
 
     context("with title", () => {
       it("should render on the label field", () => {
-        statefulForCheckbox()
+        statefulForCheckbox();
 
         cy.findAllByText(CHECKBOX_TITLE_FIELDS[0]["title"])
           .eq(0)
-          .should("be.visible")
-      })
+          .should("be.visible");
+      });
 
       context("when clicking", () => {
         it("renders checked the checkbox", () => {
-          statefulForCheckbox()
+          statefulForCheckbox();
 
-          cy.findByRole("checkbox").should("not.be.checked")
-          cy.findByText("Access").click()
-          cy.findByRole("checkbox").should("be.checked")
-        })
-      })
-    })
+          cy.findByRole("checkbox").should("not.be.checked");
+          cy.findByText("Access").click();
+          cy.findByRole("checkbox").should("be.checked");
+        });
+      });
+    });
 
     context("with placeholder", () => {
       it("should render on the right side", () => {
-        statefulForCheckbox()
+        statefulForCheckbox();
 
         cy.findAllByText(CHECKBOX_TITLE_FIELDS[0]["placeholder"])
           .eq(0)
-          .should("be.visible")
-      })
+          .should("be.visible");
+      });
 
       context("when clicking", () => {
         it("renders checked the checkbox", () => {
-          statefulForCheckbox()
+          statefulForCheckbox();
 
-          cy.findByRole("checkbox").should("not.be.checked")
-          cy.findByText("Access placeholder").click()
-          cy.findByRole("checkbox").should("be.checked")
-        })
-      })
-    })
-  })
+          cy.findByRole("checkbox").should("not.be.checked");
+          cy.findByText("Access placeholder").click();
+          cy.findByRole("checkbox").should("be.checked");
+        });
+      });
+    });
+  });
 
   context("with justifyContent", () => {
     const value = {
@@ -3463,7 +3467,7 @@ describe("StatefulForm", () => {
       note: "",
       access: false,
       country_code: DEFAULT_COUNTRY_CODES,
-    }
+    };
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
@@ -3519,7 +3523,7 @@ describe("StatefulForm", () => {
         width: "15%",
         rowJustifyPosition: "end",
       },
-    ]
+    ];
 
     it("render style align on the one row", () => {
       cy.mount(
@@ -3527,14 +3531,14 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS}
           formValues={value}
           mode="onChange"
-        />,
-      )
+        />
+      );
 
       cy.findAllByLabelText("stateful-form-row")
         .eq(5)
-        .should("have.css", "justify-content", "end")
-    })
-  })
+        .should("have.css", "justify-content", "end");
+    });
+  });
 
   context("with autoFocusField", () => {
     const value = {
@@ -3545,7 +3549,7 @@ describe("StatefulForm", () => {
       note: "",
       access: false,
       country_code: DEFAULT_COUNTRY_CODES,
-    }
+    };
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
@@ -3592,7 +3596,7 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ]
+    ];
 
     it("render in the one row", () => {
       cy.mount(
@@ -3601,21 +3605,21 @@ describe("StatefulForm", () => {
           formValues={value}
           mode="onChange"
           autoFocusField="first_name"
-        />,
-      )
+        />
+      );
       cy.findAllByLabelText("stateful-form-row")
         .eq(0)
         .within(() => {
-          cy.findAllByRole("textbox").eq(0).should("exist").and("be.focused")
-        })
-    })
-  })
+          cy.findAllByRole("textbox").eq(0).should("exist").and("be.focused");
+        });
+    });
+  });
 
   context("when not given a title", () => {
     const value = {
       first_name: "",
       access: false,
-    }
+    };
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       {
@@ -3630,11 +3634,11 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ]
+    ];
 
-    const TITLE_EMPLOYEE_FIELD = ["First Name", "Has access to login"]
+    const TITLE_EMPLOYEE_FIELD = ["First Name", "Has access to login"];
 
-    const PLACEHOLDER_EMPLOYEE_FIELD = ["Enter first name"]
+    const PLACEHOLDER_EMPLOYEE_FIELD = ["Enter first name"];
 
     it("should render only the input", () => {
       cy.mount(
@@ -3642,22 +3646,22 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS}
           formValues={value}
           mode="onChange"
-        />,
-      )
+        />
+      );
       PLACEHOLDER_EMPLOYEE_FIELD.map((data) => {
-        cy.findByPlaceholderText(data).should("exist")
-      })
+        cy.findByPlaceholderText(data).should("exist");
+      });
       TITLE_EMPLOYEE_FIELD.map((data) => {
-        cy.findByText(data).should("not.exist")
-      })
-    })
-  })
+        cy.findByText(data).should("not.exist");
+      });
+    });
+  });
 
   context("with hidden", () => {
     const value = {
       first_name: "",
       access: false,
-    }
+    };
 
     const EMPLOYEE_FIELDS_WITH_HIDDEN: FormFieldGroup[] = [
       {
@@ -3681,7 +3685,7 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ]
+    ];
 
     it("should hidden the input element", () => {
       cy.mount(
@@ -3689,13 +3693,15 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS_WITH_HIDDEN}
           formValues={value}
           mode="onChange"
-        />,
-      )
+        />
+      );
 
-      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[0]["title"]).should("exist")
-      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[1]["title"]).should("not.exist")
-      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[2]["title"]).should("exist")
-    })
+      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[0]["title"]).should("exist");
+      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[1]["title"]).should(
+        "not.exist"
+      );
+      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[2]["title"]).should("exist");
+    });
 
     it("should hidden the row input element", () => {
       cy.mount(
@@ -3703,12 +3709,12 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS_WITH_HIDDEN}
           formValues={value}
           mode="onChange"
-        />,
-      )
+        />
+      );
 
-      cy.findAllByLabelText("stateful-form-row").should("have.length", 2)
-    })
-  })
+      cy.findAllByLabelText("stateful-form-row").should("have.length", 2);
+    });
+  });
 
   context("with width", () => {
     context("when given all input elements", () => {
@@ -3716,44 +3722,44 @@ describe("StatefulForm", () => {
         const INPUT_WITH_WIDTH = ALL_INPUT.map((group) =>
           Array.isArray(group)
             ? group.map((item) => ({ ...item, width: "50%" }))
-            : { ...group, width: "50%" },
-        )
+            : { ...group, width: "50%" }
+        );
 
         cy.mount(
           <StatefulForm
             fields={INPUT_WITH_WIDTH}
             formValues={allValue}
             mode="onChange"
-          />,
-        )
+          />
+        );
 
         flattenFields(INPUT_WITH_WIDTH).forEach((prop) => {
-          if (prop.name === "country_code") return
+          if (prop.name === "country_code") return;
           if (prop.name === "toggle") {
             cy.findByLabelText("toggle-row-wrapper").then(($el) => {
-              const width = $el.width()
-              expect(width).to.be.closeTo(222.5, 10)
-            })
+              const width = $el.width();
+              expect(width).to.be.closeTo(222.5, 10);
+            });
           } else {
             cy.findByText(prop.title)
               .parent()
               .then(($el) => {
-                const elWidth = $el.width()
-                expect(elWidth).to.be.closeTo(222.5, 10)
-              })
+                const elWidth = $el.width();
+                expect(elWidth).to.be.closeTo(222.5, 10);
+              });
           }
-        })
-      })
+        });
+      });
 
       context("when using small screen", () => {
         it("still render input elements with sizing", () => {
           const INPUT_WITH_WIDTH = ALL_INPUT.map((group) =>
             Array.isArray(group)
               ? group.map((item) => ({ ...item, width: "50%" }))
-              : { ...group, width: "50%" },
-          )
+              : { ...group, width: "50%" }
+          );
 
-          cy.viewport(440, 750)
+          cy.viewport(440, 750);
           // assume this in phone
 
           cy.mount(
@@ -3761,27 +3767,27 @@ describe("StatefulForm", () => {
               fields={INPUT_WITH_WIDTH}
               formValues={allValue}
               mode="onChange"
-            />,
-          )
+            />
+          );
 
           flattenFields(INPUT_WITH_WIDTH).forEach((prop) => {
-            if (prop.name === "country_code") return
+            if (prop.name === "country_code") return;
             if (prop.name === "toggle") {
               cy.findByLabelText("toggle-row-wrapper").then(($el) => {
-                const width = $el.width()
-                expect(width).to.be.closeTo(197.5, 10)
-              })
+                const width = $el.width();
+                expect(width).to.be.closeTo(197.5, 10);
+              });
             } else {
               cy.findByText(prop.title)
                 .parent()
                 .then(($el) => {
-                  const elWidth = $el.width()
-                  expect(elWidth).to.be.closeTo(197.5, 10)
-                })
+                  const elWidth = $el.width();
+                  expect(elWidth).to.be.closeTo(197.5, 10);
+                });
             }
-          })
-        })
-      })
-    })
-  })
-})
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -317,6 +317,32 @@ const ALL_INPUT: FormFieldGroup[] = [
   },
 ]
 
+const FIELD_HELPERS: Record<string, string> = {
+  text: "Enter any text value.",
+  email: "Enter a valid email address.",
+  number: "Enter a numeric value.",
+  password: "Enter a secure password.",
+  textarea: "Enter a longer message.",
+  time: "Select a time value.",
+  pin: "Enter your PIN code.",
+  checkbox: "Toggle the checkbox.",
+  radio: "Select one option.",
+  color: "Choose a color.",
+  combo: "Select an option from the list.",
+  date: "Select a date.",
+  file_drop_box: "Drag and drop a file here.",
+  file: "Upload a file.",
+  image: "Upload an image.",
+  money: "Enter a monetary value.",
+  phone: "Enter a phone number.",
+  signbox: "Provide your signature.",
+  rating: "Rate the item.",
+  thumbfield: "Upload or select a thumbnail.",
+  toggle: "Toggle the switch.",
+  chips: "Select one or more chips.",
+  capsule: "Choose a monetary option.",
+}
+
 const flattenFields = (groups: FormFieldGroup[]): FormFieldProps[] =>
   groups.flatMap((group) =>
     Array.isArray(group) ? flattenFields(group) : [group],
@@ -554,6 +580,117 @@ describe("StatefulForm", () => {
 
   context("mobile", () => {
     context("styles", () => {
+      const INPUT_WITH_HELPER = ALL_INPUT.map((group) =>
+        Array.isArray(group)
+          ? group.map((item) => ({
+              ...item,
+              helper: (
+                <span aria-label="helper-with-react-node">
+                  {FIELD_HELPERS[item.type]}
+                </span>
+              ),
+            }))
+          : {
+              ...group,
+              helper: (
+                <span aria-label="helper-with-react-node">
+                  {FIELD_HELPERS[group.type]}
+                </span>
+              ),
+            },
+      )
+
+      const FLAT_INPUT = INPUT_WITH_HELPER.flatMap((props) => props)
+      context("helperArrowStyle", () => {
+        context("when given green background", () => {
+          it("renders with background with rgb(0, 255, 0)", () => {
+            cy.mount(
+              <StatefulForm
+                styles={{
+                  helperArrowStyle: css`
+                    background-color: rgb(0, 255, 0);
+                  `,
+                }}
+                fields={INPUT_WITH_HELPER}
+                formValues={allValue}
+                mode="onChange"
+              />,
+            )
+
+            cy.findAllByLabelText("tooltip-trigger")
+              .should("have.length", FLAT_INPUT.length)
+              .each(($el, index) => {
+                cy.wrap($el).trigger("mouseover")
+
+                cy.findAllByLabelText("tooltip-arrow")
+                  .eq(index)
+                  .should("have.css", "background-color", "rgb(0, 255, 0)")
+              })
+          })
+        })
+      })
+
+      context("helperIconStyle", () => {
+        context("when given red color", () => {
+          it("renders the svg with rgb(255, 0, 0)", () => {
+            cy.mount(
+              <StatefulForm
+                styles={{
+                  helperIconStyle: css`
+                    svg {
+                      fill: red;
+                    }
+                  `,
+                }}
+                fields={INPUT_WITH_HELPER}
+                formValues={allValue}
+                mode="onChange"
+              />,
+            )
+
+            cy.findAllByLabelText("tooltip-trigger")
+              .should("have.length", FLAT_INPUT.length)
+              .each(($el, index) => {
+                cy.wrap($el).trigger("mouseover")
+
+                cy.findAllByLabelText("tooltip-trigger")
+                  .eq(index)
+                  .find("svg")
+                  .should("have.css", "fill", "rgb(255, 0, 0)")
+              })
+          })
+        })
+      })
+
+      context("helperDrawerStyle", () => {
+        context("when given background yellow", () => {
+          it("renders the background color with rgb(255, 255, 0)", () => {
+            cy.mount(
+              <StatefulForm
+                styles={{
+                  helperDrawerStyle: css`
+                    background-color: yellow;
+                  `,
+                }}
+                fields={INPUT_WITH_HELPER}
+                formValues={allValue}
+                mode="onChange"
+              />,
+            )
+
+            cy.findAllByLabelText("tooltip-trigger")
+              .should("have.length", FLAT_INPUT.length)
+              .each(($el, index) => {
+                cy.wrap($el).trigger("mouseover")
+
+                cy.findAllByLabelText("tooltip-drawer")
+                  .eq(index)
+                  .should("have.css", "background-color", "rgb(255, 255, 0)")
+              })
+          })
+        })
+      })
+
       context("mobileFieldGroupStyle", () => {
         context("when given padding 30px", () => {
           it("should render the padding in all side with 30px", () => {
@@ -2856,32 +2993,6 @@ describe("StatefulForm", () => {
   })
 
   context("helper", () => {
-    const FIELD_HELPERS: Record<string, string> = {
-      text: "Enter any text value.",
-      email: "Enter a valid email address.",
-      number: "Enter a numeric value.",
-      password: "Enter a secure password.",
-      textarea: "Enter a longer message.",
-      time: "Select a time value.",
-      pin: "Enter your PIN code.",
-      checkbox: "Toggle the checkbox.",
-      radio: "Select one option.",
-      color: "Choose a color.",
-      combo: "Select an option from the list.",
-      date: "Select a date.",
-      file_drop_box: "Drag and drop a file here.",
-      file: "Upload a file.",
-      image: "Upload an image.",
-      money: "Enter a monetary value.",
-      phone: "Enter a phone number.",
-      signbox: "Provide your signature.",
-      rating: "Rate the item.",
-      thumbfield: "Upload or select a thumbnail.",
-      toggle: "Toggle the switch.",
-      chips: "Select one or more chips.",
-      capsule: "Choose a monetary option.",
-    }
-
     const INPUT_WITH_HELPER = ALL_INPUT.map((group) =>
       Array.isArray(group)
         ? group.map((item) => ({
@@ -2912,6 +3023,49 @@ describe("StatefulForm", () => {
 
           cy.findByText(String(FLAT_INPUT[index].helper))
         })
+    })
+
+    context("with reactNode", () => {
+      const INPUT_WITH_HELPER_REACTNODE = ALL_INPUT.map(
+        (group) =>
+          Array.isArray(group)
+            ? group.map((item) => ({
+                ...item,
+                helper: (
+                  <span aria-label="helper-with-react-node">
+                    {FIELD_HELPERS[item.type]}
+                  </span>
+                ),
+              }))
+            : {
+                ...group,
+                helper: (
+                  <span aria-label="helper-with-react-node">
+                    {FIELD_HELPERS[group.type]}
+                  </span>
+                ),
+              },
+
+        it("renders tooltip field with react node", () => {
+          cy.mount(
+            <StatefulForm
+              fields={INPUT_WITH_HELPER_REACTNODE}
+              formValues={allValue}
+              mode="onChange"
+            />,
+          )
+
+          cy.findAllByLabelText("tooltip-trigger")
+            .should("have.length", FLAT_INPUT.length)
+            .each(($el, index) => {
+              cy.wrap($el).trigger("mouseover")
+
+              cy.findAllByLabelText("helper-with-react-node")
+                .eq(index)
+                .should("have.text", FLAT_INPUT[index].helper)
+            })
+        }),
+      )
     })
   })
 

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -349,6 +349,106 @@ const flattenFields = (groups: FormFieldGroup[]): FormFieldProps[] =>
   );
 
 describe("StatefulForm", () => {
+  context("StatefulForm.FieldTooltip", () => {
+    context("items", () => {
+      context("when given only a title", () => {
+        it("should render the title", () => {
+          cy.mount(
+            <StatefulForm.FieldTooltip
+              items={[
+                {
+                  title: "Account Information",
+                },
+              ]}
+            />
+          );
+
+          cy.findByLabelText("field-tooltip-item").should(
+            "contain.text",
+            "Account Information"
+          );
+        });
+      });
+
+      context("when given only a description", () => {
+        it("should render the description", () => {
+          cy.mount(
+            <StatefulForm.FieldTooltip
+              items={[
+                {
+                  description: "Enter your full legal name.",
+                },
+              ]}
+            />
+          );
+
+          cy.findByLabelText("field-tooltip-item").should(
+            "contain.text",
+            "Enter your full legal name."
+          );
+        });
+      });
+
+      context("when given a title and description", () => {
+        it("should render both", () => {
+          cy.mount(
+            <StatefulForm.FieldTooltip
+              items={[
+                {
+                  title: "Name",
+                  description: "Enter your full legal name.",
+                },
+              ]}
+            />
+          );
+
+          cy.findByLabelText("field-tooltip-item")
+            .should("contain.text", "Name")
+            .and("contain.text", "Enter your full legal name.");
+        });
+      });
+
+      context("when given multiple items", () => {
+        it("should render all items", () => {
+          cy.mount(
+            <StatefulForm.FieldTooltip
+              items={[
+                {
+                  title: "Name",
+                  description: "Enter your full legal name.",
+                },
+                {
+                  title: "Email",
+                  description: "Use an active email address.",
+                },
+              ]}
+            />
+          );
+
+          cy.findAllByLabelText("field-tooltip-item").should("have.length", 2);
+
+          cy.findAllByLabelText("field-tooltip-item")
+            .eq(0)
+            .should("contain.text", "Name")
+            .and("contain.text", "Enter your full legal name.");
+
+          cy.findAllByLabelText("field-tooltip-item")
+            .eq(1)
+            .should("contain.text", "Email")
+            .and("contain.text", "Use an active email address.");
+        });
+      });
+
+      context("when no items are provided", () => {
+        it("should not render field-tooltip", () => {
+          cy.mount(<StatefulForm.FieldTooltip items={[]} />);
+
+          cy.findByLabelText("field-tooltip").should("not.exist");
+        });
+      });
+    });
+  });
+
   context("general", () => {
     function StatefulFormWithAsync({
       state = "valid",

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -447,7 +447,7 @@ describe("StatefulForm", () => {
         it("does not show the error", () => {
           cy.mount(<StatefulFormWithAsync state="empty" />)
 
-          cy.findByPlaceholderText("Enter first name").type("Te")
+          cy.findByPlaceholderText("Enter first name").type("T")
 
           cy.findByText("First name must be at least 3 characters long").should(
             "not.exist",
@@ -462,7 +462,7 @@ describe("StatefulForm", () => {
             "not.exist",
           )
 
-          cy.findByPlaceholderText("Enter first name").type("Te")
+          cy.findByPlaceholderText("Enter first name").type("T")
           cy.get("body").click("topRight")
 
           cy.findByText("First name must be at least 3 characters long").should(

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -442,9 +442,9 @@ describe("StatefulForm", () => {
       )
     }
 
-    context("when typing", () => {
-      context("when invalid, but still focus", () => {
-        it("still renders without error", () => {
+    context("when typing with invalid value", () => {
+      context("while focused", () => {
+        it("does not show the error", () => {
           cy.mount(<StatefulFormWithAsync state="empty" />)
 
           cy.findByPlaceholderText("Enter first name").type("Te")
@@ -455,8 +455,8 @@ describe("StatefulForm", () => {
         })
       })
 
-      context("when invalid, but unfocused", () => {
-        it("renders with error", () => {
+      context("after blur", () => {
+        it("shows the error", () => {
           cy.mount(<StatefulFormWithAsync state="empty" />)
           cy.findByText("First name must be at least 3 characters long").should(
             "not.exist",
@@ -468,6 +468,41 @@ describe("StatefulForm", () => {
           cy.findByText("First name must be at least 3 characters long").should(
             "be.visible",
           )
+        })
+
+        context("when typing in another field", () => {
+          it("keeps the previous error", () => {
+            cy.mount(<StatefulFormWithAsync state="empty" />)
+            cy.findByText(
+              "First name must be at least 3 characters long",
+            ).should("not.exist")
+
+            cy.findByPlaceholderText("Enter first name").type("Te")
+            cy.get("body").click("topRight")
+
+            cy.findByText(
+              "First name must be at least 3 characters long",
+            ).should("be.visible")
+
+            cy.findByPlaceholderText("Enter email address").type("iamalim@test")
+
+            // still shows if in focus
+
+            cy.findByText(
+              "First name must be at least 3 characters long",
+            ).should("be.visible")
+
+            cy.get("body").click("topRight")
+
+            // still shows after unfocused
+
+            cy.findByText(
+              "First name must be at least 3 characters long",
+            ).should("be.visible")
+            cy.findByText("Please enter a valid email address").should(
+              "be.visible",
+            )
+          })
         })
       })
     })

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -4,31 +4,31 @@ import {
   FormFieldType,
   StatefulForm,
   StatefulFormProps,
-} from "./../../components/stateful-form";
-import { COUNTRY_CODES } from "./../../constants/countries";
-import { Boxbar } from "./../../components/boxbar";
-import { Badge, BadgeProps } from "./../../components/badge";
-import { css } from "styled-components";
-import { SelectboxOption } from "./../../components/selectbox";
-import { CapsuleTab } from "./../../components/capsule";
-import { useMemo, useState } from "react";
+} from "./../../components/stateful-form"
+import { COUNTRY_CODES } from "./../../constants/countries"
+import { Boxbar } from "./../../components/boxbar"
+import { Badge, BadgeProps } from "./../../components/badge"
+import { css } from "styled-components"
+import { SelectboxOption } from "./../../components/selectbox"
+import { CapsuleTab } from "./../../components/capsule"
+import { useEffect, useMemo, useState } from "react"
 import {
   OnCompleteFunctionArgs,
   FileDropBox,
   OnFileDroppedFunctionArgs,
-} from "./../../components/file-drop-box";
-import { Table } from "./../../components/table";
-import { RiDeleteBin2Fill } from "@remixicon/react";
-import z from "zod";
-import { PinboxParts } from "./../../components/pinbox";
+} from "./../../components/file-drop-box"
+import { Table } from "./../../components/table"
+import { RiDeleteBin2Fill } from "@remixicon/react"
+import z from "zod"
+import { PinboxParts } from "./../../components/pinbox"
 
 const DEFAULT_COUNTRY_CODES = (() => {
   const code =
-    COUNTRY_CODES.find((data) => data.id === "US") ?? COUNTRY_CODES[206];
+    COUNTRY_CODES.find((data) => data.id === "US") ?? COUNTRY_CODES[206]
   if (!code)
-    throw new Error("Default country code 'US' not found in COUNTRY_CODES.");
-  return code;
-})();
+    throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
+  return code
+})()
 
 const FRUIT_OPTIONS: SelectboxOption[] = [
   { text: "Apple", value: "1" },
@@ -38,7 +38,7 @@ const FRUIT_OPTIONS: SelectboxOption[] = [
   { text: "Pineapple", value: "5" },
   { text: "Strawberry", value: "6" },
   { text: "Watermelon", value: "7" },
-];
+]
 
 const MONTH_NAMES = [
   { text: "JAN", value: "1" },
@@ -53,12 +53,12 @@ const MONTH_NAMES = [
   { text: "OCT", value: "10" },
   { text: "NOV", value: "11" },
   { text: "DEC", value: "12" },
-];
+]
 
 const CAPSULE_TABS: CapsuleTab[] = [
   { id: "paid", title: "Paid" },
   { id: "unpaid", title: "Unpaid" },
-];
+]
 
 const PARTS_INPUT: PinboxParts[] = [
   { type: "static", text: "S" },
@@ -66,7 +66,7 @@ const PARTS_INPUT: PinboxParts[] = [
   { type: "digit" },
   { type: "alphabet" },
   { type: "static", text: "-" },
-];
+]
 
 const BADGE_OPTIONS_FULL = [
   { id: 1, caption: "Anime" },
@@ -79,12 +79,12 @@ const BADGE_OPTIONS_FULL = [
   { id: 8, caption: "Music" },
   { id: 9, caption: "Games" },
   { id: 10, caption: "Webtoons" },
-];
+]
 
 const BADGE_OPTIONS_SHORT: BadgeProps[] = [
   { id: "1", caption: "Anime" },
   { id: "2", caption: "Manga" },
-];
+]
 
 const TYPE_TO_ID_PREFIX: Record<FormFieldType, string> = {
   text: "textbox",
@@ -114,7 +114,7 @@ const TYPE_TO_ID_PREFIX: Record<FormFieldType, string> = {
   chips: "chips",
   custom: "custom",
   frame: "frame",
-};
+}
 
 const allValue = {
   text: "",
@@ -141,7 +141,7 @@ const allValue = {
   signature: "",
   capsule: "",
   country_code: DEFAULT_COUNTRY_CODES,
-};
+}
 
 const ALL_INPUT: FormFieldGroup[] = [
   [
@@ -315,14 +315,208 @@ const ALL_INPUT: FormFieldGroup[] = [
       tabs: CAPSULE_TABS,
     },
   },
-];
+]
 
 const flattenFields = (groups: FormFieldGroup[]): FormFieldProps[] =>
   groups.flatMap((group) =>
-    Array.isArray(group) ? flattenFields(group) : [group]
-  );
+    Array.isArray(group) ? flattenFields(group) : [group],
+  )
 
 describe("StatefulForm", () => {
+  context("general", () => {
+    function StatefulFormWithAsync({
+      state = "valid",
+    }: {
+      state?: "valid" | "invalid" | "empty"
+    }) {
+      const DEFAULT_COUNTRY_CODES = COUNTRY_CODES.find(
+        (data) => data.id === "US",
+      )
+
+      if (!DEFAULT_COUNTRY_CODES) {
+        throw new Error("Default country code 'US' not found in COUNTRY_CODES.")
+      }
+
+      const [value, setValue] = useState({
+        name: "",
+        email: "",
+        phone: "",
+        country_code: DEFAULT_COUNTRY_CODES,
+      })
+
+      const [isFormValid, setIsFormValid] = useState(false)
+
+      useEffect(() => {
+        const timer = setTimeout(() => {
+          switch (state) {
+            case "valid":
+              setValue((prev) => ({
+                ...prev,
+                name: "John Doe",
+                email: "john@example.com",
+                phone: "081234567890",
+              }))
+              break
+
+            case "invalid":
+              setValue((prev) => ({
+                ...prev,
+                name: "Jo",
+                email: "invalid-email",
+                phone: "123",
+              }))
+              break
+
+            case "empty":
+            default:
+              break
+          }
+        }, 300)
+
+        return () => clearTimeout(timer)
+      }, [state])
+
+      const employeeSchema = z.object({
+        name: z
+          .string()
+          .min(3, "First name must be at least 3 characters long"),
+        email: z.string().email("Please enter a valid email address"),
+        phone: z
+          .string()
+          .regex(/^\d{10,15}$/, "Phone number must be between 10 and 15 digits")
+          .optional(),
+      })
+
+      const EMPLOYEE_FIELDS: FormFieldGroup[] = [
+        {
+          name: "name",
+          title: "First Name",
+          type: "text",
+          required: true,
+          placeholder: "Enter first name",
+        },
+        [
+          {
+            name: "email",
+            title: "Email",
+            type: "email",
+            required: true,
+            placeholder: "Enter email address",
+          },
+          {
+            name: "text",
+            title: "Verify",
+            type: "button",
+          },
+        ],
+        {
+          name: "phone",
+          title: "Phone Number",
+          type: "phone",
+          required: true,
+          placeholder: "Enter phone number",
+        },
+        {
+          name: "text",
+          title: "Save",
+          type: "button",
+          disabled: !isFormValid,
+          rowJustifyPosition: "end",
+        },
+      ]
+
+      return (
+        <StatefulForm
+          fields={EMPLOYEE_FIELDS}
+          formValues={value}
+          validationSchema={employeeSchema}
+          mode="onChange"
+          onValidityChange={setIsFormValid}
+          onChange={({ currentState }) => {
+            setValue((prev) => ({
+              ...prev,
+              ...currentState,
+            }))
+          }}
+        />
+      )
+    }
+
+    context("when typing", () => {
+      context("when invalid, but still focus", () => {
+        it("still renders without error", () => {
+          cy.mount(<StatefulFormWithAsync state="empty" />)
+
+          cy.findByPlaceholderText("Enter first name").type("Te")
+
+          cy.findByText("First name must be at least 3 characters long").should(
+            "not.exist",
+          )
+        })
+      })
+
+      context("when invalid, but unfocused", () => {
+        it("renders with error", () => {
+          cy.mount(<StatefulFormWithAsync state="empty" />)
+          cy.findByText("First name must be at least 3 characters long").should(
+            "not.exist",
+          )
+
+          cy.findByPlaceholderText("Enter first name").type("Te")
+          cy.get("body").click("topRight")
+
+          cy.findByText("First name must be at least 3 characters long").should(
+            "be.visible",
+          )
+        })
+      })
+    })
+
+    context("async", () => {
+      context("when data is valid", () => {
+        it("renders without error", () => {
+          cy.mount(<StatefulFormWithAsync state="valid" />)
+
+          cy.wait(600)
+
+          cy.findByDisplayValue("John Doe").should("exist")
+          cy.findByDisplayValue("john@example.com").should("exist")
+          cy.findByDisplayValue("081234567890").should("exist")
+
+          cy.findByText("First name must be at least 3 characters long").should(
+            "not.exist",
+          )
+          cy.findByText("Please enter a valid email address").should(
+            "not.exist",
+          )
+          cy.findByText("Phone number must be between 10 and 15 digits").should(
+            "not.exist",
+          )
+        })
+      })
+
+      context("when data is invalid", () => {
+        it("renders with error", () => {
+          cy.mount(<StatefulFormWithAsync state="invalid" />)
+
+          cy.wait(600)
+
+          cy.findByDisplayValue("Jo").should("exist")
+          cy.findByDisplayValue("invalid-email").should("exist")
+          cy.findByDisplayValue("123").should("exist")
+
+          cy.findByText("First name must be at least 3 characters long").should(
+            "exist",
+          )
+          cy.findByText("Please enter a valid email address").should("exist")
+          cy.findByText("Phone number must be between 10 and 15 digits").should(
+            "exist",
+          )
+        })
+      })
+    })
+  })
+
   context("mobile", () => {
     context("styles", () => {
       context("mobileFieldGroupStyle", () => {
@@ -339,17 +533,17 @@ describe("StatefulForm", () => {
                     padding: 30px;
                   `,
                 }}
-              />
-            );
+              />,
+            )
 
             cy.findAllByLabelText("stateful-form-field-group").should(
               "have.css",
               "padding",
-              "30px"
-            );
-          });
-        });
-      });
+              "30px",
+            )
+          })
+        })
+      })
 
       context("mobileFieldGroupRowDividerStyle", () => {
         context("when given color red", () => {
@@ -365,18 +559,18 @@ describe("StatefulForm", () => {
                     background-color: red;
                   `,
                 }}
-              />
-            );
+              />,
+            )
 
             cy.findAllByLabelText("stateful-form-field-group-divider").should(
               "have.css",
               "background-color",
-              "rgb(255, 0, 0)"
-            );
-          });
-        });
-      });
-    });
+              "rgb(255, 0, 0)",
+            )
+          })
+        })
+      })
+    })
     it("renders with background rgb(236, 236, 236)", () => {
       cy.mount(
         <StatefulForm
@@ -384,15 +578,15 @@ describe("StatefulForm", () => {
           formValues={allValue}
           mode="onChange"
           mobile
-        />
-      );
+        />,
+      )
 
       cy.findAllByLabelText("stateful-form-field-group").should(
         "have.css",
         "background-color",
-        "rgb(236, 236, 236)"
-      );
-    });
+        "rgb(236, 236, 236)",
+      )
+    })
 
     it("renders row with radius 24px and padding 10px 20px", () => {
       cy.mount(
@@ -401,18 +595,18 @@ describe("StatefulForm", () => {
           formValues={allValue}
           mode="onChange"
           mobile
-        />
-      );
+        />,
+      )
 
       cy.findAllByLabelText("stateful-form-field-group")
         .should("have.css", "border-radius", "24px")
-        .and("have.css", "padding", "10px 20px");
-    });
+        .and("have.css", "padding", "10px 20px")
+    })
 
     context("radio", () => {
       context("clicking in center row element", () => {
         it("should give callback in onChanges", () => {
-          const onChangeValue = cy.stub().as("onChangeValue");
+          const onChangeValue = cy.stub().as("onChangeValue")
 
           cy.mount(
             <StatefulForm
@@ -428,21 +622,21 @@ describe("StatefulForm", () => {
               mode="onChange"
               onChange={() => onChangeValue()}
               mobile
-            />
-          );
-          cy.get("@onChangeValue").should("not.have.been.calledOnce");
+            />,
+          )
+          cy.get("@onChangeValue").should("not.have.been.calledOnce")
 
-          cy.findAllByLabelText("stateful-form-field-group").click("center");
+          cy.findAllByLabelText("stateful-form-field-group").click("center")
 
-          cy.get("@onChangeValue").should("have.been.calledOnce");
-        });
-      });
-    });
+          cy.get("@onChangeValue").should("have.been.calledOnce")
+        })
+      })
+    })
 
     context("checkbox", () => {
       context("clicking in center row element", () => {
         it("should give callback in onChanges", () => {
-          const onChangeValue = cy.stub().as("onChangeValue");
+          const onChangeValue = cy.stub().as("onChangeValue")
 
           cy.mount(
             <StatefulForm
@@ -458,21 +652,21 @@ describe("StatefulForm", () => {
               mode="onChange"
               onChange={() => onChangeValue()}
               mobile
-            />
-          );
-          cy.get("@onChangeValue").should("not.have.been.calledOnce");
+            />,
+          )
+          cy.get("@onChangeValue").should("not.have.been.calledOnce")
 
-          cy.findAllByLabelText("stateful-form-field-group").click("center");
+          cy.findAllByLabelText("stateful-form-field-group").click("center")
 
-          cy.get("@onChangeValue").should("have.been.calledOnce");
-        });
-      });
-    });
+          cy.get("@onChangeValue").should("have.been.calledOnce")
+        })
+      })
+    })
 
     context("button", () => {
       context("when given 2 or more button", () => {
         it("should separate with percentage in flex row", () => {
-          cy.viewport(500, 500);
+          cy.viewport(500, 500)
           cy.mount(
             <StatefulForm
               fields={[
@@ -499,22 +693,22 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
           cy.findAllByLabelText("stateful-form-field-group")
             .should("have.css", "flex-direction", "row")
-            .and("have.css", "width", "460px");
+            .and("have.css", "width", "460px")
 
-          cy.findAllByRole("button").should("have.length", 2);
-          cy.findAllByRole("button").eq(0).should("have.css", "width", "230px");
-          cy.findAllByRole("button").eq(1).should("have.css", "width", "230px");
-        });
-      });
+          cy.findAllByRole("button").should("have.length", 2)
+          cy.findAllByRole("button").eq(0).should("have.css", "width", "230px")
+          cy.findAllByRole("button").eq(1).should("have.css", "width", "230px")
+        })
+      })
 
       context("when given 2 or more button and 1 input", () => {
         it("should renders as usual with flex column", () => {
-          cy.viewport(500, 500);
+          cy.viewport(500, 500)
           cy.mount(
             <StatefulForm
               fields={[
@@ -548,30 +742,30 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
           cy.findAllByLabelText("stateful-form-field-group")
             .should("have.css", "flex-direction", "column")
-            .and("have.css", "width", "460px");
+            .and("have.css", "width", "460px")
 
-          cy.findAllByRole("button").should("have.length", 2);
+          cy.findAllByRole("button").should("have.length", 2)
           cy.findAllByRole("button")
             .eq(0)
-            .should("not.have.css", "width", "230px");
+            .should("not.have.css", "width", "230px")
           cy.findAllByRole("button")
             .eq(1)
-            .should("not.have.css", "width", "230px");
-        });
-      });
-    });
+            .should("not.have.css", "width", "230px")
+        })
+      })
+    })
 
     context("Capsule", () => {
       context("when error", () => {
         it("should not render the error icon", () => {
           const capsuleSchema = z.object({
             capsule: z.string().max(4, "Paid is required"),
-          });
+          })
 
           cy.mount(
             <StatefulForm
@@ -590,22 +784,22 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
-          cy.findByText("Paid is required").should("not.exist");
-          cy.get("body").find("svg").should("not.exist");
+          cy.findByText("Paid is required").should("not.exist")
+          cy.get("body").find("svg").should("not.exist")
 
-          cy.findByText("Unpaid").click();
+          cy.findByText("Unpaid").click()
 
-          cy.findByText("Paid is required").should("exist");
+          cy.findByText("Paid is required").should("exist")
           cy.get("body")
             .find("svg")
             .parent()
-            .should("have.css", "display", "none");
-        });
-      });
-    });
+            .should("have.css", "display", "none")
+        })
+      })
+    })
 
     context("textbox", () => {
       context("when given title", () => {
@@ -623,11 +817,11 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
-          cy.findByPlaceholderText("Text Placeholder").should("exist");
-        });
+          cy.findByPlaceholderText("Text Placeholder").should("exist")
+        })
 
         context("when given placeholder", () => {
           it("should replace the placeholder input text", () => {
@@ -646,15 +840,15 @@ describe("StatefulForm", () => {
                 formValues={{}}
                 mode="onChange"
                 mobile
-              />
-            );
+              />,
+            )
 
-            cy.findByPlaceholderText("Text Placeholder").should("not.exist");
-            cy.findByPlaceholderText("Enter text").should("not.exist");
-          });
-        });
-      });
-    });
+            cy.findByPlaceholderText("Text Placeholder").should("not.exist")
+            cy.findByPlaceholderText("Enter text").should("not.exist")
+          })
+        })
+      })
+    })
 
     context("colorbox", () => {
       it("renders with flex row-reverse", () => {
@@ -672,14 +866,14 @@ describe("StatefulForm", () => {
             formValues={{}}
             mode="onChange"
             mobile
-          />
-        );
+          />,
+        )
 
         cy.findByLabelText("colorbox")
           .should("exist")
-          .and("have.css", "flex-direction", "row-reverse");
-      });
-    });
+          .and("have.css", "flex-direction", "row-reverse")
+      })
+    })
 
     context("moneybox", () => {
       context("when clicking the currency button", () => {
@@ -700,17 +894,17 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
-          cy.findByLabelText("moneybox-currency-toggle").click();
+          cy.findByLabelText("moneybox-currency-toggle").click()
 
           cy.findByLabelText("combobox-drawer-mobile")
             .should("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed");
-        });
-      });
-    });
+            .and("have.css", "position", "fixed")
+        })
+      })
+    })
 
     context("chips", () => {
       function ProductStatefulChips() {
@@ -719,7 +913,7 @@ describe("StatefulForm", () => {
             selectedOptions: [],
             searchText: "",
           },
-        });
+        })
 
         return (
           <StatefulForm
@@ -738,7 +932,7 @@ describe("StatefulForm", () => {
               },
             ]}
             onChange={({ currentState }) => {
-              const [[key, value]] = Object.entries(currentState);
+              const [[key, value]] = Object.entries(currentState)
 
               setValue((prev) => ({
                 ...prev,
@@ -752,46 +946,46 @@ describe("StatefulForm", () => {
                       },
                     }
                   : currentState),
-              }));
+              }))
             }}
             formValues={value}
             mode="onChange"
           />
-        );
+        )
       }
 
       it("renders with row reverse", () => {
-        cy.mount(<ProductStatefulChips />);
+        cy.mount(<ProductStatefulChips />)
 
-        cy.findByLabelText("chips-container-input").click();
+        cy.findByLabelText("chips-container-input").click()
 
         cy.findByLabelText("combobox-drawer-mobile")
           .should("exist")
           .and("have.css", "bottom", "10px")
-          .and("have.css", "position", "fixed");
+          .and("have.css", "position", "fixed")
 
-        cy.findByText("Anime").click();
-        cy.findByText("Manga").click();
+        cy.findByText("Anime").click()
+        cy.findByText("Manga").click()
 
         cy.findByLabelText("chips-container-input").should(
           "have.css",
           "flex-direction",
-          "row-reverse"
-        );
-      });
+          "row-reverse",
+        )
+      })
       context("when clicking the button", () => {
         it("renders in the bottom of screen", () => {
-          cy.mount(<ProductStatefulChips />);
+          cy.mount(<ProductStatefulChips />)
 
-          cy.findByLabelText("chips-container-input").click();
+          cy.findByLabelText("chips-container-input").click()
 
           cy.findByLabelText("combobox-drawer-mobile")
             .should("exist")
             .and("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed");
-        });
-      });
-    });
+            .and("have.css", "position", "fixed")
+        })
+      })
+    })
 
     context("datebox", () => {
       context("when clicking the selectbox", () => {
@@ -810,18 +1004,18 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
-          cy.findAllByPlaceholderText("Select a date").click();
+          cy.findAllByPlaceholderText("Select a date").click()
 
           cy.findByLabelText("calendar")
             .should("exist")
             .and("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed");
-        });
-      });
-    });
+            .and("have.css", "position", "fixed")
+        })
+      })
+    })
 
     context("phonebox", () => {
       context("renders in the text align to right side", () => {
@@ -840,14 +1034,14 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
           cy.findByLabelText("phonebox-input-number")
             .should("exist")
-            .and("have.css", "text-align", "end");
-        });
-      });
+            .and("have.css", "text-align", "end")
+        })
+      })
 
       context("when clicking the countrybox", () => {
         it("renders drawer in the bottom of screen", () => {
@@ -865,18 +1059,18 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
-          cy.findByLabelText("phonebox-country-toggle").click();
+          cy.findByLabelText("phonebox-country-toggle").click()
 
           cy.findByLabelText("combobox-drawer-mobile")
             .should("exist")
             .and("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed");
-        });
-      });
-    });
+            .and("have.css", "position", "fixed")
+        })
+      })
+    })
 
     context("timebox", () => {
       context("when clicking the input", () => {
@@ -894,19 +1088,19 @@ describe("StatefulForm", () => {
               formValues={{}}
               mode="onChange"
               mobile
-            />
-          );
+            />,
+          )
 
-          cy.findByLabelText("timebox-hour").click();
+          cy.findByLabelText("timebox-hour").click()
 
           cy.findByLabelText("wheel-container")
             .should("exist")
             .and("have.css", "bottom", "10px")
-            .and("have.css", "position", "fixed");
-        });
-      });
-    });
-  });
+            .and("have.css", "position", "fixed")
+        })
+      })
+    })
+  })
 
   context("chips", () => {
     function StatefulChips() {
@@ -915,7 +1109,7 @@ describe("StatefulForm", () => {
           selectedOptions: [],
           searchText: "",
         },
-      });
+      })
       return (
         <StatefulForm
           fields={[
@@ -932,7 +1126,7 @@ describe("StatefulForm", () => {
             },
           ]}
           onChange={({ currentState }) => {
-            const [[key, value]] = Object.entries(currentState);
+            const [[key, value]] = Object.entries(currentState)
 
             setValue((prev) => ({
               ...prev,
@@ -945,37 +1139,37 @@ describe("StatefulForm", () => {
                     },
                   }
                 : currentState),
-            }));
+            }))
           }}
           formValues={value}
           mode="onChange"
         />
-      );
+      )
     }
 
     context("when select one option", () => {
       it("renders option selected", () => {
-        cy.mount(<StatefulChips />);
-        cy.findByRole("button").click();
+        cy.mount(<StatefulChips />)
+        cy.findByRole("button").click()
 
-        cy.findAllByLabelText("chips-selected").should("not.exist");
+        cy.findAllByLabelText("chips-selected").should("not.exist")
 
-        cy.findByText("Anime").click();
-        cy.findByText("Manga").click();
+        cy.findByText("Anime").click()
+        cy.findByText("Manga").click()
 
-        cy.wait(400);
+        cy.wait(400)
 
         cy.findAllByLabelText("chips-selected")
           .eq(0)
           .should("exist")
-          .should("have.css", "background-color", "rgb(255, 255, 255)");
+          .should("have.css", "background-color", "rgb(255, 255, 255)")
         cy.findAllByLabelText("chips-selected")
           .eq(1)
           .should("exist")
-          .should("have.css", "background-color", "rgb(255, 255, 255)");
-      });
-    });
-  });
+          .should("have.css", "background-color", "rgb(255, 255, 255)")
+      })
+    })
+  })
 
   context("height", () => {
     it("mostly renders with 34px", () => {
@@ -984,12 +1178,12 @@ describe("StatefulForm", () => {
           fields={ALL_INPUT}
           formValues={allValue}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
       flattenFields(ALL_INPUT).map((field) => {
         if (field.type === "frame" || field.type === "chips") {
-          return;
+          return
         } else if (
           field.type === "radio" ||
           field.type === "image" ||
@@ -1001,56 +1195,56 @@ describe("StatefulForm", () => {
           cy.findAllByLabelText("radio-input-container").should(
             "have.css",
             "height",
-            "16px"
-          );
+            "16px",
+          )
           cy.findAllByLabelText("file-input-box-wrapper").should(
             "have.css",
             "height",
-            "47px"
-          );
+            "47px",
+          )
           cy.findAllByLabelText("imagebox-input").should(
             "have.css",
             "height",
-            "120px"
-          );
+            "120px",
+          )
           cy.findAllByLabelText("signbox-canvas").should(
             "have.css",
             "height",
-            "200px"
-          );
+            "200px",
+          )
           cy.findAllByLabelText("file-drop-box-area").should(
             "have.css",
             "height",
-            "221px"
-          );
+            "221px",
+          )
           cy.findAllByLabelText("signbox-canvas").should(
             "have.css",
             "height",
-            "200px"
-          );
+            "200px",
+          )
           cy.findAllByLabelText("rating-wrapper").should(
             "have.css",
             "height",
-            "24px"
-          );
+            "24px",
+          )
         } else {
           cy.findAllByLabelText("field-lane-control").should(
             "have.css",
             "height",
-            "34px"
-          );
+            "34px",
+          )
         }
-      });
-    });
-  });
+      })
+    })
+  })
 
   context("combobox", () => {
     const comboField = flattenFields(ALL_INPUT).filter(
-      (field) => field.type === "combo"
-    );
+      (field) => field.type === "combo",
+    )
 
     function ComboboxInput(props: Partial<StatefulFormProps<any>>) {
-      const [value, setValue] = useState({ combo: ["4"] });
+      const [value, setValue] = useState({ combo: ["4"] })
 
       return (
         <StatefulForm
@@ -1061,20 +1255,20 @@ describe("StatefulForm", () => {
           }
           {...props}
         />
-      );
+      )
     }
 
     beforeEach(() => {
-      cy.mount(<ComboboxInput />);
-    });
+      cy.mount(<ComboboxInput />)
+    })
 
     it("should shows value from formValues", () => {
-      cy.get("#combobox-combo").should("have.value", "Grape");
-    });
+      cy.get("#combobox-combo").should("have.value", "Grape")
+    })
 
     context("when given four comboboxes in a row", () => {
       it("renders each with a width smaller than 140px (min-width)", () => {
-        cy.viewport(500, 750);
+        cy.viewport(500, 750)
         const fields = Array.from({ length: 4 }, (_, i) => ({
           id: `combo-${i + 1}`,
           name: `combo${i + 1}`,
@@ -1085,26 +1279,26 @@ describe("StatefulForm", () => {
           combobox: {
             options: FRUIT_OPTIONS,
           },
-        }));
-        cy.mount(<StatefulForm fields={[fields]} formValues={{}} />);
+        }))
+        cy.mount(<StatefulForm fields={[fields]} formValues={{}} />)
 
         cy.then(() => {
-          const widths: number[] = [];
+          const widths: number[] = []
 
           cy.wrap(fields).each((field: (typeof fields)[number]) => {
             cy.get(`#${field.id}`).then(($el) => {
-              widths.push($el[0].getBoundingClientRect().width);
-            });
-          });
+              widths.push($el[0].getBoundingClientRect().width)
+            })
+          })
 
           cy.then(() => {
             widths.forEach((width) => {
-              expect(width).to.be.closeTo(110.5, 1);
-            });
-          });
-        });
-      });
-    });
+              expect(width).to.be.closeTo(110.5, 1)
+            })
+          })
+        })
+      })
+    })
 
     context("when given value from selectedOptions", () => {
       const comboFieldWithValue = comboField.map((field) => ({
@@ -1113,25 +1307,25 @@ describe("StatefulForm", () => {
           ...field?.combobox,
           selectedOptions: ["1"],
         },
-      }));
+      }))
 
       beforeEach(() => {
-        cy.mount(<ComboboxInput fields={comboFieldWithValue} />);
-      });
+        cy.mount(<ComboboxInput fields={comboFieldWithValue} />)
+      })
       it("should shows value from formValues", () => {
-        cy.get("#combobox-combo").should("have.value", "Apple");
-      });
-    });
-  });
+        cy.get("#combobox-combo").should("have.value", "Apple")
+      })
+    })
+  })
 
   context("with type frame", () => {
     function StatefulWithFrame() {
-      const [isFormValid, setIsFormValid] = useState(false);
+      const [isFormValid, setIsFormValid] = useState(false)
       const [value, setValue] = useState({
         start_date: [""],
         end_date: [""],
         purpose: "",
-      });
+      })
 
       const EMPLOYEE_FIELDS: FormFieldGroup[] = [
         {
@@ -1176,19 +1370,19 @@ describe("StatefulForm", () => {
           disabled: !isFormValid,
           rowJustifyPosition: "end",
         },
-      ];
+      ]
 
       const dateArraySchema = z
         .array(
-          z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date")
+          z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date"),
         )
-        .min(1, "At least one date is required");
+        .min(1, "At least one date is required")
 
       const employeeSchema = z.object({
         start_date: dateArraySchema,
         end_date: dateArraySchema,
         purpose: z.string().min(10, "Business purpose is required"),
-      });
+      })
 
       return (
         <div
@@ -1206,7 +1400,7 @@ describe("StatefulForm", () => {
         >
           <StatefulForm
             onChange={({ currentState }) => {
-              setValue((prev) => ({ ...prev, ...currentState }));
+              setValue((prev) => ({ ...prev, ...currentState }))
             }}
             fields={EMPLOYEE_FIELDS}
             onValidityChange={setIsFormValid}
@@ -1215,107 +1409,107 @@ describe("StatefulForm", () => {
             mode="onChange"
           />
         </div>
-      );
+      )
     }
 
     const initializeFrame = () => {
-      cy.mount(<StatefulWithFrame />);
+      cy.mount(<StatefulWithFrame />)
       cy.findAllByLabelText("frame").then(() => {
-        cy.findAllByLabelText("stateful-form-row").should("have.length", 4);
-        cy.get("#datebox-start_date").should("exist");
-        cy.get("#datebox-end_date").should("exist");
-        cy.get("#textbox-purpose").should("exist");
-        cy.findByRole("button").should("exist").and("be.disabled");
-      });
-    };
+        cy.findAllByLabelText("stateful-form-row").should("have.length", 4)
+        cy.get("#datebox-start_date").should("exist")
+        cy.get("#datebox-end_date").should("exist")
+        cy.get("#textbox-purpose").should("exist")
+        cy.findByRole("button").should("exist").and("be.disabled")
+      })
+    }
 
     beforeEach(() => {
-      initializeFrame();
-    });
+      initializeFrame()
+    })
 
     it("shows the form fields inside of frame", () => {
       // shows from beforeEach
-    });
+    })
 
     context("when typing", () => {
       it("should added value", () => {
         cy.get("#datebox-start_date")
           .click()
           .then(($el) => {
-            cy.findByLabelText("calendar-select-date").click();
-            cy.findByLabelText("combobox-month").click();
-            cy.findByText("March").click();
-            cy.findByLabelText("combobox-year").click();
-            cy.findByText("2026").click();
-            cy.findByText("20").click();
-            cy.wrap($el).should("have.value", "03/20/2026");
-          });
+            cy.findByLabelText("calendar-select-date").click()
+            cy.findByLabelText("combobox-month").click()
+            cy.findByText("March").click()
+            cy.findByLabelText("combobox-year").click()
+            cy.findByText("2026").click()
+            cy.findByText("20").click()
+            cy.wrap($el).should("have.value", "03/20/2026")
+          })
         cy.get("#datebox-end_date")
           .click()
           .then(($el) => {
-            cy.findByLabelText("calendar-select-date").click();
-            cy.findByLabelText("combobox-month").click();
-            cy.findByText("March").click();
-            cy.findByLabelText("combobox-year").click();
-            cy.findByText("2026").click();
-            cy.findByText("20").click();
-            cy.wrap($el).should("have.value", "03/20/2026");
-          });
+            cy.findByLabelText("calendar-select-date").click()
+            cy.findByLabelText("combobox-month").click()
+            cy.findByText("March").click()
+            cy.findByLabelText("combobox-year").click()
+            cy.findByText("2026").click()
+            cy.findByText("20").click()
+            cy.wrap($el).should("have.value", "03/20/2026")
+          })
         cy.get("#textbox-purpose")
           .type("Getting better life")
-          .should("have.value", "Getting better life");
+          .should("have.value", "Getting better life")
 
-        cy.findByRole("button").should("exist").and("not.be.disabled");
-      });
-    });
+        cy.findByRole("button").should("exist").and("not.be.disabled")
+      })
+    })
 
     context("when typing but not fully", () => {
       it("renders error validation", () => {
-        cy.findByText("Business purpose is required").should("not.exist");
+        cy.findByText("Business purpose is required").should("not.exist")
 
         cy.get("#datebox-start_date")
           .click()
           .then(($el) => {
-            cy.findByLabelText("calendar-select-date").click();
-            cy.findByLabelText("combobox-month").click();
-            cy.findByText("March").click();
-            cy.findByLabelText("combobox-year").click();
-            cy.findByText("2026").click();
-            cy.findByText("20").click();
-            cy.wrap($el).should("have.value", "03/20/2026");
-          });
+            cy.findByLabelText("calendar-select-date").click()
+            cy.findByLabelText("combobox-month").click()
+            cy.findByText("March").click()
+            cy.findByLabelText("combobox-year").click()
+            cy.findByText("2026").click()
+            cy.findByText("20").click()
+            cy.wrap($el).should("have.value", "03/20/2026")
+          })
         cy.get("#datebox-end_date")
           .click()
           .then(($el) => {
-            cy.findByLabelText("calendar-select-date").click();
-            cy.findByLabelText("combobox-month").click();
-            cy.findByText("March").click();
-            cy.findByLabelText("combobox-year").click();
-            cy.findByText("2026").click();
-            cy.findByText("20").click();
-            cy.wrap($el).should("have.value", "03/20/2026");
-          });
+            cy.findByLabelText("calendar-select-date").click()
+            cy.findByLabelText("combobox-month").click()
+            cy.findByText("March").click()
+            cy.findByLabelText("combobox-year").click()
+            cy.findByText("2026").click()
+            cy.findByText("20").click()
+            cy.wrap($el).should("have.value", "03/20/2026")
+          })
         cy.get("#textbox-purpose")
           .type("Getting")
-          .should("have.value", "Getting");
-        cy.get("body").click("bottomRight");
+          .should("have.value", "Getting")
+        cy.get("body").click("bottomRight")
 
-        cy.findByText("Business purpose is required").should("exist");
-        cy.findByRole("button").should("exist").and("be.disabled");
-      });
-    });
-  });
+        cy.findByText("Business purpose is required").should("exist")
+        cy.findByRole("button").should("exist").and("be.disabled")
+      })
+    })
+  })
 
   context("conditional form", () => {
     function ConditionalStatefulForm() {
-      const [isFormValid, setIsFormValid] = useState(false);
+      const [isFormValid, setIsFormValid] = useState(false)
       const [formFields, setFormFields] = useState({
         quantType: "",
         compEffort: "",
         scheIterations: "",
         target: "",
         hostArch: "",
-      });
+      })
 
       const schema = z.object({
         quantType: z.string().optional(),
@@ -1326,46 +1520,46 @@ describe("StatefulForm", () => {
           .optional(),
         target: z.string().min(1, "Target is required"),
         hostArch: z.string().optional(),
-      });
+      })
 
       const HostArchitecture = {
         x86: 0,
         x64: 1,
         ARM: 2,
         ARM64: 3,
-      } as const;
+      } as const
 
       const CompilationTarget = {
         Interpreter: 0,
         Simulator: 1,
         IP: 2,
-      } as const;
+      } as const
 
       const CompilationEffort = {
         SimpleScheduling: 0,
         Performance: 1,
         Aggressive: 2,
-      } as const;
+      } as const
 
       const Quantization = {
         Int8: 0,
         Bf16: 1,
         Fp16: 2,
         Fp32: 3,
-      } as const;
+      } as const
 
       const HOST_ARCHITECTURE_OPTIONS: SelectboxOption[] = [
         { value: String(HostArchitecture.x86), text: "x86" },
         { value: String(HostArchitecture.x64), text: "x64" },
         { value: String(HostArchitecture.ARM), text: "ARM" },
         { value: String(HostArchitecture.ARM64), text: "ARM64" },
-      ];
+      ]
 
       const COMPILATION_TARGET_OPTIONS: SelectboxOption[] = [
         { value: String(CompilationTarget.Interpreter), text: "Interpreter" },
         { value: String(CompilationTarget.Simulator), text: "Simulator" },
         { value: String(CompilationTarget.IP), text: "IP" },
-      ];
+      ]
 
       const COMPILATION_EFFORT_OPTIONS: SelectboxOption[] = [
         {
@@ -1380,21 +1574,21 @@ describe("StatefulForm", () => {
           value: String(CompilationEffort.Aggressive),
           text: "Aggressive",
         },
-      ];
+      ]
 
       const QUANTIZATION_TYPE_OPTIONS: SelectboxOption[] = [
         { value: String(Quantization.Int8), text: "INT8" },
         { value: String(Quantization.Bf16), text: "BF16" },
         { value: String(Quantization.Fp16), text: "FP16" },
         { value: String(Quantization.Fp32), text: "FP32" },
-      ];
+      ]
 
       const COMPILATION_FIELDS: FormFieldGroup[] = useMemo(() => {
         const isInt8Quantization =
-          formFields.quantType === String(Quantization.Int8);
+          formFields.quantType === String(Quantization.Int8)
 
         const isPerfCompilation =
-          formFields.compEffort === String(CompilationEffort.Performance);
+          formFields.compEffort === String(CompilationEffort.Performance)
 
         return [
           {
@@ -1454,13 +1648,13 @@ describe("StatefulForm", () => {
             type: "button",
             disabled: !isFormValid,
           },
-        ];
-      }, [formFields.compEffort, formFields.quantType, isFormValid]);
+        ]
+      }, [formFields.compEffort, formFields.quantType, isFormValid])
 
       return (
         <StatefulForm
           onChange={({ currentState }) => {
-            setFormFields((prev) => ({ ...prev, ...currentState }));
+            setFormFields((prev) => ({ ...prev, ...currentState }))
           }}
           onValidityChange={setIsFormValid}
           validationSchema={schema}
@@ -1468,27 +1662,27 @@ describe("StatefulForm", () => {
           formValues={formFields}
           mode="onChange"
         />
-      );
+      )
     }
 
     context("when choosen option", () => {
       it("shows the value on the another field", () => {
-        cy.mount(<ConditionalStatefulForm />);
-        cy.findAllByLabelText("stateful-form-row").should("have.length", 4);
-        cy.findByText("Compilation Effort").should("not.exist");
-        cy.findByText("Precision").should("exist").click();
-        cy.findByText("INT8").should("exist").click();
+        cy.mount(<ConditionalStatefulForm />)
+        cy.findAllByLabelText("stateful-form-row").should("have.length", 4)
+        cy.findByText("Compilation Effort").should("not.exist")
+        cy.findByText("Precision").should("exist").click()
+        cy.findByText("INT8").should("exist").click()
 
-        cy.findAllByLabelText("stateful-form-row").should("have.length", 5);
-        cy.findByText("Compilation Effort").should("exist");
-      });
-    });
-  });
+        cy.findAllByLabelText("stateful-form-row").should("have.length", 5)
+        cy.findByText("Compilation Effort").should("exist")
+      })
+    })
+  })
 
   context("disabled", () => {
     context("when given by parent", () => {
       it("should render with cursor not-allowed and user-select none", () => {
-        const onChange = cy.spy().as("onChange");
+        const onChange = cy.spy().as("onChange")
         cy.mount(
           <StatefulForm
             fields={ALL_INPUT}
@@ -1496,23 +1690,23 @@ describe("StatefulForm", () => {
             disabled={true}
             mode="onChange"
             onChange={onChange}
-          />
-        );
+          />,
+        )
 
         cy.findAllByLabelText("field-lane-wrapper")
           .should("have.css", "cursor", "not-allowed")
-          .and("have.css", "user-select", "none");
+          .and("have.css", "user-select", "none")
         cy.findAllByLabelText("chips-container-input")
           .should("have.css", "cursor", "not-allowed")
-          .and("have.css", "user-select", "none");
+          .and("have.css", "user-select", "none")
         cy.findAllByLabelText("file-drop-box-container")
           .should("have.css", "cursor", "not-allowed")
-          .and("have.css", "user-select", "none");
-      });
+          .and("have.css", "user-select", "none")
+      })
 
       context("when trying to interact", () => {
         it("should not change value", () => {
-          const onChange = cy.spy().as("onChange");
+          const onChange = cy.spy().as("onChange")
           cy.mount(
             <StatefulForm
               fields={ALL_INPUT}
@@ -1520,19 +1714,19 @@ describe("StatefulForm", () => {
               disabled={true}
               mode="onChange"
               onChange={onChange}
-            />
-          );
+            />,
+          )
 
           cy.get("input, textarea, [role='radio'], [role='checkbox']").each(
             ($el) => {
-              cy.wrap($el).should("be.disabled").click({ force: true });
-            }
-          );
+              cy.wrap($el).should("be.disabled").click({ force: true })
+            },
+          )
 
-          cy.get("@onChange").should("not.have.been.called");
-        });
-      });
-    });
+          cy.get("@onChange").should("not.have.been.called")
+        })
+      })
+    })
 
     context("when given by per field", () => {
       const INPUT_WITH_DISABLED: FormFieldGroup[] = ALL_INPUT.map((group) =>
@@ -1544,8 +1738,8 @@ describe("StatefulForm", () => {
           : {
               ...group,
               disabled: true,
-            }
-      );
+            },
+      )
       context("when given true", () => {
         it("should render with cursor not-allowed and user-select none", () => {
           cy.mount(
@@ -1558,20 +1752,20 @@ describe("StatefulForm", () => {
                   width: 480px;
                 `,
               }}
-            />
-          );
+            />,
+          )
 
           cy.findAllByLabelText("field-lane-wrapper")
             .should("have.css", "cursor", "not-allowed")
-            .and("have.css", "user-select", "none");
+            .and("have.css", "user-select", "none")
           cy.findAllByLabelText("chips-container-input")
             .should("have.css", "cursor", "not-allowed")
-            .and("have.css", "user-select", "none");
+            .and("have.css", "user-select", "none")
           cy.findAllByLabelText("file-drop-box-container")
             .should("have.css", "cursor", "not-allowed")
-            .and("have.css", "user-select", "none");
-        });
-      });
+            .and("have.css", "user-select", "none")
+        })
+      })
 
       it("should renders with disabled each input", () => {
         cy.mount(
@@ -1579,17 +1773,17 @@ describe("StatefulForm", () => {
             fields={INPUT_WITH_DISABLED}
             formValues={allValue}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         cy.get("input, textarea, [role='radio'], [role='checkbox']").each(
           ($el) => {
-            cy.wrap($el).should("be.disabled");
-          }
-        );
-      });
-    });
-  });
+            cy.wrap($el).should("be.disabled")
+          },
+        )
+      })
+    })
+  })
 
   context("label", () => {
     context("labelPosition", () => {
@@ -1604,8 +1798,8 @@ describe("StatefulForm", () => {
               : {
                   ...group,
                   labelPosition: "left",
-                }
-        );
+                },
+        )
 
         it("should render with flex-row and 25% width label", () => {
           cy.mount(
@@ -1618,26 +1812,26 @@ describe("StatefulForm", () => {
                   width: 480px;
                 `,
               }}
-            />
-          );
+            />,
+          )
 
           cy.findAllByLabelText("stateful-form-label-wrapper").each(
             ($el, i) => {
               cy.wrap($el)
                 .invoke("css", "width")
                 .then((width) => {
-                  const w = width as unknown as string;
+                  const w = width as unknown as string
                   if (i < 2) {
-                    expect(parseFloat(w)).to.be.closeTo(45, 3);
+                    expect(parseFloat(w)).to.be.closeTo(45, 3)
                   } else {
-                    expect(parseFloat(w)).to.be.closeTo(90, 6);
+                    expect(parseFloat(w)).to.be.closeTo(90, 6)
                   }
-                });
-            }
-          );
-        });
-      });
-    });
+                })
+            },
+          )
+        })
+      })
+    })
 
     context("labelWidth", () => {
       context("when given 70%", () => {
@@ -1653,8 +1847,8 @@ describe("StatefulForm", () => {
                   ...group,
                   labelPosition: "left",
                   labelWidth: "70%",
-                }
-          );
+                },
+          )
 
         it("should render with 70% width", () => {
           cy.mount(
@@ -1667,26 +1861,26 @@ describe("StatefulForm", () => {
                   width: 480px;
                 `,
               }}
-            />
-          );
+            />,
+          )
 
           cy.findAllByLabelText("stateful-form-label-wrapper").each(
             ($el, i) => {
               cy.wrap($el)
                 .invoke("css", "width")
                 .then((width) => {
-                  const w = width as unknown as string;
+                  const w = width as unknown as string
                   if (i < 2) {
-                    expect(parseFloat(w)).to.be.closeTo(100, 6);
+                    expect(parseFloat(w)).to.be.closeTo(100, 6)
                   } else {
-                    expect(parseFloat(w)).to.be.closeTo(200, 12);
+                    expect(parseFloat(w)).to.be.closeTo(200, 12)
                   }
-                });
-            }
-          );
-        });
-      });
-    });
+                })
+            },
+          )
+        })
+      })
+    })
 
     context("labelGap", () => {
       context("when given 30px", () => {
@@ -1702,8 +1896,8 @@ describe("StatefulForm", () => {
                   ...group,
                   labelPosition: "left",
                   labelGap: 30,
-                }
-          );
+                },
+          )
 
         it("should render with 30px width", () => {
           cy.mount(
@@ -1711,23 +1905,23 @@ describe("StatefulForm", () => {
               fields={INPUT_WITH_LABEL_POSITION_AND_GAP}
               formValues={allValue}
               mode="onChange"
-            />
-          );
+            />,
+          )
 
           cy.findAllByLabelText("field-lane-wrapper")
             .should("have.length", 22)
             .each(($el) => {
-              cy.wrap($el).should("have.css", "gap", "30px");
-            });
+              cy.wrap($el).should("have.css", "gap", "30px")
+            })
           cy.findAllByLabelText("file-drop-box-container")
             .should("have.length", 1)
             .each(($el) => {
-              cy.wrap($el).should("have.css", "gap", "30px");
-            });
-        });
-      });
-    });
-  });
+              cy.wrap($el).should("have.css", "gap", "30px")
+            })
+        })
+      })
+    })
+  })
 
   context("asterisk", () => {
     context("when given required", () => {
@@ -1737,25 +1931,25 @@ describe("StatefulForm", () => {
             fields={ALL_INPUT}
             formValues={allValue}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         const inputWithRequired = flattenFields(ALL_INPUT).filter(
-          (props) => props.required
-        );
+          (props) => props.required,
+        )
 
         cy.findAllByLabelText("stateful-form-label-asterisk").should(
           "have.length",
-          inputWithRequired.length
-        );
-      });
-    });
-  });
+          inputWithRequired.length,
+        )
+      })
+    })
+  })
 
   context("pinbox", () => {
     const pinboxSchema = z.object({
       pin: z.string().min(4, "Pinbox does not follow the acceptable format"),
-    });
+    })
 
     const FIELDS: FormFieldGroup[] = [
       {
@@ -1768,10 +1962,10 @@ describe("StatefulForm", () => {
           parts: PARTS_INPUT,
         },
       },
-    ];
+    ]
 
     function PinboxProduct() {
-      const [state, setState] = useState({ pin: "" });
+      const [state, setState] = useState({ pin: "" })
       return (
         <StatefulForm
           validationSchema={pinboxSchema}
@@ -1779,36 +1973,36 @@ describe("StatefulForm", () => {
           fields={FIELDS}
           formValues={state}
         />
-      );
+      )
     }
 
     context("validation error", () => {
       context("when pressing 2 character (not eligible)", () => {
         it("should not show an error", () => {
-          cy.mount(<PinboxProduct />);
-          cy.findAllByRole("textbox").eq(1).type("23");
+          cy.mount(<PinboxProduct />)
+          cy.findAllByRole("textbox").eq(1).type("23")
           cy.findByText("Pinbox does not follow the acceptable format").should(
-            "not.exist"
-          );
-        });
+            "not.exist",
+          )
+        })
 
         context("when blurring from the input", () => {
           it("should displaying an error", () => {
-            cy.mount(<PinboxProduct />);
-            cy.findAllByRole("textbox").eq(1).type("23");
+            cy.mount(<PinboxProduct />)
+            cy.findAllByRole("textbox").eq(1).type("23")
             cy.findByText(
-              "Pinbox does not follow the acceptable format"
-            ).should("not.exist");
-            cy.get("body").click("top");
-            cy.wait(200);
+              "Pinbox does not follow the acceptable format",
+            ).should("not.exist")
+            cy.get("body").click("top")
+            cy.wait(200)
             cy.findByText(
-              "Pinbox does not follow the acceptable format"
-            ).should("exist");
-          });
-        });
-      });
-    });
-  });
+              "Pinbox does not follow the acceptable format",
+            ).should("exist")
+          })
+        })
+      })
+    })
+  })
 
   context("button", () => {
     const VARIANTS = [
@@ -1847,13 +2041,13 @@ describe("StatefulForm", () => {
         hover: "rgb(42, 115, 195)",
         active: "rgb(30, 91, 168)",
       },
-    ] as const;
+    ] as const
 
     context("when hover", () => {
       it("renders the the hover color", () => {
         cy.window().then((win) => {
-          cy.spy(win.console, "log").as("consoleLog");
-        });
+          cy.spy(win.console, "log").as("consoleLog")
+        })
 
         cy.mount(
           <StatefulForm
@@ -1868,25 +2062,25 @@ describe("StatefulForm", () => {
             }))}
             formValues={{}}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         VARIANTS.forEach(({ hover }, index) => {
           cy.findAllByRole("button")
             .eq(index)
             .realHover()
             .wait(200)
-            .should("have.css", "background-color", hover);
-        });
-      });
-    });
+            .should("have.css", "background-color", hover)
+        })
+      })
+    })
 
     context("when given an onClick", () => {
       context("when clicking", () => {
         it("renders the the active with usual color", () => {
           cy.window().then((win) => {
-            cy.spy(win.console, "log").as("consoleLog");
-          });
+            cy.spy(win.console, "log").as("consoleLog")
+          })
 
           cy.mount(
             <StatefulForm
@@ -1902,24 +2096,24 @@ describe("StatefulForm", () => {
               }))}
               formValues={{}}
               mode="onChange"
-            />
-          );
+            />,
+          )
 
           VARIANTS.forEach(({ active }, index) => {
-            cy.findAllByRole("button").eq(index).realMouseDown();
+            cy.findAllByRole("button").eq(index).realMouseDown()
 
             cy.findAllByRole("button")
               .eq(index)
-              .should("have.css", "background-color", active);
+              .should("have.css", "background-color", active)
 
-            cy.findAllByRole("button").eq(index).realMouseUp();
-          });
-        });
+            cy.findAllByRole("button").eq(index).realMouseUp()
+          })
+        })
 
         it("renders the callback from top-level", () => {
           cy.window().then((win) => {
-            cy.spy(win.console, "log").as("consoleLog");
-          });
+            cy.spy(win.console, "log").as("consoleLog")
+          })
 
           cy.mount(
             <StatefulForm
@@ -1934,24 +2128,24 @@ describe("StatefulForm", () => {
               ]}
               formValues={{}}
               mode="onChange"
-            />
-          );
+            />,
+          )
 
-          cy.findByRole("button").eq(0).click();
+          cy.findByRole("button").eq(0).click()
 
           cy.get("@consoleLog").should(
             "have.been.calledWith",
-            "this is callback from the top level"
-          );
-        });
-      });
+            "this is callback from the top level",
+          )
+        })
+      })
 
       context("when given a buttonProps.onClick", () => {
         context("when clicking", () => {
           it("renders the callback from buttonProps instead", () => {
             cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
+              cy.spy(win.console, "log").as("consoleLog")
+            })
 
             cy.mount(
               <StatefulForm
@@ -1970,20 +2164,20 @@ describe("StatefulForm", () => {
                 ]}
                 formValues={{}}
                 mode="onChange"
-              />
-            );
+              />,
+            )
 
-            cy.findByRole("button").eq(0).click();
+            cy.findByRole("button").eq(0).click()
 
             cy.get("@consoleLog").should(
               "have.been.calledWith",
-              "this is callback from the specific level"
-            );
-          });
-        });
-      });
-    });
-  });
+              "this is callback from the specific level",
+            )
+          })
+        })
+      })
+    })
+  })
 
   context("when array of array", () => {
     const value = {
@@ -1994,7 +2188,7 @@ describe("StatefulForm", () => {
       note: "",
       access: false,
       country_code: DEFAULT_COUNTRY_CODES,
-    };
+    }
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
@@ -2041,7 +2235,7 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ];
+    ]
 
     it("render in the one row", () => {
       cy.mount(
@@ -2049,20 +2243,20 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS}
           formValues={value}
           mode="onChange"
-        />
-      );
+        />,
+      )
       cy.findAllByLabelText("stateful-form-row")
         .eq(0)
         .within(() => {
-          cy.contains("First Name").should("exist");
-          cy.contains("Last Name").should("exist");
+          cy.contains("First Name").should("exist")
+          cy.contains("Last Name").should("exist")
 
-          cy.contains("Email").should("not.exist");
-          cy.contains("Phone Number").should("not.exist");
-          cy.contains("Note").should("not.exist");
-          cy.contains("Has access to login").should("not.exist");
-        });
-    });
+          cy.contains("Email").should("not.exist")
+          cy.contains("Phone Number").should("not.exist")
+          cy.contains("Note").should("not.exist")
+          cy.contains("Has access to login").should("not.exist")
+        })
+    })
 
     context("when given without title", () => {
       const FIELDS_WITHOUT_TITLE: FormFieldGroup[] = [
@@ -2115,63 +2309,63 @@ describe("StatefulForm", () => {
             type: "button",
           },
         ],
-      ];
+      ]
 
       it("should not break the height", () => {
-        cy.viewport(1000, 900);
+        cy.viewport(1000, 900)
         cy.mount(
           <StatefulForm
             fields={FIELDS_WITHOUT_TITLE}
             formValues={value}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         cy.findAllByLabelText("stateful-form-row")
           .eq(0)
           .within(() => {
-            cy.contains("First Name").should("exist");
-            cy.contains("Last Name").should("not.exist");
-            cy.contains("Phone").should("not.exist");
-            cy.contains("Combo").should("not.exist");
+            cy.contains("First Name").should("exist")
+            cy.contains("Last Name").should("not.exist")
+            cy.contains("Phone").should("not.exist")
+            cy.contains("Combo").should("not.exist")
           })
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
 
         cy.get("#textbox-first_name")
           .parent()
           .parent()
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
         cy.get("#textbox-last_name")
           .parent()
           .parent()
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
         cy.get("#phonebox-phone")
           .parent()
           .parent()
           .parent()
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
         cy.get("#capsule-capsule")
           .parent()
           .parent()
           .parent()
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
         cy.get("#combobox-combo")
           .parent()
           .parent()
           .parent()
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
         cy.get("#datebox-date")
           .parent()
           .parent()
           .parent()
-          .should("have.css", "height", "60px");
+          .should("have.css", "height", "60px")
         cy.findAllByRole("button")
           .eq(1)
           .parent()
-          .should("have.css", "margin-top", "26px");
-      });
-    });
-  });
+          .should("have.css", "margin-top", "26px")
+      })
+    })
+  })
 
   context("id", () => {
     it("renders each field with a proper and unique ID", () => {
@@ -2180,26 +2374,26 @@ describe("StatefulForm", () => {
           fields={ALL_INPUT}
           formValues={allValue}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
       flattenFields(ALL_INPUT).map((field) => {
         if (field.type === "frame" || field.type === "chips") {
-          return;
+          return
         } else if (field.type === "radio") {
-          cy.get(`#radio-value-radio`).should("exist");
+          cy.get(`#radio-value-radio`).should("exist")
         } else {
           const prefix =
             TYPE_TO_ID_PREFIX[field.type] ??
-            field.type.replace(/\s+/g, "_").toLowerCase();
+            field.type.replace(/\s+/g, "_").toLowerCase()
           const expectedId = field.name
             ? `${prefix}-${field.name.replace(/\s+/g, "_").toLowerCase()}`
-            : prefix;
+            : prefix
 
-          cy.get(`#${expectedId}`).should("exist");
+          cy.get(`#${expectedId}`).should("exist")
         }
-      });
-    });
+      })
+    })
 
     context("when given with non-ASCII IDs", () => {
       const FIELDS_NOT_NORMAL_ASCII: FormFieldGroup[] = [
@@ -2328,7 +2522,7 @@ describe("StatefulForm", () => {
           required: false,
           id: "field-signature-✍️ sign here!",
         },
-      ];
+      ]
 
       it("renders sanitized ASCII-only IDs for input elements", () => {
         cy.mount(
@@ -2336,12 +2530,12 @@ describe("StatefulForm", () => {
             fields={FIELDS_NOT_NORMAL_ASCII}
             formValues={allValue}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         const sanitized = flattenFields(FIELDS_NOT_NORMAL_ASCII).map((field) =>
-          StatefulForm.sanitizeId({ id: field.id })
-        );
+          StatefulForm.sanitizeId({ id: field.id }),
+        )
 
         const expected = [
           "field-text-_hello_world",
@@ -2360,14 +2554,14 @@ describe("StatefulForm", () => {
           "field-money-_1000",
           "field-phone-_askdaosdk",
           "field-signature-_sign_here",
-        ];
+        ]
 
         sanitized.map((result, i) => {
-          expect(result).to.equal(expected[i]);
-        });
-      });
-    });
-  });
+          expect(result).to.equal(expected[i])
+        })
+      })
+    })
+  })
 
   context("with type custom", () => {
     function StatefulFormCustom() {
@@ -2375,9 +2569,9 @@ describe("StatefulForm", () => {
         first_name: "",
         access: false,
         files: [],
-      });
+      })
 
-      const [isFormValid, setIsFormValid] = useState(false);
+      const [isFormValid, setIsFormValid] = useState(false)
 
       const onFileDropped = async ({
         error,
@@ -2385,28 +2579,28 @@ describe("StatefulForm", () => {
         setProgressLabel,
         succeed,
       }: OnFileDroppedFunctionArgs) => {
-        const file = files[0];
-        setValue((prev) => ({ ...prev, files: [...prev.files, file] }));
-        setProgressLabel(`Uploading ${file.name}`);
+        const file = files[0]
+        setValue((prev) => ({ ...prev, files: [...prev.files, file] }))
+        setProgressLabel(`Uploading ${file.name}`)
 
         return new Promise<void>((resolve) => {
-          let progress = 0;
+          let progress = 0
           const interval = setInterval(() => {
-            progress += 20;
+            progress += 20
 
             if (progress >= 100) {
-              clearInterval(interval);
+              clearInterval(interval)
               if (file === null) {
-                error(file, `file ${file.name} is not uploaded`);
+                error(file, `file ${file.name} is not uploaded`)
               } else {
-                succeed(file);
+                succeed(file)
               }
-              setProgressLabel(`Uploaded ${files[0].name}`);
-              resolve();
+              setProgressLabel(`Uploaded ${files[0].name}`)
+              resolve()
             }
-          }, 300);
-        });
-      };
+          }, 300)
+        })
+      }
 
       const onComplete = async ({
         failedFiles,
@@ -2415,14 +2609,14 @@ describe("StatefulForm", () => {
         hideProgressLabel,
         showUploaderForm,
       }: OnCompleteFunctionArgs) => {
-        console.log(succeedFiles, "This is succeedFiles");
-        console.log(failedFiles, "This is failedFiles");
+        console.log(succeedFiles, "This is succeedFiles")
+        console.log(failedFiles, "This is failedFiles")
         await setProgressLabel(
-          `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`
-        );
-        await hideProgressLabel();
-        await showUploaderForm();
-      };
+          `Upload complete! Success: ${succeedFiles.length}, Failed: ${failedFiles.length}`,
+        )
+        await hideProgressLabel()
+        await showUploaderForm()
+      }
 
       const CUSTOM_FIELDS: FormFieldGroup[] = [
         {
@@ -2499,9 +2693,9 @@ describe("StatefulForm", () => {
                             setValue((prev) => ({
                               ...prev,
                               files: prev.files.filter(
-                                (val) => val.name !== id
+                                (val) => val.name !== id,
                               ),
-                            }));
+                            }))
                           }
                         },
                       },
@@ -2535,7 +2729,7 @@ describe("StatefulForm", () => {
           disabled: !isFormValid,
           rowJustifyPosition: "end",
         },
-      ];
+      ]
 
       const customSchema = z.object({
         first_name: z
@@ -2548,29 +2742,29 @@ describe("StatefulForm", () => {
           .array(
             z.instanceof(File).refine(
               (file) => {
-                if (!file) return false;
+                if (!file) return false
 
-                const allowedExtensions = ["png", "jpg", "jpeg", "gif"];
-                const ext = file.name.split(".").pop()?.toLowerCase();
+                const allowedExtensions = ["png", "jpg", "jpeg", "gif"]
+                const ext = file.name.split(".").pop()?.toLowerCase()
 
                 const isImage =
                   (file.type && file.type.startsWith("image/")) ||
-                  (ext ? allowedExtensions.includes(ext) : false);
+                  (ext ? allowedExtensions.includes(ext) : false)
 
-                if (!isImage) return false;
+                if (!isImage) return false
 
-                if (file.size > 5 * 1024 * 1024) return false;
+                if (file.size > 5 * 1024 * 1024) return false
 
-                return true;
+                return true
               },
               {
                 message:
                   "File must be an image (png, jpg, jpeg, gif) and ≤ 5 MB",
-              }
-            )
+              },
+            ),
           )
           .min(1, "At least one file must be selected"),
-      });
+      })
 
       return (
         <StatefulForm
@@ -2583,25 +2777,25 @@ describe("StatefulForm", () => {
           }
           mode="onChange"
         />
-      );
+      )
     }
 
     it("should render custom renderer", () => {
-      cy.mount(<StatefulFormCustom />);
+      cy.mount(<StatefulFormCustom />)
 
-      cy.findByLabelText("boxbar-toggle").click();
+      cy.findByLabelText("boxbar-toggle").click()
 
       BADGE_OPTIONS_FULL.map((data) => {
-        cy.findByText(data.caption).should("exist");
-      });
-    });
+        cy.findByText(data.caption).should("exist")
+      })
+    })
 
     context("when given validationSchema", () => {
       it("should synchronize values after all fields valid", () => {
-        cy.mount(<StatefulFormCustom />);
-        cy.findAllByRole("button").eq(1).and("be.disabled");
+        cy.mount(<StatefulFormCustom />)
+        cy.findAllByRole("button").eq(1).and("be.disabled")
 
-        cy.get("#textbox-first_name").type("Alim Naufal");
+        cy.get("#textbox-first_name").type("Alim Naufal")
         cy.findByLabelText("file-drop-box-area").selectFile(
           [
             "test/fixtures/test-images/sample-1.jpg",
@@ -2610,21 +2804,21 @@ describe("StatefulForm", () => {
           {
             action: "drag-drop",
             force: true,
-          }
-        );
-        cy.wait(1000);
+          },
+        )
+        cy.wait(1000)
 
         cy.findByLabelText("file-drop-box-area").then(($input) => {
-          cy.spy($input[0], "click").as("fileClick");
-        });
-        cy.findByText("sample-1.jpg").should("be.visible").click();
-        cy.findByText("sample-2.jpg").should("be.visible").click();
-        cy.findByText("Access").should("be.visible").click();
+          cy.spy($input[0], "click").as("fileClick")
+        })
+        cy.findByText("sample-1.jpg").should("be.visible").click()
+        cy.findByText("sample-2.jpg").should("be.visible").click()
+        cy.findByText("Access").should("be.visible").click()
 
-        cy.findAllByRole("button").eq(1).and("not.be.disabled");
-      });
-    });
-  });
+        cy.findAllByRole("button").eq(1).and("not.be.disabled")
+      })
+    })
+  })
 
   context("helper", () => {
     const FIELD_HELPERS: Record<string, string> = {
@@ -2651,7 +2845,7 @@ describe("StatefulForm", () => {
       toggle: "Toggle the switch.",
       chips: "Select one or more chips.",
       capsule: "Choose a monetary option.",
-    };
+    }
 
     const INPUT_WITH_HELPER = ALL_INPUT.map((group) =>
       Array.isArray(group)
@@ -2662,10 +2856,10 @@ describe("StatefulForm", () => {
         : {
             ...group,
             helper: FIELD_HELPERS[group.type],
-          }
-    );
+          },
+    )
 
-    const FLAT_INPUT = INPUT_WITH_HELPER.flatMap((props) => props);
+    const FLAT_INPUT = INPUT_WITH_HELPER.flatMap((props) => props)
 
     it("renders with tooltip", () => {
       cy.mount(
@@ -2673,18 +2867,18 @@ describe("StatefulForm", () => {
           fields={INPUT_WITH_HELPER}
           formValues={allValue}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
       cy.findAllByLabelText("tooltip-trigger")
         .should("have.length", FLAT_INPUT.length)
         .each(($el, index) => {
-          cy.wrap($el).trigger("mouseover");
+          cy.wrap($el).trigger("mouseover")
 
-          cy.findByText(String(FLAT_INPUT[index].helper));
-        });
-    });
-  });
+          cy.findByText(String(FLAT_INPUT[index].helper))
+        })
+    })
+  })
 
   context("with style", () => {
     context("when given background wheat", () => {
@@ -2839,7 +3033,7 @@ describe("StatefulForm", () => {
             },
           },
         },
-      };
+      }
 
       const INPUT_WITH_STYLE = ALL_INPUT.map((group) =>
         Array.isArray(group)
@@ -2850,8 +3044,8 @@ describe("StatefulForm", () => {
           : {
               ...group,
               ...FIELD_STYLES[group.type],
-            }
-      );
+            },
+      )
 
       it("renders with background wheat", () => {
         cy.mount(
@@ -2859,15 +3053,15 @@ describe("StatefulForm", () => {
             fields={INPUT_WITH_STYLE}
             formValues={allValue}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         const isFieldWithPlaceholder = (
-          field: FormFieldGroup
+          field: FormFieldGroup,
         ): field is FormFieldProps & { placeholder: string } =>
           !Array.isArray(field) &&
           "placeholder" in field &&
-          typeof field.placeholder === "string";
+          typeof field.placeholder === "string"
 
         const PLACEHOLDER_FIELDS = INPUT_WITH_STYLE.filter(
           (field): field is FormFieldProps & { placeholder: string } =>
@@ -2885,48 +3079,48 @@ describe("StatefulForm", () => {
               "date",
               "signature",
               "image",
-            ].includes(field.type)
-        );
+            ].includes(field.type),
+        )
 
         PLACEHOLDER_FIELDS.forEach((field) => {
           if (field.type === "image") {
             cy.findByPlaceholderText("imagebox-input")
               .should("exist")
-              .and("have.css", "background-color", "rgb(245, 222, 179)");
+              .and("have.css", "background-color", "rgb(245, 222, 179)")
           } else if (field.type === "signbox") {
             cy.findByPlaceholderText("signbox-canvas")
               .should("exist")
-              .and("have.css", "background-color", "rgb(245, 222, 179)");
+              .and("have.css", "background-color", "rgb(245, 222, 179)")
           } else if (field.type === "phone") {
             cy.findByPlaceholderText(field.placeholder)
               .should("exist")
               .parent()
-              .and("have.css", "background-color", "rgb(245, 222, 179)");
+              .and("have.css", "background-color", "rgb(245, 222, 179)")
           } else if (field.type === "color") {
             cy.findByPlaceholderText(field.placeholder)
               .should("exist")
               .parent()
               .parent()
-              .and("have.css", "background-color", "rgb(245, 222, 179)");
+              .and("have.css", "background-color", "rgb(245, 222, 179)")
           } else if (field.type === "money") {
             cy.findByPlaceholderText(field.placeholder)
               .should("exist")
               .parent()
-              .and("have.css", "background-color", "rgb(245, 222, 179)");
+              .and("have.css", "background-color", "rgb(245, 222, 179)")
           } else {
             cy.findByPlaceholderText(field.placeholder)
               .should("exist")
-              .and("have.css", "background-color", "rgb(245, 222, 179)");
+              .and("have.css", "background-color", "rgb(245, 222, 179)")
           }
-        });
-      });
-    });
-  });
+        })
+      })
+    })
+  })
 
   context("radio", () => {
     const value = {
       access: false,
-    };
+    }
 
     const RADIO_FIELDS: FormFieldGroup[] = [
       {
@@ -2936,7 +3130,7 @@ describe("StatefulForm", () => {
         type: "radio",
         required: false,
       },
-    ];
+    ]
     context("with title", () => {
       it("should render on the label field", () => {
         cy.mount(
@@ -2944,12 +3138,12 @@ describe("StatefulForm", () => {
             fields={RADIO_FIELDS}
             formValues={value}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
-        cy.findAllByText(RADIO_FIELDS[0]["title"]).eq(0).should("be.visible");
-      });
-    });
+        cy.findAllByText(RADIO_FIELDS[0]["title"]).eq(0).should("be.visible")
+      })
+    })
 
     context("with placeholder", () => {
       it("should render on the right side", () => {
@@ -2958,21 +3152,21 @@ describe("StatefulForm", () => {
             fields={RADIO_FIELDS}
             formValues={value}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         cy.findByLabelText("radio-label-wrapper").should(
           "have.text",
-          RADIO_FIELDS[0]["placeholder"]
-        );
-      });
-    });
-  });
+          RADIO_FIELDS[0]["placeholder"],
+        )
+      })
+    })
+  })
 
   context("capsule", () => {
     const value = {
       capsule: "unpaid",
-    };
+    }
 
     context("when initial value", () => {
       const CHECKBOX_TITLE_FIELDS: FormFieldGroup[] = [
@@ -2985,7 +3179,7 @@ describe("StatefulForm", () => {
             tabs: CAPSULE_TABS,
           },
         },
-      ];
+      ]
 
       it("should render active related with id value", () => {
         cy.mount(
@@ -2993,23 +3187,23 @@ describe("StatefulForm", () => {
             fields={CHECKBOX_TITLE_FIELDS}
             formValues={value}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
-        cy.findByText("Paid").should("have.css", "color", "rgb(17, 24, 39)");
+        cy.findByText("Paid").should("have.css", "color", "rgb(17, 24, 39)")
         cy.findByText("Unpaid").should(
           "have.css",
           "color",
-          "rgb(255, 255, 255)"
-        );
-      });
-    });
-  });
+          "rgb(255, 255, 255)",
+        )
+      })
+    })
+  })
 
   context("checkbox", () => {
     const value = {
       access: false,
-    };
+    }
 
     const CHECKBOX_TITLE_FIELDS: FormFieldGroup[] = [
       {
@@ -3019,7 +3213,7 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ];
+    ]
 
     const statefulForCheckbox = () =>
       cy.mount(
@@ -3027,49 +3221,49 @@ describe("StatefulForm", () => {
           fields={CHECKBOX_TITLE_FIELDS}
           formValues={value}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
     context("with title", () => {
       it("should render on the label field", () => {
-        statefulForCheckbox();
+        statefulForCheckbox()
 
         cy.findAllByText(CHECKBOX_TITLE_FIELDS[0]["title"])
           .eq(0)
-          .should("be.visible");
-      });
+          .should("be.visible")
+      })
 
       context("when clicking", () => {
         it("renders checked the checkbox", () => {
-          statefulForCheckbox();
+          statefulForCheckbox()
 
-          cy.findByRole("checkbox").should("not.be.checked");
-          cy.findByText("Access").click();
-          cy.findByRole("checkbox").should("be.checked");
-        });
-      });
-    });
+          cy.findByRole("checkbox").should("not.be.checked")
+          cy.findByText("Access").click()
+          cy.findByRole("checkbox").should("be.checked")
+        })
+      })
+    })
 
     context("with placeholder", () => {
       it("should render on the right side", () => {
-        statefulForCheckbox();
+        statefulForCheckbox()
 
         cy.findAllByText(CHECKBOX_TITLE_FIELDS[0]["placeholder"])
           .eq(0)
-          .should("be.visible");
-      });
+          .should("be.visible")
+      })
 
       context("when clicking", () => {
         it("renders checked the checkbox", () => {
-          statefulForCheckbox();
+          statefulForCheckbox()
 
-          cy.findByRole("checkbox").should("not.be.checked");
-          cy.findByText("Access placeholder").click();
-          cy.findByRole("checkbox").should("be.checked");
-        });
-      });
-    });
-  });
+          cy.findByRole("checkbox").should("not.be.checked")
+          cy.findByText("Access placeholder").click()
+          cy.findByRole("checkbox").should("be.checked")
+        })
+      })
+    })
+  })
 
   context("with justifyContent", () => {
     const value = {
@@ -3080,7 +3274,7 @@ describe("StatefulForm", () => {
       note: "",
       access: false,
       country_code: DEFAULT_COUNTRY_CODES,
-    };
+    }
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
@@ -3136,7 +3330,7 @@ describe("StatefulForm", () => {
         width: "15%",
         rowJustifyPosition: "end",
       },
-    ];
+    ]
 
     it("render style align on the one row", () => {
       cy.mount(
@@ -3144,14 +3338,14 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS}
           formValues={value}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
       cy.findAllByLabelText("stateful-form-row")
         .eq(5)
-        .should("have.css", "justify-content", "end");
-    });
-  });
+        .should("have.css", "justify-content", "end")
+    })
+  })
 
   context("with autoFocusField", () => {
     const value = {
@@ -3162,7 +3356,7 @@ describe("StatefulForm", () => {
       note: "",
       access: false,
       country_code: DEFAULT_COUNTRY_CODES,
-    };
+    }
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       [
@@ -3209,7 +3403,7 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ];
+    ]
 
     it("render in the one row", () => {
       cy.mount(
@@ -3218,21 +3412,21 @@ describe("StatefulForm", () => {
           formValues={value}
           mode="onChange"
           autoFocusField="first_name"
-        />
-      );
+        />,
+      )
       cy.findAllByLabelText("stateful-form-row")
         .eq(0)
         .within(() => {
-          cy.findAllByRole("textbox").eq(0).should("exist").and("be.focused");
-        });
-    });
-  });
+          cy.findAllByRole("textbox").eq(0).should("exist").and("be.focused")
+        })
+    })
+  })
 
   context("when not given a title", () => {
     const value = {
       first_name: "",
       access: false,
-    };
+    }
 
     const EMPLOYEE_FIELDS: FormFieldGroup[] = [
       {
@@ -3247,11 +3441,11 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ];
+    ]
 
-    const TITLE_EMPLOYEE_FIELD = ["First Name", "Has access to login"];
+    const TITLE_EMPLOYEE_FIELD = ["First Name", "Has access to login"]
 
-    const PLACEHOLDER_EMPLOYEE_FIELD = ["Enter first name"];
+    const PLACEHOLDER_EMPLOYEE_FIELD = ["Enter first name"]
 
     it("should render only the input", () => {
       cy.mount(
@@ -3259,22 +3453,22 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS}
           formValues={value}
           mode="onChange"
-        />
-      );
+        />,
+      )
       PLACEHOLDER_EMPLOYEE_FIELD.map((data) => {
-        cy.findByPlaceholderText(data).should("exist");
-      });
+        cy.findByPlaceholderText(data).should("exist")
+      })
       TITLE_EMPLOYEE_FIELD.map((data) => {
-        cy.findByText(data).should("not.exist");
-      });
-    });
-  });
+        cy.findByText(data).should("not.exist")
+      })
+    })
+  })
 
   context("with hidden", () => {
     const value = {
       first_name: "",
       access: false,
-    };
+    }
 
     const EMPLOYEE_FIELDS_WITH_HIDDEN: FormFieldGroup[] = [
       {
@@ -3298,7 +3492,7 @@ describe("StatefulForm", () => {
         type: "checkbox",
         required: false,
       },
-    ];
+    ]
 
     it("should hidden the input element", () => {
       cy.mount(
@@ -3306,15 +3500,13 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS_WITH_HIDDEN}
           formValues={value}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
-      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[0]["title"]).should("exist");
-      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[1]["title"]).should(
-        "not.exist"
-      );
-      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[2]["title"]).should("exist");
-    });
+      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[0]["title"]).should("exist")
+      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[1]["title"]).should("not.exist")
+      cy.findByText(EMPLOYEE_FIELDS_WITH_HIDDEN[2]["title"]).should("exist")
+    })
 
     it("should hidden the row input element", () => {
       cy.mount(
@@ -3322,12 +3514,12 @@ describe("StatefulForm", () => {
           fields={EMPLOYEE_FIELDS_WITH_HIDDEN}
           formValues={value}
           mode="onChange"
-        />
-      );
+        />,
+      )
 
-      cy.findAllByLabelText("stateful-form-row").should("have.length", 2);
-    });
-  });
+      cy.findAllByLabelText("stateful-form-row").should("have.length", 2)
+    })
+  })
 
   context("with width", () => {
     context("when given all input elements", () => {
@@ -3335,44 +3527,44 @@ describe("StatefulForm", () => {
         const INPUT_WITH_WIDTH = ALL_INPUT.map((group) =>
           Array.isArray(group)
             ? group.map((item) => ({ ...item, width: "50%" }))
-            : { ...group, width: "50%" }
-        );
+            : { ...group, width: "50%" },
+        )
 
         cy.mount(
           <StatefulForm
             fields={INPUT_WITH_WIDTH}
             formValues={allValue}
             mode="onChange"
-          />
-        );
+          />,
+        )
 
         flattenFields(INPUT_WITH_WIDTH).forEach((prop) => {
-          if (prop.name === "country_code") return;
+          if (prop.name === "country_code") return
           if (prop.name === "toggle") {
             cy.findByLabelText("toggle-row-wrapper").then(($el) => {
-              const width = $el.width();
-              expect(width).to.be.closeTo(222.5, 10);
-            });
+              const width = $el.width()
+              expect(width).to.be.closeTo(222.5, 10)
+            })
           } else {
             cy.findByText(prop.title)
               .parent()
               .then(($el) => {
-                const elWidth = $el.width();
-                expect(elWidth).to.be.closeTo(222.5, 10);
-              });
+                const elWidth = $el.width()
+                expect(elWidth).to.be.closeTo(222.5, 10)
+              })
           }
-        });
-      });
+        })
+      })
 
       context("when using small screen", () => {
         it("still render input elements with sizing", () => {
           const INPUT_WITH_WIDTH = ALL_INPUT.map((group) =>
             Array.isArray(group)
               ? group.map((item) => ({ ...item, width: "50%" }))
-              : { ...group, width: "50%" }
-          );
+              : { ...group, width: "50%" },
+          )
 
-          cy.viewport(440, 750);
+          cy.viewport(440, 750)
           // assume this in phone
 
           cy.mount(
@@ -3380,27 +3572,27 @@ describe("StatefulForm", () => {
               fields={INPUT_WITH_WIDTH}
               formValues={allValue}
               mode="onChange"
-            />
-          );
+            />,
+          )
 
           flattenFields(INPUT_WITH_WIDTH).forEach((prop) => {
-            if (prop.name === "country_code") return;
+            if (prop.name === "country_code") return
             if (prop.name === "toggle") {
               cy.findByLabelText("toggle-row-wrapper").then(($el) => {
-                const width = $el.width();
-                expect(width).to.be.closeTo(197.5, 10);
-              });
+                const width = $el.width()
+                expect(width).to.be.closeTo(197.5, 10)
+              })
             } else {
               cy.findByText(prop.title)
                 .parent()
                 .then(($el) => {
-                  const elWidth = $el.width();
-                  expect(elWidth).to.be.closeTo(197.5, 10);
-                });
+                  const elWidth = $el.width()
+                  expect(elWidth).to.be.closeTo(197.5, 10)
+                })
             }
-          });
-        });
-      });
-    });
-  });
-});
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/component/stateful-form.cy.tsx
+++ b/test/component/stateful-form.cy.tsx
@@ -582,119 +582,119 @@ describe("StatefulForm", () => {
     });
   });
 
-  context("mobile", () => {
-    context("styles", () => {
-      const INPUT_WITH_HELPER = ALL_INPUT.map((group) =>
-        Array.isArray(group)
-          ? group.map((item) => ({
-              ...item,
-              helper: (
-                <span aria-label="helper-with-react-node">
-                  {FIELD_HELPERS[item.type]}
-                </span>
-              ),
-            }))
-          : {
-              ...group,
-              helper: (
-                <span aria-label="helper-with-react-node">
-                  {FIELD_HELPERS[group.type]}
-                </span>
-              ),
-            }
-      );
+  context("styles", () => {
+    const INPUT_WITH_HELPER = ALL_INPUT.map((group) =>
+      Array.isArray(group)
+        ? group.map((item) => ({
+            ...item,
+            helper: (
+              <span aria-label="helper-with-react-node">
+                {FIELD_HELPERS[item.type]}
+              </span>
+            ),
+          }))
+        : {
+            ...group,
+            helper: (
+              <span aria-label="helper-with-react-node">
+                {FIELD_HELPERS[group.type]}
+              </span>
+            ),
+          }
+    );
 
-      const FLAT_INPUT = INPUT_WITH_HELPER.flatMap((props) => props);
-      context("helperArrowStyle", () => {
-        context("when given green background", () => {
-          it("renders with background with rgb(0, 255, 0)", () => {
-            cy.mount(
-              <StatefulForm
-                styles={{
-                  helperArrowStyle: css`
-                    background-color: rgb(0, 255, 0);
-                  `,
-                }}
-                fields={INPUT_WITH_HELPER}
-                formValues={allValue}
-                mode="onChange"
-              />
-            );
+    const FLAT_INPUT = INPUT_WITH_HELPER.flatMap((props) => props);
+    context("helperArrowStyle", () => {
+      context("when given green background", () => {
+        it("renders with background with rgb(0, 255, 0)", () => {
+          cy.mount(
+            <StatefulForm
+              styles={{
+                helperArrowStyle: css`
+                  background-color: rgb(0, 255, 0);
+                `,
+              }}
+              fields={INPUT_WITH_HELPER}
+              formValues={allValue}
+              mode="onChange"
+            />
+          );
 
-            cy.findAllByLabelText("tooltip-trigger")
-              .should("have.length", FLAT_INPUT.length)
-              .each(($el, index) => {
-                cy.wrap($el).trigger("mouseover");
+          cy.findAllByLabelText("tooltip-trigger")
+            .should("have.length", FLAT_INPUT.length)
+            .each(($el, index) => {
+              cy.wrap($el).trigger("mouseover");
 
-                cy.findAllByLabelText("tooltip-arrow")
-                  .eq(index)
-                  .should("have.css", "background-color", "rgb(0, 255, 0)");
-              });
-          });
+              cy.findAllByLabelText("tooltip-arrow")
+                .eq(index)
+                .should("have.css", "background-color", "rgb(0, 255, 0)");
+            });
         });
       });
+    });
 
-      context("helperIconStyle", () => {
-        context("when given red color", () => {
-          it("renders the svg with rgb(255, 0, 0)", () => {
-            cy.mount(
-              <StatefulForm
-                styles={{
-                  helperIconStyle: css`
-                    svg {
-                      fill: red;
-                    }
-                  `,
-                }}
-                fields={INPUT_WITH_HELPER}
-                formValues={allValue}
-                mode="onChange"
-              />
-            );
+    context("helperIconStyle", () => {
+      context("when given red color", () => {
+        it("renders the svg with rgb(255, 0, 0)", () => {
+          cy.mount(
+            <StatefulForm
+              styles={{
+                helperIconStyle: css`
+                  svg {
+                    fill: red;
+                  }
+                `,
+              }}
+              fields={INPUT_WITH_HELPER}
+              formValues={allValue}
+              mode="onChange"
+            />
+          );
 
-            cy.findAllByLabelText("tooltip-trigger")
-              .should("have.length", FLAT_INPUT.length)
-              .each(($el, index) => {
-                cy.wrap($el).trigger("mouseover");
+          cy.findAllByLabelText("tooltip-trigger")
+            .should("have.length", FLAT_INPUT.length)
+            .each(($el, index) => {
+              cy.wrap($el).trigger("mouseover");
 
-                cy.findAllByLabelText("tooltip-trigger")
-                  .eq(index)
-                  .find("svg")
-                  .should("have.css", "fill", "rgb(255, 0, 0)");
-              });
-          });
+              cy.findAllByLabelText("tooltip-trigger")
+                .eq(index)
+                .find("svg")
+                .should("have.css", "fill", "rgb(255, 0, 0)");
+            });
         });
       });
+    });
 
-      context("helperDrawerStyle", () => {
-        context("when given background yellow", () => {
-          it("renders the background color with rgb(255, 255, 0)", () => {
-            cy.mount(
-              <StatefulForm
-                styles={{
-                  helperDrawerStyle: css`
-                    background-color: yellow;
-                  `,
-                }}
-                fields={INPUT_WITH_HELPER}
-                formValues={allValue}
-                mode="onChange"
-              />
-            );
+    context("helperDrawerStyle", () => {
+      context("when given background yellow", () => {
+        it("renders the background color with rgb(255, 255, 0)", () => {
+          cy.mount(
+            <StatefulForm
+              styles={{
+                helperDrawerStyle: css`
+                  background-color: yellow;
+                `,
+              }}
+              fields={INPUT_WITH_HELPER}
+              formValues={allValue}
+              mode="onChange"
+            />
+          );
 
-            cy.findAllByLabelText("tooltip-trigger")
-              .should("have.length", FLAT_INPUT.length)
-              .each(($el, index) => {
-                cy.wrap($el).trigger("mouseover");
+          cy.findAllByLabelText("tooltip-trigger")
+            .should("have.length", FLAT_INPUT.length)
+            .each(($el, index) => {
+              cy.wrap($el).trigger("mouseover");
 
-                cy.findAllByLabelText("tooltip-drawer")
-                  .eq(index)
-                  .should("have.css", "background-color", "rgb(255, 255, 0)");
-              });
-          });
+              cy.findAllByLabelText("tooltip-drawer")
+                .eq(index)
+                .should("have.css", "background-color", "rgb(255, 255, 0)");
+            });
         });
       });
+    });
 
+    context("mobile", () => {
       context("mobileFieldGroupStyle", () => {
         context("when given padding 30px", () => {
           it("should render the padding in all side with 30px", () => {
@@ -747,6 +747,9 @@ describe("StatefulForm", () => {
         });
       });
     });
+  });
+
+  context("mobile", () => {
     it("renders with background rgb(236, 236, 236)", () => {
       cy.mount(
         <StatefulForm

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -1,365 +1,366 @@
-import { MessageboxVariant } from "./../components/messagebox";
-import { ButtonVariants } from "./../components/button";
-import { ToolbarVariant } from "./../components/toolbar";
-import { BaseSteplineItem } from "./../constants/step-component-util";
-import { TipMenuVariant } from "./../components/tip-menu";
-import { ToastVariant } from "./../components/toast";
-import { TrackbarVariant } from "../components/trackbar";
+import { MessageboxVariant } from "./../components/messagebox"
+import { ButtonVariants } from "./../components/button"
+import { ToolbarVariant } from "./../components/toolbar"
+import { BaseSteplineItem } from "./../constants/step-component-util"
+import { TipMenuVariant } from "./../components/tip-menu"
+import { ToastVariant } from "./../components/toast"
+import { TrackbarVariant } from "../components/trackbar"
 
 // body
 export interface BodyThemeConfig {
-  backgroundColor?: string;
-  textColor?: string;
-  borderColor?: string;
+  backgroundColor?: string
+  textColor?: string
+  borderColor?: string
+  mutedTextColor?: string
 }
 
 // action-capsule
 export interface ActionCapsuleThemeConfig {
-  activeBackgroundColor?: string;
-  textColor?: string;
-  borderColor?: string;
-  boxShadow?: string;
-  borderRadius?: string;
-  capsuleFontSize?: string;
-  tabTextColor?: string;
-  tabBorderRadius?: string;
+  activeBackgroundColor?: string
+  textColor?: string
+  borderColor?: string
+  boxShadow?: string
+  borderRadius?: string
+  capsuleFontSize?: string
+  tabTextColor?: string
+  tabBorderRadius?: string
 }
 
 // action-button.tsx
 export interface ActionButtonThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string;
-  disabledBackgroundColor?: string;
-  disabledOpacity?: number;
-  borderRadius?: string;
+  hoverBackgroundColor?: string
+  disabledBackgroundColor?: string
+  disabledOpacity?: number
+  borderRadius?: string
 
-  toggleBackgroundColor?: string;
-  toggleTextColor?: string;
-  toggleHoverBackgroundColor?: string;
-  toggleBorderColor?: string;
-  toggleBorderRadius?: string;
+  toggleBackgroundColor?: string
+  toggleTextColor?: string
+  toggleHoverBackgroundColor?: string
+  toggleBorderColor?: string
+  toggleBorderRadius?: string
 
-  dividerColor?: string;
+  dividerColor?: string
 
-  dropdownWidth?: string;
+  dropdownWidth?: string
 }
 
 // avatar.tsx
 export interface AvatarThemeConfig
   extends Omit<BodyThemeConfig, "backgroundColor"> {
-  overlayBackgroundColor?: string;
-  overlayIconColor?: string;
+  overlayBackgroundColor?: string
+  overlayIconColor?: string
 }
 
 // badge.tsx
 export interface BadgeThemeConfig extends BodyThemeConfig {
-  circleColor?: string;
+  circleColor?: string
   action?: {
-    hoverBackgroundColor?: string;
-    activeBackgroundColor?: string;
-    focusRingColor?: string;
-    disabledOpacity?: number;
-  };
+    hoverBackgroundColor?: string
+    activeBackgroundColor?: string
+    focusRingColor?: string
+    disabledOpacity?: number
+  }
 }
 
 // boxbar.tsx
 export interface BoxbarThemeConfig extends BodyThemeConfig {
-  toggleButtonColor?: string;
-  toggleButtonHoverColor?: string;
+  toggleButtonColor?: string
+  toggleButtonHoverColor?: string
 }
 
 // button.tsx
 export interface ButtonThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string;
-  activeBackgroundColor?: string;
-  textDecoration?: string;
-  focusBackgroundColor?: string;
-  dividerColor?: string;
+  hoverBackgroundColor?: string
+  activeBackgroundColor?: string
+  textDecoration?: string
+  focusBackgroundColor?: string
+  dividerColor?: string
 }
 
 export interface TipMenuContainerThemeConfig extends BodyThemeConfig {
-  boxShadow?: string;
+  boxShadow?: string
 }
 
 // calendar.tsx
 export interface CalendarThemeConfig extends BodyThemeConfig {
-  dayTextColor: string;
+  dayTextColor: string
 
-  disabledDateColor?: string;
-  weekendDateColor?: string;
+  disabledDateColor?: string
+  weekendDateColor?: string
 
-  rangeDateBackgroundColor?: string;
-  rangeDateTextColor?: string;
+  rangeDateBackgroundColor?: string
+  rangeDateTextColor?: string
 
-  highlightedDateTextColor?: string;
-  hightlightDateColor?: string;
+  highlightedDateTextColor?: string
+  hightlightDateColor?: string
 
-  mobileBackgroundColor?: string;
-  mobileBorderColor?: string;
+  mobileBackgroundColor?: string
+  mobileBorderColor?: string
 
-  boxShadow?: string;
+  boxShadow?: string
 }
 
 // capsule.tsx
 export interface CapsuleThemeConfig extends BodyThemeConfig {
-  errorBorderColor?: string;
-  boxShadow?: string;
+  errorBorderColor?: string
+  boxShadow?: string
   tab?: {
-    textColor?: string;
-    activeTextColor?: string;
-  };
+    textColor?: string
+    activeTextColor?: string
+  }
   active?: {
-    backgroundColor?: string;
-  };
+    backgroundColor?: string
+  }
   hover?: {
-    borderColor?: string;
-  };
+    borderColor?: string
+  }
 }
 
 // capsule-tab.tsx
 export interface CapsuleTabThemeConfig extends BodyThemeConfig {
-  boxShadow?: string;
-  activeBackgroundColor?: string;
+  boxShadow?: string
+  activeBackgroundColor?: string
 }
 
 // card.tsx
 export interface CardThemeConfig extends BodyThemeConfig {
-  dividerColor?: string;
-  titleColor?: string;
-  subtitleColor?: string;
-  headerBackground?: string;
-  footerBackground?: string;
-  closeIconColor?: string;
-  closeIconHoverBackground?: string;
+  dividerColor?: string
+  titleColor?: string
+  subtitleColor?: string
+  headerBackground?: string
+  footerBackground?: string
+  closeIconColor?: string
+  closeIconHoverBackground?: string
 }
 
 // chips.tsx
 export interface ChipsThemeConfig extends BodyThemeConfig {
-  mutedTextColor?: string;
+  mutedTextColor?: string
 
-  hoverBackgroundColor?: string;
-  selectedBackgroundColor?: string;
+  hoverBackgroundColor?: string
+  selectedBackgroundColor?: string
 
-  dividerColor?: string;
+  dividerColor?: string
 
-  boxShadow?: string;
+  boxShadow?: string
 }
 
 // choice-group.tsx
 export interface ChoiceGroupThemeConfig
   extends Omit<BodyThemeConfig, "textColor"> {
-  dividerColor?: string;
-  labelColor?: string;
-  descriptionColor?: string;
+  dividerColor?: string
+  labelColor?: string
+  descriptionColor?: string
 }
 
 // checkbox.tsx
 export interface CheckboxThemeConfig
   extends Omit<BodyThemeConfig, "textColor"> {
-  checkedBorderColor?: string;
-  checkedBackgroundColor?: string;
-  iconColor?: string;
-  labelColor?: string;
-  descriptionColor?: string;
-  highlightCheckedBackgroundColor?: string;
-  highlightHoverBackgroundColor?: string;
+  checkedBorderColor?: string
+  checkedBackgroundColor?: string
+  iconColor?: string
+  labelColor?: string
+  descriptionColor?: string
+  highlightCheckedBackgroundColor?: string
+  highlightHoverBackgroundColor?: string
 }
 
 // combobox.tsx
 export interface ComboboxThemeConfig extends BodyThemeConfig {
-  groupBackgroundColor?: string;
-  mobileGroupBackgroundColor?: string;
+  groupBackgroundColor?: string
+  mobileGroupBackgroundColor?: string
 
-  highlightBackgroundColor?: string;
-  selectedBackgroundColor?: string;
-  selectedTextColor?: string;
+  highlightBackgroundColor?: string
+  selectedBackgroundColor?: string
+  selectedTextColor?: string
 
-  disabledTextColor?: string;
-  emptyTextColor?: string;
+  disabledTextColor?: string
+  emptyTextColor?: string
 
-  dividerColor?: string;
-  boxShadow?: string;
+  dividerColor?: string
+  boxShadow?: string
 
-  scrollThumbColor?: string;
+  scrollThumbColor?: string
 
-  mobileBackgroundColor?: string;
-  fadeColor?: string;
+  mobileBackgroundColor?: string
+  fadeColor?: string
 }
 
 // colorbox.tsx
 export interface ColorboxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string;
+  focusedBorderColor?: string
 
-  errorBorderColor?: string;
-  errorTextColor?: string;
+  errorBorderColor?: string
+  errorTextColor?: string
 
-  disabledBorderColor?: string;
-  disabledTextColor?: string;
+  disabledBorderColor?: string
+  disabledTextColor?: string
 
-  prefixColor?: string;
+  prefixColor?: string
 
-  boxBackgroundColor?: string;
+  boxBackgroundColor?: string
 }
 
 // crumb.tsx
 export interface CrumbThemeConfig
   extends Omit<BodyThemeConfig, "borderColor" | "backgroundColor"> {
-  hoverColor?: string;
-  lastTextColor?: string;
-  arrowColor?: string;
-  ellipsisColor?: string;
-  ellipsisHoverColor?: string;
+  hoverColor?: string
+  lastTextColor?: string
+  arrowColor?: string
+  ellipsisColor?: string
+  ellipsisHoverColor?: string
 }
 
 // dialog.tsx
 export interface DialogThemeConfig extends BodyThemeConfig {
-  boxShadow?: string;
-  subtitleColor?: string;
+  boxShadow?: string
+  subtitleColor?: string
 }
 
 // document-viewer.tsx
 export interface DocumentViewerThemeConfig
   extends Omit<BodyThemeConfig, "borderColor"> {
-  toolbarBackgroundColor?: string;
-  errorColor?: string;
-  hoverBoxTextColor?: string;
-  hoverBoxBorderColor?: string;
-  hoverBoxBackgroundColor?: string;
+  toolbarBackgroundColor?: string
+  errorColor?: string
+  hoverBoxTextColor?: string
+  hoverBoxBorderColor?: string
+  hoverBoxBackgroundColor?: string
 }
 
 // dormant-text.tsx
 export interface DormantTextThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string;
-  pencilColor?: string;
-  actionButtonColor?: string;
-  actionButtonHoverBackground?: string;
+  hoverBackgroundColor?: string
+  pencilColor?: string
+  actionButtonColor?: string
+  actionButtonHoverBackground?: string
 }
 
 // drawer-tab.tsx
 export interface DrawerTabThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string;
-  headerBackgroundColor?: string;
-  closeButtonHoverBackground?: string;
-  dividerColor?: string;
+  hoverBackgroundColor?: string
+  headerBackgroundColor?: string
+  closeButtonHoverBackground?: string
+  dividerColor?: string
 }
 
 // error-slate.tsx
 export interface ErrorSlateThemeConfig {
-  cubeFaceBackground?: string;
-  cubeFaceBorder?: string;
-  cubeFaceText?: string;
-  titleColor?: string;
+  cubeFaceBackground?: string
+  cubeFaceBorder?: string
+  cubeFaceText?: string
+  titleColor?: string
 }
 
 // field-lane.tsx
 export interface FieldLaneThemeConfig
   extends Omit<BodyThemeConfig, "backgroundColor"> {
-  buttonTextColor?: string;
-  buttonBorderColor?: string;
-  buttonErrorTextColor?: string;
-  buttonErrorBorderColor?: string;
+  buttonTextColor?: string
+  buttonBorderColor?: string
+  buttonErrorTextColor?: string
+  buttonErrorBorderColor?: string
 
-  highlightBackgroundColor: string;
+  highlightBackgroundColor: string
 
-  placeholderColor?: string;
-  focusedBorderColor?: string;
+  placeholderColor?: string
+  focusedBorderColor?: string
 
-  disabledOpacity?: number;
-  disabledBorderColor?: string;
-  disabledTextColor?: string;
+  disabledOpacity?: number
+  disabledBorderColor?: string
+  disabledTextColor?: string
 
-  actionColor?: string;
-  actionHoverColor?: string;
-  actionHoverBackgroundColor?: string;
+  actionColor?: string
+  actionHoverColor?: string
+  actionHoverBackgroundColor?: string
 
-  errorColor?: string;
-  errorBackground?: string;
-  errorBorderColor?: string;
-  errorForeground?: string;
+  errorColor?: string
+  errorBackground?: string
+  errorBorderColor?: string
+  errorForeground?: string
 
-  selectedBackgroundColor?: string;
+  selectedBackgroundColor?: string
 
-  helperColor?: string;
-  dividerColor?: string;
+  helperColor?: string
+  dividerColor?: string
 }
 
 // flippable.tsx
 export interface FlippableThemeConfig {
-  front?: BodyThemeConfig;
-  back?: BodyThemeConfig;
+  front?: BodyThemeConfig
+  back?: BodyThemeConfig
 }
 
 // file-input-box.tsx
 export interface FileInputBoxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string;
-  errorBorderColor?: string;
+  focusedBorderColor?: string
+  errorBorderColor?: string
 
-  placeholderColor?: string;
+  placeholderColor?: string
 
-  disabledTextColor?: string;
+  disabledTextColor?: string
 
-  disabledGradientColor?: string;
-  errorGradientColor?: string;
-  defaultGradientColor?: string;
+  disabledGradientColor?: string
+  errorGradientColor?: string
+  defaultGradientColor?: string
 
-  dragActiveColor?: string;
-  dragActiveBackgroundColor?: string;
+  dragActiveColor?: string
+  dragActiveBackgroundColor?: string
 }
 
 // file-drop-box.tsx
 
 export interface FileDropBoxThemeConfig extends BodyThemeConfig {
-  placeholderColor?: string;
+  placeholderColor?: string
 
-  defaultGradientColor?: string;
-  dragActiveGradientColor?: string;
-  errorGradientColor?: string;
-  disabledGradientColor?: string;
+  defaultGradientColor?: string
+  dragActiveGradientColor?: string
+  errorGradientColor?: string
+  disabledGradientColor?: string
 
-  dragActiveBackgroundColor?: string;
-  dragActiveTextColor?: string;
+  dragActiveBackgroundColor?: string
+  dragActiveTextColor?: string
 
-  iconColor?: string;
+  iconColor?: string
 
-  disabledTextColor?: string;
+  disabledTextColor?: string
 
-  progressBackgroundColor?: string;
-  progressBarColor?: string;
-  progressTextColor?: string;
+  progressBackgroundColor?: string
+  progressBarColor?: string
+  progressTextColor?: string
 }
 
 // frame.tsx
 export interface FrameThemeConfig extends BodyThemeConfig {
-  titleColor?: string;
-  titleBackgroundColor?: string;
-  overlayBackgroundColor?: string;
-  boxShadow?: string;
+  titleColor?: string
+  titleBackgroundColor?: string
+  overlayBackgroundColor?: string
+  boxShadow?: string
 }
 
 // grid.tsx
 export interface GridThemeConfig extends Omit<BodyThemeConfig, "borderColor"> {
-  cardHoverBackgroundColor?: string;
-  cardSelectedBackgroundColor?: string;
-  cardBorderColor?: string;
-  cardShadow?: string;
-  thumbnailBackgroundColor?: string;
+  cardHoverBackgroundColor?: string
+  cardSelectedBackgroundColor?: string
+  cardBorderColor?: string
+  cardShadow?: string
+  thumbnailBackgroundColor?: string
 }
 
 export interface ImageboxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string;
+  focusedBorderColor?: string
 
-  draggingBackgroundColor?: string;
-  draggingBorderColor?: string;
-  draggingTextColor?: string;
+  draggingBackgroundColor?: string
+  draggingBorderColor?: string
+  draggingTextColor?: string
 
-  disabledBackgroundColor?: string;
+  disabledBackgroundColor?: string
 
-  iconColor?: string;
+  iconColor?: string
 }
 
 // keynote.tsx
 export interface KeynoteThemeConfig {
-  keyColor?: string;
-  valueColor?: string;
+  keyColor?: string
+  valueColor?: string
 }
 
 // launchpad.tsx
@@ -367,353 +368,365 @@ export interface LaunchpadThemeConfig extends BodyThemeConfig {}
 
 // list.tsx
 export interface ListThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string;
-  hoverTextColor?: string;
-  mutedTextColor?: string;
-  dragLineColor?: string;
-  emptyHoverBackgroundColor?: string;
-  toggleBackgroundColor?: string;
-  badgeTextColor?: string;
-  badgeBackgroundColor?: string;
-  badgeBorderColor?: string;
-  maxItemTextColor?: string;
+  hoverBackgroundColor?: string
+  hoverTextColor?: string
+  mutedTextColor?: string
+  dragLineColor?: string
+  emptyHoverBackgroundColor?: string
+  toggleBackgroundColor?: string
+  badgeTextColor?: string
+  badgeBackgroundColor?: string
+  badgeBorderColor?: string
+  maxItemTextColor?: string
 }
 
 // loading-skeleton.tsx
 export interface LoadingSkeletonThemeConfig {
-  baseColor?: string;
-  highlightColor?: string;
+  baseColor?: string
+  highlightColor?: string
 }
 
 // loading-spinner.tsx
 export interface LoadingSpinnerThemeConfig {
-  spinnerColor?: string;
-  textColor?: string;
+  spinnerColor?: string
+  textColor?: string
 }
 
 // messagebox.tsx
 export interface MessageboxVariantTheme
   extends Omit<BodyThemeConfig, "borderColor"> {
-  activeColor: string;
+  activeColor: string
 }
 
 export type MessageboxThemeConfig = {
-  [K in MessageboxVariant]: MessageboxVariantTheme;
-};
+  [K in MessageboxVariant]: MessageboxVariantTheme
+}
 
 // moneybox.tsx
 export interface MoneyboxThemeConfig extends BodyThemeConfig {
-  errorBorderColor?: string;
-  focusedBorderColor?: string;
+  errorBorderColor?: string
+  focusedBorderColor?: string
 
-  placeholderColor?: string;
-  disabledTextColor?: string;
+  placeholderColor?: string
+  disabledTextColor?: string
 
-  inputPadding?: string;
-  fontSize?: string;
-  borderRadius?: string;
+  inputPadding?: string
+  fontSize?: string
+  borderRadius?: string
 }
 
 // modal-dialog.tsx
 export interface ModalDialogThemeConfig extends DialogThemeConfig {
-  dividerColor?: string;
+  dividerColor?: string
 }
 
 // nav-tab.tsx
 export interface NavTabThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string;
-  activeBackgroundColor?: string;
-  selectedBackgroundColor?: string;
+  hoverBackgroundColor?: string
+  activeBackgroundColor?: string
+  selectedBackgroundColor?: string
 
-  indicatorColor?: string;
-  boxShadow?: string;
+  indicatorColor?: string
+  boxShadow?: string
 
-  circleInactiveColor?: string;
+  circleInactiveColor?: string
 
-  activeInsetShadow?: string;
+  activeInsetShadow?: string
 }
 
 // overlay-blocker.tsx
 export interface OverlayBlockerThemeConfig {
-  backgroundColor?: string;
-  backdropFilter?: string;
+  backgroundColor?: string
+  backdropFilter?: string
 }
 
 // paper-dialog.tsx
 export interface PaperDialogThemeConfig extends BodyThemeConfig {
-  boxShadow?: string;
-  actionHoverBackgroundColor?: string;
+  boxShadow?: string
+  actionHoverBackgroundColor?: string
 }
 
 // pagination.tsx
 export interface PaginationThemeConfig extends BodyThemeConfig {
-  activeBorderColor?: string;
-  hoverBorderColor?: string;
+  activeBorderColor?: string
+  hoverBorderColor?: string
 
-  activeTextColor?: string;
+  activeTextColor?: string
 
-  disabledBackgroundColor?: string;
-  disabledTextColor?: string;
+  disabledBackgroundColor?: string
+  disabledTextColor?: string
 }
 
 //pinbox.tsx
 export interface PinboxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string;
+  focusedBorderColor?: string
 
-  errorBorderColor?: string;
-  errorTextColor?: string;
+  errorBorderColor?: string
+  errorTextColor?: string
 
-  disabledBorderColor?: string;
-  disabledTextColor?: string;
+  disabledBorderColor?: string
+  disabledTextColor?: string
 
-  placeholderColor?: string;
-  boxShadow?: string;
+  placeholderColor?: string
+  boxShadow?: string
 }
 
 // phonebox.tsx
 export interface PhoneboxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string;
+  focusedBorderColor?: string
 
-  errorBorderColor?: string;
-  errorTextColor?: string;
+  errorBorderColor?: string
+  errorTextColor?: string
 
-  disabledBorderColor?: string;
-  disabledTextColor?: string;
+  disabledBorderColor?: string
+  disabledTextColor?: string
 
-  placeholderColor?: string;
+  placeholderColor?: string
 
-  boxShadow?: string;
+  boxShadow?: string
 
-  optionHighlightedBackground?: string;
+  optionHighlightedBackground?: string
 }
 
 // trackbar.tsx
 export interface TrackbarVariantTheme
   extends Omit<BodyThemeConfig, "borderColor"> {
-  barColor: string;
-  trackColor: string;
+  barColor: string
+  trackColor: string
 }
 
 export type TrackbarThemeConfig = {
-  [K in TrackbarVariant]: TrackbarVariantTheme;
-};
+  [K in TrackbarVariant]: TrackbarVariantTheme
+}
 
 // radio.tsx
 export interface RadioThemeConfig extends BodyThemeConfig {
-  checkedBorderColor?: string;
+  checkedBorderColor?: string
 
-  checkedOutsideBorderColor?: string;
-  checkedBackgroundColor?: string;
-  iconColor?: string;
-  descriptionColor?: string;
+  checkedOutsideBorderColor?: string
+  checkedBackgroundColor?: string
+  iconColor?: string
+  descriptionColor?: string
 
-  highlightCheckedBackgroundColor?: string;
-  highlightBackgroundColor?: string;
+  highlightCheckedBackgroundColor?: string
+  highlightBackgroundColor?: string
 
-  highlightCheckedBorderColor?: string;
-  highlightBorderColor?: string;
+  highlightCheckedBorderColor?: string
+  highlightBorderColor?: string
 }
 
 // rating.tsx
 export interface RatingThemeConfig {
-  starFullColor?: string;
-  starEmptyColor?: string;
-  starBorderColor?: string;
+  starFullColor?: string
+  starEmptyColor?: string
+  starBorderColor?: string
 
-  labelTextColor?: string;
+  labelTextColor?: string
 
-  disabledStarColor?: string;
-  disabledLabelColor?: string;
+  disabledStarColor?: string
+  disabledLabelColor?: string
 
-  hoverStarColor?: string;
+  hoverStarColor?: string
 }
 
 // rich-editor.tsx
 
 export interface RichEditorThemeConfig extends BodyThemeConfig {
-  placeholderColor?: string;
-  toolbarBackground?: string;
-  toolbarButtonActive?: string;
-  toolbarButtonHover?: string;
-  toolbarButtonFocused?: string;
-  scrollThumb?: string;
-  preBackgroundColor?: string;
+  placeholderColor?: string
+  toolbarBackground?: string
+  toolbarButtonActive?: string
+  toolbarButtonHover?: string
+  toolbarButtonFocused?: string
+  scrollThumb?: string
+  preBackgroundColor?: string
 }
 
 // searchbox.tsx
 export interface SearchboxThemeConfig extends BodyThemeConfig {
-  activeBackgroundColor?: string;
-  focusBorderColor?: string;
-  focusShadow?: string;
-  iconColor?: string;
-  clearIconColor?: string;
+  activeBackgroundColor?: string
+  focusBorderColor?: string
+  focusShadow?: string
+  iconColor?: string
+  clearIconColor?: string
 }
 
 // selectbox.tsx
 export interface SelectboxThemeConfig extends BodyThemeConfig {
-  hoverBorderColor: string;
-  focusedBorderColor: string;
+  hoverBorderColor: string
+  focusedBorderColor: string
 
-  errorBorderColor: string;
+  errorBorderColor: string
 
-  placeholderColor: string;
+  placeholderColor: string
 
-  iconColor: string;
-  iconActiveColor: string;
+  iconColor: string
+  iconActiveColor: string
 
-  clearIconColor: string;
-  clearIconBackground: string;
-  clearIconHoverBackground: string;
+  clearIconColor: string
+  clearIconBackground: string
+  clearIconHoverBackground: string
 
-  dividerColor: string;
-  disabledOpacity: number;
+  dividerColor: string
+  disabledOpacity: number
 }
 
 // separator.tsx
 export interface SeparatorThemeConfig {
-  containerColor?: string;
-  lineColor?: string;
-  lineShadow?: string;
-  titleColor?: string;
-  backgroundTitleColor?: string;
-  tooltipBackgroundColor?: string;
+  containerColor?: string
+  lineColor?: string
+  lineShadow?: string
+  titleColor?: string
+  backgroundTitleColor?: string
+  tooltipBackgroundColor?: string
 }
 
 // signbox.tsx
 export interface SignboxThemeConfig extends BodyThemeConfig {
-  errorBorderColor?: string;
+  errorBorderColor?: string
 
-  clearIconColor?: string;
-  clearIconHoverBackground?: string;
+  clearIconColor?: string
+  clearIconHoverBackground?: string
 }
 
 // sidebar.tsx
 export interface SidebarThemeConfig extends BodyThemeConfig {
-  boxShadow?: string;
+  boxShadow?: string
 
   item?: {
-    hoverBackgroundColor?: string;
-    activeBackgroundColor?: string;
-  };
+    hoverBackgroundColor?: string
+    activeBackgroundColor?: string
+  }
 
   toggle?: {
-    backgroundColor?: string;
-    borderColor?: string;
-    hoverBackgroundColor?: string;
-  };
+    backgroundColor?: string
+    borderColor?: string
+    hoverBackgroundColor?: string
+  }
 }
 
 // stepline.tsx
 export interface SteplineThemeConfig {
-  outerCircle: Record<BaseSteplineItem["variant"], string>;
-  innerCircle: Record<BaseSteplineItem["variant"], string>;
-  text: Record<BaseSteplineItem["variant"], string>;
+  outerCircle: Record<BaseSteplineItem["variant"], string>
+  innerCircle: Record<BaseSteplineItem["variant"], string>
+  text: Record<BaseSteplineItem["variant"], string>
   line?: {
-    default: string;
-    completed: string;
-    error: string;
-  };
+    default: string
+    completed: string
+    error: string
+  }
 }
 // statusbar.tsx
 export interface StatusbarThemeConfig extends BodyThemeConfig {
-  boxShadow: string;
+  boxShadow: string
   item: {
-    activeBackgroundColor: string;
-    hoverBackgroundColor: string;
-  };
+    activeBackgroundColor: string
+    hoverBackgroundColor: string
+  }
 }
 
+// stateful-form.tsx
 export interface StatefulFormThemeConfig extends BodyThemeConfig {
-  rowFrameBackgroundColor: string;
-  mobileRowFrameBackgroundColor: string;
+  rowFrameBackgroundColor: string
+  mobileRowFrameBackgroundColor: string
+  fieldTooltip: StatefulFormFieldTooltipThemeConfig
+}
+
+export interface StatefulFormFieldTooltipThemeConfig {
+  textColor: string
+  mutedTextColor: string
+  panelBackground: string
+  panelBorder: string
+  dividerColor: string
+  scrollbarThumbColor: string
+  scrollbarTrackColor: string
 }
 
 // table.tsx
 export interface TableThemeConfig extends Omit<BodyThemeConfig, "borderColor"> {
-  boxShadow?: string;
+  boxShadow?: string
 
-  headerActionBackgroundColor?: string;
-  headerActionBorderColor?: string;
-  headerActionHoverBackgroundColor?: string;
+  headerActionBackgroundColor?: string
+  headerActionBorderColor?: string
+  headerActionHoverBackgroundColor?: string
 
-  leftLooseEffectColor?: string;
-  rightLooseEffectColor?: string;
+  leftLooseEffectColor?: string
+  rightLooseEffectColor?: string
 
-  headerBackgroundColor?: string;
-  headerBorderColor?: string;
+  headerBackgroundColor?: string
+  headerBorderColor?: string
 
-  rowGroupBackgroundColor?: string;
-  rowGroupSubtitleTextColor?: string;
+  rowGroupBackgroundColor?: string
+  rowGroupSubtitleTextColor?: string
 
-  rowBackgroundColor?: string;
-  rowBorderColor?: string;
-  rowHoverBackgroundColor?: string;
-  rowSelectedBackgroundColor?: string;
-  rowContentBackgroundColor?: string;
-  rowContentBoxShadow?: string;
+  rowBackgroundColor?: string
+  rowBorderColor?: string
+  rowHoverBackgroundColor?: string
+  rowSelectedBackgroundColor?: string
+  rowContentBackgroundColor?: string
+  rowContentBoxShadow?: string
 
-  summaryBackgroundColor?: string;
-  summaryBorderColor?: string;
+  summaryBackgroundColor?: string
+  summaryBorderColor?: string
 
-  toggleRowBackgroundColor?: string;
+  toggleRowBackgroundColor?: string
 
-  scrollbarThumbColor?: string;
-  scrollbarTrackColor?: string;
+  scrollbarThumbColor?: string
+  scrollbarTrackColor?: string
 }
 
 // textbox.tsx
 export interface TextboxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string;
+  focusedBorderColor?: string
 
-  errorBorderColor?: string;
-  errorTextColor?: string;
+  errorBorderColor?: string
+  errorTextColor?: string
 
-  disabledBorderColor?: string;
-  disabledTextColor?: string;
+  disabledBorderColor?: string
+  disabledTextColor?: string
 
-  placeholderColor?: string;
+  placeholderColor?: string
 
-  boxShadow?: string;
+  boxShadow?: string
 }
 
 // textarea.tsx
 export interface TextareaThemeConfig extends TextboxThemeConfig {
-  scrollbarThumbColor?: string;
+  scrollbarThumbColor?: string
 }
 
 // title.tsx
 export interface TitleThemeConfig
   extends Omit<BodyThemeConfig, "textColor" | "borderColor"> {
   pretitle?: {
-    textColor?: string;
-    opacity?: number;
-    fontWeight?: number;
-  };
+    textColor?: string
+    opacity?: number
+    fontWeight?: number
+  }
 
   title?: {
-    textColor?: string;
-    fontWeight?: number;
-  };
+    textColor?: string
+    fontWeight?: number
+  }
 
   subtitle?: {
-    textColor?: string;
-    fontWeight?: number;
-  };
+    textColor?: string
+    fontWeight?: number
+  }
 
   icon?: {
-    hoverBackgroundColor?: string;
-    backgroundColor?: string;
-    textColor?: string;
-  };
+    hoverBackgroundColor?: string
+    backgroundColor?: string
+    textColor?: string
+  }
 }
 
 // timebox.tsx
 export interface TimeboxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string;
+  focusedBorderColor?: string
 
-  errorBorderColor?: string;
-  errorTextColor?: string;
-  colonColor?: string;
+  errorBorderColor?: string
+  errorTextColor?: string
+  colonColor?: string
 }
 
 // timeline.tsx
@@ -721,176 +734,176 @@ export interface TimelineThemeConfig extends SteplineThemeConfig {}
 
 // tooltip.tsx
 export interface TooltipThemeConfig {
-  boxShadow?: string;
-  arrowBackgroundColor: string;
-  literalStringBackgroundColor: string;
-  literalStringTextColor?: string;
-  nodeElementBackgroundColor: string;
-  nodeElementTextColor: string;
+  boxShadow?: string
+  arrowBackgroundColor: string
+  literalStringBackgroundColor: string
+  literalStringTextColor?: string
+  nodeElementBackgroundColor: string
+  nodeElementTextColor: string
 }
 
 // toast.tsx
 export interface ToastThemeConfig extends BodyThemeConfig {
-  iconBackgroundColor: string;
-  iconColor: string;
-  progressColor: string;
+  iconBackgroundColor: string
+  iconColor: string
+  progressColor: string
 }
 
 // thumb-field.tsx
 export interface ThumbFieldThemeConfig {
-  thumbsUpColor?: string;
-  thumbsDownColor?: string;
-  inactiveColor?: string;
-  errorColor?: string;
-  disabledOpacity?: number;
+  thumbsUpColor?: string
+  thumbsDownColor?: string
+  inactiveColor?: string
+  errorColor?: string
+  disabledOpacity?: number
 }
 
 // toggle.tsx
 export interface ToggleThemeConfig extends BodyThemeConfig {
-  checkedBackgroundColor?: string;
-  thumbColor?: string;
-  descriptionColor?: string;
-  disabledOpacity?: number;
-  boxShadow?: string;
+  checkedBackgroundColor?: string
+  thumbColor?: string
+  descriptionColor?: string
+  disabledOpacity?: number
+  boxShadow?: string
 }
 
 // toolbar.tsx
 export interface ToolbarThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string;
-  activeBackgroundColor?: string;
-  focusBackgroundColor?: string;
-  textDecoration?: string;
-  dividerColor?: string;
+  hoverBackgroundColor?: string
+  activeBackgroundColor?: string
+  focusBackgroundColor?: string
+  textDecoration?: string
+  dividerColor?: string
 }
 
 // tip-menu.tsx
 export interface TipMenuThemeConfig
   extends Omit<BodyThemeConfig, "borderColor"> {
-  hoverBackgroundColor?: string;
-  activeBackgroundColor?: string;
-  focusBackgroundColor?: string;
-  disabledTextColor?: string;
+  hoverBackgroundColor?: string
+  activeBackgroundColor?: string
+  focusBackgroundColor?: string
+  disabledTextColor?: string
 }
 
 // treelist.tsx
 export interface TreeListThemeConfig
   extends Omit<BodyThemeConfig, "borderColor"> {
-  hoverBackgroundColor?: string;
-  selectedBackgroundColor?: string;
+  hoverBackgroundColor?: string
+  selectedBackgroundColor?: string
 
-  highlightedText?: string;
+  highlightedText?: string
 
-  dividerHierarchyColor?: string;
-  dividerHierarchySelectedColor?: string;
-  dividerHierarchyRelatedColor?: string;
+  dividerHierarchyColor?: string
+  dividerHierarchySelectedColor?: string
+  dividerHierarchyRelatedColor?: string
 
-  rowActionBackgroundColor?: string;
+  rowActionBackgroundColor?: string
 }
 
 // scrollbar.tsx
 export interface ScrollbarThemeConfig {
-  scrollbarThumbActiveColor?: string;
-  scrollbarThumbColor?: string;
-  scrollbarTrackColor?: string;
+  scrollbarThumbActiveColor?: string
+  scrollbarThumbColor?: string
+  scrollbarTrackColor?: string
 }
 
 // split-pane.tsx
 export interface SplitPaneThemeConfig
   extends Omit<BodyThemeConfig, "borderColor"> {
-  dividerColor?: string;
+  dividerColor?: string
 }
 
 // wheel.tsx
 export interface WheelThemeConfig extends Omit<BodyThemeConfig, "borderColor"> {
-  overlayBackgroundColor?: string;
-  overlayBorderColor?: string;
+  overlayBackgroundColor?: string
+  overlayBorderColor?: string
 
-  fadeColor?: string;
+  fadeColor?: string
 
-  inactiveTextColor?: string;
+  inactiveTextColor?: string
 
-  separatorColor?: string;
+  separatorColor?: string
 }
 
 // app-theme.tsx
 export interface AppTheme {
-  body: BodyThemeConfig;
+  body: BodyThemeConfig
 
-  actionCapsule: ActionCapsuleThemeConfig;
-  actionButton: ActionButtonThemeConfig;
+  actionCapsule: ActionCapsuleThemeConfig
+  actionButton: ActionButtonThemeConfig
 
-  avatar: AvatarThemeConfig;
-  badge: BadgeThemeConfig;
-  boxbar: BoxbarThemeConfig;
-  button: Record<ButtonVariants["variant"], ButtonThemeConfig>;
-  buttonTipMenu: TipMenuContainerThemeConfig;
-  calendar: CalendarThemeConfig;
-  capsule: CapsuleThemeConfig;
-  capsuleTab: CapsuleTabThemeConfig;
-  card: CardThemeConfig;
-  chips: ChipsThemeConfig;
-  choiceGroup: ChoiceGroupThemeConfig;
-  checkbox: CheckboxThemeConfig;
-  colorbox: ColorboxThemeConfig;
-  combobox: ComboboxThemeConfig;
-  crumb: CrumbThemeConfig;
-  dialog: DialogThemeConfig;
-  documentViewer: DocumentViewerThemeConfig;
-  dormantText: DormantTextThemeConfig;
-  drawerTab: DrawerTabThemeConfig;
-  errorSlate: ErrorSlateThemeConfig;
-  fieldLane: FieldLaneThemeConfig;
-  flippable: FlippableThemeConfig;
-  fileInputBox: FileInputBoxThemeConfig;
-  fileDropBox: FileDropBoxThemeConfig;
-  frame: FrameThemeConfig;
-  grid: GridThemeConfig;
-  imagebox: ImageboxThemeConfig;
-  keynote: KeynoteThemeConfig;
-  launchpad: LaunchpadThemeConfig;
-  list: ListThemeConfig;
-  loadingSkeleton: LoadingSkeletonThemeConfig;
-  loadingSpinner: LoadingSpinnerThemeConfig;
-  messagebox: MessageboxThemeConfig;
-  moneybox: MoneyboxThemeConfig;
-  modalDialog: ModalDialogThemeConfig;
-  navTab: NavTabThemeConfig;
-  overlayBlocker: OverlayBlockerThemeConfig;
-  paperDialog: PaperDialogThemeConfig;
-  pagination: PaginationThemeConfig;
-  pinbox: PinboxThemeConfig;
-  phonebox: PhoneboxThemeConfig;
-  radio: RadioThemeConfig;
-  rating: RatingThemeConfig;
-  richEditor: RichEditorThemeConfig;
-  scrollbar: ScrollbarThemeConfig;
-  searchbox: SearchboxThemeConfig;
-  selectbox: SelectboxThemeConfig;
-  separator: SeparatorThemeConfig;
-  sidebar: SidebarThemeConfig;
-  signbox: SignboxThemeConfig;
-  statusbar: StatusbarThemeConfig;
-  statefulForm: StatefulFormThemeConfig;
-  stepline: SteplineThemeConfig;
-  splitPane: SplitPaneThemeConfig;
-  table: TableThemeConfig;
-  textbox: TextboxThemeConfig;
-  textarea: TextareaThemeConfig;
-  thumbField: ThumbFieldThemeConfig;
-  timeline: TimelineThemeConfig;
-  tipmenu: Record<TipMenuVariant, TipMenuThemeConfig>;
-  timebox: TimeboxThemeConfig;
-  title: TitleThemeConfig;
-  toast: Record<ToastVariant, ToastThemeConfig>;
-  toggle: ToggleThemeConfig;
-  toolbar: Record<ToolbarVariant, ToolbarThemeConfig>;
-  tooltip: TooltipThemeConfig;
-  trackbar: TrackbarThemeConfig;
-  treelist: TreeListThemeConfig;
-  wheel: WheelThemeConfig;
+  avatar: AvatarThemeConfig
+  badge: BadgeThemeConfig
+  boxbar: BoxbarThemeConfig
+  button: Record<ButtonVariants["variant"], ButtonThemeConfig>
+  buttonTipMenu: TipMenuContainerThemeConfig
+  calendar: CalendarThemeConfig
+  capsule: CapsuleThemeConfig
+  capsuleTab: CapsuleTabThemeConfig
+  card: CardThemeConfig
+  chips: ChipsThemeConfig
+  choiceGroup: ChoiceGroupThemeConfig
+  checkbox: CheckboxThemeConfig
+  colorbox: ColorboxThemeConfig
+  combobox: ComboboxThemeConfig
+  crumb: CrumbThemeConfig
+  dialog: DialogThemeConfig
+  documentViewer: DocumentViewerThemeConfig
+  dormantText: DormantTextThemeConfig
+  drawerTab: DrawerTabThemeConfig
+  errorSlate: ErrorSlateThemeConfig
+  fieldLane: FieldLaneThemeConfig
+  flippable: FlippableThemeConfig
+  fileInputBox: FileInputBoxThemeConfig
+  fileDropBox: FileDropBoxThemeConfig
+  frame: FrameThemeConfig
+  grid: GridThemeConfig
+  imagebox: ImageboxThemeConfig
+  keynote: KeynoteThemeConfig
+  launchpad: LaunchpadThemeConfig
+  list: ListThemeConfig
+  loadingSkeleton: LoadingSkeletonThemeConfig
+  loadingSpinner: LoadingSpinnerThemeConfig
+  messagebox: MessageboxThemeConfig
+  moneybox: MoneyboxThemeConfig
+  modalDialog: ModalDialogThemeConfig
+  navTab: NavTabThemeConfig
+  overlayBlocker: OverlayBlockerThemeConfig
+  paperDialog: PaperDialogThemeConfig
+  pagination: PaginationThemeConfig
+  pinbox: PinboxThemeConfig
+  phonebox: PhoneboxThemeConfig
+  radio: RadioThemeConfig
+  rating: RatingThemeConfig
+  richEditor: RichEditorThemeConfig
+  scrollbar: ScrollbarThemeConfig
+  searchbox: SearchboxThemeConfig
+  selectbox: SelectboxThemeConfig
+  separator: SeparatorThemeConfig
+  sidebar: SidebarThemeConfig
+  signbox: SignboxThemeConfig
+  statusbar: StatusbarThemeConfig
+  statefulForm: StatefulFormThemeConfig
+  stepline: SteplineThemeConfig
+  splitPane: SplitPaneThemeConfig
+  table: TableThemeConfig
+  textbox: TextboxThemeConfig
+  textarea: TextareaThemeConfig
+  thumbField: ThumbFieldThemeConfig
+  timeline: TimelineThemeConfig
+  tipmenu: Record<TipMenuVariant, TipMenuThemeConfig>
+  timebox: TimeboxThemeConfig
+  title: TitleThemeConfig
+  toast: Record<ToastVariant, ToastThemeConfig>
+  toggle: ToggleThemeConfig
+  toolbar: Record<ToolbarVariant, ToolbarThemeConfig>
+  tooltip: TooltipThemeConfig
+  trackbar: TrackbarThemeConfig
+  treelist: TreeListThemeConfig
+  wheel: WheelThemeConfig
 }
 
-export * from "./provider";
-export * from "./mode";
-export * from "./registry";
-export * from "./create-theme";
+export * from "./provider"
+export * from "./mode"
+export * from "./registry"
+export * from "./create-theme"

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -1,366 +1,366 @@
-import { MessageboxVariant } from "./../components/messagebox"
-import { ButtonVariants } from "./../components/button"
-import { ToolbarVariant } from "./../components/toolbar"
-import { BaseSteplineItem } from "./../constants/step-component-util"
-import { TipMenuVariant } from "./../components/tip-menu"
-import { ToastVariant } from "./../components/toast"
-import { TrackbarVariant } from "../components/trackbar"
+import { MessageboxVariant } from "./../components/messagebox";
+import { ButtonVariants } from "./../components/button";
+import { ToolbarVariant } from "./../components/toolbar";
+import { BaseSteplineItem } from "./../constants/step-component-util";
+import { TipMenuVariant } from "./../components/tip-menu";
+import { ToastVariant } from "./../components/toast";
+import { TrackbarVariant } from "../components/trackbar";
 
 // body
 export interface BodyThemeConfig {
-  backgroundColor?: string
-  textColor?: string
-  borderColor?: string
-  mutedTextColor?: string
+  backgroundColor?: string;
+  textColor?: string;
+  borderColor?: string;
+  mutedTextColor?: string;
 }
 
 // action-capsule
 export interface ActionCapsuleThemeConfig {
-  activeBackgroundColor?: string
-  textColor?: string
-  borderColor?: string
-  boxShadow?: string
-  borderRadius?: string
-  capsuleFontSize?: string
-  tabTextColor?: string
-  tabBorderRadius?: string
+  activeBackgroundColor?: string;
+  textColor?: string;
+  borderColor?: string;
+  boxShadow?: string;
+  borderRadius?: string;
+  capsuleFontSize?: string;
+  tabTextColor?: string;
+  tabBorderRadius?: string;
 }
 
 // action-button.tsx
 export interface ActionButtonThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string
-  disabledBackgroundColor?: string
-  disabledOpacity?: number
-  borderRadius?: string
+  hoverBackgroundColor?: string;
+  disabledBackgroundColor?: string;
+  disabledOpacity?: number;
+  borderRadius?: string;
 
-  toggleBackgroundColor?: string
-  toggleTextColor?: string
-  toggleHoverBackgroundColor?: string
-  toggleBorderColor?: string
-  toggleBorderRadius?: string
+  toggleBackgroundColor?: string;
+  toggleTextColor?: string;
+  toggleHoverBackgroundColor?: string;
+  toggleBorderColor?: string;
+  toggleBorderRadius?: string;
 
-  dividerColor?: string
+  dividerColor?: string;
 
-  dropdownWidth?: string
+  dropdownWidth?: string;
 }
 
 // avatar.tsx
 export interface AvatarThemeConfig
   extends Omit<BodyThemeConfig, "backgroundColor"> {
-  overlayBackgroundColor?: string
-  overlayIconColor?: string
+  overlayBackgroundColor?: string;
+  overlayIconColor?: string;
 }
 
 // badge.tsx
 export interface BadgeThemeConfig extends BodyThemeConfig {
-  circleColor?: string
+  circleColor?: string;
   action?: {
-    hoverBackgroundColor?: string
-    activeBackgroundColor?: string
-    focusRingColor?: string
-    disabledOpacity?: number
-  }
+    hoverBackgroundColor?: string;
+    activeBackgroundColor?: string;
+    focusRingColor?: string;
+    disabledOpacity?: number;
+  };
 }
 
 // boxbar.tsx
 export interface BoxbarThemeConfig extends BodyThemeConfig {
-  toggleButtonColor?: string
-  toggleButtonHoverColor?: string
+  toggleButtonColor?: string;
+  toggleButtonHoverColor?: string;
 }
 
 // button.tsx
 export interface ButtonThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string
-  activeBackgroundColor?: string
-  textDecoration?: string
-  focusBackgroundColor?: string
-  dividerColor?: string
+  hoverBackgroundColor?: string;
+  activeBackgroundColor?: string;
+  textDecoration?: string;
+  focusBackgroundColor?: string;
+  dividerColor?: string;
 }
 
 export interface TipMenuContainerThemeConfig extends BodyThemeConfig {
-  boxShadow?: string
+  boxShadow?: string;
 }
 
 // calendar.tsx
 export interface CalendarThemeConfig extends BodyThemeConfig {
-  dayTextColor: string
+  dayTextColor: string;
 
-  disabledDateColor?: string
-  weekendDateColor?: string
+  disabledDateColor?: string;
+  weekendDateColor?: string;
 
-  rangeDateBackgroundColor?: string
-  rangeDateTextColor?: string
+  rangeDateBackgroundColor?: string;
+  rangeDateTextColor?: string;
 
-  highlightedDateTextColor?: string
-  hightlightDateColor?: string
+  highlightedDateTextColor?: string;
+  hightlightDateColor?: string;
 
-  mobileBackgroundColor?: string
-  mobileBorderColor?: string
+  mobileBackgroundColor?: string;
+  mobileBorderColor?: string;
 
-  boxShadow?: string
+  boxShadow?: string;
 }
 
 // capsule.tsx
 export interface CapsuleThemeConfig extends BodyThemeConfig {
-  errorBorderColor?: string
-  boxShadow?: string
+  errorBorderColor?: string;
+  boxShadow?: string;
   tab?: {
-    textColor?: string
-    activeTextColor?: string
-  }
+    textColor?: string;
+    activeTextColor?: string;
+  };
   active?: {
-    backgroundColor?: string
-  }
+    backgroundColor?: string;
+  };
   hover?: {
-    borderColor?: string
-  }
+    borderColor?: string;
+  };
 }
 
 // capsule-tab.tsx
 export interface CapsuleTabThemeConfig extends BodyThemeConfig {
-  boxShadow?: string
-  activeBackgroundColor?: string
+  boxShadow?: string;
+  activeBackgroundColor?: string;
 }
 
 // card.tsx
 export interface CardThemeConfig extends BodyThemeConfig {
-  dividerColor?: string
-  titleColor?: string
-  subtitleColor?: string
-  headerBackground?: string
-  footerBackground?: string
-  closeIconColor?: string
-  closeIconHoverBackground?: string
+  dividerColor?: string;
+  titleColor?: string;
+  subtitleColor?: string;
+  headerBackground?: string;
+  footerBackground?: string;
+  closeIconColor?: string;
+  closeIconHoverBackground?: string;
 }
 
 // chips.tsx
 export interface ChipsThemeConfig extends BodyThemeConfig {
-  mutedTextColor?: string
+  mutedTextColor?: string;
 
-  hoverBackgroundColor?: string
-  selectedBackgroundColor?: string
+  hoverBackgroundColor?: string;
+  selectedBackgroundColor?: string;
 
-  dividerColor?: string
+  dividerColor?: string;
 
-  boxShadow?: string
+  boxShadow?: string;
 }
 
 // choice-group.tsx
 export interface ChoiceGroupThemeConfig
   extends Omit<BodyThemeConfig, "textColor"> {
-  dividerColor?: string
-  labelColor?: string
-  descriptionColor?: string
+  dividerColor?: string;
+  labelColor?: string;
+  descriptionColor?: string;
 }
 
 // checkbox.tsx
 export interface CheckboxThemeConfig
   extends Omit<BodyThemeConfig, "textColor"> {
-  checkedBorderColor?: string
-  checkedBackgroundColor?: string
-  iconColor?: string
-  labelColor?: string
-  descriptionColor?: string
-  highlightCheckedBackgroundColor?: string
-  highlightHoverBackgroundColor?: string
+  checkedBorderColor?: string;
+  checkedBackgroundColor?: string;
+  iconColor?: string;
+  labelColor?: string;
+  descriptionColor?: string;
+  highlightCheckedBackgroundColor?: string;
+  highlightHoverBackgroundColor?: string;
 }
 
 // combobox.tsx
 export interface ComboboxThemeConfig extends BodyThemeConfig {
-  groupBackgroundColor?: string
-  mobileGroupBackgroundColor?: string
+  groupBackgroundColor?: string;
+  mobileGroupBackgroundColor?: string;
 
-  highlightBackgroundColor?: string
-  selectedBackgroundColor?: string
-  selectedTextColor?: string
+  highlightBackgroundColor?: string;
+  selectedBackgroundColor?: string;
+  selectedTextColor?: string;
 
-  disabledTextColor?: string
-  emptyTextColor?: string
+  disabledTextColor?: string;
+  emptyTextColor?: string;
 
-  dividerColor?: string
-  boxShadow?: string
+  dividerColor?: string;
+  boxShadow?: string;
 
-  scrollThumbColor?: string
+  scrollThumbColor?: string;
 
-  mobileBackgroundColor?: string
-  fadeColor?: string
+  mobileBackgroundColor?: string;
+  fadeColor?: string;
 }
 
 // colorbox.tsx
 export interface ColorboxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string
+  focusedBorderColor?: string;
 
-  errorBorderColor?: string
-  errorTextColor?: string
+  errorBorderColor?: string;
+  errorTextColor?: string;
 
-  disabledBorderColor?: string
-  disabledTextColor?: string
+  disabledBorderColor?: string;
+  disabledTextColor?: string;
 
-  prefixColor?: string
+  prefixColor?: string;
 
-  boxBackgroundColor?: string
+  boxBackgroundColor?: string;
 }
 
 // crumb.tsx
 export interface CrumbThemeConfig
   extends Omit<BodyThemeConfig, "borderColor" | "backgroundColor"> {
-  hoverColor?: string
-  lastTextColor?: string
-  arrowColor?: string
-  ellipsisColor?: string
-  ellipsisHoverColor?: string
+  hoverColor?: string;
+  lastTextColor?: string;
+  arrowColor?: string;
+  ellipsisColor?: string;
+  ellipsisHoverColor?: string;
 }
 
 // dialog.tsx
 export interface DialogThemeConfig extends BodyThemeConfig {
-  boxShadow?: string
-  subtitleColor?: string
+  boxShadow?: string;
+  subtitleColor?: string;
 }
 
 // document-viewer.tsx
 export interface DocumentViewerThemeConfig
   extends Omit<BodyThemeConfig, "borderColor"> {
-  toolbarBackgroundColor?: string
-  errorColor?: string
-  hoverBoxTextColor?: string
-  hoverBoxBorderColor?: string
-  hoverBoxBackgroundColor?: string
+  toolbarBackgroundColor?: string;
+  errorColor?: string;
+  hoverBoxTextColor?: string;
+  hoverBoxBorderColor?: string;
+  hoverBoxBackgroundColor?: string;
 }
 
 // dormant-text.tsx
 export interface DormantTextThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string
-  pencilColor?: string
-  actionButtonColor?: string
-  actionButtonHoverBackground?: string
+  hoverBackgroundColor?: string;
+  pencilColor?: string;
+  actionButtonColor?: string;
+  actionButtonHoverBackground?: string;
 }
 
 // drawer-tab.tsx
 export interface DrawerTabThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string
-  headerBackgroundColor?: string
-  closeButtonHoverBackground?: string
-  dividerColor?: string
+  hoverBackgroundColor?: string;
+  headerBackgroundColor?: string;
+  closeButtonHoverBackground?: string;
+  dividerColor?: string;
 }
 
 // error-slate.tsx
 export interface ErrorSlateThemeConfig {
-  cubeFaceBackground?: string
-  cubeFaceBorder?: string
-  cubeFaceText?: string
-  titleColor?: string
+  cubeFaceBackground?: string;
+  cubeFaceBorder?: string;
+  cubeFaceText?: string;
+  titleColor?: string;
 }
 
 // field-lane.tsx
 export interface FieldLaneThemeConfig
   extends Omit<BodyThemeConfig, "backgroundColor"> {
-  buttonTextColor?: string
-  buttonBorderColor?: string
-  buttonErrorTextColor?: string
-  buttonErrorBorderColor?: string
+  buttonTextColor?: string;
+  buttonBorderColor?: string;
+  buttonErrorTextColor?: string;
+  buttonErrorBorderColor?: string;
 
-  highlightBackgroundColor: string
+  highlightBackgroundColor: string;
 
-  placeholderColor?: string
-  focusedBorderColor?: string
+  placeholderColor?: string;
+  focusedBorderColor?: string;
 
-  disabledOpacity?: number
-  disabledBorderColor?: string
-  disabledTextColor?: string
+  disabledOpacity?: number;
+  disabledBorderColor?: string;
+  disabledTextColor?: string;
 
-  actionColor?: string
-  actionHoverColor?: string
-  actionHoverBackgroundColor?: string
+  actionColor?: string;
+  actionHoverColor?: string;
+  actionHoverBackgroundColor?: string;
 
-  errorColor?: string
-  errorBackground?: string
-  errorBorderColor?: string
-  errorForeground?: string
+  errorColor?: string;
+  errorBackground?: string;
+  errorBorderColor?: string;
+  errorForeground?: string;
 
-  selectedBackgroundColor?: string
+  selectedBackgroundColor?: string;
 
-  helperColor?: string
-  dividerColor?: string
+  helperColor?: string;
+  dividerColor?: string;
 }
 
 // flippable.tsx
 export interface FlippableThemeConfig {
-  front?: BodyThemeConfig
-  back?: BodyThemeConfig
+  front?: BodyThemeConfig;
+  back?: BodyThemeConfig;
 }
 
 // file-input-box.tsx
 export interface FileInputBoxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string
-  errorBorderColor?: string
+  focusedBorderColor?: string;
+  errorBorderColor?: string;
 
-  placeholderColor?: string
+  placeholderColor?: string;
 
-  disabledTextColor?: string
+  disabledTextColor?: string;
 
-  disabledGradientColor?: string
-  errorGradientColor?: string
-  defaultGradientColor?: string
+  disabledGradientColor?: string;
+  errorGradientColor?: string;
+  defaultGradientColor?: string;
 
-  dragActiveColor?: string
-  dragActiveBackgroundColor?: string
+  dragActiveColor?: string;
+  dragActiveBackgroundColor?: string;
 }
 
 // file-drop-box.tsx
 
 export interface FileDropBoxThemeConfig extends BodyThemeConfig {
-  placeholderColor?: string
+  placeholderColor?: string;
 
-  defaultGradientColor?: string
-  dragActiveGradientColor?: string
-  errorGradientColor?: string
-  disabledGradientColor?: string
+  defaultGradientColor?: string;
+  dragActiveGradientColor?: string;
+  errorGradientColor?: string;
+  disabledGradientColor?: string;
 
-  dragActiveBackgroundColor?: string
-  dragActiveTextColor?: string
+  dragActiveBackgroundColor?: string;
+  dragActiveTextColor?: string;
 
-  iconColor?: string
+  iconColor?: string;
 
-  disabledTextColor?: string
+  disabledTextColor?: string;
 
-  progressBackgroundColor?: string
-  progressBarColor?: string
-  progressTextColor?: string
+  progressBackgroundColor?: string;
+  progressBarColor?: string;
+  progressTextColor?: string;
 }
 
 // frame.tsx
 export interface FrameThemeConfig extends BodyThemeConfig {
-  titleColor?: string
-  titleBackgroundColor?: string
-  overlayBackgroundColor?: string
-  boxShadow?: string
+  titleColor?: string;
+  titleBackgroundColor?: string;
+  overlayBackgroundColor?: string;
+  boxShadow?: string;
 }
 
 // grid.tsx
 export interface GridThemeConfig extends Omit<BodyThemeConfig, "borderColor"> {
-  cardHoverBackgroundColor?: string
-  cardSelectedBackgroundColor?: string
-  cardBorderColor?: string
-  cardShadow?: string
-  thumbnailBackgroundColor?: string
+  cardHoverBackgroundColor?: string;
+  cardSelectedBackgroundColor?: string;
+  cardBorderColor?: string;
+  cardShadow?: string;
+  thumbnailBackgroundColor?: string;
 }
 
 export interface ImageboxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string
+  focusedBorderColor?: string;
 
-  draggingBackgroundColor?: string
-  draggingBorderColor?: string
-  draggingTextColor?: string
+  draggingBackgroundColor?: string;
+  draggingBorderColor?: string;
+  draggingTextColor?: string;
 
-  disabledBackgroundColor?: string
+  disabledBackgroundColor?: string;
 
-  iconColor?: string
+  iconColor?: string;
 }
 
 // keynote.tsx
 export interface KeynoteThemeConfig {
-  keyColor?: string
-  valueColor?: string
+  keyColor?: string;
+  valueColor?: string;
 }
 
 // launchpad.tsx
@@ -368,365 +368,365 @@ export interface LaunchpadThemeConfig extends BodyThemeConfig {}
 
 // list.tsx
 export interface ListThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string
-  hoverTextColor?: string
-  mutedTextColor?: string
-  dragLineColor?: string
-  emptyHoverBackgroundColor?: string
-  toggleBackgroundColor?: string
-  badgeTextColor?: string
-  badgeBackgroundColor?: string
-  badgeBorderColor?: string
-  maxItemTextColor?: string
+  hoverBackgroundColor?: string;
+  hoverTextColor?: string;
+  mutedTextColor?: string;
+  dragLineColor?: string;
+  emptyHoverBackgroundColor?: string;
+  toggleBackgroundColor?: string;
+  badgeTextColor?: string;
+  badgeBackgroundColor?: string;
+  badgeBorderColor?: string;
+  maxItemTextColor?: string;
 }
 
 // loading-skeleton.tsx
 export interface LoadingSkeletonThemeConfig {
-  baseColor?: string
-  highlightColor?: string
+  baseColor?: string;
+  highlightColor?: string;
 }
 
 // loading-spinner.tsx
 export interface LoadingSpinnerThemeConfig {
-  spinnerColor?: string
-  textColor?: string
+  spinnerColor?: string;
+  textColor?: string;
 }
 
 // messagebox.tsx
 export interface MessageboxVariantTheme
   extends Omit<BodyThemeConfig, "borderColor"> {
-  activeColor: string
+  activeColor: string;
 }
 
 export type MessageboxThemeConfig = {
-  [K in MessageboxVariant]: MessageboxVariantTheme
-}
+  [K in MessageboxVariant]: MessageboxVariantTheme;
+};
 
 // moneybox.tsx
 export interface MoneyboxThemeConfig extends BodyThemeConfig {
-  errorBorderColor?: string
-  focusedBorderColor?: string
+  errorBorderColor?: string;
+  focusedBorderColor?: string;
 
-  placeholderColor?: string
-  disabledTextColor?: string
+  placeholderColor?: string;
+  disabledTextColor?: string;
 
-  inputPadding?: string
-  fontSize?: string
-  borderRadius?: string
+  inputPadding?: string;
+  fontSize?: string;
+  borderRadius?: string;
 }
 
 // modal-dialog.tsx
 export interface ModalDialogThemeConfig extends DialogThemeConfig {
-  dividerColor?: string
+  dividerColor?: string;
 }
 
 // nav-tab.tsx
 export interface NavTabThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string
-  activeBackgroundColor?: string
-  selectedBackgroundColor?: string
+  hoverBackgroundColor?: string;
+  activeBackgroundColor?: string;
+  selectedBackgroundColor?: string;
 
-  indicatorColor?: string
-  boxShadow?: string
+  indicatorColor?: string;
+  boxShadow?: string;
 
-  circleInactiveColor?: string
+  circleInactiveColor?: string;
 
-  activeInsetShadow?: string
+  activeInsetShadow?: string;
 }
 
 // overlay-blocker.tsx
 export interface OverlayBlockerThemeConfig {
-  backgroundColor?: string
-  backdropFilter?: string
+  backgroundColor?: string;
+  backdropFilter?: string;
 }
 
 // paper-dialog.tsx
 export interface PaperDialogThemeConfig extends BodyThemeConfig {
-  boxShadow?: string
-  actionHoverBackgroundColor?: string
+  boxShadow?: string;
+  actionHoverBackgroundColor?: string;
 }
 
 // pagination.tsx
 export interface PaginationThemeConfig extends BodyThemeConfig {
-  activeBorderColor?: string
-  hoverBorderColor?: string
+  activeBorderColor?: string;
+  hoverBorderColor?: string;
 
-  activeTextColor?: string
+  activeTextColor?: string;
 
-  disabledBackgroundColor?: string
-  disabledTextColor?: string
+  disabledBackgroundColor?: string;
+  disabledTextColor?: string;
 }
 
 //pinbox.tsx
 export interface PinboxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string
+  focusedBorderColor?: string;
 
-  errorBorderColor?: string
-  errorTextColor?: string
+  errorBorderColor?: string;
+  errorTextColor?: string;
 
-  disabledBorderColor?: string
-  disabledTextColor?: string
+  disabledBorderColor?: string;
+  disabledTextColor?: string;
 
-  placeholderColor?: string
-  boxShadow?: string
+  placeholderColor?: string;
+  boxShadow?: string;
 }
 
 // phonebox.tsx
 export interface PhoneboxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string
+  focusedBorderColor?: string;
 
-  errorBorderColor?: string
-  errorTextColor?: string
+  errorBorderColor?: string;
+  errorTextColor?: string;
 
-  disabledBorderColor?: string
-  disabledTextColor?: string
+  disabledBorderColor?: string;
+  disabledTextColor?: string;
 
-  placeholderColor?: string
+  placeholderColor?: string;
 
-  boxShadow?: string
+  boxShadow?: string;
 
-  optionHighlightedBackground?: string
+  optionHighlightedBackground?: string;
 }
 
 // trackbar.tsx
 export interface TrackbarVariantTheme
   extends Omit<BodyThemeConfig, "borderColor"> {
-  barColor: string
-  trackColor: string
+  barColor: string;
+  trackColor: string;
 }
 
 export type TrackbarThemeConfig = {
-  [K in TrackbarVariant]: TrackbarVariantTheme
-}
+  [K in TrackbarVariant]: TrackbarVariantTheme;
+};
 
 // radio.tsx
 export interface RadioThemeConfig extends BodyThemeConfig {
-  checkedBorderColor?: string
+  checkedBorderColor?: string;
 
-  checkedOutsideBorderColor?: string
-  checkedBackgroundColor?: string
-  iconColor?: string
-  descriptionColor?: string
+  checkedOutsideBorderColor?: string;
+  checkedBackgroundColor?: string;
+  iconColor?: string;
+  descriptionColor?: string;
 
-  highlightCheckedBackgroundColor?: string
-  highlightBackgroundColor?: string
+  highlightCheckedBackgroundColor?: string;
+  highlightBackgroundColor?: string;
 
-  highlightCheckedBorderColor?: string
-  highlightBorderColor?: string
+  highlightCheckedBorderColor?: string;
+  highlightBorderColor?: string;
 }
 
 // rating.tsx
 export interface RatingThemeConfig {
-  starFullColor?: string
-  starEmptyColor?: string
-  starBorderColor?: string
+  starFullColor?: string;
+  starEmptyColor?: string;
+  starBorderColor?: string;
 
-  labelTextColor?: string
+  labelTextColor?: string;
 
-  disabledStarColor?: string
-  disabledLabelColor?: string
+  disabledStarColor?: string;
+  disabledLabelColor?: string;
 
-  hoverStarColor?: string
+  hoverStarColor?: string;
 }
 
 // rich-editor.tsx
 
 export interface RichEditorThemeConfig extends BodyThemeConfig {
-  placeholderColor?: string
-  toolbarBackground?: string
-  toolbarButtonActive?: string
-  toolbarButtonHover?: string
-  toolbarButtonFocused?: string
-  scrollThumb?: string
-  preBackgroundColor?: string
+  placeholderColor?: string;
+  toolbarBackground?: string;
+  toolbarButtonActive?: string;
+  toolbarButtonHover?: string;
+  toolbarButtonFocused?: string;
+  scrollThumb?: string;
+  preBackgroundColor?: string;
 }
 
 // searchbox.tsx
 export interface SearchboxThemeConfig extends BodyThemeConfig {
-  activeBackgroundColor?: string
-  focusBorderColor?: string
-  focusShadow?: string
-  iconColor?: string
-  clearIconColor?: string
+  activeBackgroundColor?: string;
+  focusBorderColor?: string;
+  focusShadow?: string;
+  iconColor?: string;
+  clearIconColor?: string;
 }
 
 // selectbox.tsx
 export interface SelectboxThemeConfig extends BodyThemeConfig {
-  hoverBorderColor: string
-  focusedBorderColor: string
+  hoverBorderColor: string;
+  focusedBorderColor: string;
 
-  errorBorderColor: string
+  errorBorderColor: string;
 
-  placeholderColor: string
+  placeholderColor: string;
 
-  iconColor: string
-  iconActiveColor: string
+  iconColor: string;
+  iconActiveColor: string;
 
-  clearIconColor: string
-  clearIconBackground: string
-  clearIconHoverBackground: string
+  clearIconColor: string;
+  clearIconBackground: string;
+  clearIconHoverBackground: string;
 
-  dividerColor: string
-  disabledOpacity: number
+  dividerColor: string;
+  disabledOpacity: number;
 }
 
 // separator.tsx
 export interface SeparatorThemeConfig {
-  containerColor?: string
-  lineColor?: string
-  lineShadow?: string
-  titleColor?: string
-  backgroundTitleColor?: string
-  tooltipBackgroundColor?: string
+  containerColor?: string;
+  lineColor?: string;
+  lineShadow?: string;
+  titleColor?: string;
+  backgroundTitleColor?: string;
+  tooltipBackgroundColor?: string;
 }
 
 // signbox.tsx
 export interface SignboxThemeConfig extends BodyThemeConfig {
-  errorBorderColor?: string
+  errorBorderColor?: string;
 
-  clearIconColor?: string
-  clearIconHoverBackground?: string
+  clearIconColor?: string;
+  clearIconHoverBackground?: string;
 }
 
 // sidebar.tsx
 export interface SidebarThemeConfig extends BodyThemeConfig {
-  boxShadow?: string
+  boxShadow?: string;
 
   item?: {
-    hoverBackgroundColor?: string
-    activeBackgroundColor?: string
-  }
+    hoverBackgroundColor?: string;
+    activeBackgroundColor?: string;
+  };
 
   toggle?: {
-    backgroundColor?: string
-    borderColor?: string
-    hoverBackgroundColor?: string
-  }
+    backgroundColor?: string;
+    borderColor?: string;
+    hoverBackgroundColor?: string;
+  };
 }
 
 // stepline.tsx
 export interface SteplineThemeConfig {
-  outerCircle: Record<BaseSteplineItem["variant"], string>
-  innerCircle: Record<BaseSteplineItem["variant"], string>
-  text: Record<BaseSteplineItem["variant"], string>
+  outerCircle: Record<BaseSteplineItem["variant"], string>;
+  innerCircle: Record<BaseSteplineItem["variant"], string>;
+  text: Record<BaseSteplineItem["variant"], string>;
   line?: {
-    default: string
-    completed: string
-    error: string
-  }
+    default: string;
+    completed: string;
+    error: string;
+  };
 }
 // statusbar.tsx
 export interface StatusbarThemeConfig extends BodyThemeConfig {
-  boxShadow: string
+  boxShadow: string;
   item: {
-    activeBackgroundColor: string
-    hoverBackgroundColor: string
-  }
+    activeBackgroundColor: string;
+    hoverBackgroundColor: string;
+  };
 }
 
 // stateful-form.tsx
 export interface StatefulFormThemeConfig extends BodyThemeConfig {
-  rowFrameBackgroundColor: string
-  mobileRowFrameBackgroundColor: string
-  fieldTooltip: StatefulFormFieldTooltipThemeConfig
+  rowFrameBackgroundColor: string;
+  mobileRowFrameBackgroundColor: string;
+  fieldTooltip: StatefulFormFieldTooltipThemeConfig;
 }
 
 export interface StatefulFormFieldTooltipThemeConfig {
-  textColor: string
-  mutedTextColor: string
-  panelBackground: string
-  panelBorder: string
-  dividerColor: string
-  scrollbarThumbColor: string
-  scrollbarTrackColor: string
+  textColor: string;
+  mutedTextColor: string;
+  panelBackground: string;
+  panelBorder: string;
+  dividerColor: string;
+  scrollbarThumbColor: string;
+  scrollbarTrackColor: string;
 }
 
 // table.tsx
 export interface TableThemeConfig extends Omit<BodyThemeConfig, "borderColor"> {
-  boxShadow?: string
+  boxShadow?: string;
 
-  headerActionBackgroundColor?: string
-  headerActionBorderColor?: string
-  headerActionHoverBackgroundColor?: string
+  headerActionBackgroundColor?: string;
+  headerActionBorderColor?: string;
+  headerActionHoverBackgroundColor?: string;
 
-  leftLooseEffectColor?: string
-  rightLooseEffectColor?: string
+  leftLooseEffectColor?: string;
+  rightLooseEffectColor?: string;
 
-  headerBackgroundColor?: string
-  headerBorderColor?: string
+  headerBackgroundColor?: string;
+  headerBorderColor?: string;
 
-  rowGroupBackgroundColor?: string
-  rowGroupSubtitleTextColor?: string
+  rowGroupBackgroundColor?: string;
+  rowGroupSubtitleTextColor?: string;
 
-  rowBackgroundColor?: string
-  rowBorderColor?: string
-  rowHoverBackgroundColor?: string
-  rowSelectedBackgroundColor?: string
-  rowContentBackgroundColor?: string
-  rowContentBoxShadow?: string
+  rowBackgroundColor?: string;
+  rowBorderColor?: string;
+  rowHoverBackgroundColor?: string;
+  rowSelectedBackgroundColor?: string;
+  rowContentBackgroundColor?: string;
+  rowContentBoxShadow?: string;
 
-  summaryBackgroundColor?: string
-  summaryBorderColor?: string
+  summaryBackgroundColor?: string;
+  summaryBorderColor?: string;
 
-  toggleRowBackgroundColor?: string
+  toggleRowBackgroundColor?: string;
 
-  scrollbarThumbColor?: string
-  scrollbarTrackColor?: string
+  scrollbarThumbColor?: string;
+  scrollbarTrackColor?: string;
 }
 
 // textbox.tsx
 export interface TextboxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string
+  focusedBorderColor?: string;
 
-  errorBorderColor?: string
-  errorTextColor?: string
+  errorBorderColor?: string;
+  errorTextColor?: string;
 
-  disabledBorderColor?: string
-  disabledTextColor?: string
+  disabledBorderColor?: string;
+  disabledTextColor?: string;
 
-  placeholderColor?: string
+  placeholderColor?: string;
 
-  boxShadow?: string
+  boxShadow?: string;
 }
 
 // textarea.tsx
 export interface TextareaThemeConfig extends TextboxThemeConfig {
-  scrollbarThumbColor?: string
+  scrollbarThumbColor?: string;
 }
 
 // title.tsx
 export interface TitleThemeConfig
   extends Omit<BodyThemeConfig, "textColor" | "borderColor"> {
   pretitle?: {
-    textColor?: string
-    opacity?: number
-    fontWeight?: number
-  }
+    textColor?: string;
+    opacity?: number;
+    fontWeight?: number;
+  };
 
   title?: {
-    textColor?: string
-    fontWeight?: number
-  }
+    textColor?: string;
+    fontWeight?: number;
+  };
 
   subtitle?: {
-    textColor?: string
-    fontWeight?: number
-  }
+    textColor?: string;
+    fontWeight?: number;
+  };
 
   icon?: {
-    hoverBackgroundColor?: string
-    backgroundColor?: string
-    textColor?: string
-  }
+    hoverBackgroundColor?: string;
+    backgroundColor?: string;
+    textColor?: string;
+  };
 }
 
 // timebox.tsx
 export interface TimeboxThemeConfig extends BodyThemeConfig {
-  focusedBorderColor?: string
+  focusedBorderColor?: string;
 
-  errorBorderColor?: string
-  errorTextColor?: string
-  colonColor?: string
+  errorBorderColor?: string;
+  errorTextColor?: string;
+  colonColor?: string;
 }
 
 // timeline.tsx
@@ -734,176 +734,176 @@ export interface TimelineThemeConfig extends SteplineThemeConfig {}
 
 // tooltip.tsx
 export interface TooltipThemeConfig {
-  boxShadow?: string
-  arrowBackgroundColor: string
-  literalStringBackgroundColor: string
-  literalStringTextColor?: string
-  nodeElementBackgroundColor: string
-  nodeElementTextColor: string
+  boxShadow?: string;
+  arrowBackgroundColor: string;
+  literalStringBackgroundColor: string;
+  literalStringTextColor?: string;
+  nodeElementBackgroundColor: string;
+  nodeElementTextColor: string;
 }
 
 // toast.tsx
 export interface ToastThemeConfig extends BodyThemeConfig {
-  iconBackgroundColor: string
-  iconColor: string
-  progressColor: string
+  iconBackgroundColor: string;
+  iconColor: string;
+  progressColor: string;
 }
 
 // thumb-field.tsx
 export interface ThumbFieldThemeConfig {
-  thumbsUpColor?: string
-  thumbsDownColor?: string
-  inactiveColor?: string
-  errorColor?: string
-  disabledOpacity?: number
+  thumbsUpColor?: string;
+  thumbsDownColor?: string;
+  inactiveColor?: string;
+  errorColor?: string;
+  disabledOpacity?: number;
 }
 
 // toggle.tsx
 export interface ToggleThemeConfig extends BodyThemeConfig {
-  checkedBackgroundColor?: string
-  thumbColor?: string
-  descriptionColor?: string
-  disabledOpacity?: number
-  boxShadow?: string
+  checkedBackgroundColor?: string;
+  thumbColor?: string;
+  descriptionColor?: string;
+  disabledOpacity?: number;
+  boxShadow?: string;
 }
 
 // toolbar.tsx
 export interface ToolbarThemeConfig extends BodyThemeConfig {
-  hoverBackgroundColor?: string
-  activeBackgroundColor?: string
-  focusBackgroundColor?: string
-  textDecoration?: string
-  dividerColor?: string
+  hoverBackgroundColor?: string;
+  activeBackgroundColor?: string;
+  focusBackgroundColor?: string;
+  textDecoration?: string;
+  dividerColor?: string;
 }
 
 // tip-menu.tsx
 export interface TipMenuThemeConfig
   extends Omit<BodyThemeConfig, "borderColor"> {
-  hoverBackgroundColor?: string
-  activeBackgroundColor?: string
-  focusBackgroundColor?: string
-  disabledTextColor?: string
+  hoverBackgroundColor?: string;
+  activeBackgroundColor?: string;
+  focusBackgroundColor?: string;
+  disabledTextColor?: string;
 }
 
 // treelist.tsx
 export interface TreeListThemeConfig
   extends Omit<BodyThemeConfig, "borderColor"> {
-  hoverBackgroundColor?: string
-  selectedBackgroundColor?: string
+  hoverBackgroundColor?: string;
+  selectedBackgroundColor?: string;
 
-  highlightedText?: string
+  highlightedText?: string;
 
-  dividerHierarchyColor?: string
-  dividerHierarchySelectedColor?: string
-  dividerHierarchyRelatedColor?: string
+  dividerHierarchyColor?: string;
+  dividerHierarchySelectedColor?: string;
+  dividerHierarchyRelatedColor?: string;
 
-  rowActionBackgroundColor?: string
+  rowActionBackgroundColor?: string;
 }
 
 // scrollbar.tsx
 export interface ScrollbarThemeConfig {
-  scrollbarThumbActiveColor?: string
-  scrollbarThumbColor?: string
-  scrollbarTrackColor?: string
+  scrollbarThumbActiveColor?: string;
+  scrollbarThumbColor?: string;
+  scrollbarTrackColor?: string;
 }
 
 // split-pane.tsx
 export interface SplitPaneThemeConfig
   extends Omit<BodyThemeConfig, "borderColor"> {
-  dividerColor?: string
+  dividerColor?: string;
 }
 
 // wheel.tsx
 export interface WheelThemeConfig extends Omit<BodyThemeConfig, "borderColor"> {
-  overlayBackgroundColor?: string
-  overlayBorderColor?: string
+  overlayBackgroundColor?: string;
+  overlayBorderColor?: string;
 
-  fadeColor?: string
+  fadeColor?: string;
 
-  inactiveTextColor?: string
+  inactiveTextColor?: string;
 
-  separatorColor?: string
+  separatorColor?: string;
 }
 
 // app-theme.tsx
 export interface AppTheme {
-  body: BodyThemeConfig
+  body: BodyThemeConfig;
 
-  actionCapsule: ActionCapsuleThemeConfig
-  actionButton: ActionButtonThemeConfig
+  actionCapsule: ActionCapsuleThemeConfig;
+  actionButton: ActionButtonThemeConfig;
 
-  avatar: AvatarThemeConfig
-  badge: BadgeThemeConfig
-  boxbar: BoxbarThemeConfig
-  button: Record<ButtonVariants["variant"], ButtonThemeConfig>
-  buttonTipMenu: TipMenuContainerThemeConfig
-  calendar: CalendarThemeConfig
-  capsule: CapsuleThemeConfig
-  capsuleTab: CapsuleTabThemeConfig
-  card: CardThemeConfig
-  chips: ChipsThemeConfig
-  choiceGroup: ChoiceGroupThemeConfig
-  checkbox: CheckboxThemeConfig
-  colorbox: ColorboxThemeConfig
-  combobox: ComboboxThemeConfig
-  crumb: CrumbThemeConfig
-  dialog: DialogThemeConfig
-  documentViewer: DocumentViewerThemeConfig
-  dormantText: DormantTextThemeConfig
-  drawerTab: DrawerTabThemeConfig
-  errorSlate: ErrorSlateThemeConfig
-  fieldLane: FieldLaneThemeConfig
-  flippable: FlippableThemeConfig
-  fileInputBox: FileInputBoxThemeConfig
-  fileDropBox: FileDropBoxThemeConfig
-  frame: FrameThemeConfig
-  grid: GridThemeConfig
-  imagebox: ImageboxThemeConfig
-  keynote: KeynoteThemeConfig
-  launchpad: LaunchpadThemeConfig
-  list: ListThemeConfig
-  loadingSkeleton: LoadingSkeletonThemeConfig
-  loadingSpinner: LoadingSpinnerThemeConfig
-  messagebox: MessageboxThemeConfig
-  moneybox: MoneyboxThemeConfig
-  modalDialog: ModalDialogThemeConfig
-  navTab: NavTabThemeConfig
-  overlayBlocker: OverlayBlockerThemeConfig
-  paperDialog: PaperDialogThemeConfig
-  pagination: PaginationThemeConfig
-  pinbox: PinboxThemeConfig
-  phonebox: PhoneboxThemeConfig
-  radio: RadioThemeConfig
-  rating: RatingThemeConfig
-  richEditor: RichEditorThemeConfig
-  scrollbar: ScrollbarThemeConfig
-  searchbox: SearchboxThemeConfig
-  selectbox: SelectboxThemeConfig
-  separator: SeparatorThemeConfig
-  sidebar: SidebarThemeConfig
-  signbox: SignboxThemeConfig
-  statusbar: StatusbarThemeConfig
-  statefulForm: StatefulFormThemeConfig
-  stepline: SteplineThemeConfig
-  splitPane: SplitPaneThemeConfig
-  table: TableThemeConfig
-  textbox: TextboxThemeConfig
-  textarea: TextareaThemeConfig
-  thumbField: ThumbFieldThemeConfig
-  timeline: TimelineThemeConfig
-  tipmenu: Record<TipMenuVariant, TipMenuThemeConfig>
-  timebox: TimeboxThemeConfig
-  title: TitleThemeConfig
-  toast: Record<ToastVariant, ToastThemeConfig>
-  toggle: ToggleThemeConfig
-  toolbar: Record<ToolbarVariant, ToolbarThemeConfig>
-  tooltip: TooltipThemeConfig
-  trackbar: TrackbarThemeConfig
-  treelist: TreeListThemeConfig
-  wheel: WheelThemeConfig
+  avatar: AvatarThemeConfig;
+  badge: BadgeThemeConfig;
+  boxbar: BoxbarThemeConfig;
+  button: Record<ButtonVariants["variant"], ButtonThemeConfig>;
+  buttonTipMenu: TipMenuContainerThemeConfig;
+  calendar: CalendarThemeConfig;
+  capsule: CapsuleThemeConfig;
+  capsuleTab: CapsuleTabThemeConfig;
+  card: CardThemeConfig;
+  chips: ChipsThemeConfig;
+  choiceGroup: ChoiceGroupThemeConfig;
+  checkbox: CheckboxThemeConfig;
+  colorbox: ColorboxThemeConfig;
+  combobox: ComboboxThemeConfig;
+  crumb: CrumbThemeConfig;
+  dialog: DialogThemeConfig;
+  documentViewer: DocumentViewerThemeConfig;
+  dormantText: DormantTextThemeConfig;
+  drawerTab: DrawerTabThemeConfig;
+  errorSlate: ErrorSlateThemeConfig;
+  fieldLane: FieldLaneThemeConfig;
+  flippable: FlippableThemeConfig;
+  fileInputBox: FileInputBoxThemeConfig;
+  fileDropBox: FileDropBoxThemeConfig;
+  frame: FrameThemeConfig;
+  grid: GridThemeConfig;
+  imagebox: ImageboxThemeConfig;
+  keynote: KeynoteThemeConfig;
+  launchpad: LaunchpadThemeConfig;
+  list: ListThemeConfig;
+  loadingSkeleton: LoadingSkeletonThemeConfig;
+  loadingSpinner: LoadingSpinnerThemeConfig;
+  messagebox: MessageboxThemeConfig;
+  moneybox: MoneyboxThemeConfig;
+  modalDialog: ModalDialogThemeConfig;
+  navTab: NavTabThemeConfig;
+  overlayBlocker: OverlayBlockerThemeConfig;
+  paperDialog: PaperDialogThemeConfig;
+  pagination: PaginationThemeConfig;
+  pinbox: PinboxThemeConfig;
+  phonebox: PhoneboxThemeConfig;
+  radio: RadioThemeConfig;
+  rating: RatingThemeConfig;
+  richEditor: RichEditorThemeConfig;
+  scrollbar: ScrollbarThemeConfig;
+  searchbox: SearchboxThemeConfig;
+  selectbox: SelectboxThemeConfig;
+  separator: SeparatorThemeConfig;
+  sidebar: SidebarThemeConfig;
+  signbox: SignboxThemeConfig;
+  statusbar: StatusbarThemeConfig;
+  statefulForm: StatefulFormThemeConfig;
+  stepline: SteplineThemeConfig;
+  splitPane: SplitPaneThemeConfig;
+  table: TableThemeConfig;
+  textbox: TextboxThemeConfig;
+  textarea: TextareaThemeConfig;
+  thumbField: ThumbFieldThemeConfig;
+  timeline: TimelineThemeConfig;
+  tipmenu: Record<TipMenuVariant, TipMenuThemeConfig>;
+  timebox: TimeboxThemeConfig;
+  title: TitleThemeConfig;
+  toast: Record<ToastVariant, ToastThemeConfig>;
+  toggle: ToggleThemeConfig;
+  toolbar: Record<ToolbarVariant, ToolbarThemeConfig>;
+  tooltip: TooltipThemeConfig;
+  trackbar: TrackbarThemeConfig;
+  treelist: TreeListThemeConfig;
+  wheel: WheelThemeConfig;
 }
 
-export * from "./provider"
-export * from "./mode"
-export * from "./registry"
-export * from "./create-theme"
+export * from "./provider";
+export * from "./mode";
+export * from "./registry";
+export * from "./create-theme";

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1551,7 +1551,7 @@ export function createStatefulFormTheme(
       fieldTooltip: {
         textColor: body?.textColor,
         mutedTextColor: body?.mutedTextColor,
-        panelBackground: "rgb(238, 238, 238)",
+        panelBackground: "rgb(252, 252, 252)",
         panelBorder: "#e5e7eb",
         dividerColor: "#e5e7eb",
         scrollbarThumbColor: "rgba(145, 142, 142, 0.3)",

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1,5 +1,5 @@
-import { ToolbarVariant } from "./../../components/toolbar"
-import { ButtonVariants } from "./../../components/button"
+import { ToolbarVariant } from "./../../components/toolbar";
+import { ButtonVariants } from "./../../components/button";
 import {
   ActionButtonThemeConfig,
   ActionCapsuleThemeConfig,
@@ -73,15 +73,15 @@ import {
   TooltipThemeConfig,
   TreeListThemeConfig,
   WheelThemeConfig,
-} from "./../index"
-import { TipMenuVariant } from "./../../components/tip-menu"
-import { ToastVariant } from "./../../components/toast"
+} from "./../index";
+import { TipMenuVariant } from "./../../components/tip-menu";
+import { ToastVariant } from "./../../components/toast";
 
 function mergeTheme<T extends object>(
   defaultTheme: T,
   ...themeConfigurations: Array<Partial<T>>
 ): T {
-  return Object.assign({}, defaultTheme, ...themeConfigurations)
+  return Object.assign({}, defaultTheme, ...themeConfigurations);
 }
 
 // body
@@ -95,8 +95,8 @@ export function createBodyTheme(
       borderColor: "#d1d5db",
       mutedTextColor: "#6b7280",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // action-capsule
@@ -115,8 +115,8 @@ export function createActionCapsuleTheme(
       tabBorderRadius: "6px",
       borderColor: "#ebebeb",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // action-button.tsx
@@ -143,8 +143,8 @@ export function createActionButtonTheme(
 
       dropdownWidth: "170px",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // avatar.tsx
@@ -158,8 +158,8 @@ export function createAvatarTheme(
       textColor: body.textColor,
       overlayIconColor: "#ffffff",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // badge.tsx
@@ -178,17 +178,17 @@ export function createBadgeTheme(
       focusRingColor: "#00000033",
       disabledOpacity: 0.4,
     },
-  }
+  };
 
-  const merged = mergeTheme(defaultTheme, ...themeConfigurations)
+  const merged = mergeTheme(defaultTheme, ...themeConfigurations);
 
   return {
     ...merged,
     action: mergeTheme(
       defaultTheme.action,
-      ...themeConfigurations.map((o) => o.action ?? {}),
+      ...themeConfigurations.map((o) => o.action ?? {})
     ),
-  }
+  };
 }
 
 // boxbar.tsx
@@ -204,8 +204,8 @@ export function createBoxbarTheme(
       toggleButtonHoverColor: "#f3f4f6",
       textColor: body.textColor,
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // button.tsx
@@ -315,22 +315,22 @@ export function createButtonTheme(
       borderColor: "#42A340",
       dividerColor: "rgba(19, 156, 17, 0.69)",
     },
-  }
+  };
 
   const allKeys = new Set([
     ...Object.keys(defaultVariants),
     ...themeConfigurations.flatMap((o) => Object.keys(o)),
-  ])
+  ]);
 
-  const merged: Record<string, ButtonThemeConfig> = {}
+  const merged: Record<string, ButtonThemeConfig> = {};
   for (const key of allKeys) {
     merged[key] = mergeTheme(
       defaultVariants[key] ?? {},
-      ...themeConfigurations.map((o) => o[key] ?? {}),
-    )
+      ...themeConfigurations.map((o) => o[key] ?? {})
+    );
   }
 
-  return merged
+  return merged;
 }
 
 // tip-menu-container.tsx
@@ -345,8 +345,8 @@ export function createTipMenuContainerTheme(
       textColor: body?.textColor || "inherit",
       boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // calendar.tsx
@@ -375,8 +375,8 @@ export function createCalendarTheme(
 
       boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // capsule.tsx
@@ -401,25 +401,25 @@ export function createCapsuleTheme(
     hover: {
       borderColor: "oklch(54.6% .245 262.881)",
     },
-  }
+  };
 
-  const merged = mergeTheme(defaultTheme, ...themeConfigurations)
+  const merged = mergeTheme(defaultTheme, ...themeConfigurations);
 
   return {
     ...merged,
     tab: mergeTheme(
       defaultTheme.tab,
-      ...themeConfigurations.map((o) => o.tab ?? {}),
+      ...themeConfigurations.map((o) => o.tab ?? {})
     ),
     active: mergeTheme(
       defaultTheme.active,
-      ...themeConfigurations.map((o) => o.active ?? {}),
+      ...themeConfigurations.map((o) => o.active ?? {})
     ),
     hover: mergeTheme(
       defaultTheme.hover,
-      ...themeConfigurations.map((o) => o.hover ?? {}),
+      ...themeConfigurations.map((o) => o.hover ?? {})
     ),
-  }
+  };
 }
 
 // capsule-tab.tsx
@@ -434,8 +434,8 @@ export function createCapsuleTabTheme(
       boxShadow: "0 1px 3px -3px #5b5b5b",
       activeBackgroundColor: "black",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // card.tsx
@@ -456,8 +456,8 @@ export function createCardTheme(
       closeIconColor: body.textColor,
       closeIconHoverBackground: "#d1d5db",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // chips.tsx
@@ -479,8 +479,8 @@ export function createChipsTheme(
 
       boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // choice-group.tsx
@@ -496,8 +496,8 @@ export function createChoiceGroupTheme(
       backgroundColor: body.backgroundColor || "#fff",
       descriptionColor: "#4b5563",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // checkbox.tsx
@@ -517,8 +517,8 @@ export function createCheckboxTheme(
       highlightCheckedBackgroundColor: "#DBEAFE",
       highlightHoverBackgroundColor: "#E7F2FC",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // colorbox.tsx
@@ -545,8 +545,8 @@ export function createColorboxTheme(
 
       boxBackgroundColor: body.backgroundColor || "#ffffff",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // crumb.tsx
@@ -563,8 +563,8 @@ export function createCrumbTheme(
       ellipsisColor: "#6b7280",
       ellipsisHoverColor: "#61a9f9",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // combobox.tsx
@@ -591,8 +591,8 @@ export function createComboboxTheme(
       scrollThumbColor: "#b9bfc8",
       fadeColor: "#f4f5f8",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // dialog.tsx
@@ -608,8 +608,8 @@ export function createDialogTheme(
       boxShadow: "0px 10px 20px rgba(0, 0, 0, 0.1)",
       subtitleColor: "#5a606b",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // document-viewer.tsx
@@ -627,8 +627,8 @@ export function createDocumentViewerTheme(
       hoverBoxBackgroundColor: "rgba(77, 170, 245, 0.2)",
       hoverBoxTextColor: "#323639",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // dormant-text.tsx
@@ -646,8 +646,8 @@ export function createDormantTextTheme(
       actionButtonColor: "#666666",
       actionButtonHoverBackground: "#d1d5db",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // drawer-tab.tsx
@@ -665,8 +665,8 @@ export function createDrawerTabTheme(
       closeButtonHoverBackground: "#d1d5db",
       dividerColor: "#e5e7eb",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // error-slate.tsx
@@ -681,8 +681,8 @@ export function createErrorSlateTheme(
       cubeFaceText: "#ffffff",
       titleColor: body?.textColor,
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // field-lane.tsx
@@ -722,8 +722,8 @@ export function createFieldLaneTheme(
       helperColor: "#6b7280",
       dividerColor: "#9ca3af",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // flippable.tsx
@@ -744,8 +744,8 @@ export function createFlippable(
         textColor: body?.textColor,
       },
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // file-input-box.tsx
@@ -771,8 +771,8 @@ export function createFileInputBoxTheme(
       dragActiveColor: "#3b82f6",
       dragActiveBackgroundColor: "#eff6ff",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // file-drop-box.tsx
@@ -805,8 +805,8 @@ export function createFileDropBoxTheme(
 
       disabledTextColor: fieldLane.disabledTextColor || "#9ca3af",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // frame.tsx
@@ -824,8 +824,8 @@ export function createFrameTheme(
       overlayBackgroundColor: body.backgroundColor || "#ffffff",
       boxShadow: "var(--shadow-xs)",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // grid.tsx
@@ -843,8 +843,8 @@ export function createGridTheme(
       backgroundColor: body.backgroundColor,
       textColor: body?.textColor,
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // imagebox.tsx
@@ -868,8 +868,8 @@ export function createImageboxTheme(
 
       iconColor: "#c3c3c3",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // keynote.tsx
@@ -881,8 +881,8 @@ export function createKeynoteTheme(
       keyColor: "#374151",
       valueColor: "#111827",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // launchpad.tsx
@@ -896,8 +896,8 @@ export function createLaunchpadTheme(
       borderColor: body?.borderColor,
       textColor: body?.textColor,
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // list.tsx
@@ -921,8 +921,8 @@ export function createListTheme(
       mutedTextColor: "#6b7280",
       maxItemTextColor: "rgb(97, 97, 97)",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // loading-skeleton.tsx
@@ -934,8 +934,8 @@ export function createLoadingSkeletonTheme(
       baseColor: "#eeeeee",
       highlightColor: "#dddddd",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // loading-spinner.tsx
@@ -948,8 +948,8 @@ export function createLoadingSpinnerTheme(
       spinnerColor: "#3b82f6",
       textColor: body.textColor,
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // messagebox.tsx
@@ -977,26 +977,26 @@ export function createMessageboxTheme(
       textColor: "#9e5b20",
       activeColor: "#734418",
     },
-  }
+  };
 
   return {
     primary: mergeTheme(
       defaultTheme.primary,
-      ...themeConfigurations.map((o) => o.primary ?? {}),
+      ...themeConfigurations.map((o) => o.primary ?? {})
     ),
     success: mergeTheme(
       defaultTheme.success,
-      ...themeConfigurations.map((o) => o.success ?? {}),
+      ...themeConfigurations.map((o) => o.success ?? {})
     ),
     danger: mergeTheme(
       defaultTheme.danger,
-      ...themeConfigurations.map((o) => o.danger ?? {}),
+      ...themeConfigurations.map((o) => o.danger ?? {})
     ),
     warning: mergeTheme(
       defaultTheme.warning,
-      ...themeConfigurations.map((o) => o.warning ?? {}),
+      ...themeConfigurations.map((o) => o.warning ?? {})
     ),
-  }
+  };
 }
 
 // moneybox.tsx
@@ -1021,8 +1021,8 @@ export function createMoneyboxTheme(
       fontSize: "0.75rem",
       borderRadius: "2px",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // modal-dialog.tsx
@@ -1039,8 +1039,8 @@ export function createModalDialogTheme(
       subtitleColor: "#6b7280",
       dividerColor: "#3b82f6",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // nav-tab.tsx
@@ -1065,8 +1065,8 @@ export function createNavTabTheme(
       activeInsetShadow:
         "inset 0 0.5px 4px rgb(243 244 246 / 100%), inset 0 -0.5px 0.5px rgb(243 244 246 / 80%)",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // overlay-blocker.tsx
@@ -1078,8 +1078,8 @@ export function createOverlayBlockerTheme(
       backgroundColor: "rgba(3, 3, 3, 0.2)",
       backdropFilter: "blur(2px)",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // paper-dialog.tsx
@@ -1095,8 +1095,8 @@ export function createPaperDialogTheme(
       textColor: body.textColor,
       actionHoverBackgroundColor: "#f3f4f6",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // pagination.tsx
@@ -1119,8 +1119,8 @@ export function createPaginationTheme(
       disabledBackgroundColor: body.backgroundColor || "#ffffff",
       disabledTextColor: fieldLane.disabledTextColor || "#9ca3af",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // pinbox.tsx
@@ -1145,8 +1145,8 @@ export function createPinboxTheme(
       placeholderColor: fieldLane?.placeholderColor || "#9ca3af",
       boxShadow: "0 0 0 0.5px transparent",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // phonebox.tsx
@@ -1175,8 +1175,8 @@ export function createPhoneboxTheme(
       optionHighlightedBackground:
         fieldLane?.highlightBackgroundColor || "#dbeafe",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 export function createTrackbarTheme(
@@ -1217,30 +1217,30 @@ export function createTrackbarTheme(
       barColor: "#64748B",
       trackColor: "#CBD5E1",
     },
-  }
+  };
 
   return {
     primary: mergeTheme(
       defaultTheme.primary,
-      ...themeConfigurations.map((o) => o.primary ?? {}),
+      ...themeConfigurations.map((o) => o.primary ?? {})
     ),
     success: mergeTheme(
       defaultTheme.success,
-      ...themeConfigurations.map((o) => o.success ?? {}),
+      ...themeConfigurations.map((o) => o.success ?? {})
     ),
     danger: mergeTheme(
       defaultTheme.danger,
-      ...themeConfigurations.map((o) => o.danger ?? {}),
+      ...themeConfigurations.map((o) => o.danger ?? {})
     ),
     warning: mergeTheme(
       defaultTheme.warning,
-      ...themeConfigurations.map((o) => o.warning ?? {}),
+      ...themeConfigurations.map((o) => o.warning ?? {})
     ),
     neutral: mergeTheme(
       defaultTheme.neutral,
-      ...themeConfigurations.map((o) => o.neutral ?? {}),
+      ...themeConfigurations.map((o) => o.neutral ?? {})
     ),
-  }
+  };
 }
 
 // radio.tsx
@@ -1263,8 +1263,8 @@ export function createRadioTheme(
       highlightCheckedBackgroundColor: "#DBEAFE",
       highlightCheckedBorderColor: "#e5e7eb",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // rating.tsx
@@ -1286,8 +1286,8 @@ export function createRatingTheme(
       disabledStarColor: fieldLane?.borderColor || "#d1d5db",
       disabledLabelColor: fieldLane?.disabledTextColor || "#9ca3af",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // rich-editor.tsx
@@ -1310,8 +1310,8 @@ export function createRichEditorTheme(
       scrollThumb: "#9ca3af",
       preBackgroundColor: "#D3D3D3",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // scrollbar.tsx
@@ -1324,8 +1324,8 @@ export function createScrollbar(
       scrollbarThumbColor: "rgba(145, 142, 142, 0.3)",
       scrollbarTrackColor: "transparent",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // searchbox.tsx
@@ -1345,8 +1345,8 @@ export function createSearchboxTheme(
       clearIconColor: "#9ca3af",
       textColor: "#111827",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // stepline.tsx
@@ -1379,26 +1379,26 @@ export function createSteplineTheme(
       completed: buttonTheme?.success?.backgroundColor || "#00b62e",
       error: buttonTheme?.danger?.backgroundColor || "#b60000",
     },
-  }
+  };
 
   return {
     outerCircle: mergeTheme(
       defaultTheme.outerCircle,
-      ...themeConfigurations.map((o) => o.outerCircle ?? {}),
+      ...themeConfigurations.map((o) => o.outerCircle ?? {})
     ),
     innerCircle: mergeTheme(
       defaultTheme.innerCircle,
-      ...themeConfigurations.map((o) => o.innerCircle ?? {}),
+      ...themeConfigurations.map((o) => o.innerCircle ?? {})
     ),
     text: mergeTheme(
       defaultTheme.text,
-      ...themeConfigurations.map((o) => o.text ?? {}),
+      ...themeConfigurations.map((o) => o.text ?? {})
     ),
     line: mergeTheme(
       defaultTheme.line,
-      ...themeConfigurations.map((o) => o.line ?? {}),
+      ...themeConfigurations.map((o) => o.line ?? {})
     ),
-  }
+  };
 }
 
 // selectbox.tsx
@@ -1431,8 +1431,8 @@ export function createSelectboxTheme(
       dividerColor: fieldLane.dividerColor || "#9ca3af",
       disabledOpacity: fieldLane.disabledOpacity,
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // separator.tsx
@@ -1449,8 +1449,8 @@ export function createSeparatorTheme(
       backgroundTitleColor: body.backgroundColor,
       tooltipBackgroundColor: "rgb(236, 236, 236)",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // sidebar.tsx
@@ -1472,21 +1472,21 @@ export function createSidebarTheme(
       borderColor: "#e5e7eb",
       hoverBackgroundColor: "#f3f3f3",
     },
-  }
+  };
 
-  const merged = mergeTheme(defaultTheme, ...themeConfigurations)
+  const merged = mergeTheme(defaultTheme, ...themeConfigurations);
 
   return {
     ...merged,
     item: mergeTheme(
       defaultTheme.item,
-      ...themeConfigurations.map((o) => o.item ?? {}),
+      ...themeConfigurations.map((o) => o.item ?? {})
     ),
     toggle: mergeTheme(
       defaultTheme.toggle,
-      ...themeConfigurations.map((o) => o.toggle ?? {}),
+      ...themeConfigurations.map((o) => o.toggle ?? {})
     ),
-  }
+  };
 }
 
 // signbox.tsx
@@ -1506,8 +1506,8 @@ export function createSignboxTheme(
       clearIconColor: fieldLane?.actionColor || "#6b7280",
       clearIconHoverBackground: fieldLane?.actionHoverColor || "#e5e7eb",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // statusbar.tsx
@@ -1523,17 +1523,17 @@ export function createStatusbarTheme(
       activeBackgroundColor: "#d1d5db",
       hoverBackgroundColor: "#e5e7eb",
     },
-  }
+  };
 
-  const merged = mergeTheme(defaultTheme, ...themeConfigurations)
+  const merged = mergeTheme(defaultTheme, ...themeConfigurations);
 
   return {
     ...merged,
     item: mergeTheme(
       defaultTheme.item,
-      ...themeConfigurations.map((o) => o.item ?? {}),
+      ...themeConfigurations.map((o) => o.item ?? {})
     ),
-  }
+  };
 }
 
 // stateful-form.tsx
@@ -1558,8 +1558,8 @@ export function createStatefulFormTheme(
         scrollbarTrackColor: "rgba(168, 167, 167, 0.1)",
       },
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // textarea.tsx
@@ -1589,8 +1589,8 @@ export function createTextareaTheme(
 
       boxShadow: "0 0 0 1px transparent",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // textbox.tsx
@@ -1613,8 +1613,8 @@ export function createTextboxTheme(
       placeholderColor: fieldLane?.placeholderColor || "#9ca3af",
       boxShadow: "0 0 0 0.5px transparent",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // table.tsx
@@ -1659,8 +1659,8 @@ export function createTableTheme(
       rightLooseEffectColor:
         "linear-gradient(to left, rgba(0, 0, 0, 0.08), transparent)",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // timebox.tsx
@@ -1679,8 +1679,8 @@ export function createTimeboxTheme(
       errorTextColor: fieldLane?.errorColor,
       colonColor: body.textColor,
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // toast.tsx
@@ -1694,7 +1694,7 @@ export function createToastTheme(
     backgroundColor: "#ffffff7d",
     textColor: "rgba(0, 0, 0, 0.8)",
     iconColor: "#FFFFFF",
-  }
+  };
 
   const defaultTheme: Record<ToastVariant, ToastThemeConfig> = {
     primary: {
@@ -1731,30 +1731,30 @@ export function createToastTheme(
       iconBackgroundColor: "#64748B",
       progressColor: "#64748B",
     },
-  }
+  };
 
   return {
     primary: mergeTheme(
       defaultTheme.primary,
-      ...themeConfigurations.map((o) => o.primary ?? {}),
+      ...themeConfigurations.map((o) => o.primary ?? {})
     ),
     success: mergeTheme(
       defaultTheme.success,
-      ...themeConfigurations.map((o) => o.success ?? {}),
+      ...themeConfigurations.map((o) => o.success ?? {})
     ),
     danger: mergeTheme(
       defaultTheme.danger,
-      ...themeConfigurations.map((o) => o.danger ?? {}),
+      ...themeConfigurations.map((o) => o.danger ?? {})
     ),
     warning: mergeTheme(
       defaultTheme.warning,
-      ...themeConfigurations.map((o) => o.warning ?? {}),
+      ...themeConfigurations.map((o) => o.warning ?? {})
     ),
     neutral: mergeTheme(
       defaultTheme.neutral,
-      ...themeConfigurations.map((o) => o.neutral ?? {}),
+      ...themeConfigurations.map((o) => o.neutral ?? {})
     ),
-  }
+  };
 }
 
 // timeline.tsx
@@ -1787,26 +1787,26 @@ export function createTimelineTheme(
       completed: buttonTheme?.success?.backgroundColor || "#00b62e",
       error: buttonTheme?.danger?.backgroundColor || "#b60000",
     },
-  }
+  };
 
   return {
     outerCircle: mergeTheme(
       defaultTheme.outerCircle,
-      ...themeConfigurations.map((o) => o.outerCircle ?? {}),
+      ...themeConfigurations.map((o) => o.outerCircle ?? {})
     ),
     innerCircle: mergeTheme(
       defaultTheme.innerCircle,
-      ...themeConfigurations.map((o) => o.innerCircle ?? {}),
+      ...themeConfigurations.map((o) => o.innerCircle ?? {})
     ),
     text: mergeTheme(
       defaultTheme.text,
-      ...themeConfigurations.map((o) => o.text ?? {}),
+      ...themeConfigurations.map((o) => o.text ?? {})
     ),
     line: mergeTheme(
       defaultTheme.line,
-      ...themeConfigurations.map((o) => o.line ?? {}),
+      ...themeConfigurations.map((o) => o.line ?? {})
     ),
-  }
+  };
 }
 
 // tipmenu.tsx
@@ -1821,28 +1821,28 @@ export function createTipMenuTheme(
     danger: "danger",
     success: "success",
     primary: "primary",
-  }
+  };
 
   return Object.fromEntries(
     (Object.keys(variantMap) as TipMenuVariant[]).map((variant) => {
-      const buttonKey = variantMap[variant]
+      const buttonKey = variantMap[variant];
       const defaultConfig: TipMenuThemeConfig = {
         focusBackgroundColor: buttonTheme?.[buttonKey]?.focusBackgroundColor,
         backgroundColor: buttonTheme?.[buttonKey]?.backgroundColor,
         textColor: buttonTheme?.[buttonKey]?.textColor,
         activeBackgroundColor: buttonTheme?.[buttonKey]?.activeBackgroundColor,
         hoverBackgroundColor: buttonTheme?.[buttonKey]?.hoverBackgroundColor,
-      }
+      };
 
       return [
         variant,
         mergeTheme(
           defaultConfig,
-          ...themeConfigurations.map((o) => o[variant] ?? {}),
+          ...themeConfigurations.map((o) => o[variant] ?? {})
         ),
-      ]
-    }),
-  ) as Record<TipMenuVariant, TipMenuThemeConfig>
+      ];
+    })
+  ) as Record<TipMenuVariant, TipMenuThemeConfig>;
 }
 
 // title.tsx
@@ -1870,29 +1870,29 @@ export function createTitleTheme(
       backgroundColor: "transparent",
       hoverBackgroundColor: "rgba(255, 255, 255, 0.45)",
     },
-  }
+  };
 
-  const merged = mergeTheme(defaultTheme, ...themeConfigurations)
+  const merged = mergeTheme(defaultTheme, ...themeConfigurations);
 
   return {
     ...merged,
     pretitle: mergeTheme(
       defaultTheme.pretitle,
-      ...themeConfigurations.map((o) => o.pretitle ?? {}),
+      ...themeConfigurations.map((o) => o.pretitle ?? {})
     ),
     title: mergeTheme(
       defaultTheme.title,
-      ...themeConfigurations.map((o) => o.title ?? {}),
+      ...themeConfigurations.map((o) => o.title ?? {})
     ),
     subtitle: mergeTheme(
       defaultTheme.subtitle,
-      ...themeConfigurations.map((o) => o.subtitle ?? {}),
+      ...themeConfigurations.map((o) => o.subtitle ?? {})
     ),
     icon: mergeTheme(
       defaultTheme.icon,
-      ...themeConfigurations.map((o) => o.icon ?? {}),
+      ...themeConfigurations.map((o) => o.icon ?? {})
     ),
-  }
+  };
 }
 
 // toggle.tsx
@@ -1911,8 +1911,8 @@ export function createToggleTheme(
       disabledOpacity: 0.5,
       boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // toolbar.tsx
@@ -1968,22 +1968,22 @@ export function createToolbarTheme(
       activeBackgroundColor: baseButton?.ghost?.activeBackgroundColor,
       focusBackgroundColor: baseButton?.ghost?.focusBackgroundColor,
     },
-  }
+  };
 
   const allKeys = new Set([
     ...Object.keys(defaultVariants),
     ...themeConfigurations.flatMap((o) => Object.keys(o)),
-  ]) as Set<ToolbarVariant>
+  ]) as Set<ToolbarVariant>;
 
-  const merged = {} as Record<ToolbarVariant, ToolbarThemeConfig>
+  const merged = {} as Record<ToolbarVariant, ToolbarThemeConfig>;
   for (const key of allKeys) {
     merged[key] = mergeTheme(
       defaultVariants[key] ?? {},
-      ...themeConfigurations.map((o) => o[key] ?? {}),
-    )
+      ...themeConfigurations.map((o) => o[key] ?? {})
+    );
   }
 
-  return merged
+  return merged;
 }
 
 // tooltip.tsx
@@ -1999,8 +1999,8 @@ export function createTooltipTheme(
       boxShadow: "0 1px 2px rgba(0,0,0,0.1)",
       arrowBackgroundColor: "#b9babc",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // thumb-field.tsx
@@ -2015,8 +2015,8 @@ export function createThumbFieldTheme(
       errorColor: "#dc2626",
       disabledOpacity: 0.5,
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // treelist.tsx
@@ -2036,8 +2036,8 @@ export function createTreeListTheme(
       dividerHierarchySelectedColor: "#3b82f6",
       rowActionBackgroundColor: "rgb(193, 214, 241)",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // split-pane.tsx
@@ -2051,8 +2051,8 @@ export function createSplitPaneTheme(
       textColor: body?.textColor || "#111827",
       dividerColor: "#d1d5db",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }
 
 // wheel.tsx
@@ -2069,6 +2069,6 @@ export function createWheelTheme(
       inactiveTextColor: "rgba(17,24,39,0.35)",
       separatorColor: "rgba(17,24,39,0.45)",
     },
-    ...themeConfigurations,
-  )
+    ...themeConfigurations
+  );
 }

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1551,7 +1551,7 @@ export function createStatefulFormTheme(
       fieldTooltip: {
         textColor: body?.textColor,
         mutedTextColor: body?.mutedTextColor,
-        panelBackground: "rgb(249, 250, 251)",
+        panelBackground: "rgb(238, 238, 238)",
         panelBorder: "#e5e7eb",
         dividerColor: "#e5e7eb",
         scrollbarThumbColor: "rgba(145, 142, 142, 0.3)",

--- a/theme/mode/creator.ts
+++ b/theme/mode/creator.ts
@@ -1,5 +1,5 @@
-import { ToolbarVariant } from "./../../components/toolbar";
-import { ButtonVariants } from "./../../components/button";
+import { ToolbarVariant } from "./../../components/toolbar"
+import { ButtonVariants } from "./../../components/button"
 import {
   ActionButtonThemeConfig,
   ActionCapsuleThemeConfig,
@@ -73,15 +73,15 @@ import {
   TooltipThemeConfig,
   TreeListThemeConfig,
   WheelThemeConfig,
-} from "./../index";
-import { TipMenuVariant } from "./../../components/tip-menu";
-import { ToastVariant } from "./../../components/toast";
+} from "./../index"
+import { TipMenuVariant } from "./../../components/tip-menu"
+import { ToastVariant } from "./../../components/toast"
 
 function mergeTheme<T extends object>(
   defaultTheme: T,
   ...themeConfigurations: Array<Partial<T>>
 ): T {
-  return Object.assign({}, defaultTheme, ...themeConfigurations);
+  return Object.assign({}, defaultTheme, ...themeConfigurations)
 }
 
 // body
@@ -93,9 +93,10 @@ export function createBodyTheme(
       backgroundColor: "#ffffff",
       textColor: "#000000",
       borderColor: "#d1d5db",
+      mutedTextColor: "#6b7280",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // action-capsule
@@ -114,8 +115,8 @@ export function createActionCapsuleTheme(
       tabBorderRadius: "6px",
       borderColor: "#ebebeb",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // action-button.tsx
@@ -142,8 +143,8 @@ export function createActionButtonTheme(
 
       dropdownWidth: "170px",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // avatar.tsx
@@ -157,8 +158,8 @@ export function createAvatarTheme(
       textColor: body.textColor,
       overlayIconColor: "#ffffff",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // badge.tsx
@@ -177,17 +178,17 @@ export function createBadgeTheme(
       focusRingColor: "#00000033",
       disabledOpacity: 0.4,
     },
-  };
+  }
 
-  const merged = mergeTheme(defaultTheme, ...themeConfigurations);
+  const merged = mergeTheme(defaultTheme, ...themeConfigurations)
 
   return {
     ...merged,
     action: mergeTheme(
       defaultTheme.action,
-      ...themeConfigurations.map((o) => o.action ?? {})
+      ...themeConfigurations.map((o) => o.action ?? {}),
     ),
-  };
+  }
 }
 
 // boxbar.tsx
@@ -203,8 +204,8 @@ export function createBoxbarTheme(
       toggleButtonHoverColor: "#f3f4f6",
       textColor: body.textColor,
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // button.tsx
@@ -314,22 +315,22 @@ export function createButtonTheme(
       borderColor: "#42A340",
       dividerColor: "rgba(19, 156, 17, 0.69)",
     },
-  };
+  }
 
   const allKeys = new Set([
     ...Object.keys(defaultVariants),
     ...themeConfigurations.flatMap((o) => Object.keys(o)),
-  ]);
+  ])
 
-  const merged: Record<string, ButtonThemeConfig> = {};
+  const merged: Record<string, ButtonThemeConfig> = {}
   for (const key of allKeys) {
     merged[key] = mergeTheme(
       defaultVariants[key] ?? {},
-      ...themeConfigurations.map((o) => o[key] ?? {})
-    );
+      ...themeConfigurations.map((o) => o[key] ?? {}),
+    )
   }
 
-  return merged;
+  return merged
 }
 
 // tip-menu-container.tsx
@@ -344,8 +345,8 @@ export function createTipMenuContainerTheme(
       textColor: body?.textColor || "inherit",
       boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // calendar.tsx
@@ -374,8 +375,8 @@ export function createCalendarTheme(
 
       boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // capsule.tsx
@@ -400,25 +401,25 @@ export function createCapsuleTheme(
     hover: {
       borderColor: "oklch(54.6% .245 262.881)",
     },
-  };
+  }
 
-  const merged = mergeTheme(defaultTheme, ...themeConfigurations);
+  const merged = mergeTheme(defaultTheme, ...themeConfigurations)
 
   return {
     ...merged,
     tab: mergeTheme(
       defaultTheme.tab,
-      ...themeConfigurations.map((o) => o.tab ?? {})
+      ...themeConfigurations.map((o) => o.tab ?? {}),
     ),
     active: mergeTheme(
       defaultTheme.active,
-      ...themeConfigurations.map((o) => o.active ?? {})
+      ...themeConfigurations.map((o) => o.active ?? {}),
     ),
     hover: mergeTheme(
       defaultTheme.hover,
-      ...themeConfigurations.map((o) => o.hover ?? {})
+      ...themeConfigurations.map((o) => o.hover ?? {}),
     ),
-  };
+  }
 }
 
 // capsule-tab.tsx
@@ -433,8 +434,8 @@ export function createCapsuleTabTheme(
       boxShadow: "0 1px 3px -3px #5b5b5b",
       activeBackgroundColor: "black",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // card.tsx
@@ -455,8 +456,8 @@ export function createCardTheme(
       closeIconColor: body.textColor,
       closeIconHoverBackground: "#d1d5db",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // chips.tsx
@@ -478,8 +479,8 @@ export function createChipsTheme(
 
       boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // choice-group.tsx
@@ -495,8 +496,8 @@ export function createChoiceGroupTheme(
       backgroundColor: body.backgroundColor || "#fff",
       descriptionColor: "#4b5563",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // checkbox.tsx
@@ -516,8 +517,8 @@ export function createCheckboxTheme(
       highlightCheckedBackgroundColor: "#DBEAFE",
       highlightHoverBackgroundColor: "#E7F2FC",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // colorbox.tsx
@@ -544,8 +545,8 @@ export function createColorboxTheme(
 
       boxBackgroundColor: body.backgroundColor || "#ffffff",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // crumb.tsx
@@ -562,8 +563,8 @@ export function createCrumbTheme(
       ellipsisColor: "#6b7280",
       ellipsisHoverColor: "#61a9f9",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // combobox.tsx
@@ -590,8 +591,8 @@ export function createComboboxTheme(
       scrollThumbColor: "#b9bfc8",
       fadeColor: "#f4f5f8",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // dialog.tsx
@@ -607,8 +608,8 @@ export function createDialogTheme(
       boxShadow: "0px 10px 20px rgba(0, 0, 0, 0.1)",
       subtitleColor: "#5a606b",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // document-viewer.tsx
@@ -626,8 +627,8 @@ export function createDocumentViewerTheme(
       hoverBoxBackgroundColor: "rgba(77, 170, 245, 0.2)",
       hoverBoxTextColor: "#323639",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // dormant-text.tsx
@@ -645,8 +646,8 @@ export function createDormantTextTheme(
       actionButtonColor: "#666666",
       actionButtonHoverBackground: "#d1d5db",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // drawer-tab.tsx
@@ -664,8 +665,8 @@ export function createDrawerTabTheme(
       closeButtonHoverBackground: "#d1d5db",
       dividerColor: "#e5e7eb",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // error-slate.tsx
@@ -680,8 +681,8 @@ export function createErrorSlateTheme(
       cubeFaceText: "#ffffff",
       titleColor: body?.textColor,
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // field-lane.tsx
@@ -721,8 +722,8 @@ export function createFieldLaneTheme(
       helperColor: "#6b7280",
       dividerColor: "#9ca3af",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // flippable.tsx
@@ -743,8 +744,8 @@ export function createFlippable(
         textColor: body?.textColor,
       },
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // file-input-box.tsx
@@ -770,8 +771,8 @@ export function createFileInputBoxTheme(
       dragActiveColor: "#3b82f6",
       dragActiveBackgroundColor: "#eff6ff",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // file-drop-box.tsx
@@ -804,8 +805,8 @@ export function createFileDropBoxTheme(
 
       disabledTextColor: fieldLane.disabledTextColor || "#9ca3af",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // frame.tsx
@@ -823,8 +824,8 @@ export function createFrameTheme(
       overlayBackgroundColor: body.backgroundColor || "#ffffff",
       boxShadow: "var(--shadow-xs)",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // grid.tsx
@@ -842,8 +843,8 @@ export function createGridTheme(
       backgroundColor: body.backgroundColor,
       textColor: body?.textColor,
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // imagebox.tsx
@@ -867,8 +868,8 @@ export function createImageboxTheme(
 
       iconColor: "#c3c3c3",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // keynote.tsx
@@ -880,8 +881,8 @@ export function createKeynoteTheme(
       keyColor: "#374151",
       valueColor: "#111827",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // launchpad.tsx
@@ -895,8 +896,8 @@ export function createLaunchpadTheme(
       borderColor: body?.borderColor,
       textColor: body?.textColor,
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // list.tsx
@@ -920,8 +921,8 @@ export function createListTheme(
       mutedTextColor: "#6b7280",
       maxItemTextColor: "rgb(97, 97, 97)",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // loading-skeleton.tsx
@@ -933,8 +934,8 @@ export function createLoadingSkeletonTheme(
       baseColor: "#eeeeee",
       highlightColor: "#dddddd",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // loading-spinner.tsx
@@ -947,8 +948,8 @@ export function createLoadingSpinnerTheme(
       spinnerColor: "#3b82f6",
       textColor: body.textColor,
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // messagebox.tsx
@@ -976,26 +977,26 @@ export function createMessageboxTheme(
       textColor: "#9e5b20",
       activeColor: "#734418",
     },
-  };
+  }
 
   return {
     primary: mergeTheme(
       defaultTheme.primary,
-      ...themeConfigurations.map((o) => o.primary ?? {})
+      ...themeConfigurations.map((o) => o.primary ?? {}),
     ),
     success: mergeTheme(
       defaultTheme.success,
-      ...themeConfigurations.map((o) => o.success ?? {})
+      ...themeConfigurations.map((o) => o.success ?? {}),
     ),
     danger: mergeTheme(
       defaultTheme.danger,
-      ...themeConfigurations.map((o) => o.danger ?? {})
+      ...themeConfigurations.map((o) => o.danger ?? {}),
     ),
     warning: mergeTheme(
       defaultTheme.warning,
-      ...themeConfigurations.map((o) => o.warning ?? {})
+      ...themeConfigurations.map((o) => o.warning ?? {}),
     ),
-  };
+  }
 }
 
 // moneybox.tsx
@@ -1020,8 +1021,8 @@ export function createMoneyboxTheme(
       fontSize: "0.75rem",
       borderRadius: "2px",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // modal-dialog.tsx
@@ -1038,8 +1039,8 @@ export function createModalDialogTheme(
       subtitleColor: "#6b7280",
       dividerColor: "#3b82f6",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // nav-tab.tsx
@@ -1064,8 +1065,8 @@ export function createNavTabTheme(
       activeInsetShadow:
         "inset 0 0.5px 4px rgb(243 244 246 / 100%), inset 0 -0.5px 0.5px rgb(243 244 246 / 80%)",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // overlay-blocker.tsx
@@ -1077,8 +1078,8 @@ export function createOverlayBlockerTheme(
       backgroundColor: "rgba(3, 3, 3, 0.2)",
       backdropFilter: "blur(2px)",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // paper-dialog.tsx
@@ -1094,8 +1095,8 @@ export function createPaperDialogTheme(
       textColor: body.textColor,
       actionHoverBackgroundColor: "#f3f4f6",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // pagination.tsx
@@ -1118,8 +1119,8 @@ export function createPaginationTheme(
       disabledBackgroundColor: body.backgroundColor || "#ffffff",
       disabledTextColor: fieldLane.disabledTextColor || "#9ca3af",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // pinbox.tsx
@@ -1144,8 +1145,8 @@ export function createPinboxTheme(
       placeholderColor: fieldLane?.placeholderColor || "#9ca3af",
       boxShadow: "0 0 0 0.5px transparent",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // phonebox.tsx
@@ -1174,8 +1175,8 @@ export function createPhoneboxTheme(
       optionHighlightedBackground:
         fieldLane?.highlightBackgroundColor || "#dbeafe",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 export function createTrackbarTheme(
@@ -1216,30 +1217,30 @@ export function createTrackbarTheme(
       barColor: "#64748B",
       trackColor: "#CBD5E1",
     },
-  };
+  }
 
   return {
     primary: mergeTheme(
       defaultTheme.primary,
-      ...themeConfigurations.map((o) => o.primary ?? {})
+      ...themeConfigurations.map((o) => o.primary ?? {}),
     ),
     success: mergeTheme(
       defaultTheme.success,
-      ...themeConfigurations.map((o) => o.success ?? {})
+      ...themeConfigurations.map((o) => o.success ?? {}),
     ),
     danger: mergeTheme(
       defaultTheme.danger,
-      ...themeConfigurations.map((o) => o.danger ?? {})
+      ...themeConfigurations.map((o) => o.danger ?? {}),
     ),
     warning: mergeTheme(
       defaultTheme.warning,
-      ...themeConfigurations.map((o) => o.warning ?? {})
+      ...themeConfigurations.map((o) => o.warning ?? {}),
     ),
     neutral: mergeTheme(
       defaultTheme.neutral,
-      ...themeConfigurations.map((o) => o.neutral ?? {})
+      ...themeConfigurations.map((o) => o.neutral ?? {}),
     ),
-  };
+  }
 }
 
 // radio.tsx
@@ -1262,8 +1263,8 @@ export function createRadioTheme(
       highlightCheckedBackgroundColor: "#DBEAFE",
       highlightCheckedBorderColor: "#e5e7eb",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // rating.tsx
@@ -1285,8 +1286,8 @@ export function createRatingTheme(
       disabledStarColor: fieldLane?.borderColor || "#d1d5db",
       disabledLabelColor: fieldLane?.disabledTextColor || "#9ca3af",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // rich-editor.tsx
@@ -1309,8 +1310,8 @@ export function createRichEditorTheme(
       scrollThumb: "#9ca3af",
       preBackgroundColor: "#D3D3D3",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // scrollbar.tsx
@@ -1323,8 +1324,8 @@ export function createScrollbar(
       scrollbarThumbColor: "rgba(145, 142, 142, 0.3)",
       scrollbarTrackColor: "transparent",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // searchbox.tsx
@@ -1344,8 +1345,8 @@ export function createSearchboxTheme(
       clearIconColor: "#9ca3af",
       textColor: "#111827",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // stepline.tsx
@@ -1378,26 +1379,26 @@ export function createSteplineTheme(
       completed: buttonTheme?.success?.backgroundColor || "#00b62e",
       error: buttonTheme?.danger?.backgroundColor || "#b60000",
     },
-  };
+  }
 
   return {
     outerCircle: mergeTheme(
       defaultTheme.outerCircle,
-      ...themeConfigurations.map((o) => o.outerCircle ?? {})
+      ...themeConfigurations.map((o) => o.outerCircle ?? {}),
     ),
     innerCircle: mergeTheme(
       defaultTheme.innerCircle,
-      ...themeConfigurations.map((o) => o.innerCircle ?? {})
+      ...themeConfigurations.map((o) => o.innerCircle ?? {}),
     ),
     text: mergeTheme(
       defaultTheme.text,
-      ...themeConfigurations.map((o) => o.text ?? {})
+      ...themeConfigurations.map((o) => o.text ?? {}),
     ),
     line: mergeTheme(
       defaultTheme.line,
-      ...themeConfigurations.map((o) => o.line ?? {})
+      ...themeConfigurations.map((o) => o.line ?? {}),
     ),
-  };
+  }
 }
 
 // selectbox.tsx
@@ -1430,8 +1431,8 @@ export function createSelectboxTheme(
       dividerColor: fieldLane.dividerColor || "#9ca3af",
       disabledOpacity: fieldLane.disabledOpacity,
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // separator.tsx
@@ -1448,8 +1449,8 @@ export function createSeparatorTheme(
       backgroundTitleColor: body.backgroundColor,
       tooltipBackgroundColor: "rgb(236, 236, 236)",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // sidebar.tsx
@@ -1471,21 +1472,21 @@ export function createSidebarTheme(
       borderColor: "#e5e7eb",
       hoverBackgroundColor: "#f3f3f3",
     },
-  };
+  }
 
-  const merged = mergeTheme(defaultTheme, ...themeConfigurations);
+  const merged = mergeTheme(defaultTheme, ...themeConfigurations)
 
   return {
     ...merged,
     item: mergeTheme(
       defaultTheme.item,
-      ...themeConfigurations.map((o) => o.item ?? {})
+      ...themeConfigurations.map((o) => o.item ?? {}),
     ),
     toggle: mergeTheme(
       defaultTheme.toggle,
-      ...themeConfigurations.map((o) => o.toggle ?? {})
+      ...themeConfigurations.map((o) => o.toggle ?? {}),
     ),
-  };
+  }
 }
 
 // signbox.tsx
@@ -1505,8 +1506,8 @@ export function createSignboxTheme(
       clearIconColor: fieldLane?.actionColor || "#6b7280",
       clearIconHoverBackground: fieldLane?.actionHoverColor || "#e5e7eb",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // statusbar.tsx
@@ -1522,17 +1523,17 @@ export function createStatusbarTheme(
       activeBackgroundColor: "#d1d5db",
       hoverBackgroundColor: "#e5e7eb",
     },
-  };
+  }
 
-  const merged = mergeTheme(defaultTheme, ...themeConfigurations);
+  const merged = mergeTheme(defaultTheme, ...themeConfigurations)
 
   return {
     ...merged,
     item: mergeTheme(
       defaultTheme.item,
-      ...themeConfigurations.map((o) => o.item ?? {})
+      ...themeConfigurations.map((o) => o.item ?? {}),
     ),
-  };
+  }
 }
 
 // stateful-form.tsx
@@ -1542,13 +1543,23 @@ export function createStatefulFormTheme(
 ): StatefulFormThemeConfig {
   return mergeTheme<StatefulFormThemeConfig>(
     {
+      ...body,
       backgroundColor: body.backgroundColor,
       textColor: body.textColor,
       rowFrameBackgroundColor: "#f3f4f6",
       mobileRowFrameBackgroundColor: "rgb(236, 236, 236)",
+      fieldTooltip: {
+        textColor: body?.textColor,
+        mutedTextColor: body?.mutedTextColor,
+        panelBackground: "rgb(249, 250, 251)",
+        panelBorder: "#e5e7eb",
+        dividerColor: "#e5e7eb",
+        scrollbarThumbColor: "rgba(145, 142, 142, 0.3)",
+        scrollbarTrackColor: "rgba(168, 167, 167, 0.1)",
+      },
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // textarea.tsx
@@ -1578,8 +1589,8 @@ export function createTextareaTheme(
 
       boxShadow: "0 0 0 1px transparent",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // textbox.tsx
@@ -1602,8 +1613,8 @@ export function createTextboxTheme(
       placeholderColor: fieldLane?.placeholderColor || "#9ca3af",
       boxShadow: "0 0 0 0.5px transparent",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // table.tsx
@@ -1648,8 +1659,8 @@ export function createTableTheme(
       rightLooseEffectColor:
         "linear-gradient(to left, rgba(0, 0, 0, 0.08), transparent)",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // timebox.tsx
@@ -1668,8 +1679,8 @@ export function createTimeboxTheme(
       errorTextColor: fieldLane?.errorColor,
       colonColor: body.textColor,
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // toast.tsx
@@ -1683,7 +1694,7 @@ export function createToastTheme(
     backgroundColor: "#ffffff7d",
     textColor: "rgba(0, 0, 0, 0.8)",
     iconColor: "#FFFFFF",
-  };
+  }
 
   const defaultTheme: Record<ToastVariant, ToastThemeConfig> = {
     primary: {
@@ -1720,30 +1731,30 @@ export function createToastTheme(
       iconBackgroundColor: "#64748B",
       progressColor: "#64748B",
     },
-  };
+  }
 
   return {
     primary: mergeTheme(
       defaultTheme.primary,
-      ...themeConfigurations.map((o) => o.primary ?? {})
+      ...themeConfigurations.map((o) => o.primary ?? {}),
     ),
     success: mergeTheme(
       defaultTheme.success,
-      ...themeConfigurations.map((o) => o.success ?? {})
+      ...themeConfigurations.map((o) => o.success ?? {}),
     ),
     danger: mergeTheme(
       defaultTheme.danger,
-      ...themeConfigurations.map((o) => o.danger ?? {})
+      ...themeConfigurations.map((o) => o.danger ?? {}),
     ),
     warning: mergeTheme(
       defaultTheme.warning,
-      ...themeConfigurations.map((o) => o.warning ?? {})
+      ...themeConfigurations.map((o) => o.warning ?? {}),
     ),
     neutral: mergeTheme(
       defaultTheme.neutral,
-      ...themeConfigurations.map((o) => o.neutral ?? {})
+      ...themeConfigurations.map((o) => o.neutral ?? {}),
     ),
-  };
+  }
 }
 
 // timeline.tsx
@@ -1776,26 +1787,26 @@ export function createTimelineTheme(
       completed: buttonTheme?.success?.backgroundColor || "#00b62e",
       error: buttonTheme?.danger?.backgroundColor || "#b60000",
     },
-  };
+  }
 
   return {
     outerCircle: mergeTheme(
       defaultTheme.outerCircle,
-      ...themeConfigurations.map((o) => o.outerCircle ?? {})
+      ...themeConfigurations.map((o) => o.outerCircle ?? {}),
     ),
     innerCircle: mergeTheme(
       defaultTheme.innerCircle,
-      ...themeConfigurations.map((o) => o.innerCircle ?? {})
+      ...themeConfigurations.map((o) => o.innerCircle ?? {}),
     ),
     text: mergeTheme(
       defaultTheme.text,
-      ...themeConfigurations.map((o) => o.text ?? {})
+      ...themeConfigurations.map((o) => o.text ?? {}),
     ),
     line: mergeTheme(
       defaultTheme.line,
-      ...themeConfigurations.map((o) => o.line ?? {})
+      ...themeConfigurations.map((o) => o.line ?? {}),
     ),
-  };
+  }
 }
 
 // tipmenu.tsx
@@ -1810,28 +1821,28 @@ export function createTipMenuTheme(
     danger: "danger",
     success: "success",
     primary: "primary",
-  };
+  }
 
   return Object.fromEntries(
     (Object.keys(variantMap) as TipMenuVariant[]).map((variant) => {
-      const buttonKey = variantMap[variant];
+      const buttonKey = variantMap[variant]
       const defaultConfig: TipMenuThemeConfig = {
         focusBackgroundColor: buttonTheme?.[buttonKey]?.focusBackgroundColor,
         backgroundColor: buttonTheme?.[buttonKey]?.backgroundColor,
         textColor: buttonTheme?.[buttonKey]?.textColor,
         activeBackgroundColor: buttonTheme?.[buttonKey]?.activeBackgroundColor,
         hoverBackgroundColor: buttonTheme?.[buttonKey]?.hoverBackgroundColor,
-      };
+      }
 
       return [
         variant,
         mergeTheme(
           defaultConfig,
-          ...themeConfigurations.map((o) => o[variant] ?? {})
+          ...themeConfigurations.map((o) => o[variant] ?? {}),
         ),
-      ];
-    })
-  ) as Record<TipMenuVariant, TipMenuThemeConfig>;
+      ]
+    }),
+  ) as Record<TipMenuVariant, TipMenuThemeConfig>
 }
 
 // title.tsx
@@ -1859,29 +1870,29 @@ export function createTitleTheme(
       backgroundColor: "transparent",
       hoverBackgroundColor: "rgba(255, 255, 255, 0.45)",
     },
-  };
+  }
 
-  const merged = mergeTheme(defaultTheme, ...themeConfigurations);
+  const merged = mergeTheme(defaultTheme, ...themeConfigurations)
 
   return {
     ...merged,
     pretitle: mergeTheme(
       defaultTheme.pretitle,
-      ...themeConfigurations.map((o) => o.pretitle ?? {})
+      ...themeConfigurations.map((o) => o.pretitle ?? {}),
     ),
     title: mergeTheme(
       defaultTheme.title,
-      ...themeConfigurations.map((o) => o.title ?? {})
+      ...themeConfigurations.map((o) => o.title ?? {}),
     ),
     subtitle: mergeTheme(
       defaultTheme.subtitle,
-      ...themeConfigurations.map((o) => o.subtitle ?? {})
+      ...themeConfigurations.map((o) => o.subtitle ?? {}),
     ),
     icon: mergeTheme(
       defaultTheme.icon,
-      ...themeConfigurations.map((o) => o.icon ?? {})
+      ...themeConfigurations.map((o) => o.icon ?? {}),
     ),
-  };
+  }
 }
 
 // toggle.tsx
@@ -1900,8 +1911,8 @@ export function createToggleTheme(
       disabledOpacity: 0.5,
       boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // toolbar.tsx
@@ -1957,22 +1968,22 @@ export function createToolbarTheme(
       activeBackgroundColor: baseButton?.ghost?.activeBackgroundColor,
       focusBackgroundColor: baseButton?.ghost?.focusBackgroundColor,
     },
-  };
+  }
 
   const allKeys = new Set([
     ...Object.keys(defaultVariants),
     ...themeConfigurations.flatMap((o) => Object.keys(o)),
-  ]) as Set<ToolbarVariant>;
+  ]) as Set<ToolbarVariant>
 
-  const merged = {} as Record<ToolbarVariant, ToolbarThemeConfig>;
+  const merged = {} as Record<ToolbarVariant, ToolbarThemeConfig>
   for (const key of allKeys) {
     merged[key] = mergeTheme(
       defaultVariants[key] ?? {},
-      ...themeConfigurations.map((o) => o[key] ?? {})
-    );
+      ...themeConfigurations.map((o) => o[key] ?? {}),
+    )
   }
 
-  return merged;
+  return merged
 }
 
 // tooltip.tsx
@@ -1988,8 +1999,8 @@ export function createTooltipTheme(
       boxShadow: "0 1px 2px rgba(0,0,0,0.1)",
       arrowBackgroundColor: "#b9babc",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // thumb-field.tsx
@@ -2004,8 +2015,8 @@ export function createThumbFieldTheme(
       errorColor: "#dc2626",
       disabledOpacity: 0.5,
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // treelist.tsx
@@ -2025,8 +2036,8 @@ export function createTreeListTheme(
       dividerHierarchySelectedColor: "#3b82f6",
       rowActionBackgroundColor: "rgb(193, 214, 241)",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // split-pane.tsx
@@ -2040,8 +2051,8 @@ export function createSplitPaneTheme(
       textColor: body?.textColor || "#111827",
       dividerColor: "#d1d5db",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }
 
 // wheel.tsx
@@ -2058,6 +2069,6 @@ export function createWheelTheme(
       inactiveTextColor: "rgba(17,24,39,0.35)",
       separatorColor: "rgba(17,24,39,0.45)",
     },
-    ...themeConfigurations
-  );
+    ...themeConfigurations,
+  )
 }

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -707,7 +707,7 @@ const darkStatefulForm = createStatefulFormTheme(darkBody, {
     textColor: darkBody.textColor,
     mutedTextColor: "#838891",
 
-    panelBackground: "rgb(26, 26, 26)",
+    panelBackground: "rgb(30, 30, 30)",
     panelBorder: "rgb(39, 39, 48)",
     dividerColor: "rgb(39, 39, 48)",
 

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -1,4 +1,4 @@
-import { AppTheme } from "./../index";
+import { AppTheme } from "./../index"
 import {
   createActionButtonTheme,
   createActionCapsuleTheme,
@@ -72,14 +72,14 @@ import {
   createFlippable,
   createTrackbarTheme,
   createScrollbar,
-} from "./creator";
+} from "./creator"
 
 // Dark
 const darkBody = createBodyTheme({
   backgroundColor: "#1f2023",
   textColor: "#caced4",
   borderColor: "#4b5563",
-});
+})
 
 const darkFieldLane = createFieldLaneTheme(darkBody, {
   disabledOpacity: 0.5,
@@ -109,7 +109,7 @@ const darkFieldLane = createFieldLaneTheme(darkBody, {
 
   helperColor: "#9ca3af",
   dividerColor: "#6b7280",
-});
+})
 
 const darkActionButton = createActionButtonTheme({
   backgroundColor: "transparent",
@@ -125,19 +125,19 @@ const darkActionButton = createActionButtonTheme({
 
   dividerColor: "#3a3a3f",
   dropdownWidth: "170px",
-});
+})
 
 const darkActionCapsule = createActionCapsuleTheme(darkBody, {
   activeBackgroundColor: "rgb(57, 62, 65)",
   textColor: "#f9fafb",
   tabTextColor: "rgb(233, 233, 233)",
   borderColor: "#3a3a3f",
-});
+})
 
 const darkAvatar = createAvatarTheme(darkBody, {
   textColor: "black",
   overlayBackgroundColor: "rgba(0,0,0,0.6)",
-});
+})
 
 const darkButton = createButtonTheme(darkBody, {
   default: {
@@ -234,13 +234,13 @@ const darkButton = createButtonTheme(darkBody, {
     borderColor: "#03973d",
     dividerColor: "rgba(19, 156, 17, 0.69)",
   },
-});
+})
 
 const darkButtonTipMenuContainer = createTipMenuContainerTheme(darkBody, {
   backgroundColor: "rgb(35, 35, 35)",
   borderColor: "#303030",
   boxShadow: "0 1px 2px rgba(0, 0, 0, 0.3)",
-});
+})
 
 const darkBadge = createBadgeTheme(darkBody, {
   borderColor: "rgb(55, 55, 55)",
@@ -251,13 +251,13 @@ const darkBadge = createBadgeTheme(darkBody, {
     focusRingColor: "#ffffff33",
     disabledOpacity: 0.4,
   },
-});
+})
 
 const darkBoxbar = createBoxbarTheme(darkBody, {
   borderColor: "#333333",
   toggleButtonColor: "#f5f5f5",
   toggleButtonHoverColor: "#222222",
-});
+})
 
 const darkCalendar = createCalendarTheme(darkBody, darkFieldLane, {
   dayTextColor: "#d1d5db",
@@ -273,7 +273,7 @@ const darkCalendar = createCalendarTheme(darkBody, darkFieldLane, {
 
   mobileBorderColor: "#2c2c2e",
   mobileBackgroundColor: "#2c2c2e",
-});
+})
 
 const darkCapsule = createCapsuleTheme(darkBody, darkFieldLane, {
   borderColor: "#303030",
@@ -291,14 +291,14 @@ const darkCapsule = createCapsuleTheme(darkBody, darkFieldLane, {
   hover: {
     borderColor: "#303030",
   },
-});
+})
 
 const darkCapsuleTab = createCapsuleTabTheme(darkBody, {
   backgroundColor: "#262627",
   borderColor: "#303030",
   boxShadow: "0 2px 6px rgba(0,0,0,0.4)",
   activeBackgroundColor: "#303030",
-});
+})
 
 const darkCard = createCardTheme(darkBody, {
   backgroundColor: "rgb(31, 31, 33)",
@@ -308,7 +308,7 @@ const darkCard = createCardTheme(darkBody, {
   subtitleColor: "#9ca3af",
   closeIconColor: "#f9fafb",
   closeIconHoverBackground: "#374151",
-});
+})
 
 const darkChips = createChipsTheme(darkBody, {
   backgroundColor: "rgb(35,35,35)",
@@ -322,13 +322,13 @@ const darkChips = createChipsTheme(darkBody, {
   dividerColor: "rgba(255,255,255,0.08)",
 
   boxShadow: "0 1px 2px rgba(0,0,0,0.8)",
-});
+})
 
 const darkChoiceGroup = createChoiceGroupTheme(darkBody, {
   borderColor: "#374151",
   dividerColor: "#4b5563",
   descriptionColor: "#d1d5db",
-});
+})
 
 const darkCheckbox = createCheckboxTheme(darkBody, {
   borderColor: "rgb(55, 59, 65)",
@@ -339,9 +339,9 @@ const darkCheckbox = createCheckboxTheme(darkBody, {
   descriptionColor: "#d1d5db",
   highlightCheckedBackgroundColor: "#2563EB33",
   highlightHoverBackgroundColor: "#2563EB55",
-});
+})
 
-const darkColorbox = createColorboxTheme(darkBody, darkFieldLane);
+const darkColorbox = createColorboxTheme(darkBody, darkFieldLane)
 
 const darkCombobox = createComboboxTheme(darkBody, darkFieldLane, {
   selectedTextColor: darkBody.textColor,
@@ -350,7 +350,7 @@ const darkCombobox = createComboboxTheme(darkBody, darkFieldLane, {
   fadeColor: "#2c2c2e",
   mobileBackgroundColor: "#2c2c2e",
   mobileGroupBackgroundColor: "#2a2a2a",
-});
+})
 
 const darkCrumb = createCrumbTheme(darkBody, {
   hoverColor: darkButton?.primary?.hoverBackgroundColor,
@@ -358,14 +358,14 @@ const darkCrumb = createCrumbTheme(darkBody, {
   arrowColor: "#9ca3af",
   ellipsisColor: "#9ca3af",
   ellipsisHoverColor: darkButton?.primary?.hoverBackgroundColor,
-});
+})
 
 const darkDialog = createDialogTheme(darkBody, {
   backgroundColor: "rgb(26, 26, 26)",
   borderColor: "#303030",
   boxShadow: "rgba(0, 0, 0, 0.65) 0px 8px 24px",
   subtitleColor: "#a3a3a3",
-});
+})
 
 const darkDocumentViewer = createDocumentViewerTheme(darkBody, {
   backgroundColor: "#434345",
@@ -374,7 +374,7 @@ const darkDocumentViewer = createDocumentViewerTheme(darkBody, {
   hoverBoxBorderColor: "#3b82f6",
   hoverBoxTextColor: "#020617",
   hoverBoxBackgroundColor: "rgba(59, 130, 246, 0.15)",
-});
+})
 
 const darkDormantText = createDormantTextTheme(darkBody, {
   hoverBackgroundColor: "rgb(26, 26, 26)",
@@ -382,7 +382,7 @@ const darkDormantText = createDormantTextTheme(darkBody, {
   pencilColor: "#ccc",
   actionButtonColor: "#ccc",
   actionButtonHoverBackground: "#363636",
-});
+})
 
 const darkDrawerTab = createDrawerTabTheme(darkBody, {
   borderColor: "#303030",
@@ -390,13 +390,13 @@ const darkDrawerTab = createDrawerTabTheme(darkBody, {
   headerBackgroundColor: "#1a1a1a",
   closeButtonHoverBackground: "#363636",
   dividerColor: "#3f3f46",
-});
+})
 
 const darkErrorSlate = createErrorSlateTheme(darkBody, {
   cubeFaceBackground: "#ff4d4f",
   cubeFaceBorder: "#a8071a",
   cubeFaceText: "#ffffff",
-});
+})
 
 const darkFlippable = createFlippable(darkBody, {
   back: {
@@ -407,7 +407,7 @@ const darkFlippable = createFlippable(darkBody, {
     ...darkBody,
     backgroundColor: "rgb(26, 26, 26)",
   },
-});
+})
 
 const darkFileInputBox = createFileInputBoxTheme(darkBody, darkFieldLane, {
   defaultGradientColor: "#9ca3af",
@@ -416,7 +416,7 @@ const darkFileInputBox = createFileInputBoxTheme(darkBody, darkFieldLane, {
 
   dragActiveColor: "#60a5fa",
   dragActiveBackgroundColor: "#eff6ff",
-});
+})
 
 const darkFileDropBox = createFileDropBoxTheme(darkBody, darkFieldLane, {
   defaultGradientColor: "#9ca3af",
@@ -432,7 +432,7 @@ const darkFileDropBox = createFileDropBoxTheme(darkBody, darkFieldLane, {
 
   dragActiveBackgroundColor: "#1e3a8a",
   dragActiveTextColor: "#93c5fd",
-});
+})
 
 const darkFrame = createFrameTheme(darkBody, {
   backgroundColor: "rgb(31, 32, 35)",
@@ -441,7 +441,7 @@ const darkFrame = createFrameTheme(darkBody, {
   titleBackgroundColor: "rgb(31, 32, 35)",
   overlayBackgroundColor: "rgb(31, 32, 35)",
   boxShadow: "0 1px 3px rgba(0, 0, 0, 0.2)",
-});
+})
 
 const darkGrid = createGridTheme(darkBody, {
   backgroundColor: "#1a1a1a",
@@ -450,7 +450,7 @@ const darkGrid = createGridTheme(darkBody, {
   cardBorderColor: "#333333",
   cardShadow: "0 1px 3px rgba(0,0,0,0.6)",
   thumbnailBackgroundColor: "#2a2a2a",
-});
+})
 
 const darkImagebox = createImageboxTheme(darkBody, darkFieldLane, {
   draggingBackgroundColor: "#1e3a8a33",
@@ -458,14 +458,14 @@ const darkImagebox = createImageboxTheme(darkBody, darkFieldLane, {
   draggingTextColor: "#60a5fa",
 
   iconColor: "#9ca3af",
-});
+})
 
 const darkKeynote = createKeynoteTheme({
   keyColor: "rgb(243, 244, 246)",
   valueColor: "#f3f4f6",
-});
+})
 
-const darkLaunchpad = createLaunchpadTheme(darkBody);
+const darkLaunchpad = createLaunchpadTheme(darkBody)
 
 const darkList = createListTheme(darkBody, {
   hoverBackgroundColor: "#212c37",
@@ -479,16 +479,16 @@ const darkList = createListTheme(darkBody, {
   toggleBackgroundColor: "#1e3a5f",
   hoverTextColor: "#111111",
   maxItemTextColor: "#9ca3af",
-});
+})
 
 const darkLoadingSkeleton = createLoadingSkeletonTheme({
   baseColor: "#2b313a",
   highlightColor: "#3b424c",
-});
+})
 
 const darkLoadingSpinner = createLoadingSpinnerTheme(darkBody, {
   spinnerColor: "rgb(142 214 255)",
-});
+})
 
 const darkMessagebox = createMessageboxTheme({
   primary: {
@@ -511,16 +511,16 @@ const darkMessagebox = createMessageboxTheme({
     textColor: "#fdba74",
     activeColor: "#fb923c",
   },
-});
+})
 
-const darkMoneybox = createMoneyboxTheme(darkBody, darkFieldLane);
+const darkMoneybox = createMoneyboxTheme(darkBody, darkFieldLane)
 
 const darkModalDialog = createModalDialogTheme(darkBody, {
   backgroundColor: "#272727",
   borderColor: "#303030",
   subtitleColor: "#9ca3af",
   dividerColor: "rgb(60, 49, 110)",
-});
+})
 
 const darkNavTab = createNavTabTheme(darkBody, {
   backgroundColor: "rgb(35, 35, 35)",
@@ -538,12 +538,12 @@ const darkNavTab = createNavTabTheme(darkBody, {
     inset 0 0.5px 3px rgba(255,255,255,0.06),
     inset 0 -0.5px 0.5px rgba(0,0,0,0.8)
   `,
-});
+})
 
 const darkOverlayBlocker = createOverlayBlockerTheme({
   backgroundColor: "rgb(17 17 17 / 80%)",
   backdropFilter: "blur(1px)",
-});
+})
 
 const darkPaperDialog = createPaperDialogTheme(darkBody, {
   backgroundColor: darkBody.backgroundColor,
@@ -551,7 +551,7 @@ const darkPaperDialog = createPaperDialogTheme(darkBody, {
   boxShadow: "0 4px 12px rgba(0,0,0,0.5)",
   textColor: darkBody.textColor,
   actionHoverBackgroundColor: "#363636",
-});
+})
 
 const darkPagination = createPaginationTheme(darkBody, darkFieldLane, {
   borderColor: "rgb(55, 65, 81)",
@@ -563,11 +563,11 @@ const darkPagination = createPaginationTheme(darkBody, darkFieldLane, {
 
   disabledBackgroundColor: "rgb(56, 58, 61)",
   disabledTextColor: "rgb(160, 160, 160)",
-});
+})
 
-const darkPinbox = createPinboxTheme(darkBody, darkFieldLane);
+const darkPinbox = createPinboxTheme(darkBody, darkFieldLane)
 
-const darkPhonebox = createPhoneboxTheme(darkBody, darkFieldLane);
+const darkPhonebox = createPhoneboxTheme(darkBody, darkFieldLane)
 
 const darkTrackbar = createTrackbarTheme({
   primary: {
@@ -604,7 +604,7 @@ const darkTrackbar = createTrackbarTheme({
     barColor: "#94A3B8",
     trackColor: "#334155",
   },
-});
+})
 
 const darkRadio = createRadioTheme(darkBody, {
   borderColor: "#374151",
@@ -619,7 +619,7 @@ const darkRadio = createRadioTheme(darkBody, {
 
   highlightBorderColor: "rgb(75, 85, 99)",
   highlightCheckedBorderColor: "#1465d3bf",
-});
+})
 
 const darkRating = createRatingTheme(darkBody, darkFieldLane, {
   starFullColor: "#facc15",
@@ -627,7 +627,7 @@ const darkRating = createRatingTheme(darkBody, darkFieldLane, {
   starBorderColor: "#fbbf24",
 
   hoverStarColor: "#f59e0b",
-});
+})
 
 const darkRichEditor = createRichEditorTheme(
   darkBody,
@@ -637,14 +637,14 @@ const darkRichEditor = createRichEditorTheme(
     scrollThumb: "#52525b",
     toolbarBackground: darkButton?.default?.backgroundColor,
     preBackgroundColor: "#2D2D2D",
-  }
-);
+  },
+)
 
 const darkScrollbar = createScrollbar({
   scrollbarThumbActiveColor: "rgba(255, 255, 255, 0.7)",
   scrollbarThumbColor: "rgba(255, 255, 255, 0.3)",
   scrollbarTrackColor: "transparent",
-});
+})
 
 const darkSearchbox = createSearchboxTheme(darkBody, {
   backgroundColor: darkBody.backgroundColor,
@@ -655,9 +655,9 @@ const darkSearchbox = createSearchboxTheme(darkBody, {
   focusShadow: "0 0 0 1px rgb(85, 65, 160)",
   iconColor: "#a1a1aa",
   clearIconColor: "#a1a1aa",
-});
+})
 
-const darkSelectbox = createSelectboxTheme(darkBody, darkFieldLane);
+const darkSelectbox = createSelectboxTheme(darkBody, darkFieldLane)
 
 const darkSeparator = createSeparatorTheme(darkBody, {
   containerColor: "#d1d5db",
@@ -666,9 +666,9 @@ const darkSeparator = createSeparatorTheme(darkBody, {
   titleColor: "rgb(171, 171, 171)",
   backgroundTitleColor: "#1f2023",
   tooltipBackgroundColor: "rgb(62, 69, 89)",
-});
+})
 
-const darkSignbox = createSignboxTheme(darkBody, darkFieldLane);
+const darkSignbox = createSignboxTheme(darkBody, darkFieldLane)
 
 const darkSidebar = createSidebarTheme(darkBody, {
   backgroundColor: darkBody.backgroundColor,
@@ -685,7 +685,7 @@ const darkSidebar = createSidebarTheme(darkBody, {
     borderColor: "#303030",
     hoverBackgroundColor: "#363636",
   },
-});
+})
 
 const darkStatusbar = createStatusbarTheme({
   backgroundColor: "#272727",
@@ -697,12 +697,24 @@ const darkStatusbar = createStatusbarTheme({
     activeBackgroundColor: "#363636",
     hoverBackgroundColor: "#404040",
   },
-});
+})
 
 const darkStatefulForm = createStatefulFormTheme(darkBody, {
   rowFrameBackgroundColor: "rgb(48, 48, 48)",
   mobileRowFrameBackgroundColor: "rgb(4, 4, 4)",
-});
+
+  fieldTooltip: {
+    textColor: darkBody.textColor,
+    mutedTextColor: "#838891",
+
+    panelBackground: "rgb(26, 26, 26)",
+    panelBorder: "rgb(39, 39, 48)",
+    dividerColor: "rgb(39, 39, 48)",
+
+    scrollbarThumbColor: "rgba(255, 255, 255, 0.2)",
+    scrollbarTrackColor: "rgba(255, 255, 255, 0.1)",
+  },
+})
 
 const darkTimeline = createTimelineTheme(darkBody, darkButton, {
   outerCircle: {
@@ -722,11 +734,11 @@ const darkTimeline = createTimelineTheme(darkBody, darkButton, {
     completed: darkButton?.success?.backgroundColor || "#00b62e",
     error: darkButton?.error?.backgroundColor || "#b60000",
   },
-});
+})
 
 const darkStepline = createSteplineTheme(darkBody, darkButton, {
   line: darkTimeline.line,
-});
+})
 
 const darkTable = createTableTheme(darkBody, {
   boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
@@ -762,25 +774,25 @@ const darkTable = createTableTheme(darkBody, {
     "linear-gradient(to right, rgb(8 8 8 / 38%), transparent)",
   rightLooseEffectColor:
     "linear-gradient(to left, rgb(8 8 8 / 38%), transparent)",
-});
+})
 
 const darkTextarea = createTextareaTheme(darkBody, darkFieldLane, {
   boxShadow: "0 0 0 0.5px transparent",
   scrollbarThumbColor: "#52525b",
-});
+})
 
 const darkTextbox = createTextboxTheme(darkBody, darkFieldLane, {
   boxShadow: "0 0 0 0.5px transparent",
-});
+})
 
-const darkTimebox = createTimeboxTheme(darkBody, darkFieldLane);
+const darkTimebox = createTimeboxTheme(darkBody, darkFieldLane)
 
 const darkTipMenu = createTipMenuTheme(darkButton, {
   default: { disabledTextColor: "rgba(180, 180, 180, 0.45)" },
   primary: { disabledTextColor: "rgba(180, 180, 180, 0.45)" },
   danger: { disabledTextColor: "rgba(180, 180, 180, 0.45)" },
   success: { disabledTextColor: "rgba(180, 180, 180, 0.45)" },
-});
+})
 
 const darkTitle = createTitleTheme(darkBody, {
   pretitle: {
@@ -799,20 +811,20 @@ const darkTitle = createTitleTheme(darkBody, {
     backgroundColor: "transparent",
     hoverBackgroundColor: "rgba(0, 0, 0, 0.45)",
   },
-});
+})
 
 const darkThumbField = createThumbFieldTheme({
   thumbsUpColor: "rgb(134, 111, 238)",
   thumbsDownColor: "rgb(236, 65, 108)",
   inactiveColor: "#6b7280",
   errorColor: "#f87171",
-});
+})
 
 const sharedDarkToast = {
   backgroundColor: "#18181b7d",
   textColor: "rgba(255, 255, 255, 0.8)",
   iconColor: "#FFFFFF",
-};
+}
 
 const darkToast = createToastTheme({
   primary: {
@@ -849,7 +861,7 @@ const darkToast = createToastTheme({
     iconBackgroundColor: "#334155",
     progressColor: "#94A3B8",
   },
-});
+})
 
 const darkToggle = createToggleTheme(darkBody, {
   backgroundColor: "rgb(80, 80, 80)",
@@ -859,7 +871,7 @@ const darkToggle = createToggleTheme(darkBody, {
   textColor: "#f5f5f5",
   descriptionColor: "#9ca3af",
   boxShadow: "0 2px 6px rgba(0,0,0,0.4)",
-});
+})
 
 const darkToolbar = createToolbarTheme({
   default: darkButton.default,
@@ -867,7 +879,7 @@ const darkToolbar = createToolbarTheme({
   danger: darkButton.danger,
   ghost: darkButton.ghost,
   success: darkButton.success,
-});
+})
 
 const darkTooltip = createTooltipTheme({
   arrowBackgroundColor: "#3e4143",
@@ -875,7 +887,7 @@ const darkTooltip = createTooltipTheme({
   nodeElementBackgroundColor: "#3e4143",
   literalStringTextColor: darkBody?.textColor,
   nodeElementTextColor: darkBody?.textColor,
-});
+})
 
 const darkTreeList = createTreeListTheme(darkBody, {
   textColor: "#f9fafb",
@@ -889,11 +901,11 @@ const darkTreeList = createTreeListTheme(darkBody, {
   dividerHierarchySelectedColor: "#485c7d",
 
   rowActionBackgroundColor: "#1e3a5f",
-});
+})
 
 const darkSplitPane = createSplitPaneTheme(darkBody, {
   dividerColor: "#374151",
-});
+})
 
 const darkWheel = createWheelTheme({
   backgroundColor: "#2c2c2e",
@@ -907,7 +919,7 @@ const darkWheel = createWheelTheme({
   inactiveTextColor: "rgba(255,255,255,0.38)",
 
   separatorColor: "rgba(255,255,255,0.5)",
-});
+})
 
 export const darkTheme: AppTheme = {
   body: darkBody,
@@ -984,7 +996,7 @@ export const darkTheme: AppTheme = {
   trackbar: darkTrackbar,
   treelist: darkTreeList,
   wheel: darkWheel,
-};
+}
 
 export {
   darkActionButton,
@@ -1059,4 +1071,4 @@ export {
   darkTooltip,
   darkTreeList,
   darkWheel,
-};
+}

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -707,7 +707,7 @@ const darkStatefulForm = createStatefulFormTheme(darkBody, {
     textColor: darkBody.textColor,
     mutedTextColor: "#838891",
 
-    panelBackground: "rgb(30, 30, 30)",
+    panelBackground: "rgb(44, 44, 44)",
     panelBorder: "rgb(39, 39, 48)",
     dividerColor: "rgb(39, 39, 48)",
 

--- a/theme/mode/dark.ts
+++ b/theme/mode/dark.ts
@@ -1,4 +1,4 @@
-import { AppTheme } from "./../index"
+import { AppTheme } from "./../index";
 import {
   createActionButtonTheme,
   createActionCapsuleTheme,
@@ -72,14 +72,14 @@ import {
   createFlippable,
   createTrackbarTheme,
   createScrollbar,
-} from "./creator"
+} from "./creator";
 
 // Dark
 const darkBody = createBodyTheme({
   backgroundColor: "#1f2023",
   textColor: "#caced4",
   borderColor: "#4b5563",
-})
+});
 
 const darkFieldLane = createFieldLaneTheme(darkBody, {
   disabledOpacity: 0.5,
@@ -109,7 +109,7 @@ const darkFieldLane = createFieldLaneTheme(darkBody, {
 
   helperColor: "#9ca3af",
   dividerColor: "#6b7280",
-})
+});
 
 const darkActionButton = createActionButtonTheme({
   backgroundColor: "transparent",
@@ -125,19 +125,19 @@ const darkActionButton = createActionButtonTheme({
 
   dividerColor: "#3a3a3f",
   dropdownWidth: "170px",
-})
+});
 
 const darkActionCapsule = createActionCapsuleTheme(darkBody, {
   activeBackgroundColor: "rgb(57, 62, 65)",
   textColor: "#f9fafb",
   tabTextColor: "rgb(233, 233, 233)",
   borderColor: "#3a3a3f",
-})
+});
 
 const darkAvatar = createAvatarTheme(darkBody, {
   textColor: "black",
   overlayBackgroundColor: "rgba(0,0,0,0.6)",
-})
+});
 
 const darkButton = createButtonTheme(darkBody, {
   default: {
@@ -234,13 +234,13 @@ const darkButton = createButtonTheme(darkBody, {
     borderColor: "#03973d",
     dividerColor: "rgba(19, 156, 17, 0.69)",
   },
-})
+});
 
 const darkButtonTipMenuContainer = createTipMenuContainerTheme(darkBody, {
   backgroundColor: "rgb(35, 35, 35)",
   borderColor: "#303030",
   boxShadow: "0 1px 2px rgba(0, 0, 0, 0.3)",
-})
+});
 
 const darkBadge = createBadgeTheme(darkBody, {
   borderColor: "rgb(55, 55, 55)",
@@ -251,13 +251,13 @@ const darkBadge = createBadgeTheme(darkBody, {
     focusRingColor: "#ffffff33",
     disabledOpacity: 0.4,
   },
-})
+});
 
 const darkBoxbar = createBoxbarTheme(darkBody, {
   borderColor: "#333333",
   toggleButtonColor: "#f5f5f5",
   toggleButtonHoverColor: "#222222",
-})
+});
 
 const darkCalendar = createCalendarTheme(darkBody, darkFieldLane, {
   dayTextColor: "#d1d5db",
@@ -273,7 +273,7 @@ const darkCalendar = createCalendarTheme(darkBody, darkFieldLane, {
 
   mobileBorderColor: "#2c2c2e",
   mobileBackgroundColor: "#2c2c2e",
-})
+});
 
 const darkCapsule = createCapsuleTheme(darkBody, darkFieldLane, {
   borderColor: "#303030",
@@ -291,14 +291,14 @@ const darkCapsule = createCapsuleTheme(darkBody, darkFieldLane, {
   hover: {
     borderColor: "#303030",
   },
-})
+});
 
 const darkCapsuleTab = createCapsuleTabTheme(darkBody, {
   backgroundColor: "#262627",
   borderColor: "#303030",
   boxShadow: "0 2px 6px rgba(0,0,0,0.4)",
   activeBackgroundColor: "#303030",
-})
+});
 
 const darkCard = createCardTheme(darkBody, {
   backgroundColor: "rgb(31, 31, 33)",
@@ -308,7 +308,7 @@ const darkCard = createCardTheme(darkBody, {
   subtitleColor: "#9ca3af",
   closeIconColor: "#f9fafb",
   closeIconHoverBackground: "#374151",
-})
+});
 
 const darkChips = createChipsTheme(darkBody, {
   backgroundColor: "rgb(35,35,35)",
@@ -322,13 +322,13 @@ const darkChips = createChipsTheme(darkBody, {
   dividerColor: "rgba(255,255,255,0.08)",
 
   boxShadow: "0 1px 2px rgba(0,0,0,0.8)",
-})
+});
 
 const darkChoiceGroup = createChoiceGroupTheme(darkBody, {
   borderColor: "#374151",
   dividerColor: "#4b5563",
   descriptionColor: "#d1d5db",
-})
+});
 
 const darkCheckbox = createCheckboxTheme(darkBody, {
   borderColor: "rgb(55, 59, 65)",
@@ -339,9 +339,9 @@ const darkCheckbox = createCheckboxTheme(darkBody, {
   descriptionColor: "#d1d5db",
   highlightCheckedBackgroundColor: "#2563EB33",
   highlightHoverBackgroundColor: "#2563EB55",
-})
+});
 
-const darkColorbox = createColorboxTheme(darkBody, darkFieldLane)
+const darkColorbox = createColorboxTheme(darkBody, darkFieldLane);
 
 const darkCombobox = createComboboxTheme(darkBody, darkFieldLane, {
   selectedTextColor: darkBody.textColor,
@@ -350,7 +350,7 @@ const darkCombobox = createComboboxTheme(darkBody, darkFieldLane, {
   fadeColor: "#2c2c2e",
   mobileBackgroundColor: "#2c2c2e",
   mobileGroupBackgroundColor: "#2a2a2a",
-})
+});
 
 const darkCrumb = createCrumbTheme(darkBody, {
   hoverColor: darkButton?.primary?.hoverBackgroundColor,
@@ -358,14 +358,14 @@ const darkCrumb = createCrumbTheme(darkBody, {
   arrowColor: "#9ca3af",
   ellipsisColor: "#9ca3af",
   ellipsisHoverColor: darkButton?.primary?.hoverBackgroundColor,
-})
+});
 
 const darkDialog = createDialogTheme(darkBody, {
   backgroundColor: "rgb(26, 26, 26)",
   borderColor: "#303030",
   boxShadow: "rgba(0, 0, 0, 0.65) 0px 8px 24px",
   subtitleColor: "#a3a3a3",
-})
+});
 
 const darkDocumentViewer = createDocumentViewerTheme(darkBody, {
   backgroundColor: "#434345",
@@ -374,7 +374,7 @@ const darkDocumentViewer = createDocumentViewerTheme(darkBody, {
   hoverBoxBorderColor: "#3b82f6",
   hoverBoxTextColor: "#020617",
   hoverBoxBackgroundColor: "rgba(59, 130, 246, 0.15)",
-})
+});
 
 const darkDormantText = createDormantTextTheme(darkBody, {
   hoverBackgroundColor: "rgb(26, 26, 26)",
@@ -382,7 +382,7 @@ const darkDormantText = createDormantTextTheme(darkBody, {
   pencilColor: "#ccc",
   actionButtonColor: "#ccc",
   actionButtonHoverBackground: "#363636",
-})
+});
 
 const darkDrawerTab = createDrawerTabTheme(darkBody, {
   borderColor: "#303030",
@@ -390,13 +390,13 @@ const darkDrawerTab = createDrawerTabTheme(darkBody, {
   headerBackgroundColor: "#1a1a1a",
   closeButtonHoverBackground: "#363636",
   dividerColor: "#3f3f46",
-})
+});
 
 const darkErrorSlate = createErrorSlateTheme(darkBody, {
   cubeFaceBackground: "#ff4d4f",
   cubeFaceBorder: "#a8071a",
   cubeFaceText: "#ffffff",
-})
+});
 
 const darkFlippable = createFlippable(darkBody, {
   back: {
@@ -407,7 +407,7 @@ const darkFlippable = createFlippable(darkBody, {
     ...darkBody,
     backgroundColor: "rgb(26, 26, 26)",
   },
-})
+});
 
 const darkFileInputBox = createFileInputBoxTheme(darkBody, darkFieldLane, {
   defaultGradientColor: "#9ca3af",
@@ -416,7 +416,7 @@ const darkFileInputBox = createFileInputBoxTheme(darkBody, darkFieldLane, {
 
   dragActiveColor: "#60a5fa",
   dragActiveBackgroundColor: "#eff6ff",
-})
+});
 
 const darkFileDropBox = createFileDropBoxTheme(darkBody, darkFieldLane, {
   defaultGradientColor: "#9ca3af",
@@ -432,7 +432,7 @@ const darkFileDropBox = createFileDropBoxTheme(darkBody, darkFieldLane, {
 
   dragActiveBackgroundColor: "#1e3a8a",
   dragActiveTextColor: "#93c5fd",
-})
+});
 
 const darkFrame = createFrameTheme(darkBody, {
   backgroundColor: "rgb(31, 32, 35)",
@@ -441,7 +441,7 @@ const darkFrame = createFrameTheme(darkBody, {
   titleBackgroundColor: "rgb(31, 32, 35)",
   overlayBackgroundColor: "rgb(31, 32, 35)",
   boxShadow: "0 1px 3px rgba(0, 0, 0, 0.2)",
-})
+});
 
 const darkGrid = createGridTheme(darkBody, {
   backgroundColor: "#1a1a1a",
@@ -450,7 +450,7 @@ const darkGrid = createGridTheme(darkBody, {
   cardBorderColor: "#333333",
   cardShadow: "0 1px 3px rgba(0,0,0,0.6)",
   thumbnailBackgroundColor: "#2a2a2a",
-})
+});
 
 const darkImagebox = createImageboxTheme(darkBody, darkFieldLane, {
   draggingBackgroundColor: "#1e3a8a33",
@@ -458,14 +458,14 @@ const darkImagebox = createImageboxTheme(darkBody, darkFieldLane, {
   draggingTextColor: "#60a5fa",
 
   iconColor: "#9ca3af",
-})
+});
 
 const darkKeynote = createKeynoteTheme({
   keyColor: "rgb(243, 244, 246)",
   valueColor: "#f3f4f6",
-})
+});
 
-const darkLaunchpad = createLaunchpadTheme(darkBody)
+const darkLaunchpad = createLaunchpadTheme(darkBody);
 
 const darkList = createListTheme(darkBody, {
   hoverBackgroundColor: "#212c37",
@@ -479,16 +479,16 @@ const darkList = createListTheme(darkBody, {
   toggleBackgroundColor: "#1e3a5f",
   hoverTextColor: "#111111",
   maxItemTextColor: "#9ca3af",
-})
+});
 
 const darkLoadingSkeleton = createLoadingSkeletonTheme({
   baseColor: "#2b313a",
   highlightColor: "#3b424c",
-})
+});
 
 const darkLoadingSpinner = createLoadingSpinnerTheme(darkBody, {
   spinnerColor: "rgb(142 214 255)",
-})
+});
 
 const darkMessagebox = createMessageboxTheme({
   primary: {
@@ -511,16 +511,16 @@ const darkMessagebox = createMessageboxTheme({
     textColor: "#fdba74",
     activeColor: "#fb923c",
   },
-})
+});
 
-const darkMoneybox = createMoneyboxTheme(darkBody, darkFieldLane)
+const darkMoneybox = createMoneyboxTheme(darkBody, darkFieldLane);
 
 const darkModalDialog = createModalDialogTheme(darkBody, {
   backgroundColor: "#272727",
   borderColor: "#303030",
   subtitleColor: "#9ca3af",
   dividerColor: "rgb(60, 49, 110)",
-})
+});
 
 const darkNavTab = createNavTabTheme(darkBody, {
   backgroundColor: "rgb(35, 35, 35)",
@@ -538,12 +538,12 @@ const darkNavTab = createNavTabTheme(darkBody, {
     inset 0 0.5px 3px rgba(255,255,255,0.06),
     inset 0 -0.5px 0.5px rgba(0,0,0,0.8)
   `,
-})
+});
 
 const darkOverlayBlocker = createOverlayBlockerTheme({
   backgroundColor: "rgb(17 17 17 / 80%)",
   backdropFilter: "blur(1px)",
-})
+});
 
 const darkPaperDialog = createPaperDialogTheme(darkBody, {
   backgroundColor: darkBody.backgroundColor,
@@ -551,7 +551,7 @@ const darkPaperDialog = createPaperDialogTheme(darkBody, {
   boxShadow: "0 4px 12px rgba(0,0,0,0.5)",
   textColor: darkBody.textColor,
   actionHoverBackgroundColor: "#363636",
-})
+});
 
 const darkPagination = createPaginationTheme(darkBody, darkFieldLane, {
   borderColor: "rgb(55, 65, 81)",
@@ -563,11 +563,11 @@ const darkPagination = createPaginationTheme(darkBody, darkFieldLane, {
 
   disabledBackgroundColor: "rgb(56, 58, 61)",
   disabledTextColor: "rgb(160, 160, 160)",
-})
+});
 
-const darkPinbox = createPinboxTheme(darkBody, darkFieldLane)
+const darkPinbox = createPinboxTheme(darkBody, darkFieldLane);
 
-const darkPhonebox = createPhoneboxTheme(darkBody, darkFieldLane)
+const darkPhonebox = createPhoneboxTheme(darkBody, darkFieldLane);
 
 const darkTrackbar = createTrackbarTheme({
   primary: {
@@ -604,7 +604,7 @@ const darkTrackbar = createTrackbarTheme({
     barColor: "#94A3B8",
     trackColor: "#334155",
   },
-})
+});
 
 const darkRadio = createRadioTheme(darkBody, {
   borderColor: "#374151",
@@ -619,7 +619,7 @@ const darkRadio = createRadioTheme(darkBody, {
 
   highlightBorderColor: "rgb(75, 85, 99)",
   highlightCheckedBorderColor: "#1465d3bf",
-})
+});
 
 const darkRating = createRatingTheme(darkBody, darkFieldLane, {
   starFullColor: "#facc15",
@@ -627,7 +627,7 @@ const darkRating = createRatingTheme(darkBody, darkFieldLane, {
   starBorderColor: "#fbbf24",
 
   hoverStarColor: "#f59e0b",
-})
+});
 
 const darkRichEditor = createRichEditorTheme(
   darkBody,
@@ -637,14 +637,14 @@ const darkRichEditor = createRichEditorTheme(
     scrollThumb: "#52525b",
     toolbarBackground: darkButton?.default?.backgroundColor,
     preBackgroundColor: "#2D2D2D",
-  },
-)
+  }
+);
 
 const darkScrollbar = createScrollbar({
   scrollbarThumbActiveColor: "rgba(255, 255, 255, 0.7)",
   scrollbarThumbColor: "rgba(255, 255, 255, 0.3)",
   scrollbarTrackColor: "transparent",
-})
+});
 
 const darkSearchbox = createSearchboxTheme(darkBody, {
   backgroundColor: darkBody.backgroundColor,
@@ -655,9 +655,9 @@ const darkSearchbox = createSearchboxTheme(darkBody, {
   focusShadow: "0 0 0 1px rgb(85, 65, 160)",
   iconColor: "#a1a1aa",
   clearIconColor: "#a1a1aa",
-})
+});
 
-const darkSelectbox = createSelectboxTheme(darkBody, darkFieldLane)
+const darkSelectbox = createSelectboxTheme(darkBody, darkFieldLane);
 
 const darkSeparator = createSeparatorTheme(darkBody, {
   containerColor: "#d1d5db",
@@ -666,9 +666,9 @@ const darkSeparator = createSeparatorTheme(darkBody, {
   titleColor: "rgb(171, 171, 171)",
   backgroundTitleColor: "#1f2023",
   tooltipBackgroundColor: "rgb(62, 69, 89)",
-})
+});
 
-const darkSignbox = createSignboxTheme(darkBody, darkFieldLane)
+const darkSignbox = createSignboxTheme(darkBody, darkFieldLane);
 
 const darkSidebar = createSidebarTheme(darkBody, {
   backgroundColor: darkBody.backgroundColor,
@@ -685,7 +685,7 @@ const darkSidebar = createSidebarTheme(darkBody, {
     borderColor: "#303030",
     hoverBackgroundColor: "#363636",
   },
-})
+});
 
 const darkStatusbar = createStatusbarTheme({
   backgroundColor: "#272727",
@@ -697,7 +697,7 @@ const darkStatusbar = createStatusbarTheme({
     activeBackgroundColor: "#363636",
     hoverBackgroundColor: "#404040",
   },
-})
+});
 
 const darkStatefulForm = createStatefulFormTheme(darkBody, {
   rowFrameBackgroundColor: "rgb(48, 48, 48)",
@@ -714,7 +714,7 @@ const darkStatefulForm = createStatefulFormTheme(darkBody, {
     scrollbarThumbColor: "rgba(255, 255, 255, 0.2)",
     scrollbarTrackColor: "rgba(255, 255, 255, 0.1)",
   },
-})
+});
 
 const darkTimeline = createTimelineTheme(darkBody, darkButton, {
   outerCircle: {
@@ -734,11 +734,11 @@ const darkTimeline = createTimelineTheme(darkBody, darkButton, {
     completed: darkButton?.success?.backgroundColor || "#00b62e",
     error: darkButton?.error?.backgroundColor || "#b60000",
   },
-})
+});
 
 const darkStepline = createSteplineTheme(darkBody, darkButton, {
   line: darkTimeline.line,
-})
+});
 
 const darkTable = createTableTheme(darkBody, {
   boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
@@ -774,25 +774,25 @@ const darkTable = createTableTheme(darkBody, {
     "linear-gradient(to right, rgb(8 8 8 / 38%), transparent)",
   rightLooseEffectColor:
     "linear-gradient(to left, rgb(8 8 8 / 38%), transparent)",
-})
+});
 
 const darkTextarea = createTextareaTheme(darkBody, darkFieldLane, {
   boxShadow: "0 0 0 0.5px transparent",
   scrollbarThumbColor: "#52525b",
-})
+});
 
 const darkTextbox = createTextboxTheme(darkBody, darkFieldLane, {
   boxShadow: "0 0 0 0.5px transparent",
-})
+});
 
-const darkTimebox = createTimeboxTheme(darkBody, darkFieldLane)
+const darkTimebox = createTimeboxTheme(darkBody, darkFieldLane);
 
 const darkTipMenu = createTipMenuTheme(darkButton, {
   default: { disabledTextColor: "rgba(180, 180, 180, 0.45)" },
   primary: { disabledTextColor: "rgba(180, 180, 180, 0.45)" },
   danger: { disabledTextColor: "rgba(180, 180, 180, 0.45)" },
   success: { disabledTextColor: "rgba(180, 180, 180, 0.45)" },
-})
+});
 
 const darkTitle = createTitleTheme(darkBody, {
   pretitle: {
@@ -811,20 +811,20 @@ const darkTitle = createTitleTheme(darkBody, {
     backgroundColor: "transparent",
     hoverBackgroundColor: "rgba(0, 0, 0, 0.45)",
   },
-})
+});
 
 const darkThumbField = createThumbFieldTheme({
   thumbsUpColor: "rgb(134, 111, 238)",
   thumbsDownColor: "rgb(236, 65, 108)",
   inactiveColor: "#6b7280",
   errorColor: "#f87171",
-})
+});
 
 const sharedDarkToast = {
   backgroundColor: "#18181b7d",
   textColor: "rgba(255, 255, 255, 0.8)",
   iconColor: "#FFFFFF",
-}
+};
 
 const darkToast = createToastTheme({
   primary: {
@@ -861,7 +861,7 @@ const darkToast = createToastTheme({
     iconBackgroundColor: "#334155",
     progressColor: "#94A3B8",
   },
-})
+});
 
 const darkToggle = createToggleTheme(darkBody, {
   backgroundColor: "rgb(80, 80, 80)",
@@ -871,7 +871,7 @@ const darkToggle = createToggleTheme(darkBody, {
   textColor: "#f5f5f5",
   descriptionColor: "#9ca3af",
   boxShadow: "0 2px 6px rgba(0,0,0,0.4)",
-})
+});
 
 const darkToolbar = createToolbarTheme({
   default: darkButton.default,
@@ -879,7 +879,7 @@ const darkToolbar = createToolbarTheme({
   danger: darkButton.danger,
   ghost: darkButton.ghost,
   success: darkButton.success,
-})
+});
 
 const darkTooltip = createTooltipTheme({
   arrowBackgroundColor: "#3e4143",
@@ -887,7 +887,7 @@ const darkTooltip = createTooltipTheme({
   nodeElementBackgroundColor: "#3e4143",
   literalStringTextColor: darkBody?.textColor,
   nodeElementTextColor: darkBody?.textColor,
-})
+});
 
 const darkTreeList = createTreeListTheme(darkBody, {
   textColor: "#f9fafb",
@@ -901,11 +901,11 @@ const darkTreeList = createTreeListTheme(darkBody, {
   dividerHierarchySelectedColor: "#485c7d",
 
   rowActionBackgroundColor: "#1e3a5f",
-})
+});
 
 const darkSplitPane = createSplitPaneTheme(darkBody, {
   dividerColor: "#374151",
-})
+});
 
 const darkWheel = createWheelTheme({
   backgroundColor: "#2c2c2e",
@@ -919,7 +919,7 @@ const darkWheel = createWheelTheme({
   inactiveTextColor: "rgba(255,255,255,0.38)",
 
   separatorColor: "rgba(255,255,255,0.5)",
-})
+});
 
 export const darkTheme: AppTheme = {
   body: darkBody,
@@ -996,7 +996,7 @@ export const darkTheme: AppTheme = {
   trackbar: darkTrackbar,
   treelist: darkTreeList,
   wheel: darkWheel,
-}
+};
 
 export {
   darkActionButton,
@@ -1071,4 +1071,4 @@ export {
   darkTooltip,
   darkTreeList,
   darkWheel,
-}
+};


### PR DESCRIPTION
Description:
Previously, the `StatefulForm.helper` only can add with `string` type, which not enrich flexibility users when want to add element inside of `Stateful.Field`. 

This pull request updates a `ReactNode` prop to the `helper`, and make the tooltip drawer have `max-width` with 300px. 

Additionally, this update add the `FieldTooltip` to have another appearance on the `Tooltip` element, especially for the `drawer`.

Source:
[[Improvement] SYST-822: Allow StatefulForm.helper to be react node](https://linear.app/systatum/issue/SYST-822/allow-statefulformhelper-to-be-react-node)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself