### PR TITLE
[Improvement] SYST-736: Don't default allow all markdown features, only set of features

### DIFF
--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -35,9 +35,13 @@ const meta: Meta<typeof RichEditor> = {
   - Ensures clean spacing and consistent formatting
 
 - **Rich formatting**
-  - Bold and italic (toolbar + keyboard shortcuts)
-  - Headings (H1–H3) via floating menu
-  - Ordered and unordered lists
+  - Bold
+  - Italic
+  - Underline
+  - Headings (H1–H3)
+  - Ordered lists
+  - Unordered lists
+  - Optional task lists (checkboxes)
   - Smart inline formatting (auto-detect word styling)
 
 - **Checklist support**
@@ -67,6 +71,47 @@ const meta: Meta<typeof RichEditor> = {
     - \`view-only\`
     - \`markdown-editor\`
     - \`code-editor\`
+
+---
+
+### 🎨 Formatting Configuration
+
+Control which formatting features are available in the editor.
+
+By default, all formatting options are enabled except checkboxes.
+
+\`\`\`tsx
+<RichEditor
+  formatting={{
+    allowBold: true,
+    allowItalic: true,
+    allowUnderline: true,
+    allowOrderedList: true,
+    allowUnorderedList: true,
+    allowCheckBoxes: false,
+    allowHeading: true,
+  }}
+/>
+\`\`\`
+
+#### \`formatting\`
+
+| Option | Default | Description |
+| ------- | :-----: | ----------- |
+| \`allowBold\` | \`true\` | Enables bold formatting (\`**text**\`). |
+| \`allowItalic\` | \`true\` | Enables italic formatting (\`*text*\`). |
+| \`allowUnderline\` | \`true\` | Enables underline formatting (\`~text~\`). |
+| \`allowOrderedList\` | \`true\` | Enables ordered lists (\`1. Item\`). |
+| \`allowUnorderedList\` | \`true\` | Enables unordered lists (\`- Item\` or \`* Item\`). |
+| \`allowCheckBoxes\` | \`false\` | Enables Markdown task lists (\`[ ]\` and \`[x]\`). |
+| \`allowHeading\` | \`true\` | Enables Markdown headings (\`#\` through \`######\`). |
+
+When a formatting option is disabled:
+
+- Existing Markdown using that format is rendered as plain text.
+- Toolbar controls for the disabled feature are hidden or inactive.
+- Keyboard shortcuts and automatic formatting for the disabled feature are ignored.
+- Markdown serialization removes the disabled formatting.
 
 ---
 
@@ -292,7 +337,7 @@ export const Default: Story = {
     const { currentTheme } = useTheme();
     const richEditorTheme = currentTheme?.richEditor;
 
-    const [value, setValue] = useState("");
+    const [value, setValue] = useState("[ ] test");
     const [printValue, setPrintValue] = useState("");
 
     const ref = useRef<RichEditorRef>(null);
@@ -356,6 +401,9 @@ This is unordered list
           ref={ref}
           onChange={(e) => setValue(e)}
           value={value}
+          formatting={{
+            allowCheckBoxes: true,
+          }}
           toolbarRightPanel={TOOLBAR_RIGHT_PANEL_ACTIONS}
         />
         <div

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -554,6 +554,9 @@ export default Content
           autogrow
           onChange={(e) => setValue(e)}
           value={value}
+          formatting={{
+            allowCheckBoxes: true,
+          }}
           toolbarRightPanel={TOOLBAR_RIGHT_PANEL_ACTIONS}
         />
         <div
@@ -999,6 +1002,9 @@ export default Content
           mode="view-only"
           onChange={(e) => setValue(e)}
           value={value}
+          formatting={{
+            allowCheckBoxes: true,
+          }}
         />
         {value !== "" && (
           <pre

--- a/components/rich-editor.stories.tsx
+++ b/components/rich-editor.stories.tsx
@@ -337,7 +337,7 @@ export const Default: Story = {
     const { currentTheme } = useTheme();
     const richEditorTheme = currentTheme?.richEditor;
 
-    const [value, setValue] = useState("[ ] test");
+    const [value, setValue] = useState("");
     const [printValue, setPrintValue] = useState("");
 
     const ref = useRef<RichEditorRef>(null);

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -2110,6 +2110,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
                   editorRef.current?.innerHTML.replace(/\u00A0/g, "") || "";
                 const cleanedHTML = cleanupHtml(html);
 
+                console.log(`html:{html:${html}, cleanup: ${cleanedHTML}}`);
+
                 const markdown = turndownService.turndown(cleanedHTML);
                 const cleanedMarkdown = cleanSpacing(markdown);
                 if (onChange) {
@@ -2657,7 +2659,7 @@ const cleanupHtml = (html: string): string => {
   Array.from(container.querySelectorAll("p")).forEach((p) => {
     if (
       p.querySelector(
-        "ul, ol, h1, h2, h3, h4, h5, h6, b, i, u, input, strong, [data-token-start]"
+        "ul, ol, h1, h2, h3, h4, h5, h6, b, i, u, em, input, strong, [data-token-start]"
       )
     )
       return;

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -2657,7 +2657,7 @@ const cleanupHtml = (html: string): string => {
   Array.from(container.querySelectorAll("p")).forEach((p) => {
     if (
       p.querySelector(
-        "ul, ol, h1, h2, h3, h4, h5, h6, b, i, input, strong, [data-token-start]"
+        "ul, ol, h1, h2, h3, h4, h5, h6, b, i, u, input, strong, [data-token-start]"
       )
     )
       return;

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -40,6 +40,7 @@ export interface RichEditorFormattingOptions {
   allowOrderedList?: boolean;
   allowUnorderedList?: boolean;
   allowCheckBoxes?: boolean;
+  allowHeading?: boolean;
 }
 
 const DEFAULT_FORMATTING_OPTIONS: Required<RichEditorFormattingOptions> = {
@@ -49,6 +50,7 @@ const DEFAULT_FORMATTING_OPTIONS: Required<RichEditorFormattingOptions> = {
   allowOrderedList: true,
   allowUnorderedList: true,
   allowCheckBoxes: false,
+  allowHeading: true,
 };
 
 export interface RichEditorProps {
@@ -230,6 +232,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       allowOrderedList,
       allowUnorderedList,
       allowCheckBoxes,
+      allowHeading,
     } = useMemo(
       () => ({ ...DEFAULT_FORMATTING_OPTIONS, ...formatting }),
       [
@@ -239,6 +242,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         formatting?.allowOrderedList,
         formatting?.allowUnorderedList,
         formatting?.allowCheckBoxes,
+        formatting?.allowHeading,
       ]
     );
 
@@ -428,16 +432,6 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       },
     });
 
-    turndownService.addRule("underline", {
-      filter: ["u"],
-      replacement: (content, node) => {
-        console.log("Underline node:", node);
-        console.log("Underline content:", content);
-
-        return `~${content}~`;
-      },
-    });
-
     // When bold/italic are disallowed, strip the tags on the way back to
     // markdown instead of emitting ** / _ markers, so re-parsing never
     // reintroduces formatting the editor isn't supposed to support.
@@ -455,10 +449,25 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       });
     }
 
+    if (!allowHeading) {
+      turndownService.addRule("disallowedHeading", {
+        filter: ["h1", "h2", "h3", "h4", "h5", "h6"],
+        replacement: (content) => content,
+      });
+    }
+
+    // Underline is not part of the Markdown specification.
+    // This custom rule preserves or serializes <u> elements because
+    // Turndown does not support underline out of the box.
     if (!allowUnderline) {
       turndownService.addRule("disallowedUnderline", {
         filter: ["u"],
         replacement: (content) => content,
+      });
+    } else {
+      turndownService.addRule("italic", {
+        filter: ["u"],
+        replacement: (content) => `~${content}~`,
       });
     }
 
@@ -572,7 +581,9 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
             }
           },
           renderer(token) {
-            return `<h${token.depth}>${token.text}</h${token.depth}>`;
+            return allowHeading
+              ? `<h${token.depth}>${token.text}</h${token.depth}>`
+              : token.text;
           },
         },
         {
@@ -2109,8 +2120,6 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
                 const html =
                   editorRef.current?.innerHTML.replace(/\u00A0/g, "") || "";
                 const cleanedHTML = cleanupHtml(html);
-
-                console.log(`html:{html:${html}, cleanup: ${cleanedHTML}}`);
 
                 const markdown = turndownService.turndown(cleanedHTML);
                 const cleanedMarkdown = cleanSpacing(markdown);

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -43,16 +43,6 @@ export interface RichEditorFormattingOptions {
   allowHeading?: boolean;
 }
 
-const DEFAULT_FORMATTING_OPTIONS: Required<RichEditorFormattingOptions> = {
-  allowBold: true,
-  allowItalic: true,
-  allowUnderline: true,
-  allowOrderedList: true,
-  allowUnorderedList: true,
-  allowCheckBoxes: false,
-  allowHeading: true,
-};
-
 export interface RichEditorProps {
   value?: string;
   onChange?: (value: string) => void;
@@ -226,25 +216,14 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     ref
   ) => {
     const {
-      allowBold,
-      allowItalic,
-      allowUnderline,
-      allowOrderedList,
-      allowUnorderedList,
-      allowCheckBoxes,
-      allowHeading,
-    } = useMemo(
-      () => ({ ...DEFAULT_FORMATTING_OPTIONS, ...formatting }),
-      [
-        formatting?.allowBold,
-        formatting?.allowItalic,
-        formatting?.allowUnderline,
-        formatting?.allowOrderedList,
-        formatting?.allowUnorderedList,
-        formatting?.allowCheckBoxes,
-        formatting?.allowHeading,
-      ]
-    );
+      allowBold = true,
+      allowItalic = true,
+      allowUnderline = true,
+      allowOrderedList = true,
+      allowUnorderedList = true,
+      allowCheckBoxes = false,
+      allowHeading = true,
+    } = formatting ?? {};
 
     const {
       languageOptions: _languageOptions = Object.values(RichEditorCodeLanguage),

--- a/components/rich-editor.tsx
+++ b/components/rich-editor.tsx
@@ -20,6 +20,7 @@ import {
   RiItalic,
   RiListOrdered,
   RiListUnordered,
+  RiUnderline,
 } from "@remixicon/react";
 import TurndownService from "./../lib/turndown/turndown";
 import { marked } from "./../lib/marked/marked";
@@ -31,6 +32,24 @@ import { useTheme } from "./../theme/provider";
 import { CodeEditor, CodeEditorAction, CodeEditorOption } from "./code-editor";
 import { applyClassName } from "./../constants/classname";
 import { createPortal } from "react-dom";
+
+export interface RichEditorFormattingOptions {
+  allowBold?: boolean;
+  allowItalic?: boolean;
+  allowUnderline?: boolean;
+  allowOrderedList?: boolean;
+  allowUnorderedList?: boolean;
+  allowCheckBoxes?: boolean;
+}
+
+const DEFAULT_FORMATTING_OPTIONS: Required<RichEditorFormattingOptions> = {
+  allowBold: true,
+  allowItalic: true,
+  allowUnderline: true,
+  allowOrderedList: true,
+  allowUnorderedList: true,
+  allowCheckBoxes: false,
+};
 
 export interface RichEditorProps {
   value?: string;
@@ -47,6 +66,7 @@ export interface RichEditorProps {
   className?: string;
   tokenRenderers?: RichEditorTokenRenderer;
   onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
+  formatting?: RichEditorFormattingOptions;
 }
 
 export type RichEditorTokenRenderer = Record<string, TokenRenderer>;
@@ -199,9 +219,29 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       id,
       tokenRenderers,
       onKeyDown,
+      formatting,
     },
     ref
   ) => {
+    const {
+      allowBold,
+      allowItalic,
+      allowUnderline,
+      allowOrderedList,
+      allowUnorderedList,
+      allowCheckBoxes,
+    } = useMemo(
+      () => ({ ...DEFAULT_FORMATTING_OPTIONS, ...formatting }),
+      [
+        formatting?.allowBold,
+        formatting?.allowItalic,
+        formatting?.allowUnderline,
+        formatting?.allowOrderedList,
+        formatting?.allowUnorderedList,
+        formatting?.allowCheckBoxes,
+      ]
+    );
+
     const {
       languageOptions: _languageOptions = Object.values(RichEditorCodeLanguage),
       language = _languageOptions[0],
@@ -388,11 +428,76 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       },
     });
 
+    turndownService.addRule("underline", {
+      filter: ["u"],
+      replacement: (content, node) => {
+        console.log("Underline node:", node);
+        console.log("Underline content:", content);
+
+        return `~${content}~`;
+      },
+    });
+
+    // When bold/italic are disallowed, strip the tags on the way back to
+    // markdown instead of emitting ** / _ markers, so re-parsing never
+    // reintroduces formatting the editor isn't supposed to support.
+    if (!allowBold) {
+      turndownService.addRule("disallowedBold", {
+        filter: ["strong", "b"],
+        replacement: (content) => content,
+      });
+    }
+
+    if (!allowItalic) {
+      turndownService.addRule("disallowedItalic", {
+        filter: ["em", "i"],
+        replacement: (content) => content,
+      });
+    }
+
+    if (!allowUnderline) {
+      turndownService.addRule("disallowedUnderline", {
+        filter: ["u"],
+        replacement: (content) => content,
+      });
+    }
+
     CodeEditor.addFencedCodeMarkedExtension();
+
+    const isLegal = isLegalDocument(value);
+
+    let prevWalkToken: any = null;
 
     marked.use({
       gfm: false,
       breaks: true,
+      // Disable the built-in strong/em/list renderers when the
+      // corresponding formatting isn't allowed, so markdown syntax like
+      // `**bold**` or `- item` renders as plain text instead of the
+      // matching element.
+      renderer: {
+        strong(token) {
+          if (!allowBold) return this.parser.parseInline(token.tokens);
+          return false;
+        },
+        em(token) {
+          if (!allowItalic) return this.parser.parseInline(token.tokens);
+          return false;
+        },
+        list(token) {
+          if (
+            (token.ordered && !allowOrderedList) ||
+            (!token.ordered && !allowUnorderedList)
+          ) {
+            return token.items
+              .map(
+                (item: any) => `<p>${this.parser.parseInline(item.tokens)}</p>`
+              )
+              .join("\n");
+          }
+          return false;
+        },
+      },
       // Track previous token so we can detect
       // blank lines that appear immediately after headings.
       walkTokens(token) {
@@ -411,6 +516,38 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         prevWalkToken = token;
       },
       extensions: [
+        {
+          /**
+           * Custom underline tokenizer.
+           * Markdown has no native underline syntax, so this editor
+           * claims `~text~` as its own inline convention — safe to reuse
+           * since `gfm: false` keeps the GFM `~~strikethrough~~` extension
+           * off, so a single `~` is otherwise unclaimed here.
+           *
+           * When underline is disallowed, the tildes are dropped and the
+           * inner content renders as plain inline text instead of <u>,
+           * matching how disallowed bold/italic fall back to plain text.
+           */
+          name: "underline",
+          level: "inline",
+          start(src) {
+            return src.indexOf("~");
+          },
+          tokenizer(src) {
+            const match = src.match(/^~((?:(?!~).)+?)~/);
+            if (match) {
+              return {
+                type: "underline",
+                raw: match[0],
+                tokens: this.lexer.inlineTokens(match[1]),
+              };
+            }
+          },
+          renderer(token) {
+            if (!allowUnderline) return this.parser.parseInline(token.tokens);
+            return `<u>${this.parser.parseInline(token.tokens)}</u>`;
+          },
+        },
         {
           /**
            * Custom heading tokenizer.
@@ -559,166 +696,6 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       marked.use({ extensions });
     }
 
-    const isLegal = isLegalDocument(value);
-
-    let prevWalkToken: any = null;
-
-    marked.use({
-      gfm: false,
-      breaks: true,
-      // Track previous token so we can detect
-      // blank lines that appear immediately after headings.
-      walkTokens(token) {
-        if (
-          token.type === "space" &&
-          token.raw.length >= 2 &&
-          prevWalkToken?.type === "heading"
-        ) {
-          const blankLines = token.raw.length - 1;
-
-          // Convert heading-following spaces into a custom
-          // emptyParagraph token so we can preserve spacing.
-          token.type = "emptyParagraph";
-          (token as any).count = blankLines;
-        }
-        prevWalkToken = token;
-      },
-      extensions: [
-        {
-          /**
-           * Custom heading tokenizer.
-           * Ensures markdown headings are parsed consistently
-           * and rendered as native h1-h6 elements.
-           */
-          name: "heading",
-          level: "block",
-          start(src) {
-            return src.indexOf("#");
-          },
-          tokenizer(src) {
-            const match = src.match(/^(#{1,6}) ([^\n]+)/);
-            if (match) {
-              return {
-                type: "heading",
-                raw: match[0],
-                depth: match[1].length,
-                text: match[2],
-                tokens: [],
-              };
-            }
-          },
-          renderer(token) {
-            return `<h${token.depth}>${token.text}</h${token.depth}>`;
-          },
-        },
-        {
-          /**
-           * Preserves multiple blank lines by converting them
-           * into explicit empty paragraph elements.
-           *
-           * Skipped for:
-           * - list contexts
-           * - legal document rendering
-           */
-          name: "emptyParagraph",
-          level: "block",
-          start(src) {
-            return src.indexOf("\n\n");
-          },
-          tokenizer(src, tokens) {
-            const prevToken = tokens?.[tokens.length - 1];
-            if (prevToken?.type === "list") return;
-
-            const isListContext = /^[ \t]*([-*+]|\d+\.)\s/m.test(src);
-            if (isListContext) return;
-
-            const match = src.match(/^(\n{2,})/);
-            if (match) {
-              const isAfterHeading = prevToken?.type === "heading";
-              // Add an extra line when spacing follows a heading.
-              const blankLines = match[0].length - 1 + (isAfterHeading ? 1 : 0);
-              return {
-                type: "emptyParagraph",
-                raw: match[0],
-                count: blankLines,
-              };
-            }
-          },
-          renderer(token) {
-            if (isLegal) return "";
-
-            return "<p><br></p>".repeat(token.count);
-          },
-        },
-        {
-          /**
-           * Converts consecutive single-line breaks into
-           * individual paragraph elements.
-           *
-           * Example:
-           *   Line A
-           *   Line B
-           *
-           * Becomes:
-           *   <p>Line A</p>
-           *   <p>Line B</p>
-           *
-           * Skipped for:
-           * - headings
-           * - code fences
-           * - lists
-           * - indented blocks
-           * - wrapped paragraphs
-           */
-          name: "lineSeparated",
-          level: "block",
-          start(src) {
-            return src.indexOf("\n");
-          },
-          tokenizer(src, tokens) {
-            const isHeading = /^#{1,6}\s/.test(src);
-            if (isHeading) return;
-
-            const isCodeFence = /^`{3,}/.test(src);
-            if (isCodeFence) return;
-
-            const firstLine = src.split("\n")[0];
-            if (/^[ \t]*([-*+]|\d+\.)\s/.test(firstLine)) return;
-            if (/^[ \t]+/.test(firstLine)) return;
-
-            const match = src.match(/^([^\n]+)(\n(?!\n)[^\n]+)*(?=\n\n|\n?$)/);
-            if (match && match[0].includes("\n")) {
-              const lines = match[0].split("\n");
-
-              // Treat long consecutive lines as a wrapped paragraph,
-              // not as separate paragraphs.
-              const looksLikeWrappedParagraph =
-                lines.length > 1 && lines.every((l) => l.length > 20);
-
-              if (looksLikeWrappedParagraph) return;
-
-              if (lines.some((l) => /^`{3,}/.test(l.trim()))) return;
-              if (lines.some((l) => /^ {4,}/.test(l))) return;
-              if (lines.some((l) => /^[ \t]+\S/.test(l))) return;
-              if (lines.some((l) => /^[ \t]*([-*+]|\d+\.)\s/.test(l))) return;
-
-              return {
-                type: "lineSeparated",
-                raw: match[0],
-                lines: lines.filter((l) => l.trim() !== ""),
-              };
-            }
-          },
-          renderer(token) {
-            if (isLegal) return "";
-            return token.lines
-              .map((line: string) => `<p>${line}</p>`)
-              .join("\n");
-          },
-        },
-      ],
-    });
-
     const editorRef = useRef<HTMLDivElement>(null);
     const savedSelection = useRef<Range | null>(null);
     const menuRef = useRef<HTMLDivElement | null>(null);
@@ -829,6 +806,7 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     const [formatStates, setFormatStates] = useState({
       bold: false,
       italic: false,
+      underline: false,
     });
 
     const updateFormatStates = () => {
@@ -840,17 +818,19 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       const node = sel.anchorNode;
 
       if (!node || !editorRef.current.contains(node)) {
-        setFormatStates({ bold: false, italic: false });
+        setFormatStates({ bold: false, italic: false, underline: false });
         return;
       }
 
       try {
         const bold = document.queryCommandState("bold");
         const italic = document.queryCommandState("italic");
+        const underline = document.queryCommandState("underline");
 
         setFormatStates({
           bold,
           italic,
+          underline,
         });
       } catch (error) {
         console.warn("Error checking command state:", error);
@@ -936,6 +916,8 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
     }, []);
 
     const handleFilteringCheckbox = () => {
+      if (!allowCheckBoxes) return;
+
       const walker = document.createTreeWalker(
         editorRef.current,
         NodeFilter.SHOW_TEXT
@@ -1068,12 +1050,21 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
       command:
         | "bold"
         | "italic"
+        | "underline"
         | "insertOrderedList"
         | "insertUnorderedList"
         | "checkbox"
         | "codeBlock"
     ) => {
       if (!editorRef.current) return;
+
+      if (command === "bold" && !allowBold) return;
+      if (command === "italic" && !allowItalic) return;
+      if (command === "underline" && !allowUnderline) return;
+      if (command === "insertOrderedList" && !allowOrderedList) return;
+      if (command === "insertUnorderedList" && !allowUnorderedList) return;
+      if (command === "checkbox" && !allowCheckBoxes) return;
+
       editorRef.current.focus();
 
       if (command === "codeBlock") {
@@ -1122,6 +1113,17 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
         return;
       }
 
+      if (command === "underline") {
+        if (sel && sel.rangeCount && sel.isCollapsed) {
+          applyInlineStyleToWord(command);
+        } else {
+          document.execCommand(command);
+        }
+
+        handleEditorChange();
+        return;
+      }
+
       document.execCommand(command);
       handleEditorChange();
     };
@@ -1147,11 +1149,29 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "u") {
         e.preventDefault();
+
+        if (!allowUnderline) return;
+
+        const sel = window.getSelection();
+
+        if (sel && sel.rangeCount && sel.isCollapsed) {
+          applyInlineStyleToWord("underline");
+        } else {
+          document.execCommand("underline");
+        }
+        setTimeout(() => {
+          updateFormatStates();
+        }, 0);
+
+        handleEditorChange();
         return;
       }
 
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "b") {
         e.preventDefault();
+
+        if (!allowBold) return;
+
         const sel = window.getSelection();
 
         if (sel && sel.rangeCount && sel.isCollapsed) {
@@ -1169,6 +1189,9 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
 
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "i") {
         e.preventDefault();
+
+        if (!allowItalic) return;
+
         const sel = window.getSelection();
         if (sel && sel.rangeCount && sel.isCollapsed) {
           applyInlineStyleToWord("italic");
@@ -1449,76 +1472,82 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           const beforeCaret = text.slice(0, caretPos);
           const afterCaret = text.slice(caretPos);
 
-          const checkedCheckboxMatch = beforeCaret.match(/\[x\]$/);
-          const uncheckedCheckboxMatch = beforeCaret.match(/\[ \]$/);
+          if (allowCheckBoxes) {
+            const checkedCheckboxMatch = beforeCaret.match(/\[x\]$/);
+            const uncheckedCheckboxMatch = beforeCaret.match(/\[ \]$/);
 
-          if (checkedCheckboxMatch || uncheckedCheckboxMatch) {
-            e.preventDefault();
+            if (checkedCheckboxMatch || uncheckedCheckboxMatch) {
+              e.preventDefault();
 
-            const patternLength = checkedCheckboxMatch
-              ? checkedCheckboxMatch[0].length
-              : uncheckedCheckboxMatch![0].length;
-            const beforePattern = beforeCaret.slice(0, -patternLength);
+              const patternLength = checkedCheckboxMatch
+                ? checkedCheckboxMatch[0].length
+                : uncheckedCheckboxMatch![0].length;
+              const beforePattern = beforeCaret.slice(0, -patternLength);
 
-            const checkboxWrapper = createCheckboxWrapper(
-              !!checkedCheckboxMatch,
-              turndownService,
-              editorRef,
-              onChange
-            );
+              const checkboxWrapper = createCheckboxWrapper(
+                !!checkedCheckboxMatch,
+                turndownService,
+                editorRef,
+                onChange
+              );
 
-            const spaceNode = document.createTextNode("\u00A0");
-            checkboxWrapper.after(spaceNode);
+              const spaceNode = document.createTextNode("\u00A0");
+              checkboxWrapper.after(spaceNode);
 
-            if (beforePattern || afterCaret) {
-              const afterText = afterCaret ?? "";
+              if (beforePattern || afterCaret) {
+                const afterText = afterCaret ?? "";
 
-              node.textContent = beforePattern + afterText;
+                node.textContent = beforePattern + afterText;
 
-              const newRange = document.createRange();
-              newRange.setStart(node, beforePattern.length);
-              newRange.collapse(true);
+                const newRange = document.createRange();
+                newRange.setStart(node, beforePattern.length);
+                newRange.collapse(true);
 
-              newRange.insertNode(checkboxWrapper);
+                newRange.insertNode(checkboxWrapper);
 
-              if (!afterText.startsWith(" ")) {
-                const spaceNode = document.createTextNode("\u00A0");
-                checkboxWrapper.after(spaceNode);
-              }
-
-              const finalRange = document.createRange();
-              if (checkboxWrapper.nextSibling) {
-                finalRange.setStartAfter(checkboxWrapper.nextSibling);
-              } else {
-                finalRange.setStartAfter(checkboxWrapper);
-              }
-              finalRange.collapse(true);
-
-              sel.removeAllRanges();
-              sel.addRange(finalRange);
-            } else {
-              const parent = node.parentNode;
-              if (parent) {
-                parent.replaceChild(checkboxWrapper, node);
-
-                const spaceNode = document.createTextNode("\u00A0");
-                parent.insertBefore(spaceNode, checkboxWrapper.nextSibling);
+                if (!afterText.startsWith(" ")) {
+                  const spaceNode = document.createTextNode("\u00A0");
+                  checkboxWrapper.after(spaceNode);
+                }
 
                 const finalRange = document.createRange();
-                finalRange.setStartAfter(spaceNode);
+                if (checkboxWrapper.nextSibling) {
+                  finalRange.setStartAfter(checkboxWrapper.nextSibling);
+                } else {
+                  finalRange.setStartAfter(checkboxWrapper);
+                }
                 finalRange.collapse(true);
 
                 sel.removeAllRanges();
                 sel.addRange(finalRange);
-              }
-            }
+              } else {
+                const parent = node.parentNode;
+                if (parent) {
+                  parent.replaceChild(checkboxWrapper, node);
 
-            handleEditorChange();
-            return;
+                  const spaceNode = document.createTextNode("\u00A0");
+                  parent.insertBefore(spaceNode, checkboxWrapper.nextSibling);
+
+                  const finalRange = document.createRange();
+                  finalRange.setStartAfter(spaceNode);
+                  finalRange.collapse(true);
+
+                  sel.removeAllRanges();
+                  sel.addRange(finalRange);
+                }
+              }
+
+              handleEditorChange();
+              return;
+            }
           }
 
-          const orderedMatch = beforeCaret.match(/^(\d+)\.$/);
-          const unorderedMatch = beforeCaret.match(/^[-*]$/);
+          const orderedMatch = allowOrderedList
+            ? beforeCaret.match(/^(\d+)\.$/)
+            : null;
+          const unorderedMatch = allowUnorderedList
+            ? beforeCaret.match(/^[-*]$/)
+            : null;
 
           if (orderedMatch || unorderedMatch) {
             e.preventDefault();
@@ -1955,37 +1984,56 @@ const RichEditor = forwardRef<RichEditorRef, RichEditorProps>(
           leftSidePanel={
             mode !== "view-only" && (
               <>
-                <RichEditorToolbarButton
-                  ariaLabel="rich-editor-toolbar-bold"
-                  isActive={formatStates.bold}
-                  icon={{ image: RiBold }}
-                  onClick={() => handleCommand("bold")}
-                />
+                {allowBold && (
+                  <RichEditorToolbarButton
+                    ariaLabel="rich-editor-toolbar-bold"
+                    isActive={formatStates.bold}
+                    icon={{ image: RiBold }}
+                    onClick={() => handleCommand("bold")}
+                  />
+                )}
 
-                <RichEditorToolbarButton
-                  ariaLabel="rich-editor-toolbar-italic"
-                  isActive={formatStates.italic}
-                  icon={{ image: RiItalic }}
-                  onClick={() => handleCommand("italic")}
-                />
+                {allowItalic && (
+                  <RichEditorToolbarButton
+                    ariaLabel="rich-editor-toolbar-italic"
+                    isActive={formatStates.italic}
+                    icon={{ image: RiItalic }}
+                    onClick={() => handleCommand("italic")}
+                  />
+                )}
 
-                <RichEditorToolbarButton
-                  ariaLabel="rich-editor-toolbar-ordered-list"
-                  icon={{ image: RiListOrdered }}
-                  onClick={() => handleCommand("insertOrderedList")}
-                />
+                {allowUnderline && (
+                  <RichEditorToolbarButton
+                    ariaLabel="rich-editor-toolbar-underline"
+                    isActive={formatStates.underline}
+                    icon={{ image: RiUnderline }}
+                    onClick={() => handleCommand("underline")}
+                  />
+                )}
 
-                <RichEditorToolbarButton
-                  ariaLabel="rich-editor-toolbar-unordered-list"
-                  icon={{ image: RiListUnordered }}
-                  onClick={() => handleCommand("insertUnorderedList")}
-                />
+                {allowOrderedList && (
+                  <RichEditorToolbarButton
+                    ariaLabel="rich-editor-toolbar-ordered-list"
+                    icon={{ image: RiListOrdered }}
+                    onClick={() => handleCommand("insertOrderedList")}
+                  />
+                )}
 
-                <RichEditorToolbarButton
-                  ariaLabel="rich-editor-toolbar-checkbox"
-                  icon={{ image: RiCheckboxLine }}
-                  onClick={() => handleCommand("checkbox")}
-                />
+                {allowUnorderedList && (
+                  <RichEditorToolbarButton
+                    ariaLabel="rich-editor-toolbar-unordered-list"
+                    icon={{ image: RiListUnordered }}
+                    onClick={() => handleCommand("insertUnorderedList")}
+                  />
+                )}
+
+                {allowCheckBoxes && (
+                  <RichEditorToolbarButton
+                    ariaLabel="rich-editor-toolbar-checkbox"
+                    icon={{ image: RiCheckboxLine }}
+                    onClick={() => handleCommand("checkbox")}
+                  />
+                )}
 
                 {mode === "markdown-editor" && (
                   <RichEditorToolbarButton
@@ -2675,8 +2723,8 @@ const cleanupHtml = (html: string): string => {
   return container.innerHTML;
 };
 
-// To apply instyle to word bold or italic
-const applyInlineStyleToWord = (style: "bold" | "italic") => {
+// To apply instyle to word bold, italic or underline
+const applyInlineStyleToWord = (style: "bold" | "italic" | "underline") => {
   const sel = window.getSelection();
   if (!sel || !sel.rangeCount) return;
 

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -47,7 +47,7 @@ describe("RichEditor", () => {
     );
   }
 
-  context.only("formatting rule", () => {
+  context("formatting rule", () => {
     it("renders except checkboxes and code", () => {
       cy.mount(<ProductRichEditor />);
 
@@ -97,275 +97,588 @@ describe("RichEditor", () => {
       });
     });
 
-    context("initial value", () => {
-      context("bold", () => {
-        context("with true", () => {
-          it("renders the markdown with **", () => {
-            cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
-            cy.mount(<ProductRichEditor value="**Test**" />);
-            cy.findByLabelText("toolbar-print").click();
-
-            cy.get("@consoleLog").should("have.been.calledWith", "**Test**");
+    context("allowBold", () => {
+      context("with true and typing", () => {
+        it("renders the markdown with **", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
           });
 
-          it("renders the html with <strong>", () => {
-            cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
-            cy.mount(<ProductRichEditor value="**Test**" />);
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowBold: true,
+              }}
+              value="**Test**"
+            />
+          );
 
-            cy.findByRole("textbox")
-              .invoke("html")
-              .then((html) => html.replace(/\n/g, ""))
-              .should("eq", "<p><strong>Test</strong></p>");
-          });
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "**Test123**");
         });
 
-        context("with false", () => {
-          it("renders on the markdown without **", () => {});
-          it("renders on the markdown without <b>", () => {});
-        });
-      });
-
-      context("italic", () => {
-        context("with true", () => {
-          it("renders the markdown with _", () => {
-            cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
-
-            cy.mount(<ProductRichEditor value="_Test_" />);
-
-            cy.findByLabelText("toolbar-print").click();
-
-            cy.get("@consoleLog").should("have.been.calledWith", "_Test_");
+        it("renders the html with <strong>", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
           });
 
-          it("renders the html with <em>", () => {
-            cy.mount(<ProductRichEditor value="_Test_" />);
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowBold: true,
+              }}
+              value="**Test**"
+            />
+          );
 
-            cy.findByRole("textbox")
-              .invoke("html")
-              .then((html) => html.replace(/\n/g, ""))
-              .should("eq", "<p><em>Test</em></p>");
-          });
-        });
+          cy.findByRole("textbox").click().realType("123");
 
-        context("with false", () => {
-          it("renders the markdown without _", () => {
-            cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
+          cy.findByLabelText("toolbar-print").click();
 
-            cy.mount(<ProductRichEditor value="Test" />);
+          cy.get("@consoleLog").should("have.been.calledWith", "**Test123**");
 
-            cy.findByLabelText("toolbar-print").click();
-
-            cy.get("@consoleLog").should("have.been.calledWith", "Test");
-          });
-
-          it("renders the html without <em>", () => {
-            cy.mount(<ProductRichEditor value="Test" />);
-
-            cy.findByRole("textbox")
-              .invoke("html")
-              .then((html) => html.replace(/\n/g, ""))
-              .should("eq", "<p>Test</p>");
-          });
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<p><strong>Test123</strong></p>");
         });
       });
 
-      context("underline", () => {
-        context("with true", () => {
-          it("renders the markdown with <u>", () => {
-            cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
-
-            cy.mount(<ProductRichEditor value="<u>Test</u>" />);
-
-            cy.findByLabelText("toolbar-print").click();
-
-            cy.get("@consoleLog").should("have.been.calledWith", "<u>Test</u>");
+      context("with false and typing", () => {
+        it("renders the markdown only **", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
           });
 
-          it("renders the html with <u>", () => {
-            cy.mount(<ProductRichEditor value="<u>Test</u>" />);
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowBold: false,
+              }}
+              value="**Test**"
+            />
+          );
 
-            cy.findByRole("textbox")
-              .invoke("html")
-              .then((html) => html.replace(/\n/g, ""))
-              .should("eq", "<p><u>Test</u></p>");
-          });
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "Test123");
         });
 
-        context("with false", () => {
-          it("renders the markdown without <u>", () => {
-            cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
+        it("renders the html without <strong>", () => {
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowBold: false,
+              }}
+              value="**Test**"
+            />
+          );
 
-            cy.mount(<ProductRichEditor value="Test" />);
+          cy.findByRole("textbox").click().realType("123");
 
-            cy.findByLabelText("toolbar-print").click();
+          cy.findByLabelText("toolbar-print").click();
 
-            cy.get("@consoleLog").should("have.been.calledWith", "Test");
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<p>Test123</p>");
+        });
+      });
+    });
+
+    context("allowItalic", () => {
+      context("with true and typing", () => {
+        it("renders the markdown with _", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
           });
 
-          it("renders the html without <u>", () => {
-            cy.mount(<ProductRichEditor value="Test" />);
+          cy.mount(<ProductRichEditor value="_Test_" />);
 
-            cy.findByRole("textbox")
-              .invoke("html")
-              .then((html) => html.replace(/\n/g, ""))
-              .should("eq", "<p>Test</p>");
-          });
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "_Test123_");
+        });
+
+        it("renders the html with <em>", () => {
+          cy.mount(<ProductRichEditor value="_Test_" />);
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<p><em>Test123</em></p>");
         });
       });
 
-      context("unordered list", () => {
-        context("with true", () => {
-          it("renders the markdown with *", () => {
-            cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
-
-            cy.mount(<ProductRichEditor value="* Test" />);
-
-            cy.findByLabelText("toolbar-print").click();
-
-            cy.get("@consoleLog").should("have.been.calledWith", "* Test");
+      context("with false and typing", () => {
+        it("renders the markdown without _", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
           });
 
-          it("renders the html with <ul><li>", () => {
-            cy.mount(<ProductRichEditor value="* Test" />);
+          cy.mount(
+            <ProductRichEditor
+              formatting={{ allowItalic: false }}
+              value="_Test_"
+            />
+          );
 
-            cy.findByRole("textbox")
-              .invoke("html")
-              .then((html) => html.replace(/\n/g, ""))
-              .should("eq", "<ul><li>Test</li></ul>");
-          });
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "Test123");
         });
 
-        context("with false", () => {
-          it("renders the markdown without *", () => {
-            cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
+        it("renders the html without <em>", () => {
+          cy.mount(
+            <ProductRichEditor
+              formatting={{ allowItalic: false }}
+              value="_Test_"
+            />
+          );
 
-            cy.mount(<ProductRichEditor value="Test" />);
+          cy.findByRole("textbox").click().realType("123");
 
-            cy.findByLabelText("toolbar-print").click();
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<p>Test123</p>");
+        });
+      });
+    });
 
-            cy.get("@consoleLog").should("have.been.calledWith", "Test");
+    context("allowUnderline", () => {
+      context("with true and typing", () => {
+        it("renders the markdown with ~", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
           });
 
-          it("renders the html without <ul><li>", () => {
-            cy.mount(<ProductRichEditor value="Test" />);
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowUnderline: true,
+              }}
+              value="~Test~"
+            />
+          );
 
-            cy.findByRole("textbox")
-              .invoke("html")
-              .then((html) => html.replace(/\n/g, ""))
-              .should("eq", "<p>Test</p>");
-          });
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "~Test123~");
+        });
+
+        it("renders the html with <u>", () => {
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowUnderline: true,
+              }}
+              value="~Test~"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<p><u>Test123</u></p>");
         });
       });
 
-      context("ordered list", () => {
-        context("with true", () => {
-          it("renders the markdown with number", () => {
-            cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
-
-            cy.mount(<ProductRichEditor value="1. Test" />);
-
-            cy.findByLabelText("toolbar-print").click();
-
-            cy.get("@consoleLog").should("have.been.calledWith", "1. Test");
+      context("with false and typing", () => {
+        it("renders the markdown without ~", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
           });
 
-          it("renders the html with <ol><li>", () => {
-            cy.mount(<ProductRichEditor value="1. Test" />);
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowUnderline: false,
+              }}
+              value="~Test~"
+            />
+          );
 
-            cy.findByRole("textbox")
-              .invoke("html")
-              .then((html) => html.replace(/\n/g, ""))
-              .should("eq", "<ol><li>Test</li></ol>");
-          });
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "Test123");
         });
 
-        context("with false", () => {
-          it("renders the markdown without number", () => {
-            cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
+        it("renders the html without <u>", () => {
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowUnderline: false,
+              }}
+              value="Test"
+            />
+          );
 
-            cy.mount(<ProductRichEditor value="Test" />);
+          cy.findByRole("textbox").click().realType("123");
 
-            cy.findByLabelText("toolbar-print").click();
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<p>Test123</p>");
+        });
+      });
+    });
 
-            cy.get("@consoleLog").should("have.been.calledWith", "Test");
+    context("allowUnorderedList", () => {
+      context("with true and typing", () => {
+        it("renders the markdown with *", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
           });
 
-          it("renders the html without <ol><li>", () => {
-            cy.mount(<ProductRichEditor value="Test" />);
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowUnorderedList: true,
+              }}
+              value="* Test"
+            />
+          );
 
-            cy.findByRole("textbox")
-              .invoke("html")
-              .then((html) => html.replace(/\n/g, ""))
-              .should("eq", "<p>Test</p>");
-          });
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "* Test123");
+        });
+
+        it("renders the html with <ul><li>", () => {
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowUnorderedList: true,
+              }}
+              value="* Test"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<ul><li>Test123</li></ul>");
         });
       });
 
-      context("heading", () => {
-        context("with true", () => {
-          it("renders the markdown with #", () => {
-            cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
-
-            cy.mount(<ProductRichEditor value="# Test" />);
-
-            cy.findByLabelText("toolbar-print").click();
-
-            cy.get("@consoleLog").should("have.been.calledWith", "# Test");
+      context("with false and typing", () => {
+        it("renders the markdown without *", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
           });
 
-          it("renders the html with <h1>", () => {
-            cy.mount(<ProductRichEditor value="# Test" />);
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowUnorderedList: false,
+              }}
+              value="* Test"
+            />
+          );
 
-            cy.findByRole("textbox")
-              .invoke("html")
-              .then((html) => html.replace(/\n/g, ""))
-              .should("eq", "<h1>Test</h1>");
-          });
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "Test123");
         });
 
-        context("with false", () => {
-          it("renders the markdown without #", () => {
-            cy.window().then((win) => {
-              cy.spy(win.console, "log").as("consoleLog");
-            });
+        it("renders the html without <ul><li>", () => {
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowUnorderedList: false,
+              }}
+              value="* Test"
+            />
+          );
 
-            cy.mount(<ProductRichEditor value="Test" />);
+          cy.findByRole("textbox").click().realType("123");
 
-            cy.findByLabelText("toolbar-print").click();
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<p>Test123</p>");
+        });
+      });
+    });
 
-            cy.get("@consoleLog").should("have.been.calledWith", "Test");
+    context("allowOrderedList", () => {
+      context("with true and typing", () => {
+        it("renders the markdown with number", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
           });
 
-          it("renders the html without <h1>", () => {
-            cy.mount(<ProductRichEditor value="Test" />);
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowOrderedList: true,
+              }}
+              value="1. Test"
+            />
+          );
 
-            cy.findByRole("textbox")
-              .invoke("html")
-              .then((html) => html.replace(/\n/g, ""))
-              .should("eq", "<p>Test</p>");
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "1. Test123");
+        });
+
+        it("renders the html with <ol><li>", () => {
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowOrderedList: true,
+              }}
+              value="1. Test"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<ol><li>Test123</li></ol>");
+        });
+      });
+
+      context("with false and typing", () => {
+        it("renders the markdown without number", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
           });
+
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowOrderedList: false,
+              }}
+              value="1. Test"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "Test123");
+        });
+
+        it("renders the html without <ol><li>", () => {
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowOrderedList: false,
+              }}
+              value="1. Test"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<p>Test123</p>");
+        });
+      });
+    });
+
+    context("allowHeading", () => {
+      context("with true and typing", () => {
+        it("renders the markdown with #", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
+          });
+
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowHeading: true,
+              }}
+              value="# Test"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "# Test123");
+        });
+
+        it("renders the html with <h1>", () => {
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowHeading: true,
+              }}
+              value="# Test"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<h1>Test123</h1>");
+        });
+      });
+
+      context("with false and typing", () => {
+        it("renders the markdown without #", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
+          });
+
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowHeading: false,
+              }}
+              value="# Test"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "Test123");
+        });
+
+        it("renders the html without <h1>", () => {
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowHeading: false,
+              }}
+              value="# Test"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<p>Test123</p>");
+        });
+      });
+    });
+
+    context("allowCheckboxes", () => {
+      context("with true and typing", () => {
+        it("renders the markdown with [ ]", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
+          });
+
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowCheckBoxes: true,
+              }}
+              value="[ ] Test"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should("have.been.calledWith", "[ ] Test123");
+        });
+
+        it("renders the html with checkbox", () => {
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowCheckBoxes: true,
+              }}
+              value="[ ] Test"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should(
+              "eq",
+              `<p><input type="checkbox" class="coneto-checkbox-wrapper" contenteditable="false" data-checked="false" style="cursor: pointer;"> Test123</p>`
+            );
+        });
+      });
+
+      context("with false and typing", () => {
+        it("renders the markdown without [ ]", () => {
+          cy.window().then((win) => {
+            cy.spy(win.console, "log").as("consoleLog");
+          });
+
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowCheckBoxes: false,
+              }}
+              value="[ ] Test"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByLabelText("toolbar-print").click();
+
+          cy.get("@consoleLog").should(
+            "have.been.calledWith",
+            "\\[ \\] Test123"
+          );
+        });
+
+        it("renders the html without checkbox", () => {
+          cy.mount(
+            <ProductRichEditor
+              formatting={{
+                allowCheckBoxes: false,
+              }}
+              value="[ ] Test"
+            />
+          );
+
+          cy.findByRole("textbox").click().realType("123");
+
+          cy.findByRole("textbox")
+            .invoke("html")
+            .then((html) => html.replace(/\n/g, ""))
+            .should("eq", "<p>[ ] Test123</p>");
         });
       });
     });
@@ -577,6 +890,8 @@ describe("RichEditor", () => {
             cy.findAllByLabelText("badge")
               .eq(1)
               .should("have.text", "@mention");
+
+            cy.wait(400);
 
             cy.findByText("Print").click();
 

--- a/test/component/rich-editor.cy.tsx
+++ b/test/component/rich-editor.cy.tsx
@@ -12,7 +12,7 @@ import { Badge } from "./../../components/badge";
 
 describe("RichEditor", () => {
   function ProductRichEditor(props: RichEditorProps) {
-    const [value, setValue] = useState("test");
+    const [value, setValue] = useState(props?.value ?? "test");
 
     const CODE_EDITOR_ACTIONS: RichEditorCodeAction[] = [
       {
@@ -24,15 +24,352 @@ describe("RichEditor", () => {
       },
     ];
 
+    const TOOLBAR_RIGHT_PANEL_ACTIONS = (
+      <RichEditor.ToolbarButton
+        ariaLabel="toolbar-print"
+        icon={{ image: RiPrinterFill }}
+        onClick={() => {
+          console.log(value);
+        }}
+      >
+        Print
+      </RichEditor.ToolbarButton>
+    );
+
     return (
       <RichEditor
         value={value}
         onChange={(val) => setValue(val)}
+        toolbarRightPanel={TOOLBAR_RIGHT_PANEL_ACTIONS}
         codeEditor={{ actions: CODE_EDITOR_ACTIONS }}
         {...props}
       />
     );
   }
+
+  context.only("formatting rule", () => {
+    it("renders except checkboxes and code", () => {
+      cy.mount(<ProductRichEditor />);
+
+      cy.findByLabelText("rich-editor-toolbar-bold").should("exist");
+      cy.findByLabelText("rich-editor-toolbar-italic").should("exist");
+      cy.findByLabelText("rich-editor-toolbar-underline").should("exist");
+      cy.findByLabelText("rich-editor-toolbar-ordered-list").should("exist");
+      cy.findByLabelText("rich-editor-toolbar-unordered-list").should("exist");
+      cy.findByLabelText("rich-editor-toolbar-heading-menu").should("exist");
+
+      cy.findByLabelText("rich-editor-toolbar-checkbox").should("not.exist");
+      cy.findByLabelText("rich-editor-toolbar-code-block").should("not.exist");
+    });
+
+    context("when make all false", () => {
+      it("renders without action button", () => {
+        cy.mount(
+          <ProductRichEditor
+            formatting={{
+              allowBold: false,
+              allowCheckBoxes: false,
+              allowItalic: false,
+              allowOrderedList: false,
+              allowUnderline: false,
+              allowUnorderedList: false,
+            }}
+          />
+        );
+
+        cy.findByLabelText("rich-editor-toolbar-bold").should("not.exist");
+        cy.findByLabelText("rich-editor-toolbar-italic").should("not.exist");
+        cy.findByLabelText("rich-editor-toolbar-underline").should("not.exist");
+        cy.findByLabelText("rich-editor-toolbar-ordered-list").should(
+          "not.exist"
+        );
+        cy.findByLabelText("rich-editor-toolbar-unordered-list").should(
+          "not.exist"
+        );
+        cy.findByLabelText("rich-editor-toolbar-heading-menu").should(
+          "not.exist"
+        );
+
+        cy.findByLabelText("rich-editor-toolbar-checkbox").should("not.exist");
+        cy.findByLabelText("rich-editor-toolbar-code-block").should(
+          "not.exist"
+        );
+      });
+    });
+
+    context("initial value", () => {
+      context("bold", () => {
+        context("with true", () => {
+          it("renders the markdown with **", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+            cy.mount(<ProductRichEditor value="**Test**" />);
+            cy.findByLabelText("toolbar-print").click();
+
+            cy.get("@consoleLog").should("have.been.calledWith", "**Test**");
+          });
+
+          it("renders the html with <strong>", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+            cy.mount(<ProductRichEditor value="**Test**" />);
+
+            cy.findByRole("textbox")
+              .invoke("html")
+              .then((html) => html.replace(/\n/g, ""))
+              .should("eq", "<p><strong>Test</strong></p>");
+          });
+        });
+
+        context("with false", () => {
+          it("renders on the markdown without **", () => {});
+          it("renders on the markdown without <b>", () => {});
+        });
+      });
+
+      context("italic", () => {
+        context("with true", () => {
+          it("renders the markdown with _", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+
+            cy.mount(<ProductRichEditor value="_Test_" />);
+
+            cy.findByLabelText("toolbar-print").click();
+
+            cy.get("@consoleLog").should("have.been.calledWith", "_Test_");
+          });
+
+          it("renders the html with <em>", () => {
+            cy.mount(<ProductRichEditor value="_Test_" />);
+
+            cy.findByRole("textbox")
+              .invoke("html")
+              .then((html) => html.replace(/\n/g, ""))
+              .should("eq", "<p><em>Test</em></p>");
+          });
+        });
+
+        context("with false", () => {
+          it("renders the markdown without _", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+
+            cy.mount(<ProductRichEditor value="Test" />);
+
+            cy.findByLabelText("toolbar-print").click();
+
+            cy.get("@consoleLog").should("have.been.calledWith", "Test");
+          });
+
+          it("renders the html without <em>", () => {
+            cy.mount(<ProductRichEditor value="Test" />);
+
+            cy.findByRole("textbox")
+              .invoke("html")
+              .then((html) => html.replace(/\n/g, ""))
+              .should("eq", "<p>Test</p>");
+          });
+        });
+      });
+
+      context("underline", () => {
+        context("with true", () => {
+          it("renders the markdown with <u>", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+
+            cy.mount(<ProductRichEditor value="<u>Test</u>" />);
+
+            cy.findByLabelText("toolbar-print").click();
+
+            cy.get("@consoleLog").should("have.been.calledWith", "<u>Test</u>");
+          });
+
+          it("renders the html with <u>", () => {
+            cy.mount(<ProductRichEditor value="<u>Test</u>" />);
+
+            cy.findByRole("textbox")
+              .invoke("html")
+              .then((html) => html.replace(/\n/g, ""))
+              .should("eq", "<p><u>Test</u></p>");
+          });
+        });
+
+        context("with false", () => {
+          it("renders the markdown without <u>", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+
+            cy.mount(<ProductRichEditor value="Test" />);
+
+            cy.findByLabelText("toolbar-print").click();
+
+            cy.get("@consoleLog").should("have.been.calledWith", "Test");
+          });
+
+          it("renders the html without <u>", () => {
+            cy.mount(<ProductRichEditor value="Test" />);
+
+            cy.findByRole("textbox")
+              .invoke("html")
+              .then((html) => html.replace(/\n/g, ""))
+              .should("eq", "<p>Test</p>");
+          });
+        });
+      });
+
+      context("unordered list", () => {
+        context("with true", () => {
+          it("renders the markdown with *", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+
+            cy.mount(<ProductRichEditor value="* Test" />);
+
+            cy.findByLabelText("toolbar-print").click();
+
+            cy.get("@consoleLog").should("have.been.calledWith", "* Test");
+          });
+
+          it("renders the html with <ul><li>", () => {
+            cy.mount(<ProductRichEditor value="* Test" />);
+
+            cy.findByRole("textbox")
+              .invoke("html")
+              .then((html) => html.replace(/\n/g, ""))
+              .should("eq", "<ul><li>Test</li></ul>");
+          });
+        });
+
+        context("with false", () => {
+          it("renders the markdown without *", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+
+            cy.mount(<ProductRichEditor value="Test" />);
+
+            cy.findByLabelText("toolbar-print").click();
+
+            cy.get("@consoleLog").should("have.been.calledWith", "Test");
+          });
+
+          it("renders the html without <ul><li>", () => {
+            cy.mount(<ProductRichEditor value="Test" />);
+
+            cy.findByRole("textbox")
+              .invoke("html")
+              .then((html) => html.replace(/\n/g, ""))
+              .should("eq", "<p>Test</p>");
+          });
+        });
+      });
+
+      context("ordered list", () => {
+        context("with true", () => {
+          it("renders the markdown with number", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+
+            cy.mount(<ProductRichEditor value="1. Test" />);
+
+            cy.findByLabelText("toolbar-print").click();
+
+            cy.get("@consoleLog").should("have.been.calledWith", "1. Test");
+          });
+
+          it("renders the html with <ol><li>", () => {
+            cy.mount(<ProductRichEditor value="1. Test" />);
+
+            cy.findByRole("textbox")
+              .invoke("html")
+              .then((html) => html.replace(/\n/g, ""))
+              .should("eq", "<ol><li>Test</li></ol>");
+          });
+        });
+
+        context("with false", () => {
+          it("renders the markdown without number", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+
+            cy.mount(<ProductRichEditor value="Test" />);
+
+            cy.findByLabelText("toolbar-print").click();
+
+            cy.get("@consoleLog").should("have.been.calledWith", "Test");
+          });
+
+          it("renders the html without <ol><li>", () => {
+            cy.mount(<ProductRichEditor value="Test" />);
+
+            cy.findByRole("textbox")
+              .invoke("html")
+              .then((html) => html.replace(/\n/g, ""))
+              .should("eq", "<p>Test</p>");
+          });
+        });
+      });
+
+      context("heading", () => {
+        context("with true", () => {
+          it("renders the markdown with #", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+
+            cy.mount(<ProductRichEditor value="# Test" />);
+
+            cy.findByLabelText("toolbar-print").click();
+
+            cy.get("@consoleLog").should("have.been.calledWith", "# Test");
+          });
+
+          it("renders the html with <h1>", () => {
+            cy.mount(<ProductRichEditor value="# Test" />);
+
+            cy.findByRole("textbox")
+              .invoke("html")
+              .then((html) => html.replace(/\n/g, ""))
+              .should("eq", "<h1>Test</h1>");
+          });
+        });
+
+        context("with false", () => {
+          it("renders the markdown without #", () => {
+            cy.window().then((win) => {
+              cy.spy(win.console, "log").as("consoleLog");
+            });
+
+            cy.mount(<ProductRichEditor value="Test" />);
+
+            cy.findByLabelText("toolbar-print").click();
+
+            cy.get("@consoleLog").should("have.been.calledWith", "Test");
+          });
+
+          it("renders the html without <h1>", () => {
+            cy.mount(<ProductRichEditor value="Test" />);
+
+            cy.findByRole("textbox")
+              .invoke("html")
+              .then((html) => html.replace(/\n/g, ""))
+              .should("eq", "<p>Test</p>");
+          });
+        });
+      });
+    });
+  });
 
   context("tokenRenderers", () => {
     function ProductRichEditorWithTokenRenderers() {


### PR DESCRIPTION
Description:
This pull request introduces a `formatting` prop, allowing individual RichEditor to be enabled ro disbaled feature. It also updates the `Toolbar.Action` to respect the rule. 

Ensuring consistent rendering and Markdown serialization across both `HTML-to-Markdown` or `Markdown-to-HTML`.

By default, all formatting options are enabled except checkboxes.

```tsx
<RichEditor
  formatting={{
    allowBold: true,
    allowItalic: true,
    allowUnderline: true,
    allowOrderedList: true,
    allowUnorderedList: true,
    allowCheckBoxes: false,
    allowHeading: true,
  }}
/>
```

#### `formatting`

| Option | Default | Description |
| ---------------------- | :-------: | ----------------------------------------------------- |
| `allowBold` | `true` | Enables bold formatting (`**text**`). |
| `allowItalic` | `true` | Enables italic formatting (`*text*`). |
| `allowUnderline` | `true` | Enables underline formatting (`~text~`). |
| `allowOrderedList` | `true` | Enables ordered lists (`1. Item`). |
| `allowUnorderedList` | `true` | Enables unordered lists (`- Item` or `* Item`). |
| `allowCheckBoxes` | `false` | Enables Markdown task lists (`[ ]` and `[x]`). |
| `allowHeading` | `true` | Enables Markdown headings (`#` through `######`). |

It also ensures all works correctly, the rendering still consistently, check per prop. 

Additionally, this pull request adds `underline` support, as the `RichEditor` did not previously provide an `underline` renderer.

Source:
[[Improvement] SYST-736: Don't default allow all markdown features, only set of features](https://linear.app/systatum/issue/SYST-736/dont-default-allow-all-markdown-features-only-set-of-features)

Tick what you have done:
[x] I have double checked the functionality with the ticket in linear, or any other relevant discussion avenue
[x] I have created/updated any relevant test code
[x] I have tested it myself